### PR TITLE
fix: Make KOptListMoveSelector work when moveThreadCount != NONE

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/FlipSublistAction.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/FlipSublistAction.java
@@ -4,9 +4,6 @@ import java.util.Collections;
 import java.util.List;
 
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
-import ai.timefold.solver.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
-import ai.timefold.solver.core.impl.domain.variable.inverserelation.SingletonListInverseVariableDemand;
-import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 
 /**
  * Flips a sublist of a list variable, (the same thing as a {@link TwoOptListMove}, but no shift to restore the original
@@ -24,23 +21,20 @@ final class FlipSublistAction {
 
     private final MultipleDelegateList<Object> combinedList;
 
-    private final SingletonInverseVariableSupply inverseVariableSupply;
     private final int fromIndexInclusive;
     private final int toIndexExclusive;
 
     public FlipSublistAction(ListVariableDescriptor<?> variableDescriptor,
-            SingletonInverseVariableSupply inverseVariableSupply,
             MultipleDelegateList<Object> combinedList,
             int fromIndexInclusive, int toIndexExclusive) {
         this.variableDescriptor = variableDescriptor;
-        this.inverseVariableSupply = inverseVariableSupply;
         this.combinedList = combinedList;
         this.fromIndexInclusive = fromIndexInclusive;
         this.toIndexExclusive = toIndexExclusive;
     }
 
     FlipSublistAction createUndoMove() {
-        return new FlipSublistAction(variableDescriptor, inverseVariableSupply,
+        return new FlipSublistAction(variableDescriptor,
                 combinedList,
                 fromIndexInclusive,
                 toIndexExclusive);
@@ -62,12 +56,9 @@ final class FlipSublistAction {
         flipSublist(combinedList, fromIndexInclusive, toIndexExclusive);
     }
 
-    public FlipSublistAction rebase(InnerScoreDirector<?, ?> destinationScoreDirector) {
-        SingletonInverseVariableSupply newInverseVariableSupply = destinationScoreDirector.getSupplyManager()
-                .demand(new SingletonListInverseVariableDemand<>(variableDescriptor));
+    public FlipSublistAction rebase(MultipleDelegateList<Object> rebasedList) {
         return new FlipSublistAction(variableDescriptor,
-                newInverseVariableSupply,
-                combinedList.rebase(variableDescriptor, inverseVariableSupply, destinationScoreDirector),
+                rebasedList,
                 fromIndexInclusive,
                 toIndexExclusive);
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptDescriptor.java
@@ -254,7 +254,7 @@ final class KOptDescriptor<Node_> {
             }
             if (maximumOrientedPairCountAfterReversal >= 0) {
                 if ((bestOrientedPairFirstEndpoint & 1) == 1) {
-                    out.add(getListReversalMoveForEdgePair(listVariableDescriptor, inverseVariableSupply, indexVariableSupply,
+                    out.add(getListReversalMoveForEdgePair(listVariableDescriptor, indexVariableSupply,
                             combinedList, originalToCurrentIndexList,
                             removedEdges[currentRemovedEdgeIndexToTourOrder[bestOrientedPairFirstEndpoint + 1]],
                             removedEdges[currentRemovedEdgeIndexToTourOrder[bestOrientedPairFirstEndpoint]],
@@ -265,7 +265,7 @@ final class KOptDescriptor<Node_> {
                             bestOrientedPairFirstEndpoint + 1,
                             bestOrientedPairSecondEndpoint);
                 } else {
-                    out.add(getListReversalMoveForEdgePair(listVariableDescriptor, inverseVariableSupply, indexVariableSupply,
+                    out.add(getListReversalMoveForEdgePair(listVariableDescriptor, indexVariableSupply,
                             combinedList, originalToCurrentIndexList,
                             removedEdges[currentRemovedEdgeIndexToTourOrder[bestOrientedPairFirstEndpoint - 1]],
                             removedEdges[currentRemovedEdgeIndexToTourOrder[bestOrientedPairFirstEndpoint]],
@@ -286,7 +286,7 @@ final class KOptDescriptor<Node_> {
                 int secondEndpoint = currentInverseRemovedEdgeIndexToTourOrder[nextEndpointTourIndex];
 
                 if (secondEndpoint >= firstEndpoint + 2) {
-                    out.add(getListReversalMoveForEdgePair(listVariableDescriptor, inverseVariableSupply, indexVariableSupply,
+                    out.add(getListReversalMoveForEdgePair(listVariableDescriptor, indexVariableSupply,
                             combinedList, originalToCurrentIndexList,
                             removedEdges[currentRemovedEdgeIndexToTourOrder[firstEndpoint]],
                             removedEdges[currentRemovedEdgeIndexToTourOrder[firstEndpoint + 1]],
@@ -431,7 +431,6 @@ final class KOptDescriptor<Node_> {
     @SuppressWarnings("unchecked")
     private static <Node_> FlipSublistAction getListReversalMoveForEdgePair(
             ListVariableDescriptor<?> listVariableDescriptor,
-            SingletonInverseVariableSupply inverseVariableSupply,
             IndexVariableSupply indexVariableSupply,
             MultipleDelegateList<Node_> combinedList,
             int[] originalToCurrentIndexList,
@@ -455,7 +454,7 @@ final class KOptDescriptor<Node_> {
 
         KOptUtils.flipSubarray(originalToCurrentIndexList, firstEndpoint, secondEndpoint);
 
-        return new FlipSublistAction(listVariableDescriptor, inverseVariableSupply, (MultipleDelegateList<Object>) combinedList,
+        return new FlipSublistAction(listVariableDescriptor, (MultipleDelegateList<Object>) combinedList,
                 firstEndpoint, secondEndpoint);
     }
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMove.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMove.java
@@ -11,7 +11,6 @@ import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescr
 import ai.timefold.solver.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
 import ai.timefold.solver.core.impl.domain.variable.inverserelation.SingletonListInverseVariableDemand;
 import ai.timefold.solver.core.impl.heuristic.move.AbstractMove;
-import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.util.Pair;
 
@@ -115,7 +114,7 @@ final class KOptListMove<Solution_> extends AbstractMove<Solution_> {
     }
 
     @Override
-    public Move<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
+    public KOptListMove<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
         List<FlipSublistAction> rebasedEquivalent2Opts = new ArrayList<>(equivalent2Opts.size());
         InnerScoreDirector<?, ?> innerScoreDirector = (InnerScoreDirector<?, ?>) destinationScoreDirector;
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/MultipleDelegateList.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/MultipleDelegateList.java
@@ -11,7 +11,6 @@ import java.util.RandomAccess;
 import java.util.stream.Stream;
 
 import ai.timefold.solver.core.api.function.TriConsumer;
-import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.index.IndexVariableSupply;
 import ai.timefold.solver.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
@@ -27,7 +26,6 @@ public final class MultipleDelegateList<T> implements List<T>, RandomAccess {
     final int[] delegateSizes;
     final int[] offsets;
     final int totalSize;
-    MultipleDelegateList<T> cachedRebaseResult;
 
     @SafeVarargs
     public MultipleDelegateList(List<T>... delegates) {
@@ -43,7 +41,6 @@ public final class MultipleDelegateList<T> implements List<T>, RandomAccess {
         }
 
         this.totalSize = sizeSoFar;
-        this.cachedRebaseResult = null;
     }
 
     public int getIndexOfValue(ListVariableDescriptor<?> listVariableDescriptor,
@@ -57,25 +54,6 @@ public final class MultipleDelegateList<T> implements List<T>, RandomAccess {
             }
         }
         throw new IllegalArgumentException("Value (" + value + ") is not contained in any entity list");
-    }
-
-    public MultipleDelegateList<T> rebase(ListVariableDescriptor<?> variableDescriptor,
-            SingletonInverseVariableSupply inverseVariableSupply, ScoreDirector<?> destinationScoreDirector) {
-        if (cachedRebaseResult != null) {
-            return cachedRebaseResult;
-        }
-        @SuppressWarnings("unchecked")
-        List<T>[] out = new List[delegates.length];
-        for (int i = 0; i < delegates.length; i++) {
-            List<T> delegate = delegates[i];
-            @SuppressWarnings("unchecked")
-            List<T> rebasedDelegate = (List<T>) variableDescriptor.getListVariable(
-                    destinationScoreDirector.lookUpWorkingObject(
-                            inverseVariableSupply.getInverseSingleton(delegate.get(0))));
-            out[i] = rebasedDelegate;
-        }
-        cachedRebaseResult = new MultipleDelegateList<>(out);
-        return cachedRebaseResult;
     }
 
     public void actOnAffectedElements(Object[] originalEntities, TriConsumer<Object, Integer, Integer> action) {


### PR DESCRIPTION
The issue came from the fact MultipleDelegateList returns a new instance of the rebased list on every call. This is problematic, since each FlipSublistAction expects rebase to return the same list across mulitple calls. When different instances are used, the FlipSublistAction modify different lists, causing the Undo move to be incorrect. (Since the list the FlipSublistAction operation on only has its flip incorporated in it instead of all flips). Since a new MultipleDelegateList is created for each move, we can safely store a cached result in one of its fields.

Fixes #250 