### PR TITLE
Fix missing solver version/typo in benchmark report

### DIFF
--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/result/PlannerBenchmarkResult.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/result/PlannerBenchmarkResult.java
@@ -123,7 +123,7 @@ public class PlannerBenchmarkResult {
         return operatingSystem;
     }
 
-    public String getTimefoldVersion() {
+    public String getTimefoldSolverVersion() {
         return timefoldSolverVersion;
     }
 

--- a/benchmark/src/main/resources/ai/timefold/solver/benchmark/impl/report/benchmarkReport.html.ftl
+++ b/benchmark/src/main/resources/ai/timefold/solver/benchmark/impl/report/benchmarkReport.html.ftl
@@ -766,7 +766,7 @@
                     <tr>
                         <th>Benchmark time spent</th>
                         <#if benchmarkReport.plannerBenchmarkResult.benchmarkTimeMillisSpent??>
-                            <td>${benchmarkReport.plannerBenchmarkResult.benchmarkTimeMillisSpent?string.@msDuration}</td>[
+                            <td>${benchmarkReport.plannerBenchmarkResult.benchmarkTimeMillisSpent?string.@msDuration}</td>
                         <#else>
                             <td>Differs</td>
                         </#if>


### PR DESCRIPTION
Fixes a problem with missing solver version in benchmark report.

Before:
<img width="761" alt="image" src="https://github.com/TimefoldAI/timefold-solver/assets/4274233/994e9790-5e42-4e33-9a1c-89f74a1fb179">

After:
<img width="739" alt="image" src="https://github.com/TimefoldAI/timefold-solver/assets/4274233/bd04d16f-90a6-4855-9162-b74566817eee">


Also removes redundant square bracket (presumably a typo).

Before:
<img width="740" alt="image" src="https://github.com/TimefoldAI/timefold-solver/assets/4274233/b253d295-d707-4e22-8002-44ae56f8ce81">

After:
<img width="734" alt="image" src="https://github.com/TimefoldAI/timefold-solver/assets/4274233/fa64983a-2e45-4c06-9e2f-0149355f481c">
