### PR TITLE
Changed from 'extends AbstractCustomPhaseCommand' to 'implements …'

### DIFF
--- a/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
+++ b/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
@@ -733,7 +733,7 @@ For example, implement `CustomPhaseCommand` and its `changeWorkingSolution()` me
 
 [source,java,options="nowrap"]
 ----
-public class ToOriginalMachineSolutionInitializer extends AbstractCustomPhaseCommand<MachineReassignment> {
+public class ToOriginalMachineSolutionInitializer implements CustomPhaseCommand<MachineReassignment> {
 
     public void changeWorkingSolution(ScoreDirector<MachineReassignment> scoreDirector) {
         MachineReassignment machineReassignment = scoreDirector.getWorkingSolution();


### PR DESCRIPTION
Documentation update.

I believe `AbstractCustomPhaseCommand` no longer exists. I suspect one should simply implement `CustomPhaseCommand` instead?

If this understanding is wrong, then I apologize for the noise.