### PR TITLE
feat: improve support for Java records

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
@@ -487,7 +487,8 @@ public class ConfigUtils {
         if (memberList.isEmpty()) {
             return null;
         }
-        if (memberList.size() > 1) {
+        // Once a record field is annotated with @PlanningId, Java also adds the annotation on the getter.
+        if (memberList.size() > 1 && !clazz.isRecord()) {
             throw new IllegalArgumentException("The class (" + clazz
                     + ") has " + memberList.size() + " members (" + memberList + ") with a "
                     + annotationClass.getSimpleName() + " annotation.");

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
@@ -487,8 +487,16 @@ public class ConfigUtils {
         if (memberList.isEmpty()) {
             return null;
         }
-        // Once a record field is annotated with @PlanningId, Java also adds the annotation on the getter.
-        if (memberList.size() > 1 && !clazz.isRecord()) {
+        int size = memberList.size();
+        if (size == 2 && clazz.isRecord()) {
+            /*
+             * A record has a field and a getter for each record component.
+             * When the component is annotated with @PlanningId,
+             * the annotation ends up on both the field and the getter.
+             * The getter is the one that should be used.
+             */
+            return memberList.get(1);
+        } else if (size > 1) {
             throw new IllegalArgumentException("The class (" + clazz
                     + ") has " + memberList.size() + " members (" + memberList + ") with a "
                     + annotationClass.getSimpleName() + " annotation.");

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/entity/descriptor/EntityDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/entity/descriptor/EntityDescriptor.java
@@ -114,6 +114,7 @@ public class EntityDescriptor<Solution_> {
     // ************************************************************************
 
     public EntityDescriptor(SolutionDescriptor<Solution_> solutionDescriptor, Class<?> entityClass) {
+        SolutionDescriptor.assertMutable(entityClass, "entityClass");
         this.solutionDescriptor = solutionDescriptor;
         this.entityClass = entityClass;
         isInitializedPredicate = this::isInitialized;

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/DeepCloningFieldCloner.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/DeepCloningFieldCloner.java
@@ -82,15 +82,7 @@ final class DeepCloningFieldCloner {
         return fieldDeepCloneDecision.get() == 1;
     }
 
-    private static final class Metadata {
-
-        private final Class<?> clz;
-        private final boolean decision;
-
-        public Metadata(Class<?> clz, boolean decision) {
-            this.clz = clz;
-            this.decision = decision;
-        }
-
+    private record Metadata(Class<?> clz, boolean decision) {
     }
+
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/DeepCloningUtils.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/DeepCloningUtils.java
@@ -81,7 +81,13 @@ public final class DeepCloningUtils {
         Class<?> fieldType = field.getType();
         if (isImmutable(fieldType)) {
             return false;
+        } else {
+            return needsDeepClone(solutionDescriptor, field, owningClass);
         }
+
+    }
+
+    public static boolean needsDeepClone(SolutionDescriptor<?> solutionDescriptor, Field field, Class<?> owningClass) {
         return isFieldAnEntityPropertyOnSolution(solutionDescriptor, field, owningClass)
                 || isFieldAnEntityOrSolution(solutionDescriptor, field)
                 || isFieldAPlanningListVariable(field, owningClass)
@@ -89,14 +95,14 @@ public final class DeepCloningUtils {
     }
 
     static boolean isImmutable(Class<?> clz) {
-        if (clz.isPrimitive() || clz.isEnum() || Score.class.isAssignableFrom(clz)) {
+        if (clz.isPrimitive() || clz.isEnum() || clz.isRecord() || Score.class.isAssignableFrom(clz)) {
             return true;
         }
         return IMMUTABLE_CLASSES.contains(clz);
     }
 
     /**
-     * Return true only if a field represent an entity property on the solution class.
+     * Return true only if a field represents an entity property on the solution class.
      * An entity property is one who type is a PlanningEntity or a collection
      * of PlanningEntity.
      *

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
@@ -327,17 +327,5 @@ public final class FieldAccessingSolutionCloner<Solution_> implements SolutionCl
 
     }
 
-    private static final class Unprocessed {
-
-        final Object bean;
-        final Field field;
-        final Object originalValue;
-
-        public Unprocessed(Object bean, Field field, Object originalValue) {
-            this.bean = bean;
-            this.field = field;
-            this.originalValue = originalValue;
-        }
-
-    }
+    private record Unprocessed(Object bean, Field field, Object originalValue) { }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -93,6 +93,7 @@ public class SolutionDescriptor<Solution_> {
     public static <Solution_> SolutionDescriptor<Solution_> buildSolutionDescriptor(DomainAccessType domainAccessType,
             Class<Solution_> solutionClass, Map<String, MemberAccessor> memberAccessorMap,
             Map<String, SolutionCloner> solutionClonerMap, List<Class<?>> entityClassList) {
+        assertMutable(solutionClass, "solutionClass");
         solutionClonerMap = Objects.requireNonNullElse(solutionClonerMap, Collections.emptyMap());
         SolutionDescriptor<Solution_> solutionDescriptor = new SolutionDescriptor<>(solutionClass, memberAccessorMap);
         DescriptorPolicy descriptorPolicy = new DescriptorPolicy();
@@ -108,6 +109,20 @@ public class SolutionDescriptor<Solution_> {
         }
         solutionDescriptor.afterAnnotationsProcessed(descriptorPolicy);
         return solutionDescriptor;
+    }
+
+    public static void assertMutable(Class<?> clz, String classType) {
+        if (clz.isRecord()) {
+            throw new IllegalArgumentException("""
+                    The %s (%s) cannot be a record as it needs to be mutable.
+                    Use a regular class instead.
+                    """.formatted(classType, clz.getCanonicalName()));
+        } else if (clz.isEnum()) {
+            throw new IllegalArgumentException("""
+                    The %s (%s) cannot be an enum as it needs to be mutable.
+                    Use a regular class instead.
+                    """.formatted(classType, clz.getCanonicalName()));
+        }
     }
 
     private static List<Class<?>> sortEntityClassList(List<Class<?>> entityClassList) {

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -887,6 +887,7 @@ public abstract class AbstractSolutionClonerTest {
             softly.assertThat(cloned.bigDecimal).isSameAs(original.bigDecimal);
             softly.assertThat(cloned.uuidRef).isSameAs(original.uuidRef);
             softly.assertThat(cloned.stringRef).isSameAs(original.stringRef);
+            softly.assertThat(cloned.nonClonedRecord).isSameAs(original.nonClonedRecord);
         });
         // Ensure that the rest is cloned properly too.
         assertSoftly(softly -> {

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/TestdataVariousTypes.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/TestdataVariousTypes.java
@@ -34,9 +34,17 @@ public class TestdataVariousTypes {
     public UUID uuidRef = UUID.randomUUID();
     public String stringRef = uuidRef.toString();
 
+    // Records.
+    public NonClonedRecord nonClonedRecord = new NonClonedRecord(17, "18");
+    public ClonedRecord clonedRecord = new ClonedRecord(19, "20", new TestdataDeepCloningEntity("21"));
+
     // And something mutable.
     public List<String> shallowClonedListRef = Collections.singletonList(stringRef);
     @DeepPlanningClone
     public List<String> deepClonedListRef = Collections.singletonList(stringRef);
+
+    public record NonClonedRecord(int a, String b) { }
+
+    public record ClonedRecord(int a, String b, TestdataDeepCloningEntity entity) { }
 
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/TestdataVariousTypes.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/TestdataVariousTypes.java
@@ -35,16 +35,18 @@ public class TestdataVariousTypes {
     public String stringRef = uuidRef.toString();
 
     // Records.
-    public NonClonedRecord nonClonedRecord = new NonClonedRecord(17, "18");
-    public ClonedRecord clonedRecord = new ClonedRecord(19, "20", new TestdataDeepCloningEntity("21"));
+    public NonClonedRecord nonClonedRecord = new NonClonedRecord(19, "19");
+    public ClonedRecord clonedRecord = new ClonedRecord(20, "20", new TestdataDeepCloningEntity("20"));
 
     // And something mutable.
     public List<String> shallowClonedListRef = Collections.singletonList(stringRef);
     @DeepPlanningClone
     public List<String> deepClonedListRef = Collections.singletonList(stringRef);
 
-    public record NonClonedRecord(int a, String b) { }
+    public record NonClonedRecord(int a, String b) {
+    }
 
-    public record ClonedRecord(int a, String b, TestdataDeepCloningEntity entity) { }
+    public record ClonedRecord(int a, String b, TestdataDeepCloningEntity entity) {
+    }
 
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/TestdataVariousTypes.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/TestdataVariousTypes.java
@@ -36,7 +36,6 @@ public class TestdataVariousTypes {
 
     // Records.
     public NonClonedRecord nonClonedRecord = new NonClonedRecord(19, "19");
-    public ClonedRecord clonedRecord = new ClonedRecord(20, "20", new TestdataDeepCloningEntity("20"));
 
     // And something mutable.
     public List<String> shallowClonedListRef = Collections.singletonList(stringRef);
@@ -44,9 +43,6 @@ public class TestdataVariousTypes {
     public List<String> deepClonedListRef = Collections.singletonList(stringRef);
 
     public record NonClonedRecord(int a, String b) {
-    }
-
-    public record ClonedRecord(int a, String b, TestdataDeepCloningEntity entity) {
     }
 
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/record/TestdataRecordEntity.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/record/TestdataRecordEntity.java
@@ -1,0 +1,47 @@
+package ai.timefold.solver.core.impl.testdata.domain.record;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataObject;
+
+@PlanningEntity
+public class TestdataRecordEntity extends TestdataObject {
+
+    public static EntityDescriptor<TestdataRecordSolution> buildEntityDescriptor() {
+        return TestdataRecordSolution.buildSolutionDescriptor().findEntityDescriptorOrFail(TestdataRecordEntity.class);
+    }
+
+    public static GenuineVariableDescriptor<TestdataRecordSolution> buildVariableDescriptorForValue() {
+        return buildEntityDescriptor().getGenuineVariableDescriptor("value");
+    }
+
+    private TestdataRecordValue value;
+
+    public TestdataRecordEntity() {
+    }
+
+    public TestdataRecordEntity(String code) {
+        super(code);
+    }
+
+    public TestdataRecordEntity(String code, TestdataRecordValue value) {
+        this(code);
+        this.value = value;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public TestdataRecordValue getValue() {
+        return value;
+    }
+
+    public void setValue(TestdataRecordValue value) {
+        this.value = value;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/record/TestdataRecordSolution.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/record/TestdataRecordSolution.java
@@ -1,0 +1,88 @@
+package ai.timefold.solver.core.impl.testdata.domain.record;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataObject;
+
+@PlanningSolution
+public class TestdataRecordSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataRecordSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataRecordSolution.class, TestdataRecordEntity.class);
+    }
+
+    public static TestdataRecordSolution generateSolution() {
+        return generateSolution(5, 7);
+    }
+
+    public static TestdataRecordSolution generateSolution(int valueListSize, int entityListSize) {
+        TestdataRecordSolution solution = new TestdataRecordSolution("Generated Solution 0");
+        List<TestdataRecordValue> valueList = new ArrayList<>(valueListSize);
+        for (int i = 0; i < valueListSize; i++) {
+            TestdataRecordValue value = new TestdataRecordValue("Generated Value " + i);
+            valueList.add(value);
+        }
+        solution.setValueList(valueList);
+        List<TestdataRecordEntity> entityList = new ArrayList<>(entityListSize);
+        for (int i = 0; i < entityListSize; i++) {
+            TestdataRecordValue value = valueList.get(i % valueListSize);
+            TestdataRecordEntity entity = new TestdataRecordEntity("Generated Entity " + i, value);
+            entityList.add(entity);
+        }
+        solution.setEntityList(entityList);
+        return solution;
+    }
+
+    private List<TestdataRecordValue> valueList;
+    private List<TestdataRecordEntity> entityList;
+
+    private SimpleScore score;
+
+    public TestdataRecordSolution() {
+    }
+
+    public TestdataRecordSolution(String code) {
+        super(code);
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataRecordValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataRecordValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataRecordEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataRecordEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/record/TestdataRecordValue.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/record/TestdataRecordValue.java
@@ -1,0 +1,6 @@
+package ai.timefold.solver.core.impl.testdata.domain.record;
+
+import ai.timefold.solver.core.api.domain.lookup.PlanningId;
+
+public record TestdataRecordValue(@PlanningId String code) {
+}

--- a/docs/src/modules/ROOT/pages/configuration/configuration.adoc
+++ b/docs/src/modules/ROOT/pages/configuration/configuration.adoc
@@ -385,7 +385,17 @@ If historic data needs to be considered too, then create problem fact to hold th
 
 [NOTE]
 ====
-Planning entity `hashCode()` implementations must remain constant. Therefore entity `hashCode()` must not depend on any planning variables. Pay special attention when using data structures with auto-generated `hashCode()` as entities, such as Java records or Kotlin data classes.
+Planning entity `hashCode()` implementations must remain constant.
+Therefore entity `hashCode()` must not depend on any planning variables.
+Pay special attention when using data structures with auto-generated `hashCode()` as entities,
+such as Kotlin data classes or Lombok's `@EqualsAndHashCode`.
+====
+
+[NOTE]
+====
+Planning entity implementations must not be of Java's `enum` or `record` types.
+Those are immutable by design and therefore cannot change during planning,
+whereas planning entities will.
 ====
 
 [[planningEntityDifficulty]]
@@ -1594,6 +1604,14 @@ The solver configuration needs to declare the planning solution class:
 </solver>
 ----
 
+[NOTE]
+====
+Solution class must not be of Java's `enum` or `record` types.
+Those are immutable by design and therefore cannot change during planning,
+whereas a planning solution will.
+====
+
+
 [[planningEntitiesOfASolution]]
 ==== Planning entities of a solution (`@PlanningEntityCollectionProperty`)
 
@@ -1876,6 +1894,11 @@ Alternatively, the `@DeepPlanningClone` annotation also works on a getter method
 If that property is a `Collection` or a `Map`, it will shallow clone it and deep planning clone
 any element thereof that is an instance of a class that has a `@DeepPlanningClone` annotation.
 
+[NOTE]
+====
+Values of Java's `enum` and `record` types are never deep-cloned.
+They are immutable by design and shouldn't be used to store mutable state, such as planning entities.
+====
 
 [[customCloning]]
 ===== Custom cloning with a `SolutionCloner`


### PR DESCRIPTION
Does several things:

1. Records can serve as planning variables; planning ID annotation on record components no longer throws.
2. Records can no longer be solutions or entities, as these need to be mutable.
3. Records are no longer deep-cloned, receiving the same treatment as enums.
4. Throws a better exception when cloning fails due to an exception in constructor.

The second and third change are technically backwards incompatible behavior but we introduce it anyway, as the old behavior was erroneous.