### PR TITLE
feat: CH - fail fast on combination of basic variables & list variables on a single entity

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.constructionheuristic;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,7 +33,9 @@ import ai.timefold.solver.core.impl.constructionheuristic.placer.EntityPlacerFac
 import ai.timefold.solver.core.impl.constructionheuristic.placer.PooledEntityPlacerFactory;
 import ai.timefold.solver.core.impl.constructionheuristic.placer.QueuedEntityPlacerFactory;
 import ai.timefold.solver.core.impl.constructionheuristic.placer.QueuedValuePlacerFactory;
+import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicy;
 import ai.timefold.solver.core.impl.phase.AbstractPhaseFactory;
@@ -125,11 +129,26 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
                     + listVariableDescriptors + ").");
         }
 
+        ListVariableDescriptor<Solution_> listVariableDescriptor = listVariableDescriptors.get(0);
+        failIfBasicAndListVariablesAreCombinedOnSingleEntity(listVariableDescriptor);
         failIfConfigured(phaseConfig.getConstructionHeuristicType(), "constructionHeuristicType");
         failIfConfigured(phaseConfig.getEntityPlacerConfig(), "entityPlacerConfig");
         failIfConfigured(phaseConfig.getMoveSelectorConfigList(), "moveSelectorConfigList");
 
-        return Optional.of(listVariableDescriptors.get(0));
+        return Optional.of(listVariableDescriptor);
+    }
+
+    private static void failIfBasicAndListVariablesAreCombinedOnSingleEntity(ListVariableDescriptor<?> listVariableDescriptor) {
+        EntityDescriptor<?> listVariableEntityDescriptor = listVariableDescriptor.getEntityDescriptor();
+        if (listVariableEntityDescriptor.getDeclaredGenuineVariableDescriptors().size() > 1) {
+            Collection<GenuineVariableDescriptor<?>> basicVariableDescriptors =
+                    new ArrayList<>(listVariableEntityDescriptor.getDeclaredGenuineVariableDescriptors());
+            basicVariableDescriptors.remove(listVariableDescriptor);
+            throw new IllegalArgumentException(
+                    "Construction Heuristic phase does not support combination of basic variables ("
+                            + basicVariableDescriptors + ") and list variables (" + listVariableDescriptor
+                            + ") on a single planning entity (" + listVariableDescriptor.getEntityDescriptor() + ").");
+        }
     }
 
     private static void failIfConfigured(Object configValue, String configName) {


### PR DESCRIPTION
Improves getting started experience. Most people start with the basic CH settings:

<constructionHeuristic/>
<localSearch/>

Imagine an entity that contains both list & basic planning variable. This ends up with the following error that gives users false hope this can be fixed by updating the configuration. Fail fast instead.

```
Exception in thread "main" java.lang.IllegalArgumentException: The config (ValueSelectorConfig(null)) has no configured variableName for entityClass (class org.mcimbora.domain.Vehicle) and because there are multiple variableNames ([basicVariable, visits]), it cannot be deduced automatically.

```