### PR TITLE
perf: read value range size instead of the value range

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/domain/valuerange/ValueRangeFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/domain/valuerange/ValueRangeFactory.java
@@ -82,7 +82,9 @@ public final class ValueRangeFactory {
      * @param from inclusive minimum
      * @param to exclusive maximum, {@code >= from}
      * @return never null
+     * @deprecated Prefer {@link #createBigDecimalValueRange(BigDecimal, BigDecimal)}.
      */
+    @Deprecated(forRemoval = true, since = "1.1.0")
     public static ValueRange<Double> createDoubleValueRange(double from, double to) {
         return new DoubleValueRange(from, to);
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -1010,7 +1010,9 @@ public class SolutionDescriptor<Solution_> {
      * @return {@code >= 0}
      */
     public int countUninitialized(Solution_ solution) {
-        return countUninitializedVariables(solution) + countUnassignedListVariableValues(solution);
+        int uninitializedVariableCount = countUninitializedVariables(solution);
+        int uninitializedValueCount = countUnassignedListVariableValues(solution);
+        return uninitializedValueCount + uninitializedVariableCount;
     }
 
     /**

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/AbstractUncountableValueRange.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/AbstractUncountableValueRange.java
@@ -9,7 +9,11 @@ import ai.timefold.solver.core.api.domain.valuerange.ValueRangeFactory;
  *
  * @see ValueRange
  * @see ValueRangeFactory
+ * @deprecated Uncountable value ranges were never fully supported in many places throughout the solver
+ *             and therefore never gained traction.
+ *             Use {@link CountableValueRange} instead, and configure a step.
  */
+@Deprecated(forRemoval = true, since = "1.1.0")
 public abstract class AbstractUncountableValueRange<T> implements ValueRange<T> {
 
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primdouble/DoubleValueRange.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primdouble/DoubleValueRange.java
@@ -5,13 +5,17 @@ import java.util.NoSuchElementException;
 import java.util.Random;
 
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractUncountableValueRange;
+import ai.timefold.solver.core.impl.domain.valuerange.buildin.bigdecimal.BigDecimalValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.util.ValueRangeIterator;
 
 /**
  * Note: Floating point numbers (float, double) cannot represent a decimal number correctly.
  * If floating point numbers leak into the scoring function, they are likely to cause score corruptions.
  * To avoid that, use either {@link java.math.BigDecimal} or fixed-point arithmetic.
+ *
+ * @deprecated Prefer {@link BigDecimalValueRange}.
  */
+@Deprecated(forRemoval = true, since = "1.1.0")
 public class DoubleValueRange extends AbstractUncountableValueRange<Double> {
 
     private final double from;

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/CompositeValueRangeDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/CompositeValueRangeDescriptor.java
@@ -70,4 +70,24 @@ public class CompositeValueRangeDescriptor<Solution_> extends AbstractValueRange
         return doNullInValueRangeWrapping(new CompositeCountableValueRange(childValueRangeList));
     }
 
+    @Override
+    public long extractValueRangeSize(Solution_ solution, Object entity) {
+        int size = addNullInValueRange ? 1 : 0;
+        for (ValueRangeDescriptor<Solution_> valueRangeDescriptor : childValueRangeDescriptorList) {
+            size += ((CountableValueRange) valueRangeDescriptor.extractValueRange(solution, entity)).getSize();
+        }
+        return size;
+    }
+
+    @Override
+    public long extractValueRangeSize(Solution_ solution) {
+        int size = addNullInValueRange ? 1 : 0;
+        for (ValueRangeDescriptor<Solution_> valueRangeDescriptor : childValueRangeDescriptorList) {
+            EntityIndependentValueRangeDescriptor<Solution_> entityIndependentValueRangeDescriptor =
+                    (EntityIndependentValueRangeDescriptor) valueRangeDescriptor;
+            size += ((CountableValueRange) entityIndependentValueRangeDescriptor.extractValueRange(solution)).getSize();
+        }
+        return size;
+    }
+
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/EntityIndependentValueRangeDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/EntityIndependentValueRangeDescriptor.java
@@ -17,4 +17,13 @@ public interface EntityIndependentValueRangeDescriptor<Solution_> extends ValueR
      */
     ValueRange<?> extractValueRange(Solution_ solution);
 
+    /**
+     * As specified by {@link ValueRangeDescriptor#extractValueRangeSize}.
+     *
+     * @param solution never null
+     * @return never null
+     * @see ValueRangeDescriptor#extractValueRangeSize
+     */
+    long extractValueRangeSize(Solution_ solution);
+
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/FromEntityPropertyValueRangeDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/FromEntityPropertyValueRangeDescriptor.java
@@ -30,4 +30,9 @@ public class FromEntityPropertyValueRangeDescriptor<Solution_>
         return readValueRange(entity);
     }
 
+    @Override
+    public long extractValueRangeSize(Solution_ solution, Object entity) {
+        return readValueRangeSize(entity);
+    }
+
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/FromSolutionPropertyValueRangeDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/FromSolutionPropertyValueRangeDescriptor.java
@@ -33,8 +33,18 @@ public class FromSolutionPropertyValueRangeDescriptor<Solution_>
     }
 
     @Override
+    public long extractValueRangeSize(Solution_ solution, Object entity) {
+        return readValueRangeSize(solution);
+    }
+
+    @Override
     public ValueRange<?> extractValueRange(Solution_ solution) {
         return readValueRange(solution);
+    }
+
+    @Override
+    public long extractValueRangeSize(Solution_ solution) {
+        return readValueRangeSize(solution);
     }
 
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/ValueRangeDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/ValueRangeDescriptor.java
@@ -42,4 +42,13 @@ public interface ValueRangeDescriptor<Solution_> {
      */
     ValueRange<?> extractValueRange(Solution_ solution, Object entity);
 
+    /**
+     * @param solution never null
+     * @param entity never null. To avoid this parameter,
+     *        use {@link EntityIndependentValueRangeDescriptor#extractValueRangeSize} instead.
+     * @return never null
+     * @throws UnsupportedOperationException if {@link #isCountable()} returns false
+     */
+    long extractValueRangeSize(Solution_ solution, Object entity);
+
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
-import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
@@ -275,11 +274,7 @@ public abstract class GenuineVariableDescriptor<Solution_> extends VariableDescr
     }
 
     public long getValueCount(Solution_ solution, Object entity) {
-        if (!valueRangeDescriptor.isCountable()) {
-            // TODO report this better than just ignoring it
-            return 0L;
-        }
-        return ((CountableValueRange<?>) valueRangeDescriptor.extractValueRange(solution, entity)).getSize();
+        return valueRangeDescriptor.extractValueRangeSize(solution, entity);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/FromEntityPropertyValueSelector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/FromEntityPropertyValueSelector.java
@@ -64,8 +64,7 @@ public final class FromEntityPropertyValueSelector<Solution_>
 
     @Override
     public long getSize(Object entity) {
-        ValueRange<?> valueRange = valueRangeDescriptor.extractValueRange(workingSolution, entity);
-        return ((CountableValueRange<?>) valueRange).getSize();
+        return valueRangeDescriptor.extractValueRangeSize(workingSolution, entity);
     }
 
     @Override


### PR DESCRIPTION
To read an entire value range to get its size,
the value range needs to be first converted to a collection. 
This is costly and we therefore implement a shortcut, 
allowing us to read the size without creating a collection.