### PR TITLE
fix: impact assertion in constraint verifier

### DIFF
--- a/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintAssertion.java
+++ b/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintAssertion.java
@@ -113,13 +113,13 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
         if (actualScoreImpactType == ScoreImpactType.MIXED) {
             // Impact means we need to check for expected impact type and actual impact match.
             switch (scoreImpactType) {
-                case REWARD:
+                case PENALTY:
                     Number negatedImpact = deducedImpacts.getValue();
                     if (equalityPredicate.test(matchWeightTotal, negatedImpact)) {
                         return;
                     }
                     break;
-                case PENALTY:
+                case REWARD:
                     if (equalityPredicate.test(matchWeightTotal, impact)) {
                         return;
                     }
@@ -216,9 +216,9 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
                     if (actualImpactType == ScoreImpactType.MIXED) {
                         boolean isImpactPositive = constraintMatchTotal.getScore().compareTo(zeroScore) > 0;
                         boolean isImpactNegative = constraintMatchTotal.getScore().compareTo(zeroScore) < 0;
-                        if (isImpactPositive && scoreImpactType == ScoreImpactType.PENALTY) {
+                        if (isImpactPositive && scoreImpactType == ScoreImpactType.REWARD) {
                             return constraintMatchTotal.getConstraintMatchSet().size();
-                        } else if (isImpactNegative && scoreImpactType == ScoreImpactType.REWARD) {
+                        } else if (isImpactNegative && scoreImpactType == ScoreImpactType.PENALTY) {
                             return constraintMatchTotal.getConstraintMatchSet().size();
                         } else {
                             return 0;

--- a/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
+++ b/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
@@ -54,21 +54,21 @@ class SingleConstraintAssertionTest {
                 .penalizes(0, "There should be no penalties"))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("PENALIZE", new TestdataValue()))
                 .penalizes(0, "There should be no penalties"))
                 .hasMessageContaining("There should be no penalties")
                 .hasMessageContaining("Expected penalty");
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("PENALIZE", new TestdataValue()))
                 .penalizes(1, "There should be penalties"))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("PENALIZE", new TestdataValue()))
                 .penalizes(2, "There should only be one penalty"))
                 .hasMessageContaining("There should only be one penalty")
                 .hasMessageContaining("Expected penalty");
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("PENALIZE", new TestdataValue()))
                 .rewards(1, "There should not be rewards"))
                 .hasMessageContaining("There should not be rewards")
                 .hasMessageContaining("Expected reward");
@@ -78,21 +78,21 @@ class SingleConstraintAssertionTest {
                 .rewards(0, "There should be no rewards"))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("REWARD", new TestdataValue()))
                 .rewards(0, "There should be no rewards"))
                 .hasMessageContaining("There should be no rewards")
                 .hasMessageContaining("Expected reward");
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("REWARD", new TestdataValue()))
                 .rewards(1, "There should be rewards"))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("REWARD", new TestdataValue()))
                 .rewards(2, "There should only be one reward"))
                 .hasMessageContaining("There should only be one reward")
                 .hasMessageContaining("Expected reward");
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("REWARD", new TestdataValue()))
                 .penalizes(1, "There should not be penalties"))
                 .hasMessageContaining("There should not be penalties")
                 .hasMessageContaining("Expected penalty");
@@ -105,21 +105,21 @@ class SingleConstraintAssertionTest {
                 .penalizesBy(0, "There should no penalties"))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("PENALIZE", new TestdataValue()))
                 .penalizesBy(0, "There should be no penalties"))
                 .hasMessageContaining("There should be no penalties")
                 .hasMessageContaining("Expected penalty");
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("PENALIZE", new TestdataValue()))
                 .penalizesBy(1, "There should be penalties"))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("PENALIZE", new TestdataValue()))
                 .penalizesBy(2, "There should only be one penalty"))
                 .hasMessageContaining("There should only be one penalty")
                 .hasMessageContaining("Expected penalty");
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("PENALIZE", new TestdataValue()))
                 .rewardsWith(1, "There should not be rewards"))
                 .hasMessageContaining("There should not be rewards")
                 .hasMessageContaining("Expected reward");
@@ -129,21 +129,21 @@ class SingleConstraintAssertionTest {
                 .rewardsWith(0, "There should no rewards"))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("REWARD", new TestdataValue()))
                 .rewardsWith(0, "There should be no rewards"))
                 .hasMessageContaining("There should be no rewards")
                 .hasMessageContaining("Expected reward");
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("REWARD", new TestdataValue()))
                 .rewardsWith(1, "There should be rewards"))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("REWARD", new TestdataValue()))
                 .rewardsWith(2, "There should only be one reward"))
                 .hasMessageContaining("There should only be one reward")
                 .hasMessageContaining("Expected reward");
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity("REWARD", new TestdataValue()))
                 .penalizesBy(1, "There should not be penalties"))
                 .hasMessageContaining("There should not be penalties")
                 .hasMessageContaining("Expected penalty");

--- a/test/src/test/java/ai/timefold/solver/test/api/score/stream/testdata/TestdataConstraintVerifierConstraintProvider.java
+++ b/test/src/test/java/ai/timefold/solver/test/api/score/stream/testdata/TestdataConstraintVerifierConstraintProvider.java
@@ -34,7 +34,7 @@ public final class TestdataConstraintVerifierConstraintProvider implements Const
     public Constraint impactEveryEntity(ConstraintFactory constraintFactory) {
         return constraintFactory.forEach(TestdataConstraintVerifierFirstEntity.class)
                 .impact(HardSoftScore.ofHard(4),
-                        entity -> Objects.equals(entity.getCode(), "A") ? 1 : -1)
+                        entity -> Objects.equals(entity.getCode(), "REWARD") ? 1 : -1)
                 .asConstraint("Impact every standard entity");
     }
 


### PR DESCRIPTION
# Issue
Constraint Verifier gives unexpected result when verifying a constraint terminating with impact() (i.e. MIXED score type).

# Resolution
- Invert PENALTY and REWARD branches of switches.
- Clarify the test case data naming.