### PR TITLE
ci: replace JDK 20 with 21

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java-version: [ 17, 20 ] #Latest two LTS + latest non-LTS.
+        java-version: [ 17, 21 ] #Latest two LTS + latest non-LTS.
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
JDK 21 build status:
https://github.com/adoptium/temurin/issues/8