### PR TITLE
ci: don't remove dependabot from release notes

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -31,7 +31,6 @@ release:
           - ci
         contributors:
           - "GitHub"
-          - "dependabot"
           - "Timefold Release Bot"
 
 deploy:


### PR DESCRIPTION
Changed my mind; release notes should include version bumps.