### PR TITLE
fix: allow min/max constraint collectors on planning variables

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
@@ -732,7 +732,7 @@ public final class ConstraintCollectors {
      * incremental score calculation.
      * <p>
      * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]} with
-     * {@code .groupBy(max(Person::name, Person::age))} returns {@code Ann} or {@code Eric},
+     * {@code .groupBy(min(Person::name, Person::age))} returns {@code Ann} or {@code Eric},
      * as both have the same age.
      * <p>
      * The default result of the collector (e.g. when never called) is {@code null}.

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
@@ -331,16 +332,15 @@ public final class ConstraintCollectors {
         MutableLong valueCountContainer = resultContainer.computeIfAbsent(value, k -> new MutableLong());
         valueCountContainer.increment();
         return () -> {
-            MutableLong valueCountContainer2 = resultContainer.get(value);
-            if (valueCountContainer2 == null) {
+            long valueCount = valueCountContainer.longValue();
+            if (valueCount < 1L) {
                 throw new IllegalStateException("Impossible state: the value (" + value +
                         ") is removed more times than it was added.");
             }
-            long valueCount = valueCountContainer2.longValue();
             if (valueCount == 1L) {
                 resultContainer.remove(value);
             } else {
-                valueCountContainer2.setValue(valueCount - 1L);
+                valueCountContainer.setValue(valueCount - 1L);
             }
         };
     }
@@ -694,7 +694,7 @@ public final class ConstraintCollectors {
      * @return never null
      */
     public static <A extends Comparable<A>> UniConstraintCollector<A, ?, A> min() {
-        return min(Comparator.naturalOrder());
+        return minOrMax(a -> a, Comparator.naturalOrder(), true);
     }
 
     /**
@@ -718,19 +718,130 @@ public final class ConstraintCollectors {
      */
     public static <A, Mapped extends Comparable<? super Mapped>> UniConstraintCollector<A, ?, Mapped> min(
             Function<A, Mapped> groupValueMapping) {
-        return min(groupValueMapping, Comparator.naturalOrder());
+        return minOrMax(groupValueMapping, Comparator.naturalOrder(), true);
+    }
+
+    /**
+     * Returns a collector that finds a minimum value in a group of {@link Comparable} elements.
+     * The elements will be compared according to the value returned by the comparable function.
+     * <p>
+     * Important: The {@link Comparable}'s {@link Comparable#compareTo(Object)} must be <i>consistent with equals</i>,
+     * such that {@code e1.compareTo(e2) == 0} has the same boolean value as {@code e1.equals(e2)}.
+     * In other words, if two elements compare to zero, any of them can be returned by the collector.
+     * It can even differ between 2 score calculations on the exact same {@link PlanningSolution} state, due to
+     * incremental score calculation.
+     * <p>
+     * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]} with
+     * {@code .groupBy(max(Person::name, Person::age))} returns {@code Ann} or {@code Eric},
+     * as both have the same age.
+     * <p>
+     * The default result of the collector (e.g. when never called) is {@code null}.
+     *
+     * @param <A> type of the matched fact
+     * @param <Mapped> type of the result
+     * @param <Comparable_> type of the comparable property
+     * @param groupValueMapping never null, maps facts from the matched type to the result type
+     * @param comparableFunction never null, maps facts from the matched type to the comparable property
+     * @return never null
+     */
+    public static <A, Mapped, Comparable_ extends Comparable<? super Comparable_>> UniConstraintCollector<A, ?, Mapped> min(
+            Function<A, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction) {
+        return minOrMax(groupValueMapping, comparableFunction, true);
+    }
+
+    private static <A, Mapped, Comparable_ extends Comparable<? super Comparable_>> UniConstraintCollector<A, ?, Mapped>
+            minOrMax(Function<A, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction, boolean min) {
+        return new DefaultUniConstraintCollector<>(
+                getMinOrMaxSupplier(min),
+                (NavigableMap<Comparable_, Map<Mapped, MutableLong>> resultContainer, A a) -> {
+                    Mapped value = groupValueMapping.apply(a);
+                    return innerMinOrMax(resultContainer, value, comparableFunction);
+                },
+                getMinOrMaxFinisherForComparable(min));
+    }
+
+    private static <Value_, Comparable_ extends Comparable<? super Comparable_>>
+            Supplier<NavigableMap<Comparable_, Map<Value_, MutableLong>>> getMinOrMaxSupplier(boolean returnMinimum) {
+        if (returnMinimum) {
+            return () -> {
+                Comparator<Comparable_> comparator = Comparator.nullsLast(Comparator.naturalOrder());
+                return new TreeMap<>(comparator);
+            };
+        } else {
+            return () -> {
+                Comparator<Comparable_> comparator = Comparator.nullsFirst(Comparator.naturalOrder());
+                return new TreeMap<>(comparator);
+            };
+        }
+    }
+
+    private static <Value_, Comparable_ extends Comparable<? super Comparable_>> Runnable innerMinOrMax(
+            SortedMap<Comparable_, Map<Value_, MutableLong>> resultContainer, Value_ value,
+            Function<Value_, Comparable_> comparableFunction) {
+        Comparable_ comparable = comparableFunction.apply(value);
+        Map<Value_, MutableLong> valueCountMap = resultContainer.computeIfAbsent(comparable, k -> new LinkedHashMap<>());
+        MutableLong valueCounter = valueCountMap.computeIfAbsent(value, k -> new MutableLong(0L));
+        valueCounter.increment();
+        return () -> {
+            long valueCount = valueCounter.longValue();
+            if (valueCount < 1L) {
+                throw new IllegalStateException("Impossible state: the value (" + value +
+                        ") is removed more times than it was added.");
+            }
+            if (valueCounter.longValue() == 1L) {
+                if (valueCountMap.remove(value) == null) {
+                    throw new IllegalStateException("Impossible state: the value (" + value +
+                            ") is removed more times than it was added.");
+                }
+                if (valueCountMap.isEmpty()) {
+                    resultContainer.remove(comparable);
+                }
+            } else {
+                valueCounter.decrement();
+            }
+        };
+    }
+
+    private static <Value_, Comparable_ extends Comparable<? super Comparable_>>
+            Function<NavigableMap<Comparable_, Map<Value_, MutableLong>>, Value_>
+            getMinOrMaxFinisherForComparable(boolean returnMinimum) {
+        if (returnMinimum) {
+            return resultContainer -> {
+                if (resultContainer.isEmpty()) {
+                    return null;
+                }
+                Map.Entry<Comparable_, Map<Value_, MutableLong>> entry = resultContainer.firstEntry();
+                return entry.getValue().keySet().iterator().next();
+            };
+        } else {
+            return resultContainer -> {
+                if (resultContainer.isEmpty()) {
+                    return null;
+                }
+                Map.Entry<Comparable_, Map<Value_, MutableLong>> entry = resultContainer.lastEntry();
+                return entry.getValue().keySet().iterator().next();
+            };
+        }
     }
 
     /**
      * As defined by {@link #min()}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #min(Function, Function)},
+     *             as this method can lead to unavoidable score corruptions.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A> UniConstraintCollector<A, ?, A> min(Comparator<? super A> comparator) {
         return min(Function.identity(), comparator);
     }
 
     /**
      * As defined by {@link #min(Function)}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #min(Function, Function)},
+     *             as this method can lead to unavoidable score corruptions.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A, Mapped> UniConstraintCollector<A, ?, Mapped> min(Function<A, Mapped> groupValueMapping,
             Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, true);
@@ -741,12 +852,36 @@ public final class ConstraintCollectors {
      */
     public static <A, B, Mapped extends Comparable<? super Mapped>> BiConstraintCollector<A, B, ?, Mapped> min(
             BiFunction<A, B, Mapped> groupValueMapping) {
-        return min(groupValueMapping, Comparator.naturalOrder());
+        return minOrMax(groupValueMapping, Comparator.naturalOrder(), true);
+    }
+
+    /**
+     * As defined by {@link #min(Function, Function)}.
+     */
+    public static <A, B, Mapped, Comparable_ extends Comparable<? super Comparable_>> BiConstraintCollector<A, B, ?, Mapped>
+            min(BiFunction<A, B, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction) {
+        return minOrMax(groupValueMapping, comparableFunction, true);
+    }
+
+    private static <A, B, Mapped, Comparable_ extends Comparable<? super Comparable_>> BiConstraintCollector<A, B, ?, Mapped>
+            minOrMax(BiFunction<A, B, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction,
+                    boolean min) {
+        return new DefaultBiConstraintCollector<>(
+                getMinOrMaxSupplier(min),
+                (NavigableMap<Comparable_, Map<Mapped, MutableLong>> resultContainer, A a, B b) -> {
+                    Mapped value = groupValueMapping.apply(a, b);
+                    return innerMinOrMax(resultContainer, value, comparableFunction);
+                },
+                getMinOrMaxFinisherForComparable(min));
     }
 
     /**
      * As defined by {@link #min(Function)}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #min(BiFunction, Function)},
+     *             as this method can lead to unavoidable score corruptions.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A, B, Mapped> BiConstraintCollector<A, B, ?, Mapped> min(BiFunction<A, B, Mapped> groupValueMapping,
             Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, true);
@@ -757,12 +892,38 @@ public final class ConstraintCollectors {
      */
     public static <A, B, C, Mapped extends Comparable<? super Mapped>> TriConstraintCollector<A, B, C, ?, Mapped> min(
             TriFunction<A, B, C, Mapped> groupValueMapping) {
-        return min(groupValueMapping, Comparator.naturalOrder());
+        return minOrMax(groupValueMapping, Comparator.naturalOrder(), true);
+    }
+
+    /**
+     * As defined by {@link #min(Function, Function)}.
+     */
+    public static <A, B, C, Mapped, Comparable_ extends Comparable<? super Comparable_>>
+            TriConstraintCollector<A, B, C, ?, Mapped>
+            min(TriFunction<A, B, C, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction) {
+        return minOrMax(groupValueMapping, comparableFunction, true);
+    }
+
+    private static <A, B, C, Mapped, Comparable_ extends Comparable<? super Comparable_>>
+            TriConstraintCollector<A, B, C, ?, Mapped> minOrMax(
+                    TriFunction<A, B, C, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction,
+                    boolean min) {
+        return new DefaultTriConstraintCollector<>(
+                getMinOrMaxSupplier(min),
+                (NavigableMap<Comparable_, Map<Mapped, MutableLong>> resultContainer, A a, B b, C c) -> {
+                    Mapped value = groupValueMapping.apply(a, b, c);
+                    return innerMinOrMax(resultContainer, value, comparableFunction);
+                },
+                getMinOrMaxFinisherForComparable(min));
     }
 
     /**
      * As defined by {@link #min(Function)}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #min(TriFunction, Function)},
+     *             as this method can lead to unavoidable score corruptions.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A, B, C, Mapped> TriConstraintCollector<A, B, C, ?, Mapped> min(
             TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, true);
@@ -773,12 +934,38 @@ public final class ConstraintCollectors {
      */
     public static <A, B, C, D, Mapped extends Comparable<? super Mapped>> QuadConstraintCollector<A, B, C, D, ?, Mapped> min(
             QuadFunction<A, B, C, D, Mapped> groupValueMapping) {
-        return min(groupValueMapping, Comparator.naturalOrder());
+        return minOrMax(groupValueMapping, Comparator.naturalOrder(), true);
+    }
+
+    /**
+     * As defined by {@link #min(Function, Function)}.
+     */
+    public static <A, B, C, D, Mapped, Comparable_ extends Comparable<? super Comparable_>>
+            QuadConstraintCollector<A, B, C, D, ?, Mapped>
+            min(QuadFunction<A, B, C, D, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction) {
+        return minOrMax(groupValueMapping, comparableFunction, true);
+    }
+
+    private static <A, B, C, D, Mapped, Comparable_ extends Comparable<? super Comparable_>>
+            QuadConstraintCollector<A, B, C, D, ?, Mapped> minOrMax(
+                    QuadFunction<A, B, C, D, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction,
+                    boolean min) {
+        return new DefaultQuadConstraintCollector<>(
+                getMinOrMaxSupplier(min),
+                (NavigableMap<Comparable_, Map<Mapped, MutableLong>> resultContainer, A a, B b, C c, D d) -> {
+                    Mapped value = groupValueMapping.apply(a, b, c, d);
+                    return innerMinOrMax(resultContainer, value, comparableFunction);
+                },
+                getMinOrMaxFinisherForComparable(min));
     }
 
     /**
      * As defined by {@link #min(Function)}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #min(QuadFunction, Function)},
+     *             as this method can lead to unavoidable score corruptions.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A, B, C, D, Mapped> QuadConstraintCollector<A, B, C, D, ?, Mapped> min(
             QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, true);
@@ -809,7 +996,7 @@ public final class ConstraintCollectors {
      * @return never null
      */
     public static <A extends Comparable<A>> UniConstraintCollector<A, ?, A> max() {
-        return max(Comparator.naturalOrder());
+        return minOrMax(a -> a, Comparator.naturalOrder(), false);
     }
 
     /**
@@ -833,19 +1020,55 @@ public final class ConstraintCollectors {
      */
     public static <A, Mapped extends Comparable<? super Mapped>> UniConstraintCollector<A, ?, Mapped> max(
             Function<A, Mapped> groupValueMapping) {
-        return max(groupValueMapping, Comparator.naturalOrder());
+        return minOrMax(groupValueMapping, Comparator.naturalOrder(), false);
     }
 
     /**
      * As defined by {@link #max()}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #max(Function, Function)},
+     *             as this method can lead to unavoidable score corruptions.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A> UniConstraintCollector<A, ?, A> max(Comparator<? super A> comparator) {
         return max(Function.identity(), comparator);
     }
 
     /**
-     * As defined by {@link #max(Function)}, only with a custom {@link Comparator}.
+     * Returns a collector that finds a maximum value in a group of elements.
+     * The elements will be compared according to the value returned by the comparable function.
+     * <p>
+     * Important: The {@link Comparable}'s {@link Comparable#compareTo(Object)} must be <i>consistent with equals</i>,
+     * such that {@code e1.compareTo(e2) == 0} has the same boolean value as {@code e1.equals(e2)}.
+     * In other words, if two elements compare to zero, any of them can be returned by the collector.
+     * It can even differ between 2 score calculations on the exact same {@link PlanningSolution} state, due to
+     * incremental score calculation.
+     * <p>
+     * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]} with
+     * {@code .groupBy(max(Person::name, Person::age))} returns {@code Cathy} or {@code David},
+     * as both have the same age.
+     * <p>
+     * The default result of the collector (e.g. when never called) is {@code null}.
+     *
+     * @param <A> type of the matched fact
+     * @param <Mapped> type of the result
+     * @param <Comparable_> type of the comparable property
+     * @param groupValueMapping never null, maps facts from the matched type to the result type
+     * @param comparableFunction never null, maps facts from the matched type to the comparable property
+     * @return never null
      */
+    public static <A, Mapped, Comparable_ extends Comparable<? super Comparable_>> UniConstraintCollector<A, ?, Mapped>
+            max(Function<A, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction) {
+        return minOrMax(groupValueMapping, comparableFunction, false);
+    }
+
+    /**
+     * As defined by {@link #max(Function)}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #max(Function, Function)},
+     *             as this method can lead to unavoidable score corruptions.
+     */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A, Mapped> UniConstraintCollector<A, ?, Mapped> max(Function<A, Mapped> groupValueMapping,
             Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, false);
@@ -859,10 +1082,11 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                getMinOrMaxFinisher(min));
+                getMinOrMaxFinisherForComparator(min));
     }
 
-    private static <Value_> Function<SortedMap<Value_, MutableLong>, Value_> getMinOrMaxFinisher(boolean returnMinimum) {
+    private static <Value_> Function<SortedMap<Value_, MutableLong>, Value_>
+            getMinOrMaxFinisherForComparator(boolean returnMinimum) {
         if (returnMinimum) {
             return resultContainer -> resultContainer.isEmpty() ? null : resultContainer.firstKey();
         } else {
@@ -875,12 +1099,24 @@ public final class ConstraintCollectors {
      */
     public static <A, B, Mapped extends Comparable<? super Mapped>> BiConstraintCollector<A, B, ?, Mapped> max(
             BiFunction<A, B, Mapped> groupValueMapping) {
-        return max(groupValueMapping, Comparator.naturalOrder());
+        return minOrMax(groupValueMapping, Comparator.naturalOrder(), false);
     }
 
     /**
-     * As defined by {@link #max(Function)}, only with a custom {@link Comparator}.
+     * As defined by {@link #max(Function, Function)}, only with a custom {@link Comparator}.
      */
+    public static <A, B, Mapped, Comparable_ extends Comparable<? super Comparable_>> BiConstraintCollector<A, B, ?, Mapped>
+            max(BiFunction<A, B, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction) {
+        return minOrMax(groupValueMapping, comparableFunction, false);
+    }
+
+    /**
+     * As defined by {@link #max()}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #max(BiFunction, Function)},
+     *             as this method can lead to unavoidable score corruptions.
+     */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A, B, Mapped> BiConstraintCollector<A, B, ?, Mapped> max(BiFunction<A, B, Mapped> groupValueMapping,
             Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, false);
@@ -894,7 +1130,7 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                getMinOrMaxFinisher(min));
+                getMinOrMaxFinisherForComparator(min));
     }
 
     /**
@@ -902,12 +1138,25 @@ public final class ConstraintCollectors {
      */
     public static <A, B, C, Mapped extends Comparable<? super Mapped>> TriConstraintCollector<A, B, C, ?, Mapped> max(
             TriFunction<A, B, C, Mapped> groupValueMapping) {
-        return max(groupValueMapping, Comparator.naturalOrder());
+        return minOrMax(groupValueMapping, Comparator.naturalOrder(), false);
     }
 
     /**
-     * As defined by {@link #max(Function)}, only with a custom {@link Comparator}.
+     * As defined by {@link #max(Function, Function)}, only with a custom {@link Comparator}.
      */
+    public static <A, B, C, Mapped, Comparable_ extends Comparable<? super Comparable_>>
+            TriConstraintCollector<A, B, C, ?, Mapped>
+            max(TriFunction<A, B, C, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction) {
+        return minOrMax(groupValueMapping, comparableFunction, false);
+    }
+
+    /**
+     * As defined by {@link #max()}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #max(TriFunction, Function)},
+     *             as this method can lead to unavoidable score corruptions.
+     */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A, B, C, Mapped> TriConstraintCollector<A, B, C, ?, Mapped> max(
             TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, false);
@@ -921,7 +1170,7 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b, c);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                getMinOrMaxFinisher(min));
+                getMinOrMaxFinisherForComparator(min));
     }
 
     /**
@@ -929,12 +1178,25 @@ public final class ConstraintCollectors {
      */
     public static <A, B, C, D, Mapped extends Comparable<? super Mapped>> QuadConstraintCollector<A, B, C, D, ?, Mapped> max(
             QuadFunction<A, B, C, D, Mapped> groupValueMapping) {
-        return max(groupValueMapping, Comparator.naturalOrder());
+        return minOrMax(groupValueMapping, Comparator.naturalOrder(), false);
     }
 
     /**
-     * As defined by {@link #max(Function)}, only with a custom {@link Comparator}.
+     * As defined by {@link #max(Function, Function)}, only with a custom {@link Comparator}.
      */
+    public static <A, B, C, D, Mapped, Comparable_ extends Comparable<? super Comparable_>>
+            QuadConstraintCollector<A, B, C, D, ?, Mapped>
+            max(QuadFunction<A, B, C, D, Mapped> groupValueMapping, Function<Mapped, Comparable_> comparableFunction) {
+        return minOrMax(groupValueMapping, comparableFunction, false);
+    }
+
+    /**
+     * As defined by {@link #max()}, only with a custom {@link Comparator}.
+     *
+     * @deprecated Deprecated in favor of {@link #max(QuadFunction, Function)},
+     *             as this method can lead to unavoidable score corruptions.
+     */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static <A, B, C, D, Mapped> QuadConstraintCollector<A, B, C, D, ?, Mapped> max(
             QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, false);
@@ -948,7 +1210,7 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b, c, d);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                getMinOrMaxFinisher(min));
+                getMinOrMaxFinisherForComparator(min));
     }
 
     /**

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectorsTest.java
@@ -25,7 +25,6 @@ import java.math.BigInteger;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.Period;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1418,7 +1417,7 @@ class ConstraintCollectorsTest {
 
     @Test
     void minNotComparable() {
-        UniConstraintCollector<Object, ?, Object> collector = min(Comparator.comparing(o -> (String) o));
+        UniConstraintCollector<Object, ?, Object> collector = min(Function.identity(), o -> (String) o);
         Object container = collector.supplier().get();
 
         // Default state.
@@ -1483,7 +1482,7 @@ class ConstraintCollectorsTest {
 
     @Test
     void minNotComparableBi() {
-        BiConstraintCollector<String, String, ?, String> collector = min((a, b) -> a, Comparator.comparing(o -> o));
+        BiConstraintCollector<String, String, ?, String> collector = min((a, b) -> a, o -> o);
         Object container = collector.supplier().get();
 
         // Default state.
@@ -1548,8 +1547,7 @@ class ConstraintCollectorsTest {
 
     @Test
     void minNotComparableTri() {
-        TriConstraintCollector<String, String, String, ?, String> collector = min((a, b, c) -> a,
-                Comparator.comparing(o -> o));
+        TriConstraintCollector<String, String, String, ?, String> collector = min((a, b, c) -> a, o -> o);
         Object container = collector.supplier().get();
 
         // Default state.
@@ -1614,8 +1612,7 @@ class ConstraintCollectorsTest {
 
     @Test
     void minNotComparableQuad() {
-        QuadConstraintCollector<String, String, String, String, ?, String> collector = min((a, b, c, d) -> a,
-                Comparator.comparing(o -> o));
+        QuadConstraintCollector<String, String, String, String, ?, String> collector = min((a, b, c, d) -> a, o -> o);
         Object container = collector.supplier().get();
 
         // Default state.
@@ -1677,7 +1674,7 @@ class ConstraintCollectorsTest {
 
     @Test
     void maxNotComparable() {
-        UniConstraintCollector<String, ?, String> collector = max(Comparator.comparing(o -> o));
+        UniConstraintCollector<String, ?, String> collector = max(Function.identity(), o -> o);
         Object container = collector.supplier().get();
 
         // Default state.
@@ -1742,7 +1739,7 @@ class ConstraintCollectorsTest {
 
     @Test
     void maxNotComparableBi() {
-        BiConstraintCollector<String, String, ?, String> collector = max((a, b) -> a, Comparator.comparing(o -> o));
+        BiConstraintCollector<String, String, ?, String> collector = max((a, b) -> a, o -> o);
         Object container = collector.supplier().get();
 
         // Default state.
@@ -1807,8 +1804,7 @@ class ConstraintCollectorsTest {
 
     @Test
     void maxNotComparableTri() {
-        TriConstraintCollector<String, String, String, ?, String> collector = max((a, b, c) -> a,
-                Comparator.comparing(o -> o));
+        TriConstraintCollector<String, String, String, ?, String> collector = max((a, b, c) -> a, o -> o);
         Object container = collector.supplier().get();
 
         // Default state.
@@ -1873,8 +1869,7 @@ class ConstraintCollectorsTest {
 
     @Test
     void maxNotComparableQuad() {
-        QuadConstraintCollector<String, String, String, String, ?, String> collector = max((a, b, c, d) -> a,
-                Comparator.comparing(o -> o));
+        QuadConstraintCollector<String, String, String, String, ?, String> collector = max((a, b, c, d) -> a, o -> o);
         Object container = collector.supplier().get();
 
         // Default state.
@@ -3442,7 +3437,7 @@ class ConstraintCollectorsTest {
     void conditionallyBi() {
         BiConstraintCollector<Integer, Integer, Object, Integer> collector = ConstraintCollectors.conditionally(
                 (i, i2) -> i < 2,
-                max(Integer::sum, Integer::compareTo));
+                max(Integer::sum, i -> i));
         Object container = collector.supplier().get();
 
         // Default state.
@@ -3474,7 +3469,7 @@ class ConstraintCollectorsTest {
         TriConstraintCollector<Integer, Integer, Integer, Object, Integer> collector =
                 ConstraintCollectors.conditionally(
                         (i, i2, i3) -> i < 2,
-                        max((i, i2, i3) -> i + i2 + i3, Integer::compareTo));
+                        max((i, i2, i3) -> i + i2 + i3, i -> i));
         Object container = collector.supplier().get();
 
         // Default state.
@@ -3506,7 +3501,7 @@ class ConstraintCollectorsTest {
         QuadConstraintCollector<Integer, Integer, Integer, Integer, Object, Integer> collector =
                 ConstraintCollectors.conditionally(
                         (i, i2, i3, i4) -> i < 2,
-                        max((i, i2, i3, i4) -> i + i2 + i3 + i4, Integer::compareTo));
+                        max((i, i2, i3, i4) -> i + i2 + i3 + i4, i -> i));
         Object container = collector.supplier().get();
 
         // Default state.
@@ -3630,8 +3625,8 @@ class ConstraintCollectorsTest {
     @Test
     void compose2Bi() {
         BiConstraintCollector<Integer, Integer, ?, Pair<Integer, Integer>> collector =
-                compose(min(Integer::sum, Integer::compareTo),
-                        max(Integer::sum, Integer::compareTo),
+                compose(min(Integer::sum, i -> i),
+                        max(Integer::sum, i -> i),
                         Pair::of);
         Object container = collector.supplier().get();
 
@@ -3662,8 +3657,8 @@ class ConstraintCollectorsTest {
     @Test
     void compose3Bi() {
         BiConstraintCollector<Integer, Integer, ?, Triple<Integer, Integer, Double>> collector =
-                compose(min(Integer::sum, Integer::compareTo),
-                        max(Integer::sum, Integer::compareTo),
+                compose(min(Integer::sum, i -> i),
+                        max(Integer::sum, i -> i),
                         ConstraintCollectors.average(Integer::sum),
                         Triple::of);
         Object container = collector.supplier().get();
@@ -3696,8 +3691,8 @@ class ConstraintCollectorsTest {
     void compose4Bi() {
         BiConstraintCollector<Integer, Integer, ?, Quadruple<Integer, Integer, Integer, Double>> collector =
                 compose(ConstraintCollectors.countBi(),
-                        min(Integer::sum, Integer::compareTo),
-                        max(Integer::sum, Integer::compareTo),
+                        min(Integer::sum, i -> i),
+                        max(Integer::sum, i -> i),
                         ConstraintCollectors.average(Integer::sum),
                         Quadruple::of);
         Object container = collector.supplier().get();
@@ -3729,8 +3724,8 @@ class ConstraintCollectorsTest {
     @Test
     void compose2Tri() {
         TriConstraintCollector<Integer, Integer, Integer, ?, Pair<Integer, Integer>> collector =
-                compose(min((i, i2, i3) -> i + i2 + i3, Integer::compareTo),
-                        max((i, i2, i3) -> i + i2 + i3, Integer::compareTo),
+                compose(min((i, i2, i3) -> i + i2 + i3, i -> i),
+                        max((i, i2, i3) -> i + i2 + i3, i -> i),
                         Pair::of);
         Object container = collector.supplier().get();
 
@@ -3761,8 +3756,8 @@ class ConstraintCollectorsTest {
     @Test
     void compose3Tri() {
         TriConstraintCollector<Integer, Integer, Integer, ?, Triple<Integer, Integer, Double>> collector =
-                compose(min((i, i2, i3) -> i + i2 + i3, Integer::compareTo),
-                        max((i, i2, i3) -> i + i2 + i3, Integer::compareTo),
+                compose(min((i, i2, i3) -> i + i2 + i3, i -> i),
+                        max((i, i2, i3) -> i + i2 + i3, i -> i),
                         ConstraintCollectors.average((i, i2, i3) -> i + i2 + i3),
                         Triple::of);
         Object container = collector.supplier().get();
@@ -3795,8 +3790,8 @@ class ConstraintCollectorsTest {
     void compose4Tri() {
         TriConstraintCollector<Integer, Integer, Integer, ?, Quadruple<Integer, Integer, Integer, Double>> collector =
                 compose(ConstraintCollectors.countTri(),
-                        min((i, i2, i3) -> i + i2 + i3, Integer::compareTo),
-                        max((i, i2, i3) -> i + i2 + i3, Integer::compareTo),
+                        min((i, i2, i3) -> i + i2 + i3, i -> i),
+                        max((i, i2, i3) -> i + i2 + i3, i -> i),
                         ConstraintCollectors.average((i, i2, i3) -> i + i2 + i3),
                         Quadruple::of);
         Object container = collector.supplier().get();
@@ -3828,8 +3823,8 @@ class ConstraintCollectorsTest {
     @Test
     void compose2Quad() {
         QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, Pair<Integer, Integer>> collector =
-                compose(min((i, i2, i3, i4) -> i + i2 + i3 + i4, Integer::compareTo),
-                        max((i, i2, i3, i4) -> i + i2 + i3 + i4, Integer::compareTo),
+                compose(min((i, i2, i3, i4) -> i + i2 + i3 + i4, i -> i),
+                        max((i, i2, i3, i4) -> i + i2 + i3 + i4, i -> i),
                         Pair::of);
         Object container = collector.supplier().get();
 
@@ -3860,8 +3855,8 @@ class ConstraintCollectorsTest {
     @Test
     void compose3Quad() {
         QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, Triple<Integer, Integer, Double>> collector =
-                compose(min((i, i2, i3, i4) -> i + i2 + i3 + i4, Integer::compareTo),
-                        max((i, i2, i3, i4) -> i + i2 + i3 + i4, Integer::compareTo),
+                compose(min((i, i2, i3, i4) -> i + i2 + i3 + i4, i -> i),
+                        max((i, i2, i3, i4) -> i + i2 + i3 + i4, i -> i),
                         ConstraintCollectors.average((i, i2, i3, i4) -> i + i2 + i3 + i4),
                         Triple::of);
         Object container = collector.supplier().get();
@@ -3894,8 +3889,8 @@ class ConstraintCollectorsTest {
     void compose4Quad() {
         QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, Quadruple<Integer, Integer, Integer, Double>> collector =
                 compose(ConstraintCollectors.countQuad(),
-                        min((i, i2, i3, i4) -> i + i2 + i3 + i4, Integer::compareTo),
-                        max((i, i2, i3, i4) -> i + i2 + i3 + i4, Integer::compareTo),
+                        min((i, i2, i3, i4) -> i + i2 + i3 + i4, i -> i),
+                        max((i, i2, i3, i4) -> i + i2 + i3 + i4, i -> i),
                         ConstraintCollectors.average((i, i2, i3, i4) -> i + i2 + i3 + i4),
                         Quadruple::of);
         Object container = collector.supplier().get();


### PR DESCRIPTION
The pre-existing way of doing min/max constraint collectors relied on a user-supplied comparator.
The values would then be put straight into a `TreeMap`, sorted according to this comparator.

However, if the comparator relied on a planning variable, there would be issues.
During insertion, the value would be put into a map.
But then the value's comparison would change due to the planning variable changing.
As a result, on value removal from the map, the value would fail to be removed, leading to exceptions.

The new code no longer relies on user-supplied comparator. 
Instead, it asks the user to supply a function to return the comparable object and creates the comparator internally.
This allows the collector to store the value that was inserted, and on removal, remove that same value; not the current value returned by the user-supplied function.

This performs worse, but it is safer and therefore preferrable.
The old methods were deprecated, as there is no way to make them safe.