### PR TITLE
build: do not check for Android-unfriendly code

### DIFF
--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -57,7 +57,6 @@
     <version.jaxb2.plugin>3.1.0</version.jaxb2.plugin>
     <version.resources.plugin>3.3.1</version.resources.plugin>
     <version.revapi.plugin>0.15.0</version.revapi.plugin>
-    <version.sniffer.plugin>1.23</version.sniffer.plugin>
     <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>
     <version.source.plugin>3.3.0</version.source.plugin>
     <version.surefire.plugin>3.1.2</version.surefire.plugin>
@@ -551,31 +550,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>${version.sniffer.plugin}</version>
-          <configuration>
-            <signature>
-              <groupId>net.sf.androidscents.signature</groupId>
-              <artifactId>android-api-level-32</artifactId>
-              <version>12_r1</version>
-            </signature>
-            <ignores>
-              <ignore>java.lang.invoke.LambdaMetafactory</ignore>
-              <ignore>java.lang.invoke.MethodHandle</ignore>
-            </ignores>
-          </configuration>
-          <executions>
-            <execution>
-              <id>animal-sniffer</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${version.assembly.plugin}</version>
         </plugin>
@@ -778,7 +752,6 @@
         <skipTests>true</skipTests>
         <skipITs>true</skipITs>
         <formatter.skip>true</formatter.skip>
-        <animal.sniffer.skip>true</animal.sniffer.skip>
       </properties>
     </profile>
 

--- a/core/constraint-streams/pom.xml
+++ b/core/constraint-streams/pom.xml
@@ -84,13 +84,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/core/core-impl/pom.xml
+++ b/core/core-impl/pom.xml
@@ -150,10 +150,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/common/ReflectionHelper.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/common/ReflectionHelper.java
@@ -30,9 +30,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Avoids the usage of Introspector to work on Android too.
- */
 public final class ReflectionHelper {
 
     private static final String PROPERTY_ACCESSOR_PREFIX_GET = "get";

--- a/core/core/pom.xml
+++ b/core/core/pom.xml
@@ -44,10 +44,6 @@
           <skip>true</skip> <!-- This is an empty JAR to drag in dependencies; dep checks make no sense here. -->
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 

--- a/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
+++ b/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
@@ -899,11 +899,11 @@ A `@PlanningId` property must be:
 
 
 [[customThreadFactory]]
-=== Custom thread factory (WildFly, Android, GAE, ...)
+=== Custom thread factory (WildFly, GAE, ...)
 
 The `threadFactoryClass` allows to plug in a custom `ThreadFactory` for environments
 where arbitrary thread creation should be avoided,
-such as most application servers (including WildFly), Android, or Google App Engine.
+such as most application servers (including WildFly) or Google App Engine.
 
 Configure the `ThreadFactory` on the solver to create the <<multithreadedIncrementalSolving,move threads>>
 and the xref:partitioned-search/partitioned-search.adoc#partitionedSearch[Partition Search threads] with it:

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -31,13 +31,4 @@
     <module>jsonb</module>
   </modules>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>


### PR DESCRIPTION
Timefold Solver does not support Android,
especially as it would force us not to use stuff from recent JDKs.