### PR TITLE
fix(quarkus): Workaround quarkus-run.jar fails fast due to gizmo missing

### DIFF
--- a/quarkus-integration/quarkus/runtime/pom.xml
+++ b/quarkus-integration/quarkus/runtime/pom.xml
@@ -31,6 +31,11 @@
       <artifactId>timefold-solver-core</artifactId>
     </dependency>
     <dependency>
+      <!-- TODO Remove after gizmo is no longer needed at runtime https://github.com/TimefoldAI/timefold-solver/issues/133  -->
+      <groupId>io.quarkus.gizmo</groupId>
+      <artifactId>gizmo</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>graal-sdk</artifactId>
     </dependency>


### PR DESCRIPTION
STOPGAP for https://github.com/TimefoldAI/timefold-solver/issues/133
GOOD FIX that is still open: https://github.com/TimefoldAI/timefold-solver/pull/134