### PR TITLE
chore: move to 0.8.41-SNAPSHOT

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build/build-parent/pom.xml</relativePath>
   </parent>
 

--- a/build/bom/pom.xml
+++ b/build/bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/distribution-internal/pom.xml
+++ b/build/distribution-internal/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/build/ide-config/pom.xml
+++ b/build/ide-config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>timefold-solver-ide-config</artifactId>

--- a/build/javadoc/pom.xml
+++ b/build/javadoc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/constraint-drl/pom.xml
+++ b/core/constraint-drl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-core-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/constraint-streams-bavet/pom.xml
+++ b/core/constraint-streams-bavet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.timefold.solver</groupId>
         <artifactId>timefold-solver-core-parent</artifactId>
-        <version>0.8.40-SNAPSHOT</version>
+        <version>0.8.41-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/constraint-streams-common/pom.xml
+++ b/core/constraint-streams-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-core-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/core-impl/pom.xml
+++ b/core/core-impl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-core-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-core-impl</artifactId>

--- a/core/core/pom.xml
+++ b/core/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-core-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build/build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build/build-parent/pom.xml</relativePath>
   </parent>
 

--- a/docs/src/antora.yml
+++ b/docs/src/antora.yml
@@ -5,14 +5,14 @@
 # The goal is to have the antora.yml containing correct attributes available in the release branch before
 # the timefold-solver-website is refreshed.
 name: timefold-solver
-title: Timefold Solver 0.8.39
+title: Timefold Solver 0.8.40
 version: 0.8.x
 asciidoc:
   attributes:
-    timefold-solver-version: 0.8.39
+    timefold-solver-version: 0.8.40
     java-version: 11
     maven-version: 3.8.1
-    quarkus-version: 2.16.6.Final
-    spring-boot-version: 2.7.10
+    quarkus-version: 2.16.9.Final
+    spring-boot-version: 2.7.14
 nav:
   - modules/ROOT/nav.adoc

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build/build-parent/pom.xml</relativePath>
   </parent>
 

--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build/build-parent/pom.xml</relativePath>
   </parent>
 

--- a/persistence/common/pom.xml
+++ b/persistence/common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-persistence-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-persistence-common</artifactId>

--- a/persistence/jackson/pom.xml
+++ b/persistence/jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-persistence-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-jackson</artifactId>

--- a/persistence/jaxb/pom.xml
+++ b/persistence/jaxb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-persistence-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-jaxb</artifactId>

--- a/persistence/jpa/pom.xml
+++ b/persistence/jpa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-persistence-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-jpa</artifactId>

--- a/persistence/jsonb/pom.xml
+++ b/persistence/jsonb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-persistence-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-jsonb</artifactId>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build/build-parent/pom.xml</relativePath>
   </parent>
 

--- a/persistence/xstream/pom.xml
+++ b/persistence/xstream/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-persistence-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-xstream</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <groupId>ai.timefold.solver</groupId>
   <artifactId>timefold-solver-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.8.40-SNAPSHOT</version>
+  <version>0.8.41-SNAPSHOT</version>
 
   <name>Timefold Solver multiproject parent</name>
   <description>

--- a/quarkus-integration/pom.xml
+++ b/quarkus-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build/build-parent/pom.xml</relativePath>
   </parent>
 

--- a/quarkus-integration/quarkus-benchmark/deployment/pom.xml
+++ b/quarkus-integration/quarkus-benchmark/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-benchmark-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-benchmark-deployment</artifactId>

--- a/quarkus-integration/quarkus-benchmark/integration-test/pom.xml
+++ b/quarkus-integration/quarkus-benchmark/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-benchmark-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-benchmark-integration-test</artifactId>

--- a/quarkus-integration/quarkus-benchmark/pom.xml
+++ b/quarkus-integration/quarkus-benchmark/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-integration</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus-integration/quarkus-benchmark/runtime/pom.xml
+++ b/quarkus-integration/quarkus-benchmark/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-benchmark-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-benchmark</artifactId>

--- a/quarkus-integration/quarkus-jackson/deployment/pom.xml
+++ b/quarkus-integration/quarkus-jackson/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-jackson-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-jackson-deployment</artifactId>

--- a/quarkus-integration/quarkus-jackson/integration-test/pom.xml
+++ b/quarkus-integration/quarkus-jackson/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-jackson-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-jackson-integration-test</artifactId>

--- a/quarkus-integration/quarkus-jackson/pom.xml
+++ b/quarkus-integration/quarkus-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-integration</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-jackson-parent</artifactId>

--- a/quarkus-integration/quarkus-jackson/runtime/pom.xml
+++ b/quarkus-integration/quarkus-jackson/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-jackson-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-jackson</artifactId>

--- a/quarkus-integration/quarkus-jsonb/deployment/pom.xml
+++ b/quarkus-integration/quarkus-jsonb/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-jsonb-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-jsonb-deployment</artifactId>

--- a/quarkus-integration/quarkus-jsonb/integration-test/pom.xml
+++ b/quarkus-integration/quarkus-jsonb/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-jsonb-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-jsonb-integration-test</artifactId>

--- a/quarkus-integration/quarkus-jsonb/pom.xml
+++ b/quarkus-integration/quarkus-jsonb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-integration</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-jsonb-parent</artifactId>

--- a/quarkus-integration/quarkus-jsonb/runtime/pom.xml
+++ b/quarkus-integration/quarkus-jsonb/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-jsonb-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-jsonb</artifactId>

--- a/quarkus-integration/quarkus/deployment/pom.xml
+++ b/quarkus-integration/quarkus/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-deployment</artifactId>

--- a/quarkus-integration/quarkus/devui-integration-test/pom.xml
+++ b/quarkus-integration/quarkus/devui-integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-devui-integration-test</artifactId>

--- a/quarkus-integration/quarkus/drl-integration-test/pom.xml
+++ b/quarkus-integration/quarkus/drl-integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-drl-integration-test</artifactId>

--- a/quarkus-integration/quarkus/integration-test/pom.xml
+++ b/quarkus-integration/quarkus/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-integration-test</artifactId>

--- a/quarkus-integration/quarkus/pom.xml
+++ b/quarkus-integration/quarkus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-integration</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-parent</artifactId>

--- a/quarkus-integration/quarkus/reflection-integration-test/pom.xml
+++ b/quarkus-integration/quarkus/reflection-integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus-reflection-integration-test</artifactId>

--- a/quarkus-integration/quarkus/runtime/pom.xml
+++ b/quarkus-integration/quarkus/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-quarkus-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-quarkus</artifactId>

--- a/spring-integration/pom.xml
+++ b/spring-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build/build-parent/pom.xml</relativePath>
   </parent>
 

--- a/spring-integration/spring-boot-autoconfigure/pom.xml
+++ b/spring-integration/spring-boot-autoconfigure/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-spring-integration</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-spring-boot-autoconfigure</artifactId>

--- a/spring-integration/spring-boot-starter/pom.xml
+++ b/spring-integration/spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-spring-integration</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
   </parent>
 
   <artifactId>timefold-solver-spring-boot-starter</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ai.timefold.solver</groupId>
     <artifactId>timefold-solver-build-parent</artifactId>
-    <version>0.8.40-SNAPSHOT</version>
+    <version>0.8.41-SNAPSHOT</version>
     <relativePath>../build/build-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
At this point, the release of _Timefold Solver Community Edition_ is ready to be published.
Artifacts have been uploaded to OSSRH.
Release branch has been created.

To finish the release of _Timefold Solver Community Edition_, 
please follow the steps below in the given order:

- [ ] Release the [staging repository on OSSRH](https://s01.oss.sonatype.org/#stagingRepositories).
- [ ] Wait for the artifacts to [reach Maven Central](https://central.sonatype.com/search?q=ai.timefold.solver&smo=true).
- [ ] [Undraft the release](https://github.com/TimefoldAI/timefold-solver/releases) on Github.
- [ ] Merge this PR.
- [ ] Delete the branch that this PR is based on. (Typically a button appears on this page once the PR is merged.)
- [ ] Update 0.8.x branch of the quickstarts.

Note: If this is a dry run, 
none of the above applies and this PR should not be merged.