### PR TITLE
fix: Always propagate map's update even if mapped value does not change

### DIFF
--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/MapBiToBiNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/MapBiToBiNode.java
@@ -30,12 +30,13 @@ final class MapBiToBiNode<A, B, NewA, NewB> extends AbstractMapNode<BiTuple<A, B
     }
 
     @Override
-    protected boolean remap(BiTuple<A, B> inTuple, BiTuple<NewA, NewB> outTuple) {
+    protected void remap(BiTuple<A, B> inTuple, BiTuple<NewA, NewB> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         NewA newA = mappingFunctionA.apply(factA, factB);
         NewB newB = mappingFunctionB.apply(factA, factB);
-        return outTuple.updateIfDifferent(newA, newB);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/MapBiToQuadNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/MapBiToQuadNode.java
@@ -39,14 +39,17 @@ final class MapBiToQuadNode<A, B, NewA, NewB, NewC, NewD>
     }
 
     @Override
-    protected boolean remap(BiTuple<A, B> inTuple, QuadTuple<NewA, NewB, NewC, NewD> outTuple) {
+    protected void remap(BiTuple<A, B> inTuple, QuadTuple<NewA, NewB, NewC, NewD> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         NewA newA = mappingFunctionA.apply(factA, factB);
         NewB newB = mappingFunctionB.apply(factA, factB);
         NewC newC = mappingFunctionC.apply(factA, factB);
         NewD newD = mappingFunctionD.apply(factA, factB);
-        return outTuple.updateIfDifferent(newA, newB, newC, newD);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
+        outTuple.factC = newC;
+        outTuple.factD = newD;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/MapBiToTriNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/MapBiToTriNode.java
@@ -35,13 +35,15 @@ final class MapBiToTriNode<A, B, NewA, NewB, NewC> extends AbstractMapNode<BiTup
     }
 
     @Override
-    protected boolean remap(BiTuple<A, B> inTuple, TriTuple<NewA, NewB, NewC> outTuple) {
+    protected void remap(BiTuple<A, B> inTuple, TriTuple<NewA, NewB, NewC> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         NewA newA = mappingFunctionA.apply(factA, factB);
         NewB newB = mappingFunctionB.apply(factA, factB);
         NewC newC = mappingFunctionC.apply(factA, factB);
-        return outTuple.updateIfDifferent(newA, newB, newC);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
+        outTuple.factC = newC;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/MapBiToUniNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/MapBiToUniNode.java
@@ -28,11 +28,11 @@ final class MapBiToUniNode<A, B, NewA> extends AbstractMapNode<BiTuple<A, B>, Un
     }
 
     @Override
-    protected boolean remap(BiTuple<A, B> inTuple, UniTuple<NewA> outTuple) {
+    protected void remap(BiTuple<A, B> inTuple, UniTuple<NewA> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         NewA newA = mappingFunction.apply(factA, factB);
-        return outTuple.updateIfDifferent(newA);
+        outTuple.factA = newA;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractMapNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractMapNode.java
@@ -53,7 +53,6 @@ public abstract class AbstractMapNode<InTuple_ extends AbstractTuple, OutTuple_ 
     /**
      * @param inTuple never null; the tuple to apply mappings on
      * @param oldOutTuple never null; the tuple that was previously mapped to the inTuple
-     * @return true if oldOutTuple changed during remapping
      */
     protected abstract void remap(InTuple_ inTuple, OutTuple_ oldOutTuple);
 

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractMapNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractMapNode.java
@@ -39,15 +39,15 @@ public abstract class AbstractMapNode<InTuple_ extends AbstractTuple, OutTuple_ 
             insert(tuple);
             return;
         }
-        boolean wasUpdated = remap(tuple, outTuple);
-        if (wasUpdated) { // Only propagate if the tuple actually changed.
-            TupleState previousState = outTuple.state;
-            if (previousState == TupleState.CREATING || previousState == TupleState.UPDATING) {
-                // Already in the queue in the correct state.
-                return;
-            }
-            propagationQueue.update(outTuple);
+        remap(tuple, outTuple);
+        // Update must be propagated even if outTuple did not change, since if it is a planning
+        // entity, the entity's planning variable might have changed.
+        TupleState previousState = outTuple.state;
+        if (previousState == TupleState.CREATING || previousState == TupleState.UPDATING) {
+            // Already in the queue in the correct state.
+            return;
         }
+        propagationQueue.update(outTuple);
     }
 
     /**

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractMapNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractMapNode.java
@@ -55,7 +55,7 @@ public abstract class AbstractMapNode<InTuple_ extends AbstractTuple, OutTuple_ 
      * @param oldOutTuple never null; the tuple that was previously mapped to the inTuple
      * @return true if oldOutTuple changed during remapping
      */
-    protected abstract boolean remap(InTuple_ inTuple, OutTuple_ oldOutTuple);
+    protected abstract void remap(InTuple_ inTuple, OutTuple_ oldOutTuple);
 
     @Override
     public final void retract(InTuple_ tuple) {

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/tuple/BiTuple.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/tuple/BiTuple.java
@@ -12,19 +12,6 @@ public final class BiTuple<A, B> extends AbstractTuple {
         this.factB = factB;
     }
 
-    public boolean updateIfDifferent(A newFactA, B newFactB) {
-        boolean different = false;
-        if (factA != newFactA) {
-            factA = newFactA;
-            different = true;
-        }
-        if (factB != newFactB) {
-            factB = newFactB;
-            different = true;
-        }
-        return different;
-    }
-
     @Override
     public String toString() {
         return "{" + factA + ", " + factB + "}";

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/tuple/QuadTuple.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/tuple/QuadTuple.java
@@ -16,27 +16,6 @@ public final class QuadTuple<A, B, C, D> extends AbstractTuple {
         this.factD = factD;
     }
 
-    public boolean updateIfDifferent(A newFactA, B newFactB, C newFactC, D newFactD) {
-        boolean different = false;
-        if (factA != newFactA) {
-            factA = newFactA;
-            different = true;
-        }
-        if (factB != newFactB) {
-            factB = newFactB;
-            different = true;
-        }
-        if (factC != newFactC) {
-            factC = newFactC;
-            different = true;
-        }
-        if (factD != newFactD) {
-            factD = newFactD;
-            different = true;
-        }
-        return different;
-    }
-
     @Override
     public String toString() {
         return "{" + factA + ", " + factB + ", " + factC + ", " + factD + "}";

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/tuple/TriTuple.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/tuple/TriTuple.java
@@ -14,23 +14,6 @@ public final class TriTuple<A, B, C> extends AbstractTuple {
         this.factC = factC;
     }
 
-    public boolean updateIfDifferent(A newFactA, B newFactB, C newFactC) {
-        boolean different = false;
-        if (factA != newFactA) {
-            factA = newFactA;
-            different = true;
-        }
-        if (factB != newFactB) {
-            factB = newFactB;
-            different = true;
-        }
-        if (factC != newFactC) {
-            factC = newFactC;
-            different = true;
-        }
-        return different;
-    }
-
     @Override
     public String toString() {
         return "{" + factA + ", " + factB + ", " + factC + "}";

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/tuple/UniTuple.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/tuple/UniTuple.java
@@ -10,14 +10,6 @@ public final class UniTuple<A> extends AbstractTuple {
         this.factA = factA;
     }
 
-    public boolean updateIfDifferent(A newFactA) {
-        if (factA != newFactA) {
-            factA = newFactA;
-            return true;
-        }
-        return false;
-    }
-
     @Override
     public String toString() {
         return "{" + factA + "}";

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/MapQuadToBiNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/MapQuadToBiNode.java
@@ -34,14 +34,15 @@ final class MapQuadToBiNode<A, B, C, D, NewA, NewB> extends AbstractMapNode<Quad
     }
 
     @Override
-    protected boolean remap(QuadTuple<A, B, C, D> inTuple, BiTuple<NewA, NewB> outTuple) {
+    protected void remap(QuadTuple<A, B, C, D> inTuple, BiTuple<NewA, NewB> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         C factC = inTuple.factC;
         D factD = inTuple.factD;
         NewA newA = mappingFunctionA.apply(factA, factB, factC, factD);
         NewB newB = mappingFunctionB.apply(factA, factB, factC, factD);
-        return outTuple.updateIfDifferent(newA, newB);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/MapQuadToQuadNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/MapQuadToQuadNode.java
@@ -41,7 +41,7 @@ final class MapQuadToQuadNode<A, B, C, D, NewA, NewB, NewC, NewD>
     }
 
     @Override
-    protected boolean remap(QuadTuple<A, B, C, D> inTuple, QuadTuple<NewA, NewB, NewC, NewD> outTuple) {
+    protected void remap(QuadTuple<A, B, C, D> inTuple, QuadTuple<NewA, NewB, NewC, NewD> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         C factC = inTuple.factC;
@@ -50,7 +50,10 @@ final class MapQuadToQuadNode<A, B, C, D, NewA, NewB, NewC, NewD>
         NewB newB = mappingFunctionB.apply(factA, factB, factC, factD);
         NewC newC = mappingFunctionC.apply(factA, factB, factC, factD);
         NewD newD = mappingFunctionD.apply(factA, factB, factC, factD);
-        return outTuple.updateIfDifferent(newA, newB, newC, newD);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
+        outTuple.factC = newC;
+        outTuple.factD = newD;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/MapQuadToTriNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/MapQuadToTriNode.java
@@ -38,7 +38,7 @@ final class MapQuadToTriNode<A, B, C, D, NewA, NewB, NewC>
     }
 
     @Override
-    protected boolean remap(QuadTuple<A, B, C, D> inTuple, TriTuple<NewA, NewB, NewC> outTuple) {
+    protected void remap(QuadTuple<A, B, C, D> inTuple, TriTuple<NewA, NewB, NewC> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         C factC = inTuple.factC;
@@ -46,7 +46,9 @@ final class MapQuadToTriNode<A, B, C, D, NewA, NewB, NewC>
         NewA newA = mappingFunctionA.apply(factA, factB, factC, factD);
         NewB newB = mappingFunctionB.apply(factA, factB, factC, factD);
         NewC newC = mappingFunctionC.apply(factA, factB, factC, factD);
-        return outTuple.updateIfDifferent(newA, newB, newC);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
+        outTuple.factC = newC;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/MapQuadToUniNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/MapQuadToUniNode.java
@@ -30,13 +30,13 @@ final class MapQuadToUniNode<A, B, C, D, NewA> extends AbstractMapNode<QuadTuple
     }
 
     @Override
-    protected boolean remap(QuadTuple<A, B, C, D> inTuple, UniTuple<NewA> outTuple) {
+    protected void remap(QuadTuple<A, B, C, D> inTuple, UniTuple<NewA> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         C factC = inTuple.factC;
         D factD = inTuple.factD;
         NewA newA = mappingFunction.apply(factA, factB, factC, factD);
-        return outTuple.updateIfDifferent(newA);
+        outTuple.factA = newA;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/MapTriToBiNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/MapTriToBiNode.java
@@ -32,13 +32,14 @@ final class MapTriToBiNode<A, B, C, NewA, NewB> extends AbstractMapNode<TriTuple
     }
 
     @Override
-    protected boolean remap(TriTuple<A, B, C> inTuple, BiTuple<NewA, NewB> outTuple) {
+    protected void remap(TriTuple<A, B, C> inTuple, BiTuple<NewA, NewB> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         C factC = inTuple.factC;
         NewA newA = mappingFunctionA.apply(factA, factB, factC);
         NewB newB = mappingFunctionB.apply(factA, factB, factC);
-        return outTuple.updateIfDifferent(newA, newB);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/MapTriToQuadNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/MapTriToQuadNode.java
@@ -41,7 +41,7 @@ final class MapTriToQuadNode<A, B, C, NewA, NewB, NewC, NewD>
     }
 
     @Override
-    protected boolean remap(TriTuple<A, B, C> inTuple, QuadTuple<NewA, NewB, NewC, NewD> outTuple) {
+    protected void remap(TriTuple<A, B, C> inTuple, QuadTuple<NewA, NewB, NewC, NewD> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         C factC = inTuple.factC;
@@ -49,7 +49,10 @@ final class MapTriToQuadNode<A, B, C, NewA, NewB, NewC, NewD>
         NewB newB = mappingFunctionB.apply(factA, factB, factC);
         NewC newC = mappingFunctionC.apply(factA, factB, factC);
         NewD newD = mappingFunctionD.apply(factA, factB, factC);
-        return outTuple.updateIfDifferent(newA, newB, newC, newD);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
+        outTuple.factC = newC;
+        outTuple.factD = newD;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/MapTriToTriNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/MapTriToTriNode.java
@@ -36,14 +36,16 @@ final class MapTriToTriNode<A, B, C, NewA, NewB, NewC>
     }
 
     @Override
-    protected boolean remap(TriTuple<A, B, C> inTuple, TriTuple<NewA, NewB, NewC> outTuple) {
+    protected void remap(TriTuple<A, B, C> inTuple, TriTuple<NewA, NewB, NewC> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         C factC = inTuple.factC;
         NewA newA = mappingFunctionA.apply(factA, factB, factC);
         NewB newB = mappingFunctionB.apply(factA, factB, factC);
         NewC newC = mappingFunctionC.apply(factA, factB, factC);
-        return outTuple.updateIfDifferent(newA, newB, newC);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
+        outTuple.factC = newC;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/MapTriToUniNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/MapTriToUniNode.java
@@ -29,12 +29,12 @@ final class MapTriToUniNode<A, B, C, NewA> extends AbstractMapNode<TriTuple<A, B
     }
 
     @Override
-    protected boolean remap(TriTuple<A, B, C> inTuple, UniTuple<NewA> outTuple) {
+    protected void remap(TriTuple<A, B, C> inTuple, UniTuple<NewA> outTuple) {
         A factA = inTuple.factA;
         B factB = inTuple.factB;
         C factC = inTuple.factC;
         NewA newA = mappingFunction.apply(factA, factB, factC);
-        return outTuple.updateIfDifferent(newA);
+        outTuple.factA = newA;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/MapUniToBiNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/MapUniToBiNode.java
@@ -30,11 +30,12 @@ final class MapUniToBiNode<A, NewA, NewB> extends AbstractMapNode<UniTuple<A>, B
     }
 
     @Override
-    protected boolean remap(UniTuple<A> inTuple, BiTuple<NewA, NewB> outTuple) {
+    protected void remap(UniTuple<A> inTuple, BiTuple<NewA, NewB> outTuple) {
         A factA = inTuple.factA;
         NewA newA = mappingFunctionA.apply(factA);
         NewB newB = mappingFunctionB.apply(factA);
-        return outTuple.updateIfDifferent(newA, newB);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/MapUniToQuadNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/MapUniToQuadNode.java
@@ -38,13 +38,16 @@ final class MapUniToQuadNode<A, NewA, NewB, NewC, NewD>
     }
 
     @Override
-    protected boolean remap(UniTuple<A> inTuple, QuadTuple<NewA, NewB, NewC, NewD> outTuple) {
+    protected void remap(UniTuple<A> inTuple, QuadTuple<NewA, NewB, NewC, NewD> outTuple) {
         A factA = inTuple.factA;
         NewA newA = mappingFunctionA.apply(factA);
         NewB newB = mappingFunctionB.apply(factA);
         NewC newC = mappingFunctionC.apply(factA);
         NewD newD = mappingFunctionD.apply(factA);
-        return outTuple.updateIfDifferent(newA, newB, newC, newD);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
+        outTuple.factC = newC;
+        outTuple.factD = newD;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/MapUniToTriNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/MapUniToTriNode.java
@@ -34,12 +34,14 @@ final class MapUniToTriNode<A, NewA, NewB, NewC> extends AbstractMapNode<UniTupl
     }
 
     @Override
-    protected boolean remap(UniTuple<A> inTuple, TriTuple<NewA, NewB, NewC> outTuple) {
+    protected void remap(UniTuple<A> inTuple, TriTuple<NewA, NewB, NewC> outTuple) {
         A factA = inTuple.factA;
         NewA newA = mappingFunctionA.apply(factA);
         NewB newB = mappingFunctionB.apply(factA);
         NewC newC = mappingFunctionC.apply(factA);
-        return outTuple.updateIfDifferent(newA, newB, newC);
+        outTuple.factA = newA;
+        outTuple.factB = newB;
+        outTuple.factC = newC;
     }
 
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/MapUniToUniNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/MapUniToUniNode.java
@@ -26,10 +26,10 @@ final class MapUniToUniNode<A, NewA> extends AbstractMapNode<UniTuple<A>, UniTup
     }
 
     @Override
-    protected boolean remap(UniTuple<A> inTuple, UniTuple<NewA> outTuple) {
+    protected void remap(UniTuple<A> inTuple, UniTuple<NewA> outTuple) {
         A factA = inTuple.factA;
         NewA newA = mappingFunction.apply(factA);
-        return outTuple.updateIfDifferent(newA);
+        outTuple.factA = newA;
     }
 
 }


### PR DESCRIPTION
If map maps to a planning entity, then update MUST always be propagated, since variables on the planning entity might of changed.