### PR TITLE
fix: Deep clone unknown classes in GIZMO solution cloner

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
@@ -62,6 +62,27 @@ public final class FieldAccessingSolutionCloner<Solution_> implements SolutionCl
         return cloneSolution;
     }
 
+    /**
+     * Used by GIZMO when it encounters an undeclared entity class, such as when an abstract planning entity is extended.
+     */
+    public Object gizmoFallbackDeepClone(Object originalValue, Map<Object, Object> originalToCloneMap) {
+        if (originalValue == null) {
+            return null;
+        }
+        Queue<Unprocessed> unprocessedQueue = new ArrayDeque<>();
+        Class<?> fieldType = originalValue.getClass();
+        if (originalValue instanceof Collection<?> collection) {
+            return cloneCollection(fieldType, collection, originalToCloneMap, unprocessedQueue);
+        } else if (originalValue instanceof Map<?, ?> map) {
+            return cloneMap(fieldType, map, originalToCloneMap, unprocessedQueue);
+        } else if (originalValue.getClass().isArray()) {
+            return cloneArray(fieldType, originalValue, originalToCloneMap, unprocessedQueue);
+        } else {
+            return clone(originalValue, originalToCloneMap, unprocessedQueue,
+                    retrieveClassMetadata(originalValue.getClass()));
+        }
+    }
+
     private Object process(Unprocessed unprocessed, Map<Object, Object> originalToCloneMap,
             Queue<Unprocessed> unprocessedQueue) {
         Object originalValue = unprocessed.originalValue;

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionCloner.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionCloner.java
@@ -1,0 +1,8 @@
+package ai.timefold.solver.core.impl.domain.solution.cloner.gizmo;
+
+import ai.timefold.solver.core.api.domain.solution.cloner.SolutionCloner;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+public interface GizmoSolutionCloner<Solution_> extends SolutionCloner<Solution_> {
+    void setSolutionDescriptor(SolutionDescriptor<Solution_> descriptor);
+}

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -57,6 +57,7 @@ import ai.timefold.solver.core.impl.domain.lookup.LookUpStrategyResolver;
 import ai.timefold.solver.core.impl.domain.policy.DescriptorPolicy;
 import ai.timefold.solver.core.impl.domain.score.descriptor.ScoreDescriptor;
 import ai.timefold.solver.core.impl.domain.solution.cloner.FieldAccessingSolutionCloner;
+import ai.timefold.solver.core.impl.domain.solution.cloner.gizmo.GizmoSolutionCloner;
 import ai.timefold.solver.core.impl.domain.solution.cloner.gizmo.GizmoSolutionClonerFactory;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
@@ -613,6 +614,10 @@ public class SolutionDescriptor<Solution_> {
         solutionCloner = solutionCloner == null ? descriptorPolicy.getGeneratedSolutionClonerMap()
                 .get(GizmoSolutionClonerFactory.getGeneratedClassName(this))
                 : solutionCloner;
+
+        if (solutionCloner instanceof GizmoSolutionCloner<Solution_> gizmoSolutionCloner) {
+            gizmoSolutionCloner.setSolutionDescriptor(this);
+        }
         if (solutionCloner == null) {
             switch (descriptorPolicy.getDomainAccessType()) {
                 case GIZMO:

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -1099,7 +1099,7 @@ public abstract class AbstractSolutionClonerTest {
     @Test
     void cloneExtendedShadowEntities() {
         var solutionDescriptor = SolutionDescriptor.buildSolutionDescriptor(TestdataExtendedShadowSolution.class,
-                        TestdataExtendedShadowEntity.class, TestdataExtendedShadowShadowEntity.class);
+                TestdataExtendedShadowEntity.class, TestdataExtendedShadowShadowEntity.class);
         var cloner = createSolutionCloner(solutionDescriptor);
 
         var entity0 = new TestdataExtendedShadowEntity(0);
@@ -1111,9 +1111,12 @@ public abstract class AbstractSolutionClonerTest {
 
         assertThat(clone.shadowEntityList)
                 .hasSize(1)
-                .isNotEqualTo(original.shadowEntityList)
+                .isNotSameAs(original.shadowEntityList)
                 .first()
                 .isNotNull();
+
+        assertThat(clone.shadowEntityList.get(0))
+                .isNotSameAs(original.shadowEntityList.get(0));
     }
 
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -51,6 +51,11 @@ import ai.timefold.solver.core.impl.testdata.domain.extended.TestdataUnannotated
 import ai.timefold.solver.core.impl.testdata.domain.extended.thirdparty.TestdataExtendedThirdPartyEntity;
 import ai.timefold.solver.core.impl.testdata.domain.extended.thirdparty.TestdataExtendedThirdPartySolution;
 import ai.timefold.solver.core.impl.testdata.domain.extended.thirdparty.TestdataThirdPartyEntityPojo;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowEntity;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowExtendedShadowEntity;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowShadowEntity;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowSolution;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowVariable;
 import ai.timefold.solver.core.impl.testdata.domain.list.externalized.TestdataListEntityExternalized;
 import ai.timefold.solver.core.impl.testdata.domain.list.externalized.TestdataListSolutionExternalized;
 import ai.timefold.solver.core.impl.testdata.domain.list.externalized.TestdataListValueExternalized;
@@ -1089,6 +1094,26 @@ public abstract class AbstractSolutionClonerTest {
             }
         }
 
+    }
+
+    @Test
+    void cloneExtendedShadowEntities() {
+        var solutionDescriptor = SolutionDescriptor.buildSolutionDescriptor(TestdataExtendedShadowSolution.class,
+                        TestdataExtendedShadowEntity.class, TestdataExtendedShadowShadowEntity.class);
+        var cloner = createSolutionCloner(solutionDescriptor);
+
+        var entity0 = new TestdataExtendedShadowEntity(0);
+        entity0.myPlanningVariable = new TestdataExtendedShadowVariable(0);
+        var shadowEntity = new TestdataExtendedShadowExtendedShadowEntity(entity0);
+
+        var original = new TestdataExtendedShadowSolution(shadowEntity);
+        var clone = cloner.cloneSolution(original);
+
+        assertThat(clone.shadowEntityList)
+                .hasSize(1)
+                .isNotEqualTo(original.shadowEntityList)
+                .first()
+                .isNotNull();
     }
 
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerTest.java
@@ -52,7 +52,7 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
                 GizmoSolutionClonerImplementor.createClassOutputWithDebuggingCapability(classBytecodeHolder);
         ClassCreator classCreator = ClassCreator.builder()
                 .className(className)
-                .interfaces(SolutionCloner.class)
+                .interfaces(GizmoSolutionCloner.class)
                 .superClass(Object.class)
                 .classOutput(classOutput)
                 .setFinal(true)
@@ -94,7 +94,11 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
         };
 
         try {
-            return (SolutionCloner<Solution_>) gizmoClassLoader.loadClass(className).getConstructor().newInstance();
+            @SuppressWarnings("unchecked")
+            GizmoSolutionCloner<Solution_> solutionCloner =
+                    (GizmoSolutionCloner<Solution_>) gizmoClassLoader.loadClass(className).getConstructor().newInstance();
+            solutionCloner.setSolutionDescriptor(solutionDescriptor);
+            return solutionCloner;
         } catch (Exception e) {
             throw new IllegalStateException("Failed creating generated Gizmo Class (" + className + ").", e);
         }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowEntity.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowEntity.java
@@ -1,0 +1,21 @@
+package ai.timefold.solver.core.impl.testdata.domain.extendedshadow;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class TestdataExtendedShadowEntity {
+
+    public int desiredId;
+
+    @PlanningVariable(nullable = true)
+    public TestdataExtendedShadowVariable myPlanningVariable;
+
+    public TestdataExtendedShadowEntity() {
+    }
+
+    public TestdataExtendedShadowEntity(int desiredId) {
+        this.desiredId = desiredId;
+    }
+
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowExtendedShadowEntity.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowExtendedShadowEntity.java
@@ -1,0 +1,14 @@
+package ai.timefold.solver.core.impl.testdata.domain.extendedshadow;
+
+public class TestdataExtendedShadowExtendedShadowEntity extends TestdataExtendedShadowShadowEntity {
+
+    public TestdataExtendedShadowExtendedShadowEntity() {
+        super();
+    }
+
+    public TestdataExtendedShadowExtendedShadowEntity(TestdataExtendedShadowEntity myPlanningEntity) {
+        super();
+        this.planningEntityList.add(myPlanningEntity);
+    }
+
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowShadowEntity.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowShadowEntity.java
@@ -8,7 +8,6 @@ import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
 
 @PlanningEntity
 public abstract class TestdataExtendedShadowShadowEntity {
-
     @ShadowVariable(
             variableListenerClass = TestdataExtendedShadowVariableListener.class,
             sourceVariableName = "myPlanningVariable",

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowShadowEntity.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowShadowEntity.java
@@ -1,0 +1,25 @@
+package ai.timefold.solver.core.impl.testdata.domain.extendedshadow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+
+@PlanningEntity
+public abstract class TestdataExtendedShadowShadowEntity {
+
+    @ShadowVariable(
+            variableListenerClass = TestdataExtendedShadowVariableListener.class,
+            sourceVariableName = "myPlanningVariable",
+            sourceEntityClass = TestdataExtendedShadowEntity.class)
+    public List<TestdataExtendedShadowEntity> planningEntityList = new ArrayList<>();
+
+    protected TestdataExtendedShadowShadowEntity() {
+    }
+
+    protected TestdataExtendedShadowShadowEntity(List<TestdataExtendedShadowEntity> planningEntityList) {
+        this.planningEntityList = planningEntityList;
+    }
+
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowSolution.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowSolution.java
@@ -1,0 +1,34 @@
+package ai.timefold.solver.core.impl.testdata.domain.extendedshadow;
+
+import java.util.Collections;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataExtendedShadowSolution {
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataExtendedShadowShadowEntity> shadowEntityList;
+
+    @ValueRangeProvider
+    @ProblemFactCollectionProperty
+    public List<TestdataExtendedShadowVariable> planningVariableList;
+
+    @PlanningScore
+    public SimpleScore score;
+
+    public TestdataExtendedShadowSolution() {
+    }
+
+    public TestdataExtendedShadowSolution(TestdataExtendedShadowShadowEntity shadowShadowEntity) {
+        this.shadowEntityList = Collections.singletonList(shadowShadowEntity);
+        this.planningVariableList = Collections.emptyList();
+    }
+
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowSolution.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowSolution.java
@@ -4,21 +4,31 @@ import java.util.Collections;
 import java.util.List;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityProperty;
 import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 
 @PlanningSolution
 public class TestdataExtendedShadowSolution {
-
     @PlanningEntityCollectionProperty
     public List<TestdataExtendedShadowShadowEntity> shadowEntityList;
 
     @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<TestdataExtendedShadowVariable> planningVariableList;
+
+    // Exists so Quarkus does not return the original solution because there are no planning variables
+    @PlanningEntityProperty
+    public TestdataEntity testdataEntity;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> testdataValueList;
 
     @PlanningScore
     public SimpleScore score;
@@ -27,6 +37,8 @@ public class TestdataExtendedShadowSolution {
     }
 
     public TestdataExtendedShadowSolution(TestdataExtendedShadowShadowEntity shadowShadowEntity) {
+        this.testdataEntity = new TestdataEntity("Entity 1");
+        this.testdataValueList = List.of(new TestdataValue("Value 1"));
         this.shadowEntityList = Collections.singletonList(shadowShadowEntity);
         this.planningVariableList = Collections.emptyList();
     }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowVariable.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowVariable.java
@@ -1,0 +1,10 @@
+package ai.timefold.solver.core.impl.testdata.domain.extendedshadow;
+
+public class TestdataExtendedShadowVariable {
+
+    public int id;
+
+    public TestdataExtendedShadowVariable(int id) {
+        this.id = id;
+    }
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowVariableListener.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/extendedshadow/TestdataExtendedShadowVariableListener.java
@@ -1,0 +1,38 @@
+package ai.timefold.solver.core.impl.testdata.domain.extendedshadow;
+
+import ai.timefold.solver.core.api.domain.variable.VariableListener;
+import ai.timefold.solver.core.api.score.director.ScoreDirector;
+
+public class TestdataExtendedShadowVariableListener
+        implements VariableListener<TestdataExtendedShadowSolution, TestdataExtendedShadowEntity> {
+
+    @Override
+    public void beforeEntityAdded(ScoreDirector<TestdataExtendedShadowSolution> scoreDirector,
+            TestdataExtendedShadowEntity entity) {
+    }
+
+    @Override
+    public void afterEntityAdded(ScoreDirector<TestdataExtendedShadowSolution> scoreDirector,
+            TestdataExtendedShadowEntity entity) {
+    }
+
+    @Override
+    public void beforeEntityRemoved(ScoreDirector<TestdataExtendedShadowSolution> scoreDirector,
+            TestdataExtendedShadowEntity entity) {
+    }
+
+    @Override
+    public void afterEntityRemoved(ScoreDirector<TestdataExtendedShadowSolution> scoreDirector,
+            TestdataExtendedShadowEntity entity) {
+    }
+
+    @Override
+    public void beforeVariableChanged(ScoreDirector<TestdataExtendedShadowSolution> scoreDirector,
+            TestdataExtendedShadowEntity entity) {
+    }
+
+    @Override
+    public void afterVariableChanged(ScoreDirector<TestdataExtendedShadowSolution> scoreDirector,
+            TestdataExtendedShadowEntity entity) {
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -36,6 +36,7 @@ import ai.timefold.solver.core.impl.domain.common.accessor.gizmo.GizmoMemberAcce
 import ai.timefold.solver.core.impl.domain.common.accessor.gizmo.GizmoMemberDescriptor;
 import ai.timefold.solver.core.impl.domain.common.accessor.gizmo.GizmoMemberInfo;
 import ai.timefold.solver.core.impl.domain.solution.cloner.gizmo.GizmoCloningUtils;
+import ai.timefold.solver.core.impl.domain.solution.cloner.gizmo.GizmoSolutionCloner;
 import ai.timefold.solver.core.impl.domain.solution.cloner.gizmo.GizmoSolutionClonerFactory;
 import ai.timefold.solver.core.impl.domain.solution.cloner.gizmo.GizmoSolutionClonerImplementor;
 import ai.timefold.solver.core.impl.domain.solution.cloner.gizmo.GizmoSolutionOrEntityDescriptor;
@@ -211,7 +212,7 @@ final class GizmoMemberAccessorEntityEnhancer {
         try (ClassCreator classCreator = ClassCreator
                 .builder()
                 .className(generatedClassName)
-                .interfaces(SolutionCloner.class)
+                .interfaces(GizmoSolutionCloner.class)
                 .classOutput(classOutput)
                 .setFinal(true)
                 .build()) {

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorExtendedShadowSolutionSolveTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorExtendedShadowSolutionSolveTest.java
@@ -1,0 +1,69 @@
+package ai.timefold.solver.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.concurrent.ExecutionException;
+
+import jakarta.inject.Inject;
+
+import ai.timefold.solver.core.api.score.ScoreManager;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
+import ai.timefold.solver.core.api.solver.SolverFactory;
+import ai.timefold.solver.core.api.solver.SolverJob;
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataObject;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowEntity;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowExtendedShadowEntity;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowShadowEntity;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowSolution;
+import ai.timefold.solver.quarkus.testdata.extended.TestdataExtendedShadowSolutionConstraintProvider;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldProcessorExtendedShadowSolutionSolveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataExtendedShadowSolution.class,
+                            TestdataExtendedShadowEntity.class,
+                            TestdataExtendedShadowShadowEntity.class,
+                            TestdataEntity.class,
+                            TestdataObject.class,
+                            TestdataValue.class,
+                            TestdataExtendedShadowSolutionConstraintProvider.class));
+
+    @Inject
+    SolverFactory<TestdataExtendedShadowSolution> solverFactory;
+    @Inject
+    SolverManager<TestdataExtendedShadowSolution, Long> solverManager;
+    @Inject
+    ScoreManager<TestdataExtendedShadowSolution, SimpleScore> scoreManager;
+    @Inject
+    SolutionManager<TestdataExtendedShadowSolution, SimpleScore> solutionManager;
+
+    @Test
+    void solve() throws ExecutionException, InterruptedException {
+        TestdataExtendedShadowShadowEntity shadowEntity =
+                new TestdataExtendedShadowExtendedShadowEntity();
+        TestdataExtendedShadowSolution problem = new TestdataExtendedShadowSolution(shadowEntity);
+        SolverJob<TestdataExtendedShadowSolution, Long> solverJob = solverManager.solve(1L, problem);
+        TestdataExtendedShadowSolution solution = solverJob.getFinalBestSolution();
+        assertNotNull(solution);
+        assertNotSame(solution, problem);
+        assertEquals(0, solution.score.score());
+        assertNotSame(solution.shadowEntityList.get(0), problem.shadowEntityList.get(0));
+    }
+
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/extended/TestdataExtendedShadowSolutionConstraintProvider.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/extended/TestdataExtendedShadowSolutionConstraintProvider.java
@@ -1,0 +1,19 @@
+package ai.timefold.solver.quarkus.testdata.extended;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.impl.testdata.domain.extendedshadow.TestdataExtendedShadowEntity;
+
+public class TestdataExtendedShadowSolutionConstraintProvider implements ConstraintProvider {
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
+        return new Constraint[] {
+                constraintFactory.forEach(TestdataExtendedShadowEntity.class)
+                        .filter(e -> e.myPlanningVariable.id != e.desiredId)
+                        .penalize(SimpleScore.ONE)
+                        .asConstraint("Variable does not match desired id")
+        };
+    }
+}


### PR DESCRIPTION
If a deep cloned class that is not accessible from the SolutionDescriptor (for instance, a class that extends a @PlanningEntity but adds no new variables) is inside the solution, it would incorrectly be shallowly cloned. The GIZMO solution cloner will now fall back to the reflection solution cloner if it encounters an unknown class.
