### PR TITLE
fix: avoid fail-fast to fix SolutionManager.update() on chained var

### DIFF
--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/BavetConstraintStreamScoreDirector.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/BavetConstraintStreamScoreDirector.java
@@ -26,10 +26,9 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
 
     protected BavetConstraintSession<Score_> session;
 
-    public BavetConstraintStreamScoreDirector(
-            BavetConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
-            boolean lookUpEnabled, boolean constraintMatchEnabledPreference) {
-        super(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference);
+    public BavetConstraintStreamScoreDirector(BavetConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
+            boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState) {
+        super(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState);
     }
 
     // ************************************************************************

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/BavetConstraintStreamScoreDirectorFactory.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/BavetConstraintStreamScoreDirectorFactory.java
@@ -27,8 +27,9 @@ public final class BavetConstraintStreamScoreDirectorFactory<Solution_, Score_ e
 
     @Override
     public BavetConstraintStreamScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
-            boolean constraintMatchEnabledPreference) {
-        return new BavetConstraintStreamScoreDirector<>(this, lookUpEnabled, constraintMatchEnabledPreference);
+            boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState) {
+        return new BavetConstraintStreamScoreDirector<>(this, lookUpEnabled, constraintMatchEnabledPreference,
+                expectShadowVariablesInCorrectState);
     }
 
     public BavetConstraintSession<Score_> newSession(boolean constraintMatchEnabled, Solution_ workingSolution) {

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/solver/SolutionUpdatePolicy.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/solver/SolutionUpdatePolicy.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.api.solver;
 
+import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+
 /**
  * To fully de-normalize a planning solution freshly loaded from persistent storage,
  * two operations need to happen:
@@ -63,6 +65,12 @@ public enum SolutionUpdatePolicy {
         return scoreUpdateEnabled;
     }
 
+    /**
+     * If this is true, variable listeners will ignore certain fail-fasts.
+     * See {@link InnerScoreDirector#expectShadowVariablesInCorrectState()}.
+     *
+     * @return true if shadow variables should be updated
+     */
     public boolean isShadowVariableUpdateEnabled() {
         return shadowVariableUpdateEnabled;
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/CollectionInverseVariableListener.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/CollectionInverseVariableListener.java
@@ -53,7 +53,7 @@ public class CollectionInverseVariableListener<Solution_>
         Object shadowEntity = sourceVariableDescriptor.getValue(entity);
         if (shadowEntity != null) {
             Collection shadowCollection = (Collection) shadowVariableDescriptor.getValue(shadowEntity);
-            if (shadowCollection == null) {
+            if (scoreDirector.expectShadowVariablesInCorrectState() && shadowCollection == null) {
                 throw new IllegalStateException("The entity (" + entity
                         + ") has a variable (" + sourceVariableDescriptor.getVariableName()
                         + ") with value (" + shadowEntity
@@ -65,7 +65,7 @@ public class CollectionInverseVariableListener<Solution_>
             }
             scoreDirector.beforeVariableChanged(shadowVariableDescriptor, shadowEntity);
             boolean added = shadowCollection.add(entity);
-            if (!added) {
+            if (scoreDirector.expectShadowVariablesInCorrectState() && !added) {
                 throw new IllegalStateException("The entity (" + entity
                         + ") has a variable (" + sourceVariableDescriptor.getVariableName()
                         + ") with value (" + shadowEntity
@@ -82,7 +82,7 @@ public class CollectionInverseVariableListener<Solution_>
         Object shadowEntity = sourceVariableDescriptor.getValue(entity);
         if (shadowEntity != null) {
             Collection shadowCollection = (Collection) shadowVariableDescriptor.getValue(shadowEntity);
-            if (shadowCollection == null) {
+            if (scoreDirector.expectShadowVariablesInCorrectState() && shadowCollection == null) {
                 throw new IllegalStateException("The entity (" + entity
                         + ") has a variable (" + sourceVariableDescriptor.getVariableName()
                         + ") with value (" + shadowEntity
@@ -94,7 +94,7 @@ public class CollectionInverseVariableListener<Solution_>
             }
             scoreDirector.beforeVariableChanged(shadowVariableDescriptor, shadowEntity);
             boolean removed = shadowCollection.remove(entity);
-            if (!removed) {
+            if (scoreDirector.expectShadowVariablesInCorrectState() && !removed) {
                 throw new IllegalStateException("The entity (" + entity
                         + ") has a variable (" + sourceVariableDescriptor.getVariableName()
                         + ") with value (" + shadowEntity

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/SingletonInverseVariableListener.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/SingletonInverseVariableListener.java
@@ -51,7 +51,7 @@ public class SingletonInverseVariableListener<Solution_>
         Object shadowEntity = sourceVariableDescriptor.getValue(entity);
         if (shadowEntity != null) {
             Object shadowValue = shadowVariableDescriptor.getValue(shadowEntity);
-            if (shadowValue != null) {
+            if (scoreDirector.expectShadowVariablesInCorrectState() && shadowValue != null) {
                 throw new IllegalStateException("The entity (" + entity
                         + ") has a variable (" + sourceVariableDescriptor.getVariableName()
                         + ") with value (" + shadowEntity
@@ -69,7 +69,7 @@ public class SingletonInverseVariableListener<Solution_>
         Object shadowEntity = sourceVariableDescriptor.getValue(entity);
         if (shadowEntity != null) {
             Object shadowValue = shadowVariableDescriptor.getValue(shadowEntity);
-            if (shadowValue != entity) {
+            if (scoreDirector.expectShadowVariablesInCorrectState() && shadowValue != entity) {
                 throw new IllegalStateException("The entity (" + entity
                         + ") has a variable (" + sourceVariableDescriptor.getVariableName()
                         + ") with value (" + shadowEntity

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/SingletonListInverseVariableListener.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/SingletonListInverseVariableListener.java
@@ -78,7 +78,7 @@ public class SingletonListInverseVariableListener<Solution_>
         if (oldInverseEntity == inverseEntity) {
             return;
         }
-        if (oldInverseEntity != expectedOldInverseEntity) {
+        if (scoreDirector.expectShadowVariablesInCorrectState() && oldInverseEntity != expectedOldInverseEntity) {
             throw new IllegalStateException("The entity (" + inverseEntity
                     + ") has a list variable (" + sourceVariableDescriptor.getVariableName()
                     + ") and one of its elements (" + element

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -126,6 +126,23 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
     boolean requiresFlushing();
 
     /**
+     * Inverse shadow variables have a fail-fast for cases
+     * where the shadow variable doesn't actually point to its correct inverse.
+     * This is very useful to pinpoint improperly initialized solutions.
+     * <p>
+     * However, {@link SolutionManager#update(Object)} exists precisely for the purpose of initializing solutions.
+     * And when this API is used, the fail-fast must not be triggered as it is guaranteed and expected
+     * that the inverse relationships will be wrong.
+     * In fact, they will be null.
+     * <p>
+     * For this case and this case only, this method is allowed to return false.
+     * All other cases must return true, otherwise a very valuable fail-fast is lost.
+     *
+     * @return false if the fail-fast on shadow variables should not be triggered
+     */
+    boolean expectShadowVariablesInCorrectState();
+
+    /**
      * @return never null
      */
     InnerScoreDirectorFactory<Solution_, Score_> getScoreDirectorFactory();

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
@@ -40,8 +40,27 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
      * @see InnerScoreDirector#isConstraintMatchEnabled()
      * @see InnerScoreDirector#getConstraintMatchTotalMap()
      */
-    InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
-            boolean constraintMatchEnabledPreference);
+    default InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
+            boolean constraintMatchEnabledPreference) {
+        return buildScoreDirector(lookUpEnabled, constraintMatchEnabledPreference, true);
+    }
+
+    /**
+     * Like {@link #buildScoreDirector()}, but optionally disables {@link ConstraintMatch} tracking and look up
+     * for more performance (presuming the {@link ScoreDirector} implementation actually supports it to begin with).
+     *
+     * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
+     *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
+     * @param constraintMatchEnabledPreference false if a {@link ScoreDirector} implementation
+     *        should not do {@link ConstraintMatch} tracking even if it supports it.
+     * @param expectShadowVariablesInCorrectState true, unless you have an exceptional reason.
+     *        See {@link InnerScoreDirector#expectShadowVariablesInCorrectState()} for details.
+     * @return never null
+     * @see InnerScoreDirector#isConstraintMatchEnabled()
+     * @see InnerScoreDirector#getConstraintMatchTotalMap()
+     */
+    InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled, boolean constraintMatchEnabledPreference,
+            boolean expectShadowVariablesInCorrectState);
 
     /**
      * @return never null

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
@@ -28,9 +28,9 @@ public class EasyScoreDirector<Solution_, Score_ extends Score<Score_>>
     private final EasyScoreCalculator<Solution_, Score_> easyScoreCalculator;
 
     public EasyScoreDirector(EasyScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
-            boolean lookUpEnabled, boolean constraintMatchEnabledPreference,
+            boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState,
             EasyScoreCalculator<Solution_, Score_> easyScoreCalculator) {
-        super(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference);
+        super(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState);
         this.easyScoreCalculator = easyScoreCalculator;
     }
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactory.java
@@ -32,8 +32,10 @@ public class EasyScoreDirectorFactory<Solution_, Score_ extends Score<Score_>>
 
     @Override
     public EasyScoreDirector<Solution_, Score_> buildScoreDirector(
-            boolean lookUpEnabled, boolean constraintMatchEnabledPreference) {
-        return new EasyScoreDirector<>(this, lookUpEnabled, constraintMatchEnabledPreference, easyScoreCalculator);
+            boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState) {
+        return new EasyScoreDirector<>(this, lookUpEnabled, constraintMatchEnabledPreference,
+                expectShadowVariablesInCorrectState,
+                easyScoreCalculator);
     }
 
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirector.java
@@ -35,9 +35,9 @@ public class IncrementalScoreDirector<Solution_, Score_ extends Score<Score_>>
     private final IncrementalScoreCalculator<Solution_, Score_> incrementalScoreCalculator;
 
     public IncrementalScoreDirector(IncrementalScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
-            boolean lookUpEnabled, boolean constraintMatchEnabledPreference,
+            boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState,
             IncrementalScoreCalculator<Solution_, Score_> incrementalScoreCalculator) {
-        super(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference);
+        super(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState);
         this.incrementalScoreCalculator = incrementalScoreCalculator;
     }
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirectorFactory.java
@@ -33,10 +33,11 @@ public class IncrementalScoreDirectorFactory<Solution_, Score_ extends Score<Sco
     // ************************************************************************
 
     @Override
-    public IncrementalScoreDirector<Solution_, Score_> buildScoreDirector(
-            boolean lookUpEnabled, boolean constraintMatchEnabledPreference) {
+    public IncrementalScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
+            boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState) {
         return new IncrementalScoreDirector<>(this,
-                lookUpEnabled, constraintMatchEnabledPreference, incrementalScoreCalculatorSupplier.get());
+                lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState,
+                incrementalScoreCalculatorSupplier.get());
     }
 
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -69,14 +69,15 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
     private <Result_> Result_ callScoreDirector(Solution_ solution,
             SolutionUpdatePolicy solutionUpdatePolicy, Function<InnerScoreDirector<Solution_, Score_>, Result_> function,
             boolean enableConstraintMatch) {
+        boolean isShadowVariableUpdateEnabled = solutionUpdatePolicy.isShadowVariableUpdateEnabled();
         Solution_ nonNullSolution = Objects.requireNonNull(solution);
         try (InnerScoreDirector<Solution_, Score_> scoreDirector =
-                scoreDirectorFactory.buildScoreDirector(false, enableConstraintMatch)) {
+                scoreDirectorFactory.buildScoreDirector(false, enableConstraintMatch, !isShadowVariableUpdateEnabled)) {
             scoreDirector.setWorkingSolution(nonNullSolution); // Init the ScoreDirector first, else NPEs may be thrown.
             if (enableConstraintMatch && !scoreDirector.isConstraintMatchEnabled()) {
                 throw new IllegalStateException("When constraintMatchEnabled is disabled, this method should not be called.");
             }
-            if (solutionUpdatePolicy.isShadowVariableUpdateEnabled()) {
+            if (isShadowVariableUpdateEnabled) {
                 scoreDirector.forceTriggerVariableListeners();
             }
             if (solutionUpdatePolicy.isScoreUpdateEnabled()) {

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactoryTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactoryTest.java
@@ -25,14 +25,14 @@ class EasyScoreDirectorFactoryTest {
         EasyScoreDirectorFactory<TestdataSolution, SimpleScore> directorFactory = new EasyScoreDirectorFactory<>(
                 solutionDescriptor, scoreCalculator);
 
-        EasyScoreDirector<TestdataSolution, SimpleScore> director =
-                directorFactory.buildScoreDirector(false, false);
-        TestdataSolution solution = new TestdataSolution();
-        solution.setValueList(Collections.emptyList());
-        solution.setEntityList(Collections.emptyList());
-        director.setWorkingSolution(solution);
-        assertThat(director.calculateScore())
-                .isEqualTo(SimpleScore.ofUninitialized(0, -10));
+        try (var director = directorFactory.buildScoreDirector(false, false)) {
+            TestdataSolution solution = new TestdataSolution();
+            solution.setValueList(Collections.emptyList());
+            solution.setEntityList(Collections.emptyList());
+            director.setWorkingSolution(solution);
+            assertThat(director.calculateScore())
+                    .isEqualTo(SimpleScore.ofUninitialized(0, -10));
+        }
     }
 
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
@@ -22,7 +22,8 @@ class EasyScoreDirectorTest {
 
     @Test
     void constraintMatchTotalsUnsupported() {
-        EasyScoreDirector<Object, ?> director = new EasyScoreDirector<>(mockEasyScoreDirectorFactory(), false, true, null);
+        EasyScoreDirector<Object, ?> director =
+                new EasyScoreDirector<>(mockEasyScoreDirectorFactory(), false, true, true, null);
         assertThat(director.isConstraintMatchEnabled()).isFalse();
         assertThatIllegalStateException()
                 .isThrownBy(director::getConstraintMatchTotalMap)
@@ -44,7 +45,7 @@ class EasyScoreDirectorTest {
         scoreDirectorFactory.setInitializingScoreTrend(
                 InitializingScoreTrend.buildUniformTrend(InitializingScoreTrendLevel.ONLY_DOWN, 1));
         EasyScoreDirector<TestdataCorruptedShadowedSolution, SimpleScore> scoreDirector =
-                scoreDirectorFactory.buildScoreDirector(false, false);
+                scoreDirectorFactory.buildScoreDirector(false, false, true);
 
         TestdataCorruptedShadowedSolution solution = new TestdataCorruptedShadowedSolution("s1");
         TestdataValue v1 = new TestdataValue("v1");

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/chained/shadow/TestdataShadowingChainedIncrementalScoreCalculator.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/chained/shadow/TestdataShadowingChainedIncrementalScoreCalculator.java
@@ -1,0 +1,102 @@
+package ai.timefold.solver.core.impl.testdata.domain.chained.shadow;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.calculator.ConstraintMatchAwareIncrementalScoreCalculator;
+import ai.timefold.solver.core.api.score.constraint.ConstraintMatch;
+import ai.timefold.solver.core.api.score.constraint.ConstraintMatchTotal;
+import ai.timefold.solver.core.api.score.constraint.Indictment;
+import ai.timefold.solver.core.impl.score.constraint.DefaultConstraintMatchTotal;
+import ai.timefold.solver.core.impl.score.constraint.DefaultIndictment;
+
+public class TestdataShadowingChainedIncrementalScoreCalculator
+        implements ConstraintMatchAwareIncrementalScoreCalculator<TestdataShadowingChainedSolution, SimpleScore> {
+
+    private int score = 0;
+    private DefaultConstraintMatchTotal<SimpleScore> constraintMatchTotal;
+    private Map<Object, Indictment<SimpleScore>> indictmentMap;
+
+    @Override
+    public void resetWorkingSolution(TestdataShadowingChainedSolution workingSolution) {
+        score = 0;
+        constraintMatchTotal =
+                new DefaultConstraintMatchTotal<>("ai.timefold.solver.core.impl.testdata.domain.chained.shadow",
+                        "testConstraint");
+        indictmentMap = new HashMap<>();
+        for (TestdataShadowingChainedEntity left : workingSolution.getChainedEntityList()) {
+            String code = left.getCode();
+            if (code == null) {
+                continue;
+            }
+            for (TestdataShadowingChainedEntity right : workingSolution.getChainedEntityList()) {
+                if (Objects.equals(right.getCode(), code)) {
+                    score -= 1;
+                    ConstraintMatch<SimpleScore> constraintMatch =
+                            constraintMatchTotal.addConstraintMatch(List.of(left, right), SimpleScore.ONE);
+                    Stream.of(left, right)
+                            .forEach(entity -> indictmentMap
+                                    .computeIfAbsent(entity, key -> new DefaultIndictment<>(key, SimpleScore.ZERO))
+                                    .getConstraintMatchSet()
+                                    .add(constraintMatch));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void resetWorkingSolution(TestdataShadowingChainedSolution workingSolution, boolean constraintMatchEnabled) {
+        resetWorkingSolution(workingSolution);
+    }
+
+    @Override
+    public void beforeEntityAdded(Object entity) {
+
+    }
+
+    @Override
+    public void afterEntityAdded(Object entity) {
+
+    }
+
+    @Override
+    public void beforeVariableChanged(Object entity, String variableName) {
+
+    }
+
+    @Override
+    public void afterVariableChanged(Object entity, String variableName) {
+
+    }
+
+    @Override
+    public void beforeEntityRemoved(Object entity) {
+
+    }
+
+    @Override
+    public void afterEntityRemoved(Object entity) {
+
+    }
+
+    @Override
+    public SimpleScore calculateScore() {
+        return SimpleScore.of(score);
+    }
+
+    @Override
+    public Collection<ConstraintMatchTotal<SimpleScore>> getConstraintMatchTotals() {
+        return Collections.singleton(constraintMatchTotal);
+    }
+
+    @Override
+    public Map<Object, Indictment<SimpleScore>> getIndictmentMap() {
+        return indictmentMap;
+    }
+}

--- a/core/core-impl/src/test/resources/ai/timefold/solver/core/api/solver/testdataShadowingChainedSolverConfig.xml
+++ b/core/core-impl/src/test/resources/ai/timefold/solver/core/api/solver/testdataShadowingChainedSolverConfig.xml
@@ -1,0 +1,8 @@
+<solver>
+  <solutionClass>ai.timefold.solver.core.impl.testdata.domain.chained.shadow.TestdataShadowingChainedSolution</solutionClass>
+  <entityClass>ai.timefold.solver.core.impl.testdata.domain.chained.shadow.TestdataShadowingChainedEntity</entityClass>
+  <entityClass>ai.timefold.solver.core.impl.testdata.domain.chained.shadow.TestdataShadowingChainedObject</entityClass>
+  <scoreDirectorFactory>
+    <incrementalScoreCalculatorClass>ai.timefold.solver.core.impl.testdata.domain.chained.shadow.TestdataShadowingChainedIncrementalScoreCalculator</incrementalScoreCalculatorClass>
+  </scoreDirectorFactory>
+</solver>


### PR DESCRIPTION
There is a fail fast to detect that an inverse var points to the incorrect inverse.
But update() is used to fix those cases, so the fail-fast must not trigger there.