### PR TITLE
fix: bail out of a never-ending loop when no move is doable

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/decider/ConstructionHeuristicDecider.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/decider/ConstructionHeuristicDecider.java
@@ -86,8 +86,6 @@ public class ConstructionHeuristicDecider<Solution_> {
             ConstructionHeuristicMoveScope<Solution_> moveScope = new ConstructionHeuristicMoveScope<>(stepScope, moveIndex,
                     move);
             moveIndex++;
-            // Do not filter out pointless moves, because the original value of the entity(s) is irrelevant.
-            // If the original value is null and the variable is nullable, the move to null must be done too.
             doMove(moveScope);
             if (forager.isQuitEarly()) {
                 break;

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/PooledEntityPlacerFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/PooledEntityPlacerFactory.java
@@ -68,7 +68,7 @@ public class PooledEntityPlacerFactory<Solution_>
                 config.getMoveSelectorConfig() == null ? buildMoveSelectorConfig(configPolicy) : config.getMoveSelectorConfig();
 
         MoveSelector<Solution_> moveSelector = MoveSelectorFactory.<Solution_> create(moveSelectorConfig_)
-                .buildMoveSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.ORIGINAL);
+                .buildMoveSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.ORIGINAL, false);
         return new PooledEntityPlacer<>(moveSelector);
     }
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/QueuedEntityPlacerFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/QueuedEntityPlacerFactory.java
@@ -91,7 +91,7 @@ public class QueuedEntityPlacerFactory<Solution_>
         List<MoveSelector<Solution_>> moveSelectorList = new ArrayList<>(moveSelectorConfigList_.size());
         for (MoveSelectorConfig moveSelectorConfig : moveSelectorConfigList_) {
             MoveSelector<Solution_> moveSelector = MoveSelectorFactory.<Solution_> create(moveSelectorConfig)
-                    .buildMoveSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.ORIGINAL);
+                    .buildMoveSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.ORIGINAL, false);
             moveSelectorList.add(moveSelector);
         }
         return new QueuedEntityPlacer<>(entitySelector, moveSelectorList);

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/QueuedValuePlacerFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/QueuedValuePlacerFactory.java
@@ -45,7 +45,7 @@ public class QueuedValuePlacerFactory<Solution_>
                 : config.getMoveSelectorConfig();
 
         MoveSelector<Solution_> moveSelector = MoveSelectorFactory.<Solution_> create(moveSelectorConfig_)
-                .buildMoveSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.ORIGINAL);
+                .buildMoveSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.ORIGINAL, false);
         if (!(valueSelector instanceof EntityIndependentValueSelector)) {
             throw new IllegalArgumentException("The queuedValuePlacer (" + this
                     + ") needs to be based on an "

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
@@ -145,7 +145,7 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
         MoveSelectorConfig<?> moveSelectorConfig_ = buildMoveSelectorConfig(configPolicy,
                 sourceEntitySelector, mimicSelectorId);
         MoveSelector<Solution_> moveSelector = MoveSelectorFactory.<Solution_> create(moveSelectorConfig_)
-                .buildMoveSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.ORIGINAL);
+                .buildMoveSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.ORIGINAL, true);
         ScoreBounder scoreBounder = scoreBounderEnabled
                 ? new TrendBasedScoreBounder(configPolicy.getScoreDefinition(), configPolicy.getInitializingScoreTrend())
                 : null;

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/move/CompositeMove.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/move/CompositeMove.java
@@ -62,7 +62,7 @@ public class CompositeMove<Solution_> implements Move<Solution_> {
      * @param moves never null, never empty. Do not modify this argument afterwards or this CompositeMove corrupts.
      */
     @SafeVarargs
-    public CompositeMove(Move<Solution_>... moves) {
+    CompositeMove(Move<Solution_>... moves) {
         this.moves = moves;
     }
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/PinEntityFilter.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/PinEntityFilter.java
@@ -45,4 +45,9 @@ public class PinEntityFilter<Solution_> implements SelectionFilter<Solution_, Ob
     public int hashCode() {
         return Objects.hash(memberAccessor);
     }
+
+    @Override
+    public String toString() {
+        return "Non-pinned entities only";
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/DoableMoveSelectionFilter.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/DoableMoveSelectionFilter.java
@@ -1,0 +1,24 @@
+package ai.timefold.solver.core.impl.heuristic.selector.move;
+
+import ai.timefold.solver.core.api.score.director.ScoreDirector;
+import ai.timefold.solver.core.impl.heuristic.move.Move;
+import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
+
+final class DoableMoveSelectionFilter<Solution_> implements SelectionFilter<Solution_, Move<Solution_>> {
+
+    static final SelectionFilter INSTANCE = new DoableMoveSelectionFilter<>();
+
+    @Override
+    public boolean accept(ScoreDirector<Solution_> scoreDirector, Move<Solution_> move) {
+        return move.isMoveDoable(scoreDirector);
+    }
+
+    private DoableMoveSelectionFilter() {
+
+    }
+
+    @Override
+    public String toString() {
+        return "Doable moves only";
+    }
+}

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/MoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/MoveSelectorFactory.java
@@ -41,7 +41,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.move.generic.list.kopt.KO
 
 public interface MoveSelectorFactory<Solution_> {
 
-    static <Solution_> MoveSelectorFactory<Solution_> create(MoveSelectorConfig<?> moveSelectorConfig) {
+    static <Solution_> AbstractMoveSelectorFactory<Solution_, ?> create(MoveSelectorConfig<?> moveSelectorConfig) {
         if (ChangeMoveSelectorConfig.class.isAssignableFrom(moveSelectorConfig.getClass())) {
             return new ChangeMoveSelectorFactory<>((ChangeMoveSelectorConfig) moveSelectorConfig);
         } else if (SwapMoveSelectorConfig.class.isAssignableFrom(moveSelectorConfig.getClass())) {
@@ -90,8 +90,9 @@ public interface MoveSelectorFactory<Solution_> {
      *        then it should be at least this {@link SelectionCacheType} because an ancestor already uses such caching
      *        and less would be pointless.
      * @param inheritedSelectionOrder never null
+     * @param skipNonDoableMoves
      * @return never null
      */
     MoveSelector<Solution_> buildMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
-            SelectionCacheType minimumCacheType, SelectionOrder inheritedSelectionOrder);
+            SelectionCacheType minimumCacheType, SelectionOrder inheritedSelectionOrder, boolean skipNonDoableMoves);
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/AbstractCompositeMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/AbstractCompositeMoveSelectorFactory.java
@@ -22,9 +22,10 @@ abstract class AbstractCompositeMoveSelectorFactory<Solution_, MoveSelectorConfi
             HeuristicConfigPolicy<Solution_> configPolicy, SelectionCacheType minimumCacheType, boolean randomSelection) {
         return innerMoveSelectorList.stream()
                 .map(moveSelectorConfig -> {
-                    MoveSelectorFactory<Solution_> innerMoveSelectorFactory = MoveSelectorFactory.create(moveSelectorConfig);
+                    AbstractMoveSelectorFactory<Solution_, ?> moveSelectorFactory =
+                            MoveSelectorFactory.create(moveSelectorConfig);
                     SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
-                    return innerMoveSelectorFactory.buildMoveSelector(configPolicy, minimumCacheType, selectionOrder);
+                    return moveSelectorFactory.buildMoveSelector(configPolicy, minimumCacheType, selectionOrder, false);
                 }).collect(Collectors.toList());
     }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelector.java
@@ -151,7 +151,7 @@ public class CartesianProductMoveSelector<Solution_> extends CompositeMoveSelect
                 }
                 moveList = Arrays.copyOfRange(newMoveList, 0, newSize);
             }
-            return new CompositeMove<>(moveList);
+            return CompositeMove.buildMove(moveList);
         }
 
     }
@@ -217,7 +217,7 @@ public class CartesianProductMoveSelector<Solution_> extends CompositeMoveSelect
                     return moveList.get(0);
                 }
             }
-            return new CompositeMove<>(moveList.toArray(new Move[0]));
+            return CompositeMove.buildMove(moveList.toArray(new Move[0]));
         }
 
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
@@ -20,7 +20,7 @@ public class UnionMoveSelectorFactory<Solution_>
     }
 
     @Override
-    public MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
+    protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
         List<MoveSelector<Solution_>> moveSelectorList = buildInnerMoveSelectors(config.getMoveSelectorList(),
                 configPolicy, minimumCacheType, randomSelection);

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
@@ -180,10 +180,10 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
         }
         if (phaseConfig.getMoveSelectorConfig() == null) {
             moveSelector = new UnionMoveSelectorFactory<Solution_>(determineDefaultMoveSelectorConfig(configPolicy))
-                    .buildMoveSelector(configPolicy, defaultCacheType, defaultSelectionOrder);
+                    .buildMoveSelector(configPolicy, defaultCacheType, defaultSelectionOrder, true);
         } else {
             moveSelector = MoveSelectorFactory.<Solution_> create(phaseConfig.getMoveSelectorConfig())
-                    .buildMoveSelector(configPolicy, defaultCacheType, defaultSelectionOrder);
+                    .buildMoveSelector(configPolicy, defaultCacheType, defaultSelectionOrder, true);
         }
         return moveSelector;
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/LocalSearchDecider.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/LocalSearchDecider.java
@@ -94,15 +94,9 @@ public class LocalSearchDecider<Solution_> {
         for (Move<Solution_> move : moveSelector) {
             LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, moveIndex, move);
             moveIndex++;
-            // TODO use Selector filtering to filter out not doable moves
-            if (!move.isMoveDoable(scoreDirector)) {
-                logger.trace("{}        Move index ({}) not doable, ignoring move ({}).",
-                        logIndentation, moveScope.getMoveIndex(), move);
-            } else {
-                doMove(moveScope);
-                if (forager.isQuitEarly()) {
-                    break;
-                }
+            doMove(moveScope);
+            if (forager.isQuitEarly()) {
+                break;
             }
             stepScope.getPhaseScope().getSolverScope().checkYielding();
             if (termination.isPhaseTerminated(stepScope.getPhaseScope())) {
@@ -115,6 +109,10 @@ public class LocalSearchDecider<Solution_> {
 
     protected <Score_ extends Score<Score_>> void doMove(LocalSearchMoveScope<Solution_> moveScope) {
         InnerScoreDirector<Solution_, Score_> scoreDirector = moveScope.getScoreDirector();
+        if (!moveScope.getMove().isMoveDoable(scoreDirector)) {
+            throw new IllegalStateException("Impossible state: Local search move selector (" + moveSelector
+                    + ") provided a non-doable move (" + moveScope.getMove() + ").");
+        }
         scoreDirector.doAndProcessMove(moveScope.getMove(), assertMoveScoreFromScratch, score -> {
             moveScope.setScore(score);
             boolean accepted = acceptor.isAccepted(moveScope);

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/MoveSelectorFactoryTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/MoveSelectorFactoryTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.move;
 
 import static ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -14,9 +15,11 @@ import ai.timefold.solver.core.config.heuristic.selector.common.decorator.Select
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
 import ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicy;
 import ai.timefold.solver.core.impl.heuristic.move.DummyMove;
+import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.heuristic.selector.SelectorTestUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionProbabilityWeightFactory;
 import ai.timefold.solver.core.impl.heuristic.selector.move.decorator.CachingMoveSelector;
+import ai.timefold.solver.core.impl.heuristic.selector.move.decorator.FilteringMoveSelector;
 import ai.timefold.solver.core.impl.heuristic.selector.move.decorator.ProbabilityMoveSelector;
 import ai.timefold.solver.core.impl.heuristic.selector.move.decorator.ShufflingMoveSelector;
 import ai.timefold.solver.core.impl.heuristic.selector.move.decorator.SortingMoveSelector;
@@ -35,7 +38,7 @@ class MoveSelectorFactoryTest {
         MoveSelectorFactory<TestdataSolution> moveSelectorFactory =
                 new AssertingMoveSelectorFactory(moveSelectorConfig, baseMoveSelector, SelectionCacheType.PHASE, false);
         MoveSelector<TestdataSolution> moveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(CachingMoveSelector.class)
                 .isNotInstanceOf(ShufflingMoveSelector.class);
@@ -53,7 +56,7 @@ class MoveSelectorFactoryTest {
         MoveSelectorFactory<TestdataSolution> moveSelectorFactory =
                 new AssertingMoveSelectorFactory(moveSelectorConfig, baseMoveSelector, SelectionCacheType.STEP, false);
         MoveSelector<TestdataSolution> moveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(CachingMoveSelector.class)
                 .isNotInstanceOf(ShufflingMoveSelector.class);
@@ -71,7 +74,7 @@ class MoveSelectorFactoryTest {
         moveSelectorConfig.setCacheType(SelectionCacheType.JUST_IN_TIME);
         moveSelectorConfig.setSelectionOrder(SelectionOrder.ORIGINAL);
         MoveSelector<TestdataSolution> moveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector).isSameAs(baseMoveSelector);
         assertThat(moveSelector.getCacheType()).isEqualTo(SelectionCacheType.JUST_IN_TIME);
     }
@@ -85,7 +88,7 @@ class MoveSelectorFactoryTest {
         moveSelectorConfig.setCacheType(SelectionCacheType.PHASE);
         moveSelectorConfig.setSelectionOrder(SelectionOrder.RANDOM);
         MoveSelector<TestdataSolution> moveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(CachingMoveSelector.class)
                 .isNotInstanceOf(ShufflingMoveSelector.class);
@@ -103,7 +106,7 @@ class MoveSelectorFactoryTest {
         moveSelectorConfig.setCacheType(SelectionCacheType.STEP);
         moveSelectorConfig.setSelectionOrder(SelectionOrder.RANDOM);
         MoveSelector<TestdataSolution> moveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(CachingMoveSelector.class)
                 .isNotInstanceOf(ShufflingMoveSelector.class);
@@ -121,7 +124,7 @@ class MoveSelectorFactoryTest {
         moveSelectorConfig.setCacheType(SelectionCacheType.JUST_IN_TIME);
         moveSelectorConfig.setSelectionOrder(SelectionOrder.RANDOM);
         MoveSelector<TestdataSolution> moveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector).isSameAs(baseMoveSelector);
         assertThat(moveSelector.getCacheType()).isEqualTo(SelectionCacheType.JUST_IN_TIME);
     }
@@ -135,7 +138,7 @@ class MoveSelectorFactoryTest {
         moveSelectorConfig.setCacheType(SelectionCacheType.PHASE);
         moveSelectorConfig.setSelectionOrder(SelectionOrder.SHUFFLED);
         MoveSelector<TestdataSolution> moveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(ShufflingMoveSelector.class);
         assertThat(moveSelector.getCacheType()).isEqualTo(SelectionCacheType.PHASE);
@@ -152,7 +155,7 @@ class MoveSelectorFactoryTest {
         moveSelectorConfig.setCacheType(SelectionCacheType.STEP);
         moveSelectorConfig.setSelectionOrder(SelectionOrder.SHUFFLED);
         MoveSelector<TestdataSolution> moveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(ShufflingMoveSelector.class);
         assertThat(moveSelector.getCacheType()).isEqualTo(SelectionCacheType.STEP);
@@ -170,7 +173,7 @@ class MoveSelectorFactoryTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM));
+                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false));
     }
 
     @Test
@@ -219,8 +222,33 @@ class MoveSelectorFactoryTest {
 
         DummyMoveSelectorFactory moveSelectorFactory = new DummyMoveSelectorFactory(moveSelectorConfig, baseMoveSelector);
         MoveSelector<TestdataSolution> sortingMoveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
-                SelectionCacheType.PHASE, SelectionOrder.PROBABILISTIC);
+                SelectionCacheType.PHASE, SelectionOrder.PROBABILISTIC, false);
         assertThat(sortingMoveSelector).isExactlyInstanceOf(ProbabilityMoveSelector.class);
+    }
+
+    @Test
+    void applyFilter_nonMovableMoves() {
+        Move<TestdataSolution> notDoableMove = new Move<>() {
+            @Override
+            public boolean isMoveDoable(ScoreDirector<TestdataSolution> scoreDirector) {
+                return false;
+            }
+
+            @Override
+            public Move<TestdataSolution> doMove(ScoreDirector<TestdataSolution> scoreDirector) {
+                return null;
+            }
+        };
+        final MoveSelector<TestdataSolution> baseMoveSelector =
+                SelectorTestUtils.mockMoveSelector(DummyMove.class, notDoableMove);
+        DummyMoveSelectorConfig moveSelectorConfig = new DummyMoveSelectorConfig();
+        MoveSelectorFactory<TestdataSolution> moveSelectorFactory =
+                new DummyMoveSelectorFactory(moveSelectorConfig, baseMoveSelector);
+        MoveSelector<TestdataSolution> moveSelector = moveSelectorFactory.buildMoveSelector(buildHeuristicConfigPolicy(),
+                SelectionCacheType.PHASE, SelectionOrder.RANDOM, true);
+        assertThat(moveSelector)
+                .isInstanceOf(FilteringMoveSelector.class);
+        assertThat(moveSelector.iterator().hasNext()).isFalse();
     }
 
     static class DummyMoveSelectorConfig extends MoveSelectorConfig<DummyMoveSelectorConfig> {

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactoryTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactoryTest.java
@@ -36,8 +36,8 @@ class ChangeMoveSelectorFactoryTest {
         ChangeMoveSelectorConfig moveSelectorConfig = new ChangeMoveSelectorConfig()
                 .withValueSelectorConfig(new ValueSelectorConfig("secondaryValue"));
         MoveSelector moveSelector =
-                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor),
+                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(ChangeMoveSelector.class);
     }
@@ -49,8 +49,8 @@ class ChangeMoveSelectorFactoryTest {
                 .withValueSelectorConfig(new ValueSelectorConfig("nonExistingValue"));
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM));
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false));
     }
 
     @Test
@@ -59,7 +59,8 @@ class ChangeMoveSelectorFactoryTest {
         ChangeMoveSelectorConfig moveSelectorConfig = new ChangeMoveSelectorConfig();
         MoveSelector moveSelector =
                 MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector)
                 .isInstanceOf(UnionMoveSelector.class);
         assertThat(((UnionMoveSelector) moveSelector).getChildMoveSelectorList()).hasSize(3);
@@ -71,8 +72,8 @@ class ChangeMoveSelectorFactoryTest {
         ChangeMoveSelectorConfig moveSelectorConfig = new ChangeMoveSelectorConfig()
                 .withEntitySelectorConfig(new EntitySelectorConfig(TestdataHerdEntity.class));
         MoveSelector moveSelector =
-                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor),
+                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(ChangeMoveSelector.class);
     }
@@ -84,8 +85,8 @@ class ChangeMoveSelectorFactoryTest {
                 .withEntitySelectorConfig(new EntitySelectorConfig(TestdataEntity.class));
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM));
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false));
     }
 
     @Test
@@ -93,8 +94,8 @@ class ChangeMoveSelectorFactoryTest {
         SolutionDescriptor solutionDescriptor = TestdataMultiEntitySolution.buildSolutionDescriptor();
         ChangeMoveSelectorConfig moveSelectorConfig = new ChangeMoveSelectorConfig();
         MoveSelector moveSelector =
-                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor),
+                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(UnionMoveSelector.class);
         assertThat(((UnionMoveSelector) moveSelector).getChildMoveSelectorList()).hasSize(2);
@@ -111,7 +112,7 @@ class ChangeMoveSelectorFactoryTest {
         MoveSelector<TestdataListSolution> moveSelector =
                 MoveSelectorFactory.<TestdataListSolution> create(moveSelectorConfig)
                         .buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                                SelectionOrder.RANDOM);
+                                SelectionOrder.RANDOM, false);
         assertThat(moveSelector).isInstanceOf(ListChangeMoveSelector.class);
     }
 

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactoryTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactoryTest.java
@@ -36,7 +36,7 @@ class SwapMoveSelectorFactoryTest {
                 .withVariableNameIncludes("secondaryValue");
         MoveSelector moveSelector = MoveSelectorFactory.create(moveSelectorConfig)
                 .buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM);
+                        SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(SwapMoveSelector.class);
     }
@@ -48,8 +48,8 @@ class SwapMoveSelectorFactoryTest {
                 .withVariableNameIncludes("nonExistingValue");
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM));
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false));
     }
 
     @Test
@@ -57,8 +57,8 @@ class SwapMoveSelectorFactoryTest {
         SolutionDescriptor solutionDescriptor = TestdataMultiVarSolution.buildSolutionDescriptor();
         SwapMoveSelectorConfig moveSelectorConfig = new SwapMoveSelectorConfig();
         MoveSelector moveSelector =
-                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor),
+                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(SwapMoveSelector.class);
     }
@@ -69,8 +69,8 @@ class SwapMoveSelectorFactoryTest {
         SwapMoveSelectorConfig moveSelectorConfig = new SwapMoveSelectorConfig()
                 .withEntitySelectorConfig(new EntitySelectorConfig(TestdataHerdEntity.class));
         MoveSelector moveSelector =
-                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor),
+                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false);
         assertThat(moveSelector)
                 .isInstanceOf(SwapMoveSelector.class);
     }
@@ -82,8 +82,8 @@ class SwapMoveSelectorFactoryTest {
                 .withEntitySelectorConfig(new EntitySelectorConfig(TestdataEntity.class));
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM));
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false));
     }
 
     @Test
@@ -92,7 +92,8 @@ class SwapMoveSelectorFactoryTest {
         SwapMoveSelectorConfig moveSelectorConfig = new SwapMoveSelectorConfig();
         MoveSelector moveSelector =
                 MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector)
                 .isInstanceOf(UnionMoveSelector.class);
         assertThat(((UnionMoveSelector) moveSelector).getChildMoveSelectorList()).hasSize(2);
@@ -106,7 +107,8 @@ class SwapMoveSelectorFactoryTest {
                 .withSecondaryEntitySelectorConfig(new EntitySelectorConfig(TestdataHerdEntity.class));
         MoveSelector moveSelector =
                 MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector)
                 .isInstanceOf(SwapMoveSelector.class);
     }
@@ -119,8 +121,8 @@ class SwapMoveSelectorFactoryTest {
                 .withSecondaryEntitySelectorConfig(new EntitySelectorConfig(TestdataHerdEntity.class));
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM));
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false));
     }
 
     @Test
@@ -131,7 +133,8 @@ class SwapMoveSelectorFactoryTest {
                 .withSecondaryEntitySelectorConfig(new EntitySelectorConfig());
         MoveSelector moveSelector =
                 MoveSelectorFactory.create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector)
                 .isInstanceOf(UnionMoveSelector.class);
         assertThat(((UnionMoveSelector) moveSelector).getChildMoveSelectorList()).hasSize(2);
@@ -147,7 +150,7 @@ class SwapMoveSelectorFactoryTest {
                 () -> MoveSelectorFactory
                         .<TestdataMixedVariablesSolution> create(moveSelectorConfig)
                         .buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                                SelectionOrder.RANDOM))
+                                SelectionOrder.RANDOM, false))
                 .withMessageContaining("variableDescriptorList");
 
         SwapMoveSelectorConfig moveSelectorConfigWithEntitySelector = new SwapMoveSelectorConfig()
@@ -156,7 +159,7 @@ class SwapMoveSelectorFactoryTest {
                 () -> MoveSelectorFactory
                         .<TestdataMixedVariablesSolution> create(moveSelectorConfigWithEntitySelector)
                         .buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                                SelectionOrder.RANDOM))
+                                SelectionOrder.RANDOM, false))
                 .withMessageContaining("variableDescriptorList");
     }
 
@@ -171,7 +174,7 @@ class SwapMoveSelectorFactoryTest {
         MoveSelector<TestdataListSolution> moveSelector =
                 MoveSelectorFactory.<TestdataListSolution> create(moveSelectorConfig)
                         .buildMoveSelector(buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME,
-                                SelectionOrder.RANDOM);
+                                SelectionOrder.RANDOM, false);
         assertThat(moveSelector).isInstanceOf(ListSwapMoveSelector.class);
     }
 

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactoryTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactoryTest.java
@@ -35,7 +35,8 @@ class ListChangeMoveSelectorFactoryTest {
                         .withValueSelectorConfig(new ValueSelectorConfig("valueList")));
         MoveSelector<TestdataListSolution> moveSelector =
                 MoveSelectorFactory.<TestdataListSolution> create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector).isInstanceOf(ListChangeMoveSelector.class);
     }
 
@@ -45,7 +46,8 @@ class ListChangeMoveSelectorFactoryTest {
         ListChangeMoveSelectorConfig moveSelectorConfig = new ListChangeMoveSelectorConfig();
         MoveSelector<TestdataListSolution> moveSelector =
                 MoveSelectorFactory.<TestdataListSolution> create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector).isInstanceOf(ListChangeMoveSelector.class);
     }
 
@@ -92,7 +94,8 @@ class ListChangeMoveSelectorFactoryTest {
         ListChangeMoveSelectorConfig moveSelectorConfig = new ListChangeMoveSelectorConfig();
         MoveSelector<TestdataMixedVariablesSolution> moveSelector =
                 MoveSelectorFactory.<TestdataMixedVariablesSolution> create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector).isInstanceOf(ListChangeMoveSelector.class);
     }
 
@@ -106,7 +109,7 @@ class ListChangeMoveSelectorFactoryTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> moveSelectorFactory.buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM))
+                        SelectionOrder.RANDOM, false))
                 .withMessageContaining("cannot unfold");
     }
 
@@ -125,8 +128,8 @@ class ListChangeMoveSelectorFactoryTest {
                 buildHeuristicConfigPolicy(TestdataMixedVariablesSolution.buildSolutionDescriptor());
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> moveSelectorFactory.buildMoveSelector(heuristicConfigPolicy,
-                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM))
+                .isThrownBy(() -> moveSelectorFactory.buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME,
+                        SelectionOrder.RANDOM, false))
                 .withMessageContaining("not a planning list variable");
     }
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactoryTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactoryTest.java
@@ -27,7 +27,8 @@ class ListSwapMoveSelectorFactoryTest {
                 .withValueSelectorConfig(new ValueSelectorConfig("valueList"));
         MoveSelector<TestdataListSolution> moveSelector =
                 MoveSelectorFactory.<TestdataListSolution> create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector).isInstanceOf(ListSwapMoveSelector.class);
     }
 
@@ -37,7 +38,8 @@ class ListSwapMoveSelectorFactoryTest {
         ListSwapMoveSelectorConfig moveSelectorConfig = new ListSwapMoveSelectorConfig();
         MoveSelector<TestdataListSolution> moveSelector =
                 MoveSelectorFactory.<TestdataListSolution> create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector).isInstanceOf(ListSwapMoveSelector.class);
     }
 
@@ -48,7 +50,8 @@ class ListSwapMoveSelectorFactoryTest {
         ListSwapMoveSelectorConfig moveSelectorConfig = new ListSwapMoveSelectorConfig();
         MoveSelector<TestdataMixedVariablesSolution> moveSelector =
                 MoveSelectorFactory.<TestdataMixedVariablesSolution> create(moveSelectorConfig).buildMoveSelector(
-                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                        false);
         assertThat(moveSelector).isInstanceOf(ListSwapMoveSelector.class);
     }
 
@@ -62,7 +65,7 @@ class ListSwapMoveSelectorFactoryTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> moveSelectorFactory.buildMoveSelector(heuristicConfigPolicy,
-                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM))
+                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false))
                 .withMessageContaining("cannot unfold");
     }
 
@@ -79,7 +82,7 @@ class ListSwapMoveSelectorFactoryTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> moveSelectorFactory.buildMoveSelector(heuristicConfigPolicy,
-                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM))
+                        SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM, false))
                 .withMessageContaining("not a planning list variable");
     }
 

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactoryTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactoryTest.java
@@ -39,7 +39,8 @@ class SubListChangeMoveSelectorFactoryTest {
 
         RandomSubListChangeMoveSelector<TestdataListSolution> selector =
                 (RandomSubListChangeMoveSelector<TestdataListSolution>) moveSelectorFactory
-                        .buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        .buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                                false);
 
         assertThat(selector.isCountable()).isTrue();
         assertThat(selector.isNeverEnding()).isTrue();
@@ -58,7 +59,8 @@ class SubListChangeMoveSelectorFactoryTest {
 
         RandomSubListChangeMoveSelector<TestdataListSolution> selector =
                 (RandomSubListChangeMoveSelector<TestdataListSolution>) moveSelectorFactory
-                        .buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        .buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                                false);
 
         assertThat(selector.isSelectReversingMoveToo()).isFalse();
     }
@@ -73,7 +75,7 @@ class SubListChangeMoveSelectorFactoryTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> moveSelectorFactory.buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM))
+                        SelectionOrder.RANDOM, false))
                 .withMessageContaining("cannot unfold");
     }
 
@@ -94,7 +96,7 @@ class SubListChangeMoveSelectorFactoryTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> moveSelectorFactory.buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM))
+                        SelectionOrder.RANDOM, false))
                 .withMessageContaining("not a planning list variable");
     }
 
@@ -129,7 +131,7 @@ class SubListChangeMoveSelectorFactoryTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> factory.buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME,
-                        SelectionOrder.RANDOM))
+                        SelectionOrder.RANDOM, false))
                 .withMessageContainingAll(propertyName, childConfigName);
     }
 
@@ -148,7 +150,8 @@ class SubListChangeMoveSelectorFactoryTest {
 
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector =
                 (RandomSubListChangeMoveSelector<TestdataListSolution>) factory
-                        .buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+                        .buildMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM,
+                                false);
 
         assertThat(((RandomSubListSelector<?>) moveSelector.getSubListSelector()).getMinimumSubListSize())
                 .isEqualTo(minimumSubListSize);


### PR DESCRIPTION
Move selector has supported bail-out for a long time.
However, it did not apply to non-doable moves, so when all the moves were non-doable, the bail-out would never happen.
This change makes bail-out happen for non-doable moves as well, by filtering out non-doable moves directly in the move selector. This requires to force an arbitrary limit on the number of moves that will be evaluated, as not every move selector provides its size.
