### PR TITLE
perf: Implement node sharing for ifExists, expand, map, groupby

### DIFF
--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetAbstractBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetAbstractBiConstraintStream.java
@@ -47,6 +47,7 @@ import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintStream;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintStream;
 import ai.timefold.solver.core.api.score.stream.tri.TriJoiner;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintStream;
+import ai.timefold.solver.core.impl.util.ConstantLambdaUtils;
 
 public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends BavetAbstractConstraintStream<Solution_>
         implements InnerBiConstraintStream<A, B> {
@@ -168,7 +169,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         GroupNodeConstructor<UniTuple<Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping1CollectorBiNode<>(groupStoreIndex, undoStoreIndex, collector,
-                                tupleLifecycle, outputStoreSize, environmentMode));
+                                tupleLifecycle, outputStoreSize, environmentMode),
+                        collector);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -185,7 +187,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         GroupNodeConstructor<BiTuple<ResultA_, ResultB_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping2CollectorBiNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA, collectorB);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -204,7 +207,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         GroupNodeConstructor<TriTuple<ResultA_, ResultB_, ResultC_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping3CollectorBiNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA, collectorB, collectorC);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -225,7 +229,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         GroupNodeConstructor<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping4CollectorBiNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA, collectorB, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -240,7 +245,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(BiFunction<A, B, GroupKey_> groupKeyMapping) {
         GroupNodeConstructor<UniTuple<GroupKey_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group1Mapping0CollectorBiNode<>(
-                        groupKeyMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode));
+                        groupKeyMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -252,7 +258,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         GroupNodeConstructor<TriTuple<GroupKey_, ResultB_, ResultC_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping2CollectorBiNode<>(groupKeyMapping, groupStoreIndex,
-                                undoStoreIndex, collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode));
+                                undoStoreIndex, collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping, collectorB, collectorC);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -267,7 +274,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping3CollectorBiNode<>(groupKeyMapping, groupStoreIndex,
                                 undoStoreIndex, collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyMapping, collectorB, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -278,7 +286,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         GroupNodeConstructor<BiTuple<GroupKey_, Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping1CollectorBiNode<>(groupKeyMapping, groupStoreIndex,
-                                undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode));
+                                undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping, collector);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -287,7 +296,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
             BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping) {
         GroupNodeConstructor<BiTuple<GroupKeyA_, GroupKeyB_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group2Mapping0CollectorBiNode<>(
-                        groupKeyAMapping, groupKeyBMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode));
+                        groupKeyAMapping, groupKeyBMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -298,7 +308,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group2Mapping1CollectorBiNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupStoreIndex, undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode));
+                                groupStoreIndex, undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, collector);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -312,7 +323,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group2Mapping2CollectorBiNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupStoreIndex, undoStoreIndex, collectorC, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -323,7 +335,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group3Mapping0CollectorBiNode<>(
                         groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupStoreIndex, tupleLifecycle, outputStoreSize,
-                        environmentMode));
+                        environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -337,7 +350,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group3Mapping1CollectorBiNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupKeyCMapping, groupStoreIndex, undoStoreIndex, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -348,7 +362,8 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         GroupNodeConstructor<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group4Mapping0CollectorBiNode<>(
                         groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupKeyDMapping, groupStoreIndex, tupleLifecycle,
-                        outputStoreSize, environmentMode));
+                        outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupKeyDMapping);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -357,11 +372,13 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
     // ************************************************************************
 
     @Override
+    @SuppressWarnings("unchecked")
     public BiConstraintStream<A, B> distinct() {
         if (guaranteesDistinct()) {
             return this;
         } else {
-            return groupBy((a, b) -> a, (a, b) -> b);
+            return groupBy((BiFunction<A, B, A>) ConstantLambdaUtils.BI_PICK_FIRST,
+                    (BiFunction<A, B, B>) ConstantLambdaUtils.BI_PICK_SECOND);
         }
     }
 
@@ -462,8 +479,11 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
 
     @Override
     public <ResultC_> TriConstraintStream<A, B, ResultC_> expand(BiFunction<A, B, ResultC_> mapping) {
+        @SuppressWarnings("unchecked")
         var stream = shareAndAddChild(
-                new BavetTriMapBiConstraintStream<>(constraintFactory, this, (a, b) -> a, (a, b) -> b, mapping, true));
+                new BavetTriMapBiConstraintStream<>(constraintFactory, this,
+                        (BiFunction<A, B, A>) ConstantLambdaUtils.BI_PICK_FIRST,
+                        (BiFunction<A, B, B>) ConstantLambdaUtils.BI_PICK_SECOND, mapping, true));
         return constraintFactory.share(new BavetAftBridgeTriConstraintStream<>(constraintFactory, stream),
                 stream::setAftBridge);
     }
@@ -471,8 +491,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
     @Override
     public <ResultC_, ResultD_> QuadConstraintStream<A, B, ResultC_, ResultD_> expand(BiFunction<A, B, ResultC_> mappingC,
             BiFunction<A, B, ResultD_> mappingD) {
-        var stream = shareAndAddChild(new BavetQuadMapBiConstraintStream<>(constraintFactory, this, (a, b) -> a,
-                (a, b) -> b, mappingC, mappingD, true));
+        @SuppressWarnings("unchecked")
+        var stream = shareAndAddChild(new BavetQuadMapBiConstraintStream<>(constraintFactory, this,
+                (BiFunction<A, B, A>) ConstantLambdaUtils.BI_PICK_FIRST,
+                (BiFunction<A, B, B>) ConstantLambdaUtils.BI_PICK_SECOND, mappingC, mappingD, true));
         return constraintFactory.share(new BavetAftBridgeQuadConstraintStream<>(constraintFactory, stream),
                 stream::setAftBridge);
     }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetBiGroupBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetBiGroupBiConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,26 @@ final class BavetBiGroupBiConstraintStream<Solution_, A, B, NewA, NewB>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetBiGroupBiConstraintStream<?, ?, ?, ?, ?> that = (BavetBiGroupBiConstraintStream<?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetBiMapBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetBiMapBiConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -49,7 +50,22 @@ final class BavetBiMapBiConstraintStream<Solution_, A, B, NewA, NewB>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetBiMapBiConstraintStream<?, ?, ?, ?, ?> that = (BavetBiMapBiConstraintStream<?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunctionA, that.mappingFunctionA) && Objects.equals(
+                mappingFunctionB,
+                that.mappingFunctionB);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetFlattenLastBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetFlattenLastBiConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -51,7 +52,20 @@ final class BavetFlattenLastBiConstraintStream<Solution_, A, B, NewB>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetFlattenLastBiConstraintStream<?, ?, ?, ?> that = (BavetFlattenLastBiConstraintStream<?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunction, that.mappingFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunction);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetIfExistsBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetIfExistsBiConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
+import java.util.Objects;
 import java.util.Set;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -98,7 +99,31 @@ final class BavetIfExistsBiConstraintStream<Solution_, A, B, C>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetIfExistsBiConstraintStream<?, ?, ?, ?> that = (BavetIfExistsBiConstraintStream<?, ?, ?, ?>) object;
+        /*
+         * Bridge streams do not implement equality because their equals() would have to point back to this stream,
+         * resulting in StackOverflowError.
+         * Therefore we need to check bridge parents to see where this ifExists node comes from.
+         */
+        return shouldExist == that.shouldExist && Objects.equals(parentAB,
+                that.parentAB) && Objects.equals(
+                        parentBridgeC.getParent(), that.parentBridgeC.getParent())
+                && Objects.equals(joiner,
+                        that.joiner)
+                && Objects.equals(
+                        filtering, that.filtering);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parentAB, parentBridgeC.getParent(), shouldExist, joiner, filtering);
+    }
 
     @Override
     public String toString() {

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetQuadGroupBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetQuadGroupBiConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,27 @@ final class BavetQuadGroupBiConstraintStream<Solution_, A, B, NewA, NewB, NewC, 
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetQuadGroupBiConstraintStream<?, ?, ?, ?, ?, ?, ?> that =
+                (BavetQuadGroupBiConstraintStream<?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetQuadMapBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetQuadMapBiConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -58,7 +59,26 @@ final class BavetQuadMapBiConstraintStream<Solution_, A, B, NewA, NewB, NewC, Ne
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetQuadMapBiConstraintStream<?, ?, ?, ?, ?, ?, ?> that = (BavetQuadMapBiConstraintStream<?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && guaranteesDistinct == that.guaranteesDistinct && Objects.equals(
+                mappingFunctionA,
+                that.mappingFunctionA) && Objects.equals(mappingFunctionB,
+                        that.mappingFunctionB)
+                && Objects.equals(mappingFunctionC,
+                        that.mappingFunctionC)
+                && Objects.equals(mappingFunctionD, that.mappingFunctionD);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB, mappingFunctionC, mappingFunctionD, guaranteesDistinct);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetTriGroupBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetTriGroupBiConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,26 @@ final class BavetTriGroupBiConstraintStream<Solution_, A, B, NewA, NewB, NewC>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetTriGroupBiConstraintStream<?, ?, ?, ?, ?, ?> that = (BavetTriGroupBiConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetTriMapBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetTriMapBiConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -54,7 +55,24 @@ final class BavetTriMapBiConstraintStream<Solution_, A, B, NewA, NewB, NewC>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetTriMapBiConstraintStream<?, ?, ?, ?, ?, ?> that = (BavetTriMapBiConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && guaranteesDistinct == that.guaranteesDistinct && Objects.equals(
+                mappingFunctionA,
+                that.mappingFunctionA) && Objects.equals(mappingFunctionB,
+                        that.mappingFunctionB)
+                && Objects.equals(mappingFunctionC, that.mappingFunctionC);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB, mappingFunctionC, guaranteesDistinct);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetUniGroupBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetUniGroupBiConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,26 @@ final class BavetUniGroupBiConstraintStream<Solution_, A, B, NewA>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetUniGroupBiConstraintStream<?, ?, ?, ?> that = (BavetUniGroupBiConstraintStream<?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetUniMapBiConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/bi/BavetUniMapBiConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.bi;
 
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -46,7 +47,20 @@ final class BavetUniMapBiConstraintStream<Solution_, A, B, NewA>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetUniMapBiConstraintStream<?, ?, ?, ?> that = (BavetUniMapBiConstraintStream<?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunction, that.mappingFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunction);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/GroupNodeConstructor.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/GroupNodeConstructor.java
@@ -11,13 +11,13 @@ import ai.timefold.solver.core.config.solver.EnvironmentMode;
 public interface GroupNodeConstructor<Tuple_ extends AbstractTuple> {
 
     static <Tuple_ extends AbstractTuple> GroupNodeConstructor<Tuple_>
-            of(NodeConstructorWithAccumulate<Tuple_> nodeConstructorWithAccumulate) {
-        return new GroupNodeConstructorWithAccumulate<>(nodeConstructorWithAccumulate);
+            of(NodeConstructorWithAccumulate<Tuple_> nodeConstructorWithAccumulate, Object... equalityArgs) {
+        return new GroupNodeConstructorWithAccumulate<>(nodeConstructorWithAccumulate, equalityArgs);
     }
 
     static <Tuple_ extends AbstractTuple> GroupNodeConstructor<Tuple_>
-            of(NodeConstructorWithoutAccumulate<Tuple_> nodeConstructorWithoutAccumulate) {
-        return new GroupNodeConstructorWithoutAccumulate<>(nodeConstructorWithoutAccumulate);
+            of(NodeConstructorWithoutAccumulate<Tuple_> nodeConstructorWithoutAccumulate, Object... equalityArgs) {
+        return new GroupNodeConstructorWithoutAccumulate<>(nodeConstructorWithoutAccumulate, equalityArgs);
     }
 
     @FunctionalInterface

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/GroupNodeConstructorWithAccumulate.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/GroupNodeConstructorWithAccumulate.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.common;
 
+import java.util.Arrays;
 import java.util.List;
 
 import ai.timefold.solver.constraint.streams.bavet.common.tuple.AbstractTuple;
@@ -11,9 +12,12 @@ import ai.timefold.solver.core.config.solver.EnvironmentMode;
 final class GroupNodeConstructorWithAccumulate<Tuple_ extends AbstractTuple> implements GroupNodeConstructor<Tuple_> {
 
     private final NodeConstructorWithAccumulate<Tuple_> nodeConstructorFunction;
+    private final Object[] equalityArgs;
 
-    public GroupNodeConstructorWithAccumulate(NodeConstructorWithAccumulate<Tuple_> nodeConstructorFunction) {
+    public GroupNodeConstructorWithAccumulate(NodeConstructorWithAccumulate<Tuple_> nodeConstructorFunction,
+            Object... equalityArgs) {
         this.nodeConstructorFunction = nodeConstructorFunction;
+        this.equalityArgs = equalityArgs;
     }
 
     @Override
@@ -33,5 +37,24 @@ final class GroupNodeConstructorWithAccumulate<Tuple_ extends AbstractTuple> imp
         var node = nodeConstructorFunction.apply(groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                 environmentMode);
         buildHelper.addNode(node, bridgeStream);
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        GroupNodeConstructorWithAccumulate<?> that = (GroupNodeConstructorWithAccumulate<?>) object;
+        return Arrays.equals(equalityArgs, that.equalityArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(equalityArgs);
     }
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/GroupNodeConstructorWithoutAccumulate.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/GroupNodeConstructorWithoutAccumulate.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.common;
 
+import java.util.Arrays;
 import java.util.List;
 
 import ai.timefold.solver.constraint.streams.bavet.common.tuple.AbstractTuple;
@@ -11,9 +12,12 @@ import ai.timefold.solver.core.config.solver.EnvironmentMode;
 final class GroupNodeConstructorWithoutAccumulate<Tuple_ extends AbstractTuple> implements GroupNodeConstructor<Tuple_> {
 
     private final NodeConstructorWithoutAccumulate<Tuple_> nodeConstructorFunction;
+    private final Object[] equalityArgs;
 
-    public GroupNodeConstructorWithoutAccumulate(NodeConstructorWithoutAccumulate<Tuple_> nodeConstructorFunction) {
+    public GroupNodeConstructorWithoutAccumulate(NodeConstructorWithoutAccumulate<Tuple_> nodeConstructorFunction,
+            Object... equalityArgs) {
         this.nodeConstructorFunction = nodeConstructorFunction;
+        this.equalityArgs = equalityArgs;
     }
 
     @Override
@@ -31,5 +35,24 @@ final class GroupNodeConstructorWithoutAccumulate<Tuple_ extends AbstractTuple> 
         int outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
         var node = nodeConstructorFunction.apply(groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode);
         buildHelper.addNode(node, bridgeStream);
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        GroupNodeConstructorWithoutAccumulate<?> that = (GroupNodeConstructorWithoutAccumulate<?>) object;
+        return Arrays.equals(equalityArgs, that.equalityArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(equalityArgs);
     }
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetAbstractQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetAbstractQuadConstraintStream.java
@@ -44,6 +44,7 @@ import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintStream;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintStream;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintStream;
+import ai.timefold.solver.core.impl.util.ConstantLambdaUtils;
 
 public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         extends BavetAbstractConstraintStream<Solution_>
@@ -149,7 +150,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         GroupNodeConstructor<UniTuple<Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping1CollectorQuadNode<>(groupStoreIndex, undoStoreIndex, collector,
-                                tupleLifecycle, outputStoreSize, environmentMode));
+                                tupleLifecycle, outputStoreSize, environmentMode),
+                        collector);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -166,7 +168,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         GroupNodeConstructor<BiTuple<ResultA_, ResultB_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping2CollectorQuadNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA, collectorB);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -185,7 +188,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         GroupNodeConstructor<TriTuple<ResultA_, ResultB_, ResultC_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping3CollectorQuadNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA, collectorB, collectorC);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -206,7 +210,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         GroupNodeConstructor<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping4CollectorQuadNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA, collectorB, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -221,7 +226,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping) {
         GroupNodeConstructor<UniTuple<GroupKey_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group1Mapping0CollectorQuadNode<>(
-                        groupKeyMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode));
+                        groupKeyMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -233,7 +239,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         GroupNodeConstructor<TriTuple<GroupKey_, ResultB_, ResultC_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping2CollectorQuadNode<>(groupKeyMapping, groupStoreIndex,
-                                undoStoreIndex, collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode));
+                                undoStoreIndex, collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping, collectorB, collectorC);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -248,7 +255,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping3CollectorQuadNode<>(groupKeyMapping, groupStoreIndex,
                                 undoStoreIndex, collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyMapping, collectorB, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -259,7 +267,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         GroupNodeConstructor<BiTuple<GroupKey_, Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping1CollectorQuadNode<>(groupKeyMapping, groupStoreIndex,
-                                undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode));
+                                undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping, collector);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -269,7 +278,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
             QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping) {
         GroupNodeConstructor<BiTuple<GroupKeyA_, GroupKeyB_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group2Mapping0CollectorQuadNode<>(
-                        groupKeyAMapping, groupKeyBMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode));
+                        groupKeyAMapping, groupKeyBMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -281,7 +291,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group2Mapping1CollectorQuadNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupStoreIndex, undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode));
+                                groupStoreIndex, undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, collector);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -296,7 +307,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group2Mapping2CollectorQuadNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupStoreIndex, undoStoreIndex, collectorC, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -307,7 +319,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group3Mapping0CollectorQuadNode<>(
                         groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupStoreIndex, tupleLifecycle, outputStoreSize,
-                        environmentMode));
+                        environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -322,7 +335,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group3Mapping1CollectorQuadNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupKeyCMapping, groupStoreIndex, undoStoreIndex, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -335,7 +349,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         GroupNodeConstructor<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group4Mapping0CollectorQuadNode<>(
                         groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupKeyDMapping, groupStoreIndex, tupleLifecycle,
-                        outputStoreSize, environmentMode));
+                        outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupKeyDMapping);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -344,11 +359,15 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     // ************************************************************************
 
     @Override
+    @SuppressWarnings("unchecked")
     public QuadConstraintStream<A, B, C, D> distinct() {
         if (guaranteesDistinct()) {
             return this;
         } else {
-            return groupBy((a, b, c, d) -> a, (a, b, c, d) -> b, (a, b, c, d) -> c, (a, b, c, d) -> d);
+            return groupBy((QuadFunction<A, B, C, D, A>) ConstantLambdaUtils.QUAD_PICK_FIRST,
+                    (QuadFunction<A, B, C, D, B>) ConstantLambdaUtils.QUAD_PICK_SECOND,
+                    (QuadFunction<A, B, C, D, C>) ConstantLambdaUtils.QUAD_PICK_THIRD,
+                    (QuadFunction<A, B, C, D, D>) ConstantLambdaUtils.QUAD_PICK_FOURTH);
         }
     }
 

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetBiGroupQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetBiGroupQuadConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,27 @@ final class BavetBiGroupQuadConstraintStream<Solution_, A, B, C, D, NewA, NewB>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetBiGroupQuadConstraintStream<?, ?, ?, ?, ?, ?, ?> that =
+                (BavetBiGroupQuadConstraintStream<?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetBiMapQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetBiMapQuadConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
+import java.util.Objects;
+
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.NodeBuildHelper;
 import ai.timefold.solver.constraint.streams.bavet.common.bridge.BavetAftBridgeBiConstraintStream;
@@ -48,7 +50,22 @@ final class BavetBiMapQuadConstraintStream<Solution_, A, B, C, D, NewA, NewB>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetBiMapQuadConstraintStream<?, ?, ?, ?, ?, ?, ?> that = (BavetBiMapQuadConstraintStream<?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunctionA, that.mappingFunctionA) && Objects.equals(
+                mappingFunctionB,
+                that.mappingFunctionB);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetFlattenLastQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetFlattenLastQuadConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -48,7 +49,21 @@ final class BavetFlattenLastQuadConstraintStream<Solution_, A, B, C, D, NewD>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetFlattenLastQuadConstraintStream<?, ?, ?, ?, ?, ?> that =
+                (BavetFlattenLastQuadConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunction, that.mappingFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunction);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetIfExistsQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetIfExistsQuadConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
+import java.util.Objects;
 import java.util.Set;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -98,7 +99,31 @@ final class BavetIfExistsQuadConstraintStream<Solution_, A, B, C, D, E>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetIfExistsQuadConstraintStream<?, ?, ?, ?, ?, ?> that = (BavetIfExistsQuadConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        /*
+         * Bridge streams do not implement equality because their equals() would have to point back to this stream,
+         * resulting in StackOverflowError.
+         * Therefore we need to check bridge parents to see where this ifExists node comes from.
+         */
+        return shouldExist == that.shouldExist && Objects.equals(parentABCD,
+                that.parentABCD) && Objects.equals(
+                        parentBridgeE.getParent(), that.parentBridgeE.getParent())
+                && Objects.equals(joiner,
+                        that.joiner)
+                && Objects.equals(
+                        filtering, that.filtering);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parentABCD, parentBridgeE.getParent(), shouldExist, joiner, filtering);
+    }
 
     @Override
     public String toString() {

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetQuadGroupQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetQuadGroupQuadConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,27 @@ final class BavetQuadGroupQuadConstraintStream<Solution_, A, B, C, D, NewA, NewB
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetQuadGroupQuadConstraintStream<?, ?, ?, ?, ?, ?, ?, ?, ?> that =
+                (BavetQuadGroupQuadConstraintStream<?, ?, ?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetQuadMapQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetQuadMapQuadConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
+import java.util.Objects;
+
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.NodeBuildHelper;
 import ai.timefold.solver.constraint.streams.bavet.common.bridge.BavetAftBridgeQuadConstraintStream;
@@ -54,7 +56,26 @@ final class BavetQuadMapQuadConstraintStream<Solution_, A, B, C, D, NewA, NewB, 
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetQuadMapQuadConstraintStream<?, ?, ?, ?, ?, ?, ?, ?, ?> that =
+                (BavetQuadMapQuadConstraintStream<?, ?, ?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunctionA, that.mappingFunctionA) && Objects.equals(
+                mappingFunctionB,
+                that.mappingFunctionB)
+                && Objects.equals(mappingFunctionC,
+                        that.mappingFunctionC)
+                && Objects.equals(mappingFunctionD, that.mappingFunctionD);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB, mappingFunctionC, mappingFunctionD);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetTriGroupQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetTriGroupQuadConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,27 @@ final class BavetTriGroupQuadConstraintStream<Solution_, A, B, C, D, NewA, NewB,
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetTriGroupQuadConstraintStream<?, ?, ?, ?, ?, ?, ?, ?> that =
+                (BavetTriGroupQuadConstraintStream<?, ?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetTriMapQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetTriMapQuadConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
+import java.util.Objects;
+
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.NodeBuildHelper;
 import ai.timefold.solver.constraint.streams.bavet.common.bridge.BavetAftBridgeTriConstraintStream;
@@ -50,7 +52,23 @@ final class BavetTriMapQuadConstraintStream<Solution_, A, B, C, D, NewA, NewB, N
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetTriMapQuadConstraintStream<?, ?, ?, ?, ?, ?, ?, ?> that =
+                (BavetTriMapQuadConstraintStream<?, ?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunctionA, that.mappingFunctionA) && Objects.equals(
+                mappingFunctionB,
+                that.mappingFunctionB) && Objects.equals(mappingFunctionC, that.mappingFunctionC);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB, mappingFunctionC);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetUniGroupQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetUniGroupQuadConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,26 @@ final class BavetUniGroupQuadConstraintStream<Solution_, A, B, C, D, NewA>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetUniGroupQuadConstraintStream<?, ?, ?, ?, ?, ?> that = (BavetUniGroupQuadConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetUniMapQuadConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/quad/BavetUniMapQuadConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.quad;
 
+import java.util.Objects;
+
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.NodeBuildHelper;
 import ai.timefold.solver.constraint.streams.bavet.common.bridge.BavetAftBridgeUniConstraintStream;
@@ -45,7 +47,20 @@ final class BavetUniMapQuadConstraintStream<Solution_, A, B, C, D, NewA>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetUniMapQuadConstraintStream<?, ?, ?, ?, ?, ?> that = (BavetUniMapQuadConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunction, that.mappingFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunction);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetAbstractTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetAbstractTriConstraintStream.java
@@ -46,6 +46,7 @@ import ai.timefold.solver.core.api.score.stream.tri.TriConstraintBuilder;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintStream;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintStream;
+import ai.timefold.solver.core.impl.util.ConstantLambdaUtils;
 
 public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> extends BavetAbstractConstraintStream<Solution_>
         implements InnerTriConstraintStream<A, B, C> {
@@ -171,7 +172,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
         GroupNodeConstructor<UniTuple<Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping1CollectorTriNode<>(groupStoreIndex, undoStoreIndex, collector,
-                                tupleLifecycle, outputStoreSize, environmentMode));
+                                tupleLifecycle, outputStoreSize, environmentMode),
+                        collector);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -189,7 +191,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
         GroupNodeConstructor<BiTuple<ResultA_, ResultB_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping2CollectorTriNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA, collectorB);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -208,7 +211,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
         GroupNodeConstructor<TriTuple<ResultA_, ResultB_, ResultC_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping3CollectorTriNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA, collectorB, collectorC);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -229,7 +233,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
         GroupNodeConstructor<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping4CollectorTriNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA, collectorB, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -244,7 +249,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(TriFunction<A, B, C, GroupKey_> groupKeyMapping) {
         GroupNodeConstructor<UniTuple<GroupKey_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group1Mapping0CollectorTriNode<>(
-                        groupKeyMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode));
+                        groupKeyMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -256,7 +262,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
         GroupNodeConstructor<TriTuple<GroupKey_, ResultB_, ResultC_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping2CollectorTriNode<>(groupKeyMapping, groupStoreIndex,
-                                undoStoreIndex, collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode));
+                                undoStoreIndex, collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping, collectorB, collectorC);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -271,7 +278,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping3CollectorTriNode<>(groupKeyMapping, groupStoreIndex,
                                 undoStoreIndex, collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyMapping, collectorB, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -282,7 +290,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
         GroupNodeConstructor<BiTuple<GroupKey_, Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping1CollectorTriNode<>(groupKeyMapping, groupStoreIndex,
-                                undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode));
+                                undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping, collector);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -292,7 +301,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
             TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping) {
         GroupNodeConstructor<BiTuple<GroupKeyA_, GroupKeyB_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group2Mapping0CollectorTriNode<>(
-                        groupKeyAMapping, groupKeyBMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode));
+                        groupKeyAMapping, groupKeyBMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -304,7 +314,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group2Mapping1CollectorTriNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupStoreIndex, undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode));
+                                groupStoreIndex, undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, collector);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -319,7 +330,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group2Mapping2CollectorTriNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupStoreIndex, undoStoreIndex, collectorC, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -330,7 +342,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group3Mapping0CollectorTriNode<>(
                         groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupStoreIndex, tupleLifecycle, outputStoreSize,
-                        environmentMode));
+                        environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -345,7 +358,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group3Mapping1CollectorTriNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupKeyCMapping, groupStoreIndex, undoStoreIndex, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -358,7 +372,8 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
         GroupNodeConstructor<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group4Mapping0CollectorTriNode<>(
                         groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupKeyDMapping, groupStoreIndex, tupleLifecycle,
-                        outputStoreSize, environmentMode));
+                        outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupKeyDMapping);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -367,11 +382,14 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
     // ************************************************************************
 
     @Override
+    @SuppressWarnings("unchecked")
     public TriConstraintStream<A, B, C> distinct() {
         if (guaranteesDistinct()) {
             return this;
         } else {
-            return groupBy((a, b, c) -> a, (a, b, c) -> b, (a, b, c) -> c);
+            return groupBy((TriFunction<A, B, C, A>) ConstantLambdaUtils.TRI_PICK_FIRST,
+                    (TriFunction<A, B, C, B>) ConstantLambdaUtils.TRI_PICK_SECOND,
+                    (TriFunction<A, B, C, C>) ConstantLambdaUtils.TRI_PICK_THIRD);
         }
     }
 
@@ -474,8 +492,11 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
 
     @Override
     public <ResultD_> QuadConstraintStream<A, B, C, ResultD_> expand(TriFunction<A, B, C, ResultD_> mapping) {
-        var stream = shareAndAddChild(new BavetQuadMapTriConstraintStream<>(constraintFactory, this, (a, b, c) -> a,
-                (a, b, c) -> b, (a, b, c) -> c, mapping, true));
+        @SuppressWarnings("unchecked")
+        var stream = shareAndAddChild(new BavetQuadMapTriConstraintStream<>(constraintFactory, this,
+                (TriFunction<A, B, C, A>) ConstantLambdaUtils.TRI_PICK_FIRST,
+                (TriFunction<A, B, C, B>) ConstantLambdaUtils.TRI_PICK_SECOND,
+                (TriFunction<A, B, C, C>) ConstantLambdaUtils.TRI_PICK_THIRD, mapping, true));
         return constraintFactory.share(new BavetAftBridgeQuadConstraintStream<>(constraintFactory, stream),
                 stream::setAftBridge);
     }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetBiGroupTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetBiGroupTriConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,26 @@ final class BavetBiGroupTriConstraintStream<Solution_, A, B, C, NewA, NewB>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetBiGroupTriConstraintStream<?, ?, ?, ?, ?, ?> that = (BavetBiGroupTriConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetBiMapTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetBiMapTriConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
+import java.util.Objects;
+
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.NodeBuildHelper;
 import ai.timefold.solver.constraint.streams.bavet.common.bridge.BavetAftBridgeBiConstraintStream;
@@ -48,7 +50,22 @@ final class BavetBiMapTriConstraintStream<Solution_, A, B, C, NewA, NewB>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetBiMapTriConstraintStream<?, ?, ?, ?, ?, ?> that = (BavetBiMapTriConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunctionA, that.mappingFunctionA) && Objects.equals(
+                mappingFunctionB,
+                that.mappingFunctionB);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetFlattenLastTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetFlattenLastTriConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -48,7 +49,20 @@ final class BavetFlattenLastTriConstraintStream<Solution_, A, B, C, NewC>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetFlattenLastTriConstraintStream<?, ?, ?, ?, ?> that = (BavetFlattenLastTriConstraintStream<?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunction, that.mappingFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunction);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetIfExistsTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetIfExistsTriConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
+import java.util.Objects;
 import java.util.Set;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -98,7 +99,31 @@ final class BavetIfExistsTriConstraintStream<Solution_, A, B, C, D>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetIfExistsTriConstraintStream<?, ?, ?, ?, ?> that = (BavetIfExistsTriConstraintStream<?, ?, ?, ?, ?>) object;
+        /*
+         * Bridge streams do not implement equality because their equals() would have to point back to this stream,
+         * resulting in StackOverflowError.
+         * Therefore we need to check bridge parents to see where this ifExists node comes from.
+         */
+        return shouldExist == that.shouldExist && Objects.equals(parentABC,
+                that.parentABC) && Objects.equals(
+                        parentBridgeD.getParent(), that.parentBridgeD.getParent())
+                && Objects.equals(joiner,
+                        that.joiner)
+                && Objects.equals(
+                        filtering, that.filtering);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parentABC, parentBridgeD.getParent(), shouldExist, joiner, filtering);
+    }
 
     @Override
     public String toString() {

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetQuadGroupTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetQuadGroupTriConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,27 @@ final class BavetQuadGroupTriConstraintStream<Solution_, A, B, C, NewA, NewB, Ne
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetQuadGroupTriConstraintStream<?, ?, ?, ?, ?, ?, ?, ?> that =
+                (BavetQuadGroupTriConstraintStream<?, ?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetQuadMapTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetQuadMapTriConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
+import java.util.Objects;
+
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.NodeBuildHelper;
 import ai.timefold.solver.constraint.streams.bavet.common.bridge.BavetAftBridgeQuadConstraintStream;
@@ -56,7 +58,27 @@ final class BavetQuadMapTriConstraintStream<Solution_, A, B, C, NewA, NewB, NewC
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetQuadMapTriConstraintStream<?, ?, ?, ?, ?, ?, ?, ?> that =
+                (BavetQuadMapTriConstraintStream<?, ?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && guaranteesDistinct == that.guaranteesDistinct && Objects.equals(
+                mappingFunctionA,
+                that.mappingFunctionA) && Objects.equals(mappingFunctionB,
+                        that.mappingFunctionB)
+                && Objects.equals(mappingFunctionC,
+                        that.mappingFunctionC)
+                && Objects.equals(mappingFunctionD, that.mappingFunctionD);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB, mappingFunctionC, mappingFunctionD, guaranteesDistinct);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetTriGroupTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetTriGroupTriConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,27 @@ final class BavetTriGroupTriConstraintStream<Solution_, A, B, C, NewA, NewB, New
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetTriGroupTriConstraintStream<?, ?, ?, ?, ?, ?, ?> that =
+                (BavetTriGroupTriConstraintStream<?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetTriMapTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetTriMapTriConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
+import java.util.Objects;
+
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.NodeBuildHelper;
 import ai.timefold.solver.constraint.streams.bavet.common.bridge.BavetAftBridgeTriConstraintStream;
@@ -50,7 +52,22 @@ final class BavetTriMapTriConstraintStream<Solution_, A, B, C, NewA, NewB, NewC>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetTriMapTriConstraintStream<?, ?, ?, ?, ?, ?, ?> that = (BavetTriMapTriConstraintStream<?, ?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunctionA, that.mappingFunctionA) && Objects.equals(
+                mappingFunctionB,
+                that.mappingFunctionB) && Objects.equals(mappingFunctionC, that.mappingFunctionC);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB, mappingFunctionC);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetUniGroupTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetUniGroupTriConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -40,6 +41,26 @@ final class BavetUniGroupTriConstraintStream<Solution_, A, B, C, NewA>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetUniGroupTriConstraintStream<?, ?, ?, ?, ?> that = (BavetUniGroupTriConstraintStream<?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetUniMapTriConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/tri/BavetUniMapTriConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.tri;
 
+import java.util.Objects;
+
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.NodeBuildHelper;
 import ai.timefold.solver.constraint.streams.bavet.common.bridge.BavetAftBridgeUniConstraintStream;
@@ -45,7 +47,20 @@ final class BavetUniMapTriConstraintStream<Solution_, A, B, C, NewA>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetUniMapTriConstraintStream<?, ?, ?, ?, ?> that = (BavetUniMapTriConstraintStream<?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunction, that.mappingFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunction);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetAbstractUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetAbstractUniConstraintStream.java
@@ -47,6 +47,7 @@ import ai.timefold.solver.core.api.score.stream.tri.TriConstraintStream;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintBuilder;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintStream;
+import ai.timefold.solver.core.impl.util.ConstantLambdaUtils;
 
 public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends BavetAbstractConstraintStream<Solution_>
         implements InnerUniConstraintStream<A> {
@@ -173,7 +174,8 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
         GroupNodeConstructor<UniTuple<Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping1CollectorUniNode<>(groupStoreIndex, undoStoreIndex, collector,
-                                tupleLifecycle, outputStoreSize, environmentMode));
+                                tupleLifecycle, outputStoreSize, environmentMode),
+                        collector);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -190,7 +192,9 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
         GroupNodeConstructor<BiTuple<ResultA_, ResultB_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping2CollectorUniNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA,
+                        collectorB);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -209,7 +213,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
         GroupNodeConstructor<TriTuple<ResultA_, ResultB_, ResultC_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping3CollectorUniNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA,
+                        collectorB,
+                        collectorC);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -230,7 +237,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
         GroupNodeConstructor<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group0Mapping4CollectorUniNode<>(groupStoreIndex, undoStoreIndex, collectorA,
-                                collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize, environmentMode));
+                                collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize, environmentMode),
+                        collectorA,
+                        collectorB,
+                        collectorC,
+                        collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -245,7 +256,8 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(Function<A, GroupKey_> groupKeyMapping) {
         GroupNodeConstructor<UniTuple<GroupKey_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group1Mapping0CollectorUniNode<>(
-                        groupKeyMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode));
+                        groupKeyMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -257,7 +269,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
         GroupNodeConstructor<TriTuple<GroupKey_, ResultB_, ResultC_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping2CollectorUniNode<>(groupKeyMapping, groupStoreIndex,
-                                undoStoreIndex, collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode));
+                                undoStoreIndex, collectorB, collectorC, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping,
+                        collectorB,
+                        collectorC);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -272,7 +287,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping3CollectorUniNode<>(groupKeyMapping, groupStoreIndex,
                                 undoStoreIndex, collectorB, collectorC, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyMapping,
+                        collectorB,
+                        collectorC,
+                        collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -283,7 +302,9 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
         GroupNodeConstructor<BiTuple<GroupKey_, Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group1Mapping1CollectorUniNode<>(groupKeyMapping, groupStoreIndex,
-                                undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode));
+                                undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyMapping,
+                        collector);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -292,7 +313,9 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
             Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping) {
         GroupNodeConstructor<BiTuple<GroupKeyA_, GroupKeyB_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group2Mapping0CollectorUniNode<>(
-                        groupKeyAMapping, groupKeyBMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode));
+                        groupKeyAMapping, groupKeyBMapping, groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyAMapping,
+                        groupKeyBMapping);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -303,7 +326,8 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> nodeConstructor =
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group2Mapping1CollectorUniNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupStoreIndex, undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode));
+                                groupStoreIndex, undoStoreIndex, collector, tupleLifecycle, outputStoreSize, environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, collector);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -317,7 +341,8 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group2Mapping2CollectorUniNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupStoreIndex, undoStoreIndex, collectorC, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, collectorC, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -328,7 +353,7 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group3Mapping0CollectorUniNode<>(
                         groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupStoreIndex, tupleLifecycle, outputStoreSize,
-                        environmentMode));
+                        environmentMode), groupKeyAMapping, groupKeyBMapping, groupKeyCMapping);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -342,7 +367,8 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                 of((groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
                         environmentMode) -> new Group3Mapping1CollectorUniNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupKeyCMapping, groupStoreIndex, undoStoreIndex, collectorD, tupleLifecycle, outputStoreSize,
-                                environmentMode));
+                                environmentMode),
+                        groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, collectorD);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -353,7 +379,8 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
         GroupNodeConstructor<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> nodeConstructor =
                 of((groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode) -> new Group4Mapping0CollectorUniNode<>(
                         groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupKeyDMapping, groupStoreIndex, tupleLifecycle,
-                        outputStoreSize, environmentMode));
+                        outputStoreSize, environmentMode), groupKeyAMapping, groupKeyBMapping, groupKeyCMapping,
+                        groupKeyDMapping);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -362,11 +389,12 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
     // ************************************************************************
 
     @Override
+    @SuppressWarnings("unchecked")
     public UniConstraintStream<A> distinct() {
         if (guaranteesDistinct()) {
             return this;
         } else {
-            return groupBy(a -> a);
+            return groupBy((Function<A, A>) ConstantLambdaUtils.IDENTITY);
         }
     }
 
@@ -468,26 +496,35 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
     // ************************************************************************
 
     @Override
+    @SuppressWarnings("unchecked")
     public <ResultB_> BiConstraintStream<A, ResultB_> expand(Function<A, ResultB_> mapping) {
         var stream =
-                shareAndAddChild(new BavetBiMapUniConstraintStream<>(constraintFactory, this, a -> a, mapping, true));
+                shareAndAddChild(
+                        new BavetBiMapUniConstraintStream<>(constraintFactory, this,
+                                (Function<A, A>) ConstantLambdaUtils.IDENTITY, mapping, true));
         return constraintFactory.share(new BavetAftBridgeBiConstraintStream<>(constraintFactory, stream), stream::setAftBridge);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <ResultB_, ResultC_> TriConstraintStream<A, ResultB_, ResultC_> expand(Function<A, ResultB_> mappingB,
             Function<A, ResultC_> mappingC) {
         var stream = shareAndAddChild(
-                new BavetTriMapUniConstraintStream<>(constraintFactory, this, a -> a, mappingB, mappingC, true));
+                new BavetTriMapUniConstraintStream<>(constraintFactory, this, (Function<A, A>) ConstantLambdaUtils.IDENTITY,
+                        mappingB, mappingC,
+                        true));
         return constraintFactory.share(new BavetAftBridgeTriConstraintStream<>(constraintFactory, stream),
                 stream::setAftBridge);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <ResultB_, ResultC_, ResultD_> QuadConstraintStream<A, ResultB_, ResultC_, ResultD_>
             expand(Function<A, ResultB_> mappingB, Function<A, ResultC_> mappingC, Function<A, ResultD_> mappingD) {
-        var stream = shareAndAddChild(new BavetQuadMapUniConstraintStream<>(constraintFactory, this, a -> a, mappingB,
-                mappingC, mappingD, true));
+        var stream = shareAndAddChild(
+                new BavetQuadMapUniConstraintStream<>(constraintFactory, this, (Function<A, A>) ConstantLambdaUtils.IDENTITY,
+                        mappingB,
+                        mappingC, mappingD, true));
         return constraintFactory.share(new BavetAftBridgeQuadConstraintStream<>(constraintFactory, stream),
                 stream::setAftBridge);
     }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetBiGroupUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetBiGroupUniConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,26 @@ final class BavetBiGroupUniConstraintStream<Solution_, A, NewA, NewB>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetBiGroupUniConstraintStream<?, ?, ?, ?> that = (BavetBiGroupUniConstraintStream<?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetBiMapUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetBiMapUniConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -52,7 +53,23 @@ final class BavetBiMapUniConstraintStream<Solution_, A, NewA, NewB>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetBiMapUniConstraintStream<?, ?, ?, ?> that = (BavetBiMapUniConstraintStream<?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) &&
+                guaranteesDistinct == that.guaranteesDistinct && Objects.equals(mappingFunctionA,
+                        that.mappingFunctionA)
+                && Objects.equals(mappingFunctionB, that.mappingFunctionB);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB, guaranteesDistinct);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetFlattenLastUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetFlattenLastUniConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -48,7 +49,20 @@ final class BavetFlattenLastUniConstraintStream<Solution_, A, NewA>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetFlattenLastUniConstraintStream<?, ?, ?> that = (BavetFlattenLastUniConstraintStream<?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunction, that.mappingFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunction);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetIfExistsUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetIfExistsUniConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiPredicate;
 
@@ -97,7 +98,31 @@ final class BavetIfExistsUniConstraintStream<Solution_, A, B>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetIfExistsUniConstraintStream<?, ?, ?> that = (BavetIfExistsUniConstraintStream<?, ?, ?>) object;
+        /*
+         * Bridge streams do not implement equality because their equals() would have to point back to this stream,
+         * resulting in StackOverflowError.
+         * Therefore we need to check bridge parents to see where this ifExists node comes from.
+         */
+        return shouldExist == that.shouldExist && Objects.equals(parentA,
+                that.parentA) && Objects.equals(
+                        parentBridgeB.getParent(), that.parentBridgeB.getParent())
+                && Objects.equals(joiner,
+                        that.joiner)
+                && Objects.equals(
+                        filtering, that.filtering);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parentA, parentBridgeB.getParent(), shouldExist, joiner, filtering);
+    }
 
     @Override
     public String toString() {

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetQuadGroupUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetQuadGroupUniConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,26 @@ final class BavetQuadGroupUniConstraintStream<Solution_, A, NewA, NewB, NewC, Ne
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetQuadGroupUniConstraintStream<?, ?, ?, ?, ?, ?> that = (BavetQuadGroupUniConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetQuadMapUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetQuadMapUniConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -58,7 +59,26 @@ final class BavetQuadMapUniConstraintStream<Solution_, A, NewA, NewB, NewC, NewD
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetQuadMapUniConstraintStream<?, ?, ?, ?, ?, ?> that = (BavetQuadMapUniConstraintStream<?, ?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && guaranteesDistinct == that.guaranteesDistinct && Objects.equals(
+                mappingFunctionA,
+                that.mappingFunctionA) && Objects.equals(mappingFunctionB,
+                        that.mappingFunctionB)
+                && Objects.equals(mappingFunctionC,
+                        that.mappingFunctionC)
+                && Objects.equals(mappingFunctionD, that.mappingFunctionD);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB, mappingFunctionC, mappingFunctionD, guaranteesDistinct);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetTriGroupUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetTriGroupUniConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -41,6 +42,26 @@ final class BavetTriGroupUniConstraintStream<Solution_, A, NewA, NewB, NewC>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetTriGroupUniConstraintStream<?, ?, ?, ?, ?> that = (BavetTriGroupUniConstraintStream<?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetTriMapUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetTriMapUniConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -54,7 +55,24 @@ final class BavetTriMapUniConstraintStream<Solution_, A, NewA, NewB, NewC>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetTriMapUniConstraintStream<?, ?, ?, ?, ?> that = (BavetTriMapUniConstraintStream<?, ?, ?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && guaranteesDistinct == that.guaranteesDistinct && Objects.equals(
+                mappingFunctionA,
+                that.mappingFunctionA) && Objects.equals(mappingFunctionB,
+                        that.mappingFunctionB)
+                && Objects.equals(mappingFunctionC, that.mappingFunctionC);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunctionA, mappingFunctionB, mappingFunctionC, guaranteesDistinct);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetUniGroupUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetUniGroupUniConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
 import ai.timefold.solver.constraint.streams.bavet.common.GroupNodeConstructor;
@@ -40,6 +41,26 @@ final class BavetUniGroupUniConstraintStream<Solution_, A, NewA>
         List<? extends ConstraintStream> aftStreamChildList = aftStream.getChildStreamList();
         nodeConstructor.build(buildHelper, parent.getTupleSource(), aftStream, aftStreamChildList, this, childStreamList,
                 constraintFactory.getEnvironmentMode());
+    }
+
+    // ************************************************************************
+    // Equality for node sharing
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+
+        BavetUniGroupUniConstraintStream<?, ?, ?> that = (BavetUniGroupUniConstraintStream<?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(nodeConstructor, that.nodeConstructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, nodeConstructor);
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetUniMapUniConstraintStream.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/uni/BavetUniMapUniConstraintStream.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.constraint.streams.bavet.uni;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import ai.timefold.solver.constraint.streams.bavet.BavetConstraintFactory;
@@ -46,7 +47,20 @@ final class BavetUniMapUniConstraintStream<Solution_, A, NewA>
     // Equality for node sharing
     // ************************************************************************
 
-    // TODO
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        BavetUniMapUniConstraintStream<?, ?, ?> that = (BavetUniMapUniConstraintStream<?, ?, ?>) object;
+        return Objects.equals(parent, that.parent) && Objects.equals(mappingFunction, that.mappingFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, mappingFunction);
+    }
 
     // ************************************************************************
     // Getters/setters

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/ConstraintStreamFunctionalTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/ConstraintStreamFunctionalTest.java
@@ -252,4 +252,12 @@ public interface ConstraintStreamFunctionalTest {
 
     void impactNegativeBigDecimalCustomJustifications();
 
+    // ************************************************************************
+    // Node sharing
+    // ************************************************************************
+
+    void shareNodesWithSameInput();
+
+    void differentNodesForDistinctInput();
+
 }

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/bi/AbstractBiConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/bi/AbstractBiConstraintStreamTest.java
@@ -15,16 +15,20 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import ai.timefold.solver.constraint.streams.common.AbstractConstraintStreamTest;
 import ai.timefold.solver.constraint.streams.common.ConstraintStreamFunctionalTest;
 import ai.timefold.solver.constraint.streams.common.ConstraintStreamImplSupport;
+import ai.timefold.solver.core.api.function.TriPredicate;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
@@ -35,8 +39,11 @@ import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
+import ai.timefold.solver.core.api.score.stream.Joiners;
+import ai.timefold.solver.core.api.score.stream.bi.BiConstraintStream;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataSimpleBigDecimalScoreSolution;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataSimpleLongScoreSolution;
 import ai.timefold.solver.core.impl.testdata.domain.score.lavish.TestdataLavishEntity;
@@ -2998,6 +3005,232 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
                 assertMatch(entity2, entity3),
                 assertMatch(entity3, entity1),
                 assertMatch(entity3, entity2));
+    }
+
+    // ************************************************************************
+    // Node Sharing
+    // ************************************************************************
+
+    @Override
+    @TestTemplate
+    public void shareNodesWithSameInput() {
+        final List<String> failureList = new ArrayList<>();
+        buildScoreDirector(
+                TestdataSolution.buildSolutionDescriptor(),
+                factory -> {
+                    BiConstraintStream<TestdataEntity, TestdataEntity> base =
+                            factory.forEach(TestdataEntity.class).join(TestdataEntity.class);
+                    Function<TestdataEntity, TestdataEntity> function = a -> a;
+                    BiFunction<TestdataEntity, TestdataEntity, TestdataEntity> bifunction = (a, b) -> a;
+                    Function<TestdataEntity, Iterable<String>> iterableFunction = a -> Collections.emptyList();
+                    BiPredicate<TestdataEntity, TestdataEntity> bipredicate = (a, b) -> true;
+                    TriPredicate<TestdataEntity, TestdataEntity, TestdataEntity> tripredicate = (a, b, c) -> true;
+
+                    if (base.join(TestdataEntity.class) != base.join(TestdataEntity.class)) {
+                        failureList.add("join(no-joiners)");
+                    }
+
+                    if (base.join(TestdataEntity.class, Joiners.equal(bifunction, function)) != base.join(TestdataEntity.class,
+                            Joiners.equal(bifunction, function))) {
+                        failureList.add("join(indexed)");
+                    }
+
+                    if (base.join(TestdataEntity.class, Joiners.filtering(tripredicate)) != base.join(TestdataEntity.class,
+                            Joiners.filtering(tripredicate))) {
+                        failureList.add("join(filtered)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.equal(bifunction, function)) != base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.equal(bifunction, function))) {
+                        failureList.add("ifExists(indexed)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.filtering(tripredicate)) != base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(tripredicate))) {
+                        failureList.add("ifExists(filtered)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.equal(bifunction, function)) != base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.equal(bifunction, function))) {
+                        failureList.add("ifNotExists(indexed)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.filtering(tripredicate)) != base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(tripredicate))) {
+                        failureList.add("ifNotExists(filtered)");
+                    }
+
+                    if (base.filter(bipredicate) != base.filter(bipredicate)) {
+                        failureList.add("filter");
+                    }
+
+                    if (base.expand(bifunction) != base.expand(bifunction)) {
+                        failureList.add("expand");
+                    }
+
+                    if (base.map(bifunction) != base.map(bifunction)) {
+                        failureList.add("map");
+                    }
+
+                    if (base.distinct() != base.distinct()) {
+                        failureList.add("distinct");
+                    }
+
+                    if (base.concat(base) != base.concat(base)) {
+                        failureList.add("concat");
+                    }
+
+                    if (base.groupBy(bifunction) != base.groupBy(bifunction)) {
+                        failureList.add("groupby(mapping)");
+                    }
+
+                    if (base.groupBy(ConstraintCollectors.countDistinct(bifunction)) != base.groupBy(
+                            ConstraintCollectors.countDistinct(bifunction))) {
+                        failureList.add("groupby(collector)");
+                    }
+
+                    if (base.flattenLast(iterableFunction) != base.flattenLast(iterableFunction)) {
+                        failureList.add("flattenLast");
+                    }
+
+                    return new Constraint[] {};
+                });
+
+        assertThat(failureList).isEmpty();
+    }
+
+    @Override
+    @TestTemplate
+    public void differentNodesForDistinctInput() {
+        final List<String> failureList = new ArrayList<>();
+        buildScoreDirector(
+                TestdataSolution.buildSolutionDescriptor(),
+                factory -> {
+                    BiConstraintStream<TestdataEntity, TestdataEntity> base =
+                            factory.forEach(TestdataEntity.class).join(TestdataEntity.class);
+                    Function<TestdataEntity, TestdataEntity> otherJoiner = a -> a;
+                    BiFunction<TestdataEntity, TestdataEntity, TestdataEntity> f1 = (a, b) -> a;
+                    BiFunction<TestdataEntity, TestdataEntity, TestdataEntity> f2 = (a, b) -> null;
+                    Function<TestdataEntity, Iterable<String>> iterableFunction1 = (a) -> Collections.emptyList();
+                    Function<TestdataEntity, Iterable<String>> iterableFunction2 = (a) -> List.of();
+                    BiPredicate<TestdataEntity, TestdataEntity> p1 = (a, b) -> true;
+                    BiPredicate<TestdataEntity, TestdataEntity> p2 = (a, b) -> false;
+                    TriPredicate<TestdataEntity, TestdataEntity, TestdataEntity> jp1 = (a, b, c) -> true;
+                    TriPredicate<TestdataEntity, TestdataEntity, TestdataEntity> jp2 = (a, b, c) -> false;
+
+                    // Make sure different parents result in a different stream
+                    if (base.filter(p1).join(TestdataEntity.class) == base.filter(p2).join(TestdataEntity.class)) {
+                        failureList.add("join(different-parent)");
+                    }
+
+                    if (base.filter(p1).ifExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.filter(p2)
+                            .ifExists(TestdataEntity.class,
+                                    Joiners.equal(f1, otherJoiner))) {
+                        failureList.add("ifExists(different-parent)");
+                    }
+
+                    if (base.filter(p1).ifNotExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.filter(p2)
+                            .ifNotExists(
+                                    TestdataEntity.class,
+                                    Joiners.equal(f1, otherJoiner))) {
+                        failureList.add("ifNotExists(different-parent)");
+                    }
+
+                    if (base.filter(p1).filter(p1) == base.filter(p2).filter(p1)) {
+                        failureList.add("filter(different-parent)");
+                    }
+
+                    if (base.filter(p1).expand(f1) == base.filter(p2).expand(f1)) {
+                        failureList.add("expand(different-parent)");
+                    }
+
+                    if (base.filter(p1).map(f1) == base.filter(p2).map(f1)) {
+                        failureList.add("map(different-parent)");
+                    }
+
+                    if (base.filter(p1).distinct() == base.filter(p2).distinct()) {
+                        failureList.add("distinct(different-parent)");
+                    }
+
+                    if (base.filter(p1).concat(base) == base.filter(p2).concat(base)) {
+                        failureList.add("concat(different-parent)");
+                    }
+
+                    if (base.filter(p1).groupBy(f1) == base.filter(p2).groupBy(f1)) {
+                        failureList.add("groupby(different-parent)");
+                    }
+
+                    if (base.filter(p1).flattenLast(iterableFunction1) == base.filter(p2).flattenLast(iterableFunction1)) {
+                        failureList.add("flattenLast(different-parent)");
+                    }
+                    // *********************************************************************
+                    if (base.join(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.join(TestdataEntity.class,
+                            Joiners.equal(f2, otherJoiner))) {
+                        failureList.add("join(different-indexed)");
+                    }
+
+                    if (base.join(TestdataEntity.class, Joiners.filtering(jp1)) == base.join(TestdataEntity.class,
+                            Joiners.filtering(jp2))) {
+                        failureList.add("join(different-filtered)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.equal(f2, otherJoiner))) {
+                        failureList.add("ifExists(different-indexed)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.filtering(jp1)) == base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(jp2))) {
+                        failureList.add("ifExists(different-filtered)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.equal(f2, otherJoiner))) {
+                        failureList.add("ifNotExists(different-indexed)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.filtering(jp1)) == base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(jp2))) {
+                        failureList.add("ifNotExists(different-filtered)");
+                    }
+
+                    if (base.filter(p1) == base.filter(p2)) {
+                        failureList.add("filter(different-predicate)");
+                    }
+
+                    if (base.expand(f1) == base.expand(f2)) {
+                        failureList.add("expand(different-function)");
+                    }
+
+                    if (base.map(f1) == base.map(f2)) {
+                        failureList.add("map(different-function)");
+                    }
+
+                    if (base.groupBy(f1) == base.groupBy(f2)) {
+                        failureList.add("groupby(different-mapping)");
+                    }
+
+                    if (base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
+                            ConstraintCollectors.countDistinct(f2))) {
+                        failureList.add("groupby(different-collector)");
+                    }
+
+                    if (base.flattenLast(iterableFunction1) == base.flattenLast(iterableFunction2)) {
+                        failureList.add("flattenLast(different-function)");
+                    }
+
+                    return new Constraint[] {};
+                });
+
+        assertThat(failureList).isEmpty();
     }
 
 }

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/bi/AbstractBiConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/bi/AbstractBiConstraintStreamTest.java
@@ -41,6 +41,7 @@ import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.Joiners;
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintStream;
+import ai.timefold.solver.core.api.score.stream.uni.UniConstraintStream;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
@@ -3220,6 +3221,11 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
 
                     if (base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
                             ConstraintCollectors.countDistinct(f2))) {
+                        failureList.add("groupby(different-collector-function)");
+                    }
+
+                    if ((UniConstraintStream) base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
+                            ConstraintCollectors.countDistinctLong(f1))) {
                         failureList.add("groupby(different-collector)");
                     }
 

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/quad/AbstractQuadConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/quad/AbstractQuadConstraintStreamTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -24,6 +25,9 @@ import java.util.function.Function;
 import ai.timefold.solver.constraint.streams.common.AbstractConstraintStreamTest;
 import ai.timefold.solver.constraint.streams.common.ConstraintStreamFunctionalTest;
 import ai.timefold.solver.constraint.streams.common.ConstraintStreamImplSupport;
+import ai.timefold.solver.core.api.function.PentaPredicate;
+import ai.timefold.solver.core.api.function.QuadFunction;
+import ai.timefold.solver.core.api.function.QuadPredicate;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
@@ -35,8 +39,10 @@ import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.Joiners;
+import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintStream;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataSimpleBigDecimalScoreSolution;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataSimpleLongScoreSolution;
@@ -2715,6 +2721,201 @@ public abstract class AbstractQuadConstraintStreamTest
         scoreDirector.calculateScore();
         assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleBigDecimalScore.of(BigDecimal.valueOf(-4)));
         assertCustomJustifications(scoreDirector, solution.getEntityList(), solution.getValueList());
+    }
+
+    // ************************************************************************
+    // Node Sharing
+    // ************************************************************************
+
+    @Override
+    @TestTemplate
+    public void shareNodesWithSameInput() {
+        final List<String> failureList = new ArrayList<>();
+        buildScoreDirector(
+                TestdataSolution.buildSolutionDescriptor(),
+                factory -> {
+                    QuadConstraintStream<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> base =
+                            factory.forEach(TestdataEntity.class).join(TestdataEntity.class)
+                                    .join(TestdataEntity.class).join(TestdataEntity.class);
+                    Function<TestdataEntity, TestdataEntity> function = a -> a;
+                    QuadFunction<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> quadfunction =
+                            (a, b, c, d) -> a;
+                    Function<TestdataEntity, Iterable<String>> iterableFunction = a -> Collections.emptyList();
+                    QuadPredicate<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> quadpredicate =
+                            (a, b, c, d) -> true;
+                    PentaPredicate<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> pentapredicate =
+                            (a, b, c, d, e) -> true;
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.equal(quadfunction, function)) != base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.equal(quadfunction, function))) {
+                        failureList.add("ifExists(indexed)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.filtering(pentapredicate)) != base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(pentapredicate))) {
+                        failureList.add("ifExists(filtered)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.equal(quadfunction, function)) != base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.equal(quadfunction, function))) {
+                        failureList.add("ifNotExists(indexed)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.filtering(pentapredicate)) != base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(pentapredicate))) {
+                        failureList.add("ifNotExists(filtered)");
+                    }
+
+                    if (base.filter(quadpredicate) != base.filter(quadpredicate)) {
+                        failureList.add("filter");
+                    }
+
+                    if (base.map(quadfunction) != base.map(quadfunction)) {
+                        failureList.add("map");
+                    }
+
+                    if (base.distinct() != base.distinct()) {
+                        failureList.add("distinct");
+                    }
+
+                    if (base.concat(base) != base.concat(base)) {
+                        failureList.add("concat");
+                    }
+
+                    if (base.groupBy(quadfunction) != base.groupBy(quadfunction)) {
+                        failureList.add("groupby(mapping)");
+                    }
+
+                    if (base.groupBy(ConstraintCollectors.countDistinct(quadfunction)) != base.groupBy(
+                            ConstraintCollectors.countDistinct(quadfunction))) {
+                        failureList.add("groupby(collector)");
+                    }
+
+                    if (base.flattenLast(iterableFunction) != base.flattenLast(iterableFunction)) {
+                        failureList.add("flattenLast");
+                    }
+                    return new Constraint[] {};
+                });
+
+        assertThat(failureList).isEmpty();
+    }
+
+    @Override
+    @TestTemplate
+    public void differentNodesForDistinctInput() {
+        final List<String> failureList = new ArrayList<>();
+        buildScoreDirector(
+                TestdataSolution.buildSolutionDescriptor(),
+                factory -> {
+                    QuadConstraintStream<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> base =
+                            factory.forEach(TestdataEntity.class).join(TestdataEntity.class).join(TestdataEntity.class)
+                                    .join(TestdataEntity.class);
+                    Function<TestdataEntity, TestdataEntity> otherJoiner = a -> a;
+                    QuadFunction<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> f1 =
+                            (a, b, c, d) -> a;
+                    QuadFunction<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> f2 =
+                            (a, b, c, d) -> null;
+                    Function<TestdataEntity, Iterable<String>> iterableFunction1 = (a) -> Collections.emptyList();
+                    Function<TestdataEntity, Iterable<String>> iterableFunction2 = (a) -> List.of();
+                    QuadPredicate<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> p1 = (a, b, c, d) -> true;
+                    QuadPredicate<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> p2 = (a, b, c, d) -> false;
+                    PentaPredicate<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> jp1 =
+                            (a, b, c, d, e) -> true;
+                    PentaPredicate<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> jp2 =
+                            (a, b, c, d, e) -> false;
+
+                    // Make sure different parents result in a different stream
+                    if (base.filter(p1).ifExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.filter(p2)
+                            .ifExists(TestdataEntity.class,
+                                    Joiners.equal(f1, otherJoiner))) {
+                        failureList.add("ifExists(different-parent)");
+                    }
+
+                    if (base.filter(p1).ifNotExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.filter(p2)
+                            .ifNotExists(
+                                    TestdataEntity.class,
+                                    Joiners.equal(f1, otherJoiner))) {
+                        failureList.add("ifNotExists(different-parent)");
+                    }
+
+                    if (base.filter(p1).filter(p1) == base.filter(p2).filter(p1)) {
+                        failureList.add("filter(different-parent)");
+                    }
+
+                    if (base.filter(p1).map(f1) == base.filter(p2).map(f1)) {
+                        failureList.add("map(different-parent)");
+                    }
+
+                    if (base.filter(p1).distinct() == base.filter(p2).distinct()) {
+                        failureList.add("distinct(different-parent)");
+                    }
+
+                    if (base.filter(p1).concat(base) == base.filter(p2).concat(base)) {
+                        failureList.add("concat(different-parent)");
+                    }
+
+                    if (base.filter(p1).groupBy(f1) == base.filter(p2).groupBy(f1)) {
+                        failureList.add("groupby(different-parent)");
+                    }
+
+                    if (base.filter(p1).flattenLast(iterableFunction1) == base.filter(p2).flattenLast(iterableFunction1)) {
+                        failureList.add("flattenLast(different-parent)");
+                    }
+                    // *********************************************************************
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.equal(f2, otherJoiner))) {
+                        failureList.add("ifExists(different-indexed)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.filtering(jp1)) == base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(jp2))) {
+                        failureList.add("ifExists(different-filtered)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.equal(f2, otherJoiner))) {
+                        failureList.add("ifNotExists(different-indexed)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.filtering(jp1)) == base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(jp2))) {
+                        failureList.add("ifNotExists(different-filtered)");
+                    }
+
+                    if (base.filter(p1) == base.filter(p2)) {
+                        failureList.add("filter(different-predicate)");
+                    }
+
+                    if (base.map(f1) == base.map(f2)) {
+                        failureList.add("map(different-function)");
+                    }
+
+                    if (base.groupBy(f1) == base.groupBy(f2)) {
+                        failureList.add("groupby(different-mapping)");
+                    }
+
+                    if (base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
+                            ConstraintCollectors.countDistinct(f2))) {
+                        failureList.add("groupby(different-collector)");
+                    }
+
+                    if (base.flattenLast(iterableFunction1) == base.flattenLast(iterableFunction2)) {
+                        failureList.add("flattenLast(different-function)");
+                    }
+
+                    return new Constraint[] {};
+                });
+
+        assertThat(failureList).isEmpty();
     }
 
 }

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/quad/AbstractQuadConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/quad/AbstractQuadConstraintStreamTest.java
@@ -40,6 +40,7 @@ import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.Joiners;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintStream;
+import ai.timefold.solver.core.api.score.stream.uni.UniConstraintStream;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
@@ -2905,6 +2906,11 @@ public abstract class AbstractQuadConstraintStreamTest
 
                     if (base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
                             ConstraintCollectors.countDistinct(f2))) {
+                        failureList.add("groupby(different-collector-function)");
+                    }
+
+                    if ((UniConstraintStream) base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
+                            ConstraintCollectors.countDistinctLong(f1))) {
                         failureList.add("groupby(different-collector)");
                     }
 

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/tri/AbstractTriConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/tri/AbstractTriConstraintStreamTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -26,6 +27,9 @@ import java.util.stream.Stream;
 import ai.timefold.solver.constraint.streams.common.AbstractConstraintStreamTest;
 import ai.timefold.solver.constraint.streams.common.ConstraintStreamFunctionalTest;
 import ai.timefold.solver.constraint.streams.common.ConstraintStreamImplSupport;
+import ai.timefold.solver.core.api.function.QuadPredicate;
+import ai.timefold.solver.core.api.function.TriFunction;
+import ai.timefold.solver.core.api.function.TriPredicate;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
@@ -37,9 +41,11 @@ import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.Joiners;
+import ai.timefold.solver.core.api.score.stream.tri.TriConstraintStream;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataObject;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataSimpleBigDecimalScoreSolution;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataSimpleLongScoreSolution;
@@ -2976,6 +2982,233 @@ public abstract class AbstractTriConstraintStreamTest
         scoreDirector.calculateScore();
         assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleBigDecimalScore.of(BigDecimal.valueOf(-4)));
         assertCustomJustifications(scoreDirector, solution.getEntityList(), solution.getValueList());
+    }
+
+    // ************************************************************************
+    // Node Sharing
+    // ************************************************************************
+
+    @Override
+    @TestTemplate
+    public void shareNodesWithSameInput() {
+        final List<String> failureList = new ArrayList<>();
+        buildScoreDirector(
+                TestdataSolution.buildSolutionDescriptor(),
+                factory -> {
+                    TriConstraintStream<TestdataEntity, TestdataEntity, TestdataEntity> base =
+                            factory.forEach(TestdataEntity.class).join(TestdataEntity.class)
+                                    .join(TestdataEntity.class);
+                    Function<TestdataEntity, TestdataEntity> function = a -> a;
+                    TriFunction<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> trifunction = (a, b, c) -> a;
+                    Function<TestdataEntity, Iterable<String>> iterableFunction = a -> Collections.emptyList();
+                    TriPredicate<TestdataEntity, TestdataEntity, TestdataEntity> tripredicate = (a, b, c) -> true;
+                    QuadPredicate<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> quadpredicate =
+                            (a, b, c, d) -> true;
+
+                    if (base.join(TestdataEntity.class) != base.join(TestdataEntity.class)) {
+                        failureList.add("join(no-joiners)");
+                    }
+
+                    if (base.join(TestdataEntity.class, Joiners.equal(trifunction, function)) != base.join(TestdataEntity.class,
+                            Joiners.equal(trifunction, function))) {
+                        failureList.add("join(indexed)");
+                    }
+
+                    if (base.join(TestdataEntity.class, Joiners.filtering(quadpredicate)) != base.join(TestdataEntity.class,
+                            Joiners.filtering(quadpredicate))) {
+                        failureList.add("join(filtered)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.equal(trifunction, function)) != base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.equal(trifunction, function))) {
+                        failureList.add("ifExists(indexed)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.filtering(quadpredicate)) != base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(quadpredicate))) {
+                        failureList.add("ifExists(filtered)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.equal(trifunction, function)) != base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.equal(trifunction, function))) {
+                        failureList.add("ifNotExists(indexed)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.filtering(quadpredicate)) != base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(quadpredicate))) {
+                        failureList.add("ifNotExists(filtered)");
+                    }
+
+                    if (base.filter(tripredicate) != base.filter(tripredicate)) {
+                        failureList.add("filter");
+                    }
+
+                    if (base.expand(trifunction) != base.expand(trifunction)) {
+                        failureList.add("expand");
+                    }
+
+                    if (base.map(trifunction) != base.map(trifunction)) {
+                        failureList.add("map");
+                    }
+
+                    if (base.distinct() != base.distinct()) {
+                        failureList.add("distinct");
+                    }
+
+                    if (base.concat(base) != base.concat(base)) {
+                        failureList.add("concat");
+                    }
+
+                    if (base.groupBy(trifunction) != base.groupBy(trifunction)) {
+                        failureList.add("groupby(mapping)");
+                    }
+
+                    if (base.groupBy(ConstraintCollectors.countDistinct(trifunction)) != base.groupBy(
+                            ConstraintCollectors.countDistinct(trifunction))) {
+                        failureList.add("groupby(collector)");
+                    }
+
+                    if (base.flattenLast(iterableFunction) != base.flattenLast(iterableFunction)) {
+                        failureList.add("flattenLast");
+                    }
+                    return new Constraint[] {};
+                });
+
+        assertThat(failureList).isEmpty();
+    }
+
+    @Override
+    @TestTemplate
+    public void differentNodesForDistinctInput() {
+        final List<String> failureList = new ArrayList<>();
+        buildScoreDirector(
+                TestdataSolution.buildSolutionDescriptor(),
+                factory -> {
+                    TriConstraintStream<TestdataEntity, TestdataEntity, TestdataEntity> base =
+                            factory.forEach(TestdataEntity.class).join(TestdataEntity.class).join(TestdataEntity.class);
+                    Function<TestdataEntity, TestdataEntity> otherJoiner = a -> a;
+                    TriFunction<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> f1 = (a, b, c) -> a;
+                    TriFunction<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> f2 = (a, b, c) -> null;
+                    Function<TestdataEntity, Iterable<String>> iterableFunction1 = (a) -> Collections.emptyList();
+                    Function<TestdataEntity, Iterable<String>> iterableFunction2 = (a) -> List.of();
+                    TriPredicate<TestdataEntity, TestdataEntity, TestdataEntity> p1 = (a, b, c) -> true;
+                    TriPredicate<TestdataEntity, TestdataEntity, TestdataEntity> p2 = (a, b, c) -> false;
+                    QuadPredicate<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> jp1 = (a, b, c, d) -> true;
+                    QuadPredicate<TestdataEntity, TestdataEntity, TestdataEntity, TestdataEntity> jp2 = (a, b, c, d) -> false;
+
+                    // Make sure different parents result in a different stream
+                    if (base.filter(p1).join(TestdataEntity.class) == base.filter(p2).join(TestdataEntity.class)) {
+                        failureList.add("join(different-parent)");
+                    }
+
+                    if (base.filter(p1).ifExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.filter(p2)
+                            .ifExists(TestdataEntity.class,
+                                    Joiners.equal(f1, otherJoiner))) {
+                        failureList.add("ifExists(different-parent)");
+                    }
+
+                    if (base.filter(p1).ifNotExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.filter(p2)
+                            .ifNotExists(
+                                    TestdataEntity.class,
+                                    Joiners.equal(f1, otherJoiner))) {
+                        failureList.add("ifNotExists(different-parent)");
+                    }
+
+                    if (base.filter(p1).filter(p1) == base.filter(p2).filter(p1)) {
+                        failureList.add("filter(different-parent)");
+                    }
+
+                    if (base.filter(p1).expand(f1) == base.filter(p2).expand(f1)) {
+                        failureList.add("expand(different-parent)");
+                    }
+
+                    if (base.filter(p1).map(f1) == base.filter(p2).map(f1)) {
+                        failureList.add("map(different-parent)");
+                    }
+
+                    if (base.filter(p1).distinct() == base.filter(p2).distinct()) {
+                        failureList.add("distinct(different-parent)");
+                    }
+
+                    if (base.filter(p1).concat(base) == base.filter(p2).concat(base)) {
+                        failureList.add("concat(different-parent)");
+                    }
+
+                    if (base.filter(p1).groupBy(f1) == base.filter(p2).groupBy(f1)) {
+                        failureList.add("groupby(different-parent)");
+                    }
+
+                    if (base.filter(p1).flattenLast(iterableFunction1) == base.filter(p2).flattenLast(iterableFunction1)) {
+                        failureList.add("flattenLast(different-parent)");
+                    }
+                    // *********************************************************************
+                    if (base.join(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.join(TestdataEntity.class,
+                            Joiners.equal(f2, otherJoiner))) {
+                        failureList.add("join(different-indexed)");
+                    }
+
+                    if (base.join(TestdataEntity.class, Joiners.filtering(jp1)) == base.join(TestdataEntity.class,
+                            Joiners.filtering(jp2))) {
+                        failureList.add("join(different-filtered)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.equal(f2, otherJoiner))) {
+                        failureList.add("ifExists(different-indexed)");
+                    }
+
+                    if (base.ifExists(TestdataEntity.class, Joiners.filtering(jp1)) == base.ifExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(jp2))) {
+                        failureList.add("ifExists(different-filtered)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.equal(f1, otherJoiner)) == base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.equal(f2, otherJoiner))) {
+                        failureList.add("ifNotExists(different-indexed)");
+                    }
+
+                    if (base.ifNotExists(TestdataEntity.class, Joiners.filtering(jp1)) == base.ifNotExists(
+                            TestdataEntity.class,
+                            Joiners.filtering(jp2))) {
+                        failureList.add("ifNotExists(different-filtered)");
+                    }
+
+                    if (base.filter(p1) == base.filter(p2)) {
+                        failureList.add("filter(different-predicate)");
+                    }
+
+                    if (base.expand(f1) == base.expand(f2)) {
+                        failureList.add("expand(different-function)");
+                    }
+
+                    if (base.map(f1) == base.map(f2)) {
+                        failureList.add("map(different-function)");
+                    }
+
+                    if (base.groupBy(f1) == base.groupBy(f2)) {
+                        failureList.add("groupby(different-mapping)");
+                    }
+
+                    if (base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
+                            ConstraintCollectors.countDistinct(f2))) {
+                        failureList.add("groupby(different-collector)");
+                    }
+
+                    if (base.flattenLast(iterableFunction1) == base.flattenLast(iterableFunction2)) {
+                        failureList.add("flattenLast(different-function)");
+                    }
+
+                    return new Constraint[] {};
+                });
+
+        assertThat(failureList).isEmpty();
     }
 
 }

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/tri/AbstractTriConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/tri/AbstractTriConstraintStreamTest.java
@@ -42,6 +42,7 @@ import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.Joiners;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintStream;
+import ai.timefold.solver.core.api.score.stream.uni.UniConstraintStream;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataObject;
@@ -3198,6 +3199,11 @@ public abstract class AbstractTriConstraintStreamTest
 
                     if (base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
                             ConstraintCollectors.countDistinct(f2))) {
+                        failureList.add("groupby(different-collector-function)");
+                    }
+
+                    if ((UniConstraintStream) base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
+                            ConstraintCollectors.countDistinctLong(f1))) {
                         failureList.add("groupby(different-collector)");
                     }
 

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/uni/AbstractUniConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/uni/AbstractUniConstraintStreamTest.java
@@ -3693,6 +3693,11 @@ public abstract class AbstractUniConstraintStreamTest
 
                     if (base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
                             ConstraintCollectors.countDistinct(f2))) {
+                        failureList.add("groupby(different-collector-function)");
+                    }
+
+                    if ((UniConstraintStream) base.groupBy(ConstraintCollectors.countDistinct(f1)) == base.groupBy(
+                            ConstraintCollectors.countDistinctLong(f1))) {
                         failureList.add("groupby(different-collector)");
                     }
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
@@ -196,7 +196,8 @@ public final class ConstraintCollectors {
                     Object value = groupValueMapping.apply(a);
                     return innerCountDistinct(resultContainer, value);
                 },
-                Map::size);
+                Map::size,
+                groupValueMapping);
     }
 
     /**
@@ -209,7 +210,8 @@ public final class ConstraintCollectors {
                     Object value = groupValueMapping.apply(a);
                     return innerCountDistinctLong(resultContainer, value);
                 },
-                resultContainer -> (long) resultContainer.size());
+                resultContainer -> (long) resultContainer.size(),
+                groupValueMapping);
     }
 
     /**
@@ -223,7 +225,8 @@ public final class ConstraintCollectors {
                     Object value = groupValueMapping.apply(a, b);
                     return innerCountDistinct(resultContainer, value);
                 },
-                Map::size);
+                Map::size,
+                groupValueMapping);
     }
 
     /**
@@ -237,7 +240,8 @@ public final class ConstraintCollectors {
                     Object value = groupValueMapping.apply(a, b);
                     return innerCountDistinctLong(resultContainer, value);
                 },
-                resultContainer -> (long) resultContainer.size());
+                resultContainer -> (long) resultContainer.size(),
+                groupValueMapping);
     }
 
     /**
@@ -251,7 +255,8 @@ public final class ConstraintCollectors {
                     Object value = groupValueMapping.apply(a, b, c);
                     return innerCountDistinct(resultContainer, value);
                 },
-                Map::size);
+                Map::size,
+                groupValueMapping);
     }
 
     /**
@@ -265,7 +270,8 @@ public final class ConstraintCollectors {
                     Object value = groupValueMapping.apply(a, b, c);
                     return innerCountDistinctLong(resultContainer, value);
                 },
-                resultContainer -> (long) resultContainer.size());
+                resultContainer -> (long) resultContainer.size(),
+                groupValueMapping);
     }
 
     /**
@@ -279,7 +285,8 @@ public final class ConstraintCollectors {
                     Object value = groupValueMapping.apply(a, b, c, d);
                     return innerCountDistinct(resultContainer, value);
                 },
-                Map::size);
+                Map::size,
+                groupValueMapping);
     }
 
     /**
@@ -293,7 +300,8 @@ public final class ConstraintCollectors {
                     Object value = groupValueMapping.apply(a, b, c, d);
                     return innerCountDistinctLong(resultContainer, value);
                 },
-                resultContainer -> (long) resultContainer.size());
+                resultContainer -> (long) resultContainer.size(),
+                groupValueMapping);
     }
 
     /**
@@ -367,7 +375,8 @@ public final class ConstraintCollectors {
                     int value = groupValueMapping.applyAsInt(a);
                     return innerSum(resultContainer, value);
                 },
-                MutableInt::intValue);
+                MutableInt::intValue,
+                groupValueMapping);
     }
 
     private static Runnable innerSum(MutableInt resultContainer, int value) {
@@ -385,7 +394,8 @@ public final class ConstraintCollectors {
                     long value = groupValueMapping.applyAsLong(a);
                     return innerSum(resultContainer, value);
                 },
-                MutableLong::longValue);
+                MutableLong::longValue,
+                groupValueMapping);
     }
 
     private static Runnable innerSum(MutableLong resultContainer, long value) {
@@ -404,7 +414,10 @@ public final class ConstraintCollectors {
                     Result value = groupValueMapping.apply(a);
                     return innerSum(resultContainer, value, adder, subtractor);
                 },
-                MutableReference::getValue);
+                MutableReference::getValue,
+                zero,
+                adder,
+                subtractor);
     }
 
     private static <Result> Runnable innerSum(MutableReference<Result> resultContainer, Result value,
@@ -455,7 +468,8 @@ public final class ConstraintCollectors {
                     int value = groupValueMapping.applyAsInt(a, b);
                     return innerSum(resultContainer, value);
                 },
-                MutableInt::intValue);
+                MutableInt::intValue,
+                groupValueMapping);
     }
 
     /**
@@ -469,7 +483,8 @@ public final class ConstraintCollectors {
                     long value = groupValueMapping.applyAsLong(a, b);
                     return innerSum(resultContainer, value);
                 },
-                MutableLong::longValue);
+                MutableLong::longValue,
+                groupValueMapping);
     }
 
     /**
@@ -484,7 +499,8 @@ public final class ConstraintCollectors {
                     Result value = groupValueMapping.apply(a, b);
                     return innerSum(resultContainer, value, adder, subtractor);
                 },
-                MutableReference::getValue);
+                MutableReference::getValue,
+                groupValueMapping, zero, adder, subtractor);
     }
 
     /**
@@ -530,7 +546,8 @@ public final class ConstraintCollectors {
                     int value = groupValueMapping.applyAsInt(a, b, c);
                     return innerSum(resultContainer, value);
                 },
-                MutableInt::intValue);
+                MutableInt::intValue,
+                groupValueMapping);
     }
 
     /**
@@ -544,7 +561,8 @@ public final class ConstraintCollectors {
                     long value = groupValueMapping.applyAsLong(a, b, c);
                     return innerSum(resultContainer, value);
                 },
-                MutableLong::longValue);
+                MutableLong::longValue,
+                groupValueMapping);
     }
 
     /**
@@ -559,7 +577,8 @@ public final class ConstraintCollectors {
                     Result value = groupValueMapping.apply(a, b, c);
                     return innerSum(resultContainer, value, adder, subtractor);
                 },
-                MutableReference::getValue);
+                MutableReference::getValue,
+                groupValueMapping, zero, adder, subtractor);
     }
 
     /**
@@ -605,7 +624,8 @@ public final class ConstraintCollectors {
                     int value = groupValueMapping.applyAsInt(a, b, c, d);
                     return innerSum(resultContainer, value);
                 },
-                MutableInt::intValue);
+                MutableInt::intValue,
+                groupValueMapping);
     }
 
     /**
@@ -619,7 +639,8 @@ public final class ConstraintCollectors {
                     long value = groupValueMapping.applyAsLong(a, b, c, d);
                     return innerSum(resultContainer, value);
                 },
-                MutableLong::longValue);
+                MutableLong::longValue,
+                groupValueMapping);
     }
 
     /**
@@ -634,7 +655,11 @@ public final class ConstraintCollectors {
                     Result value = groupValueMapping.apply(a, b, c, d);
                     return innerSum(resultContainer, value, adder, subtractor);
                 },
-                MutableReference::getValue);
+                MutableReference::getValue,
+                groupValueMapping,
+                zero,
+                adder,
+                subtractor);
     }
 
     /**
@@ -757,7 +782,10 @@ public final class ConstraintCollectors {
                     Mapped value = groupValueMapping.apply(a);
                     return innerMinOrMax(resultContainer, value, comparableFunction);
                 },
-                getMinOrMaxFinisherForComparable(min));
+                getMinOrMaxFinisherForComparable(min),
+                groupValueMapping,
+                comparableFunction,
+                min);
     }
 
     private static <Value_, Comparable_ extends Comparable<? super Comparable_>>
@@ -872,7 +900,8 @@ public final class ConstraintCollectors {
                     Mapped value = groupValueMapping.apply(a, b);
                     return innerMinOrMax(resultContainer, value, comparableFunction);
                 },
-                getMinOrMaxFinisherForComparable(min));
+                getMinOrMaxFinisherForComparable(min),
+                groupValueMapping, comparableFunction, min);
     }
 
     /**
@@ -914,7 +943,10 @@ public final class ConstraintCollectors {
                     Mapped value = groupValueMapping.apply(a, b, c);
                     return innerMinOrMax(resultContainer, value, comparableFunction);
                 },
-                getMinOrMaxFinisherForComparable(min));
+                getMinOrMaxFinisherForComparable(min),
+                groupValueMapping,
+                comparableFunction,
+                min);
     }
 
     /**
@@ -956,7 +988,10 @@ public final class ConstraintCollectors {
                     Mapped value = groupValueMapping.apply(a, b, c, d);
                     return innerMinOrMax(resultContainer, value, comparableFunction);
                 },
-                getMinOrMaxFinisherForComparable(min));
+                getMinOrMaxFinisherForComparable(min),
+                groupValueMapping,
+                comparableFunction,
+                min);
     }
 
     /**
@@ -1082,7 +1117,10 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                getMinOrMaxFinisherForComparator(min));
+                getMinOrMaxFinisherForComparator(min),
+                groupValueMapping,
+                comparator,
+                min);
     }
 
     private static <Value_> Function<SortedMap<Value_, MutableLong>, Value_>
@@ -1130,7 +1168,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                getMinOrMaxFinisherForComparator(min));
+                getMinOrMaxFinisherForComparator(min),
+                groupValueMapping, comparator, min);
     }
 
     /**
@@ -1170,7 +1209,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b, c);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                getMinOrMaxFinisherForComparator(min));
+                getMinOrMaxFinisherForComparator(min),
+                groupValueMapping, comparator, min);
     }
 
     /**
@@ -1210,7 +1250,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b, c, d);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                getMinOrMaxFinisherForComparator(min));
+                getMinOrMaxFinisherForComparator(min),
+                groupValueMapping, comparator, min);
     }
 
     /**
@@ -1584,7 +1625,9 @@ public final class ConstraintCollectors {
                     resultContainer.add(mapped);
                     return () -> resultContainer.remove(mapped);
                 },
-                resultContainer -> toCollectionFinisher(collectionFunction, resultContainer));
+                resultContainer -> toCollectionFinisher(collectionFunction, resultContainer),
+                groupValueMapping,
+                collectionFunction);
     }
 
     private static <Mapped, Container extends List<Mapped>, Result extends Collection<Mapped>> Result toCollectionFinisher(
@@ -1616,7 +1659,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                HashMap::keySet);
+                HashMap::keySet,
+                groupValueMapping);
     }
 
     /**
@@ -1646,7 +1690,9 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                TreeMap::navigableKeySet);
+                TreeMap::navigableKeySet,
+                groupValueMapping,
+                comparator);
     }
 
     /**
@@ -1669,7 +1715,8 @@ public final class ConstraintCollectors {
                     resultContainer.add(mapped);
                     return () -> resultContainer.remove(mapped);
                 },
-                Function.identity());
+                Function.identity(),
+                groupValueMapping);
     }
 
     /**
@@ -1686,7 +1733,8 @@ public final class ConstraintCollectors {
                     resultContainer.add(mapped);
                     return () -> resultContainer.remove(mapped);
                 },
-                resultContainer -> toCollectionFinisher(collectionFunction, resultContainer));
+                resultContainer -> toCollectionFinisher(collectionFunction, resultContainer),
+                groupValueMapping, collectionFunction);
     }
 
     /**
@@ -1700,7 +1748,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                HashMap::keySet);
+                HashMap::keySet,
+                groupValueMapping);
     }
 
     /**
@@ -1723,7 +1772,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                TreeMap::navigableKeySet);
+                TreeMap::navigableKeySet,
+                groupValueMapping, comparator);
     }
 
     /**
@@ -1738,7 +1788,8 @@ public final class ConstraintCollectors {
                     resultContainer.add(mapped);
                     return () -> resultContainer.remove(mapped);
                 },
-                Function.identity());
+                Function.identity(),
+                groupValueMapping);
     }
 
     /**
@@ -1755,7 +1806,8 @@ public final class ConstraintCollectors {
                     resultContainer.add(mapped);
                     return () -> resultContainer.remove(mapped);
                 },
-                resultContainer -> toCollectionFinisher(collectionFunction, resultContainer));
+                resultContainer -> toCollectionFinisher(collectionFunction, resultContainer),
+                groupValueMapping, collectionFunction);
     }
 
     /**
@@ -1769,7 +1821,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b, c);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                HashMap::keySet);
+                HashMap::keySet,
+                groupValueMapping);
     }
 
     /**
@@ -1791,7 +1844,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b, c);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                TreeMap::navigableKeySet);
+                TreeMap::navigableKeySet,
+                groupValueMapping, comparator);
     }
 
     /**
@@ -1806,7 +1860,8 @@ public final class ConstraintCollectors {
                     resultContainer.add(mapped);
                     return () -> resultContainer.remove(mapped);
                 },
-                Function.identity());
+                Function.identity(),
+                groupValueMapping);
     }
 
     /**
@@ -1823,7 +1878,8 @@ public final class ConstraintCollectors {
                     resultContainer.add(mapped);
                     return () -> resultContainer.remove(mapped);
                 },
-                resultContainer -> toCollectionFinisher(collectionFunction, resultContainer));
+                resultContainer -> toCollectionFinisher(collectionFunction, resultContainer),
+                groupValueMapping, collectionFunction);
     }
 
     /**
@@ -1837,7 +1893,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b, c, d);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                HashMap::keySet);
+                HashMap::keySet,
+                groupValueMapping);
     }
 
     /**
@@ -1860,7 +1917,8 @@ public final class ConstraintCollectors {
                     Mapped mapped = groupValueMapping.apply(a, b, c, d);
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
-                TreeMap::navigableKeySet);
+                TreeMap::navigableKeySet,
+                groupValueMapping, comparator);
     }
 
     /**
@@ -1875,7 +1933,8 @@ public final class ConstraintCollectors {
                     resultContainer.add(mapped);
                     return () -> resultContainer.remove(mapped);
                 },
-                Function.identity());
+                Function.identity(),
+                groupValueMapping);
     }
 
     // ************************************************************************
@@ -1936,7 +1995,10 @@ public final class ConstraintCollectors {
         return new DefaultUniConstraintCollector<>(
                 () -> new ToMultiMapResultContainer<>((IntFunction<HashMap<Key, ValueSet>>) HashMap::new, valueSetFunction),
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
-                ToMultiMapResultContainer::getResult);
+                ToMultiMapResultContainer::getResult,
+                keyMapper,
+                valueMapper,
+                valueSetFunction);
     }
 
     private static final class ToMapPerKeyCounter<Value> {
@@ -2126,7 +2188,10 @@ public final class ConstraintCollectors {
         return new DefaultUniConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((IntFunction<HashMap<Key, Value>>) HashMap::new, mergeFunction),
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
-                ToMapResultContainer::getResult);
+                ToMapResultContainer::getResult,
+                keyMapper,
+                valueMapper,
+                mergeFunction);
     }
 
     /**
@@ -2183,7 +2248,10 @@ public final class ConstraintCollectors {
         return new DefaultUniConstraintCollector<>(
                 () -> new ToMultiMapResultContainer<>((Supplier<TreeMap<Key, ValueSet>>) TreeMap::new, valueSetFunction),
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
-                ToMultiMapResultContainer::getResult);
+                ToMultiMapResultContainer::getResult,
+                keyMapper,
+                valueMapper,
+                valueSetFunction);
     }
 
     /**
@@ -2210,7 +2278,10 @@ public final class ConstraintCollectors {
         return new DefaultUniConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
-                ToSimpleMapResultContainer::getResult);
+                ToSimpleMapResultContainer::getResult,
+                keyMapper,
+                valueMapper,
+                mergeFunction);
     }
 
     /**
@@ -2231,7 +2302,8 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 () -> new ToMultiMapResultContainer<>((IntFunction<HashMap<Key, ValueSet>>) HashMap::new, valueSetFunction),
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
-                ToMultiMapResultContainer::getResult);
+                ToMultiMapResultContainer::getResult,
+                keyMapper, valueMapper, valueSetFunction);
     }
 
     private static <A, B, Key, Value> Runnable toMapAccumulator(
@@ -2252,7 +2324,8 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((IntFunction<HashMap<Key, Value>>) HashMap::new, mergeFunction),
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
-                ToSimpleMapResultContainer::getResult);
+                ToSimpleMapResultContainer::getResult,
+                keyMapper, valueMapper, mergeFunction);
     }
 
     /**
@@ -2274,7 +2347,8 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 () -> new ToMultiMapResultContainer<>((Supplier<TreeMap<Key, ValueSet>>) TreeMap::new, valueSetFunction),
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
-                ToMultiMapResultContainer::getResult);
+                ToMultiMapResultContainer::getResult,
+                keyMapper, valueMapper, valueSetFunction);
     }
 
     /**
@@ -2287,7 +2361,8 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
-                ToSimpleMapResultContainer::getResult);
+                ToSimpleMapResultContainer::getResult,
+                keyMapper, valueMapper, mergeFunction);
     }
 
     /**
@@ -2309,7 +2384,8 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 () -> new ToMultiMapResultContainer<>((IntFunction<HashMap<Key, ValueSet>>) HashMap::new, valueSetFunction),
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
-                ToMultiMapResultContainer::getResult);
+                ToMultiMapResultContainer::getResult,
+                keyMapper, valueMapper, valueSetFunction);
     }
 
     private static <A, B, C, Key, Value> Runnable toMapAccumulator(
@@ -2331,7 +2407,8 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((IntFunction<HashMap<Key, Value>>) HashMap::new, mergeFunction),
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
-                ToSimpleMapResultContainer::getResult);
+                ToSimpleMapResultContainer::getResult,
+                keyMapper, valueMapper, mergeFunction);
     }
 
     /**
@@ -2355,7 +2432,8 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 () -> new ToMultiMapResultContainer<>((Supplier<TreeMap<Key, ValueSet>>) TreeMap::new, valueSetFunction),
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
-                ToMultiMapResultContainer::getResult);
+                ToMultiMapResultContainer::getResult,
+                keyMapper, valueMapper, valueSetFunction);
     }
 
     /**
@@ -2369,7 +2447,8 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
-                ToSimpleMapResultContainer::getResult);
+                ToSimpleMapResultContainer::getResult,
+                keyMapper, valueMapper, mergeFunction);
     }
 
     /**
@@ -2392,7 +2471,8 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 () -> new ToMultiMapResultContainer<>((IntFunction<HashMap<Key, ValueSet>>) HashMap::new, valueSetFunction),
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
-                ToMultiMapResultContainer::getResult);
+                ToMultiMapResultContainer::getResult,
+                keyMapper, valueMapper, valueSetFunction);
     }
 
     private static <A, B, C, D, Key, Value> Runnable toMapAccumulator(
@@ -2414,7 +2494,8 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((IntFunction<HashMap<Key, Value>>) HashMap::new, mergeFunction),
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
-                ToSimpleMapResultContainer::getResult);
+                ToSimpleMapResultContainer::getResult,
+                keyMapper, valueMapper, mergeFunction);
     }
 
     /**
@@ -2438,7 +2519,8 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 () -> new ToMultiMapResultContainer<>((Supplier<TreeMap<Key, ValueSet>>) TreeMap::new, valueSetFunction),
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
-                ToMultiMapResultContainer::getResult);
+                ToMultiMapResultContainer::getResult,
+                keyMapper, valueMapper, valueSetFunction);
     }
 
     /**
@@ -2452,7 +2534,8 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
-                ToSimpleMapResultContainer::getResult);
+                ToSimpleMapResultContainer::getResult,
+                keyMapper, valueMapper, mergeFunction);
     }
 
     // ************************************************************************
@@ -2486,7 +2569,9 @@ public final class ConstraintCollectors {
                         return NOOP;
                     }
                 },
-                delegate.finisher());
+                delegate.finisher(),
+                condition,
+                delegate);
     }
 
     /**
@@ -2505,7 +2590,8 @@ public final class ConstraintCollectors {
                         return NOOP;
                     }
                 },
-                delegate.finisher());
+                delegate.finisher(),
+                condition, delegate);
     }
 
     /**
@@ -2524,7 +2610,8 @@ public final class ConstraintCollectors {
                         return NOOP;
                     }
                 },
-                delegate.finisher());
+                delegate.finisher(),
+                condition, delegate);
     }
 
     /**
@@ -2543,7 +2630,8 @@ public final class ConstraintCollectors {
                         return NOOP;
                     }
                 },
-                delegate.finisher());
+                delegate.finisher(),
+                condition, delegate);
     }
 
     // ************************************************************************
@@ -2581,7 +2669,8 @@ public final class ConstraintCollectors {
                     Runnable undo2 = subResult2Accumulator.apply(resultContainer.getValue(), a);
                     return compose(undo1, undo2);
                 },
-                createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction));
+                createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction),
+                subCollector1, subCollector2, composeFunction);
     }
 
     private static <Result_, SubResultContainer1_, SubResultContainer2_, SubResult1_, SubResult2_>
@@ -2643,7 +2732,11 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2, undo3);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
-                        composeFunction));
+                        composeFunction),
+                subCollector1,
+                subCollector2,
+                subCollector3,
+                composeFunction);
     }
 
     private static <Result_, SubResultContainer1_, SubResultContainer2_, SubResultContainer3_, SubResult1_, SubResult2_, SubResult3_>
@@ -2715,7 +2808,12 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2, undo3, undo4);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
-                        subCollector4.finisher(), composeFunction));
+                        subCollector4.finisher(), composeFunction),
+                subCollector1,
+                subCollector2,
+                subCollector3,
+                subCollector4,
+                composeFunction);
     }
 
     private static <Result_, SubResultContainer1_, SubResultContainer2_, SubResultContainer3_, SubResultContainer4_, SubResult1_, SubResult2_, SubResult3_, SubResult4_>
@@ -2762,7 +2860,8 @@ public final class ConstraintCollectors {
                     Runnable undo2 = subResult2Accumulator.apply(resultContainer.getValue(), a, b);
                     return compose(undo1, undo2);
                 },
-                createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction));
+                createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction),
+                subCollector1, subCollector2, composeFunction);
     }
 
     /**
@@ -2790,7 +2889,8 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2, undo3);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
-                        composeFunction));
+                        composeFunction),
+                subCollector1, subCollector2, subCollector3, composeFunction);
     }
 
     /**
@@ -2823,7 +2923,8 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2, undo3, undo4);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
-                        subCollector4.finisher(), composeFunction));
+                        subCollector4.finisher(), composeFunction),
+                subCollector1, subCollector2, subCollector3, subCollector4, composeFunction);
     }
 
     /**
@@ -2845,7 +2946,8 @@ public final class ConstraintCollectors {
                     Runnable undo2 = subResult2Accumulator.apply(resultContainer.getValue(), a, b, c);
                     return compose(undo1, undo2);
                 },
-                createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction));
+                createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction),
+                subCollector1, subCollector2, composeFunction);
     }
 
     /**
@@ -2873,7 +2975,8 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2, undo3);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
-                        composeFunction));
+                        composeFunction),
+                subCollector1, subCollector2, subCollector3, composeFunction);
     }
 
     /**
@@ -2906,7 +3009,8 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2, undo3, undo4);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
-                        subCollector4.finisher(), composeFunction));
+                        subCollector4.finisher(), composeFunction),
+                subCollector1, subCollector2, subCollector3, subCollector4, composeFunction);
     }
 
     /**
@@ -2928,7 +3032,8 @@ public final class ConstraintCollectors {
                     Runnable undo2 = subResult2Accumulator.apply(resultContainer.getValue(), a, b, c, d);
                     return compose(undo1, undo2);
                 },
-                createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction));
+                createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction),
+                subCollector1, subCollector2, composeFunction);
     }
 
     /**
@@ -2956,7 +3061,8 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2, undo3);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
-                        composeFunction));
+                        composeFunction),
+                subCollector1, subCollector2, subCollector3, composeFunction);
     }
 
     /**
@@ -2989,7 +3095,8 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2, undo3, undo4);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
-                        subCollector4.finisher(), composeFunction));
+                        subCollector4.finisher(), composeFunction),
+                subCollector1, subCollector2, subCollector3, subCollector4, composeFunction);
     }
 
     private ConstraintCollectors() {

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
@@ -64,6 +64,25 @@ public final class ConstraintCollectors {
         // No operation.
     };
 
+    enum ConstraintCollectorKind {
+        AVERAGE,
+        COMPOSE,
+        CONDITIONALLY,
+        COUNT,
+        COUNT_LONG,
+        COUNT_DISTINCT,
+        COUNT_DISTINCT_LONG,
+        MAX,
+        MIN,
+        SUM,
+        TO_COLLECTION,
+        TO_LIST,
+        TO_SET,
+        TO_SORTED_SET,
+        TO_MAP,
+        TO_SORTED_MAP
+    }
+
     // ************************************************************************
     // count
     // ************************************************************************
@@ -83,7 +102,8 @@ public final class ConstraintCollectors {
         return new DefaultUniConstraintCollector<>(
                 MutableInt::new,
                 (resultContainer, a) -> innerCount(resultContainer),
-                MutableInt::intValue);
+                MutableInt::intValue,
+                ConstraintCollectorKind.COUNT);
     }
 
     private static Runnable innerCount(MutableInt resultContainer) {
@@ -98,7 +118,8 @@ public final class ConstraintCollectors {
         return new DefaultUniConstraintCollector<>(
                 MutableLong::new,
                 (resultContainer, a) -> innerCount(resultContainer),
-                MutableLong::longValue);
+                MutableLong::longValue,
+                ConstraintCollectorKind.COUNT_LONG);
     }
 
     private static Runnable innerCount(MutableLong resultContainer) {
@@ -113,7 +134,8 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 MutableInt::new,
                 (resultContainer, a, b) -> innerCount(resultContainer),
-                MutableInt::intValue);
+                MutableInt::intValue,
+                ConstraintCollectorKind.COUNT);
     }
 
     /**
@@ -123,7 +145,8 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 MutableLong::new,
                 (resultContainer, a, b) -> innerCount(resultContainer),
-                MutableLong::longValue);
+                MutableLong::longValue,
+                ConstraintCollectorKind.COUNT_LONG);
     }
 
     /**
@@ -133,7 +156,8 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 MutableInt::new,
                 (resultContainer, a, b, c) -> innerCount(resultContainer),
-                MutableInt::intValue);
+                MutableInt::intValue,
+                ConstraintCollectorKind.COUNT);
     }
 
     /**
@@ -143,7 +167,8 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 MutableLong::new,
                 (resultContainer, a, b, c) -> innerCount(resultContainer),
-                MutableLong::longValue);
+                MutableLong::longValue,
+                ConstraintCollectorKind.COUNT_LONG);
     }
 
     /**
@@ -153,7 +178,8 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 MutableInt::new,
                 (resultContainer, a, b, c, d) -> innerCount(resultContainer),
-                MutableInt::intValue);
+                MutableInt::intValue,
+                ConstraintCollectorKind.COUNT);
     }
 
     /**
@@ -163,7 +189,8 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 MutableLong::new,
                 (resultContainer, a, b, c, d) -> innerCount(resultContainer),
-                MutableLong::longValue);
+                MutableLong::longValue,
+                ConstraintCollectorKind.COUNT_LONG);
     }
 
     // ************************************************************************
@@ -197,6 +224,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinct(resultContainer, value);
                 },
                 Map::size,
+                ConstraintCollectorKind.COUNT_DISTINCT,
                 groupValueMapping);
     }
 
@@ -211,6 +239,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, value);
                 },
                 resultContainer -> (long) resultContainer.size(),
+                ConstraintCollectorKind.COUNT_DISTINCT_LONG,
                 groupValueMapping);
     }
 
@@ -226,6 +255,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinct(resultContainer, value);
                 },
                 Map::size,
+                ConstraintCollectorKind.COUNT_DISTINCT,
                 groupValueMapping);
     }
 
@@ -241,6 +271,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, value);
                 },
                 resultContainer -> (long) resultContainer.size(),
+                ConstraintCollectorKind.COUNT_DISTINCT_LONG,
                 groupValueMapping);
     }
 
@@ -256,6 +287,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinct(resultContainer, value);
                 },
                 Map::size,
+                ConstraintCollectorKind.COUNT_DISTINCT,
                 groupValueMapping);
     }
 
@@ -271,6 +303,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, value);
                 },
                 resultContainer -> (long) resultContainer.size(),
+                ConstraintCollectorKind.COUNT_DISTINCT_LONG,
                 groupValueMapping);
     }
 
@@ -286,6 +319,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinct(resultContainer, value);
                 },
                 Map::size,
+                ConstraintCollectorKind.COUNT_DISTINCT,
                 groupValueMapping);
     }
 
@@ -301,6 +335,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, value);
                 },
                 resultContainer -> (long) resultContainer.size(),
+                ConstraintCollectorKind.COUNT_DISTINCT_LONG,
                 groupValueMapping);
     }
 
@@ -376,6 +411,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value);
                 },
                 MutableInt::intValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping);
     }
 
@@ -395,6 +431,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value);
                 },
                 MutableLong::longValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping);
     }
 
@@ -415,6 +452,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value, adder, subtractor);
                 },
                 MutableReference::getValue,
+                ConstraintCollectorKind.SUM,
                 zero,
                 adder,
                 subtractor);
@@ -469,6 +507,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value);
                 },
                 MutableInt::intValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping);
     }
 
@@ -484,6 +523,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value);
                 },
                 MutableLong::longValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping);
     }
 
@@ -500,6 +540,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value, adder, subtractor);
                 },
                 MutableReference::getValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping, zero, adder, subtractor);
     }
 
@@ -547,6 +588,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value);
                 },
                 MutableInt::intValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping);
     }
 
@@ -562,6 +604,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value);
                 },
                 MutableLong::longValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping);
     }
 
@@ -578,6 +621,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value, adder, subtractor);
                 },
                 MutableReference::getValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping, zero, adder, subtractor);
     }
 
@@ -625,6 +669,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value);
                 },
                 MutableInt::intValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping);
     }
 
@@ -640,6 +685,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value);
                 },
                 MutableLong::longValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping);
     }
 
@@ -656,6 +702,7 @@ public final class ConstraintCollectors {
                     return innerSum(resultContainer, value, adder, subtractor);
                 },
                 MutableReference::getValue,
+                ConstraintCollectorKind.SUM,
                 groupValueMapping,
                 zero,
                 adder,
@@ -783,6 +830,7 @@ public final class ConstraintCollectors {
                     return innerMinOrMax(resultContainer, value, comparableFunction);
                 },
                 getMinOrMaxFinisherForComparable(min),
+                min ? ConstraintCollectorKind.MIN : ConstraintCollectorKind.MAX,
                 groupValueMapping,
                 comparableFunction,
                 min);
@@ -901,6 +949,7 @@ public final class ConstraintCollectors {
                     return innerMinOrMax(resultContainer, value, comparableFunction);
                 },
                 getMinOrMaxFinisherForComparable(min),
+                min ? ConstraintCollectorKind.MIN : ConstraintCollectorKind.MAX,
                 groupValueMapping, comparableFunction, min);
     }
 
@@ -944,6 +993,7 @@ public final class ConstraintCollectors {
                     return innerMinOrMax(resultContainer, value, comparableFunction);
                 },
                 getMinOrMaxFinisherForComparable(min),
+                min ? ConstraintCollectorKind.MIN : ConstraintCollectorKind.MAX,
                 groupValueMapping,
                 comparableFunction,
                 min);
@@ -989,6 +1039,7 @@ public final class ConstraintCollectors {
                     return innerMinOrMax(resultContainer, value, comparableFunction);
                 },
                 getMinOrMaxFinisherForComparable(min),
+                min ? ConstraintCollectorKind.MIN : ConstraintCollectorKind.MAX,
                 groupValueMapping,
                 comparableFunction,
                 min);
@@ -1118,6 +1169,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 getMinOrMaxFinisherForComparator(min),
+                min ? ConstraintCollectorKind.MIN : ConstraintCollectorKind.MAX,
                 groupValueMapping,
                 comparator,
                 min);
@@ -1169,6 +1221,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 getMinOrMaxFinisherForComparator(min),
+                min ? ConstraintCollectorKind.MIN : ConstraintCollectorKind.MAX,
                 groupValueMapping, comparator, min);
     }
 
@@ -1210,6 +1263,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 getMinOrMaxFinisherForComparator(min),
+                min ? ConstraintCollectorKind.MIN : ConstraintCollectorKind.MAX,
                 groupValueMapping, comparator, min);
     }
 
@@ -1251,6 +1305,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 getMinOrMaxFinisherForComparator(min),
+                min ? ConstraintCollectorKind.MIN : ConstraintCollectorKind.MAX,
                 groupValueMapping, comparator, min);
     }
 
@@ -1626,6 +1681,7 @@ public final class ConstraintCollectors {
                     return () -> resultContainer.remove(mapped);
                 },
                 resultContainer -> toCollectionFinisher(collectionFunction, resultContainer),
+                ConstraintCollectorKind.TO_COLLECTION,
                 groupValueMapping,
                 collectionFunction);
     }
@@ -1660,6 +1716,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 HashMap::keySet,
+                ConstraintCollectorKind.TO_SET,
                 groupValueMapping);
     }
 
@@ -1691,6 +1748,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 TreeMap::navigableKeySet,
+                ConstraintCollectorKind.TO_SORTED_SET,
                 groupValueMapping,
                 comparator);
     }
@@ -1716,6 +1774,7 @@ public final class ConstraintCollectors {
                     return () -> resultContainer.remove(mapped);
                 },
                 Function.identity(),
+                ConstraintCollectorKind.TO_LIST,
                 groupValueMapping);
     }
 
@@ -1734,6 +1793,7 @@ public final class ConstraintCollectors {
                     return () -> resultContainer.remove(mapped);
                 },
                 resultContainer -> toCollectionFinisher(collectionFunction, resultContainer),
+                ConstraintCollectorKind.TO_COLLECTION,
                 groupValueMapping, collectionFunction);
     }
 
@@ -1749,6 +1809,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 HashMap::keySet,
+                ConstraintCollectorKind.TO_SET,
                 groupValueMapping);
     }
 
@@ -1773,6 +1834,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 TreeMap::navigableKeySet,
+                ConstraintCollectorKind.TO_SORTED_SET,
                 groupValueMapping, comparator);
     }
 
@@ -1789,6 +1851,7 @@ public final class ConstraintCollectors {
                     return () -> resultContainer.remove(mapped);
                 },
                 Function.identity(),
+                ConstraintCollectorKind.TO_LIST,
                 groupValueMapping);
     }
 
@@ -1807,6 +1870,7 @@ public final class ConstraintCollectors {
                     return () -> resultContainer.remove(mapped);
                 },
                 resultContainer -> toCollectionFinisher(collectionFunction, resultContainer),
+                ConstraintCollectorKind.TO_COLLECTION,
                 groupValueMapping, collectionFunction);
     }
 
@@ -1822,6 +1886,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 HashMap::keySet,
+                ConstraintCollectorKind.TO_SET,
                 groupValueMapping);
     }
 
@@ -1845,6 +1910,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 TreeMap::navigableKeySet,
+                ConstraintCollectorKind.TO_SORTED_SET,
                 groupValueMapping, comparator);
     }
 
@@ -1861,6 +1927,7 @@ public final class ConstraintCollectors {
                     return () -> resultContainer.remove(mapped);
                 },
                 Function.identity(),
+                ConstraintCollectorKind.TO_LIST,
                 groupValueMapping);
     }
 
@@ -1879,6 +1946,7 @@ public final class ConstraintCollectors {
                     return () -> resultContainer.remove(mapped);
                 },
                 resultContainer -> toCollectionFinisher(collectionFunction, resultContainer),
+                ConstraintCollectorKind.TO_COLLECTION,
                 groupValueMapping, collectionFunction);
     }
 
@@ -1894,6 +1962,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 HashMap::keySet,
+                ConstraintCollectorKind.TO_SET,
                 groupValueMapping);
     }
 
@@ -1918,6 +1987,7 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, mapped);
                 },
                 TreeMap::navigableKeySet,
+                ConstraintCollectorKind.TO_SORTED_SET,
                 groupValueMapping, comparator);
     }
 
@@ -1934,6 +2004,7 @@ public final class ConstraintCollectors {
                     return () -> resultContainer.remove(mapped);
                 },
                 Function.identity(),
+                ConstraintCollectorKind.TO_LIST,
                 groupValueMapping);
     }
 
@@ -1996,6 +2067,7 @@ public final class ConstraintCollectors {
                 () -> new ToMultiMapResultContainer<>((IntFunction<HashMap<Key, ValueSet>>) HashMap::new, valueSetFunction),
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
                 ToMultiMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_MAP,
                 keyMapper,
                 valueMapper,
                 valueSetFunction);
@@ -2189,6 +2261,7 @@ public final class ConstraintCollectors {
                 () -> new ToSimpleMapResultContainer<>((IntFunction<HashMap<Key, Value>>) HashMap::new, mergeFunction),
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
                 ToMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_MAP,
                 keyMapper,
                 valueMapper,
                 mergeFunction);
@@ -2249,6 +2322,7 @@ public final class ConstraintCollectors {
                 () -> new ToMultiMapResultContainer<>((Supplier<TreeMap<Key, ValueSet>>) TreeMap::new, valueSetFunction),
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
                 ToMultiMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_SORTED_MAP,
                 keyMapper,
                 valueMapper,
                 valueSetFunction);
@@ -2279,6 +2353,7 @@ public final class ConstraintCollectors {
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
                 ToSimpleMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_SORTED_MAP,
                 keyMapper,
                 valueMapper,
                 mergeFunction);
@@ -2303,6 +2378,7 @@ public final class ConstraintCollectors {
                 () -> new ToMultiMapResultContainer<>((IntFunction<HashMap<Key, ValueSet>>) HashMap::new, valueSetFunction),
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
                 ToMultiMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_MAP,
                 keyMapper, valueMapper, valueSetFunction);
     }
 
@@ -2325,6 +2401,7 @@ public final class ConstraintCollectors {
                 () -> new ToSimpleMapResultContainer<>((IntFunction<HashMap<Key, Value>>) HashMap::new, mergeFunction),
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
                 ToSimpleMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_MAP,
                 keyMapper, valueMapper, mergeFunction);
     }
 
@@ -2348,6 +2425,7 @@ public final class ConstraintCollectors {
                 () -> new ToMultiMapResultContainer<>((Supplier<TreeMap<Key, ValueSet>>) TreeMap::new, valueSetFunction),
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
                 ToMultiMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_SORTED_MAP,
                 keyMapper, valueMapper, valueSetFunction);
     }
 
@@ -2362,6 +2440,7 @@ public final class ConstraintCollectors {
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
                 ToSimpleMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_SORTED_MAP,
                 keyMapper, valueMapper, mergeFunction);
     }
 
@@ -2385,6 +2464,7 @@ public final class ConstraintCollectors {
                 () -> new ToMultiMapResultContainer<>((IntFunction<HashMap<Key, ValueSet>>) HashMap::new, valueSetFunction),
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
                 ToMultiMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_MAP,
                 keyMapper, valueMapper, valueSetFunction);
     }
 
@@ -2408,6 +2488,7 @@ public final class ConstraintCollectors {
                 () -> new ToSimpleMapResultContainer<>((IntFunction<HashMap<Key, Value>>) HashMap::new, mergeFunction),
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
                 ToSimpleMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_MAP,
                 keyMapper, valueMapper, mergeFunction);
     }
 
@@ -2433,6 +2514,7 @@ public final class ConstraintCollectors {
                 () -> new ToMultiMapResultContainer<>((Supplier<TreeMap<Key, ValueSet>>) TreeMap::new, valueSetFunction),
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
                 ToMultiMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_SORTED_MAP,
                 keyMapper, valueMapper, valueSetFunction);
     }
 
@@ -2448,6 +2530,7 @@ public final class ConstraintCollectors {
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
                 ToSimpleMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_SORTED_MAP,
                 keyMapper, valueMapper, mergeFunction);
     }
 
@@ -2472,6 +2555,7 @@ public final class ConstraintCollectors {
                 () -> new ToMultiMapResultContainer<>((IntFunction<HashMap<Key, ValueSet>>) HashMap::new, valueSetFunction),
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
                 ToMultiMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_MAP,
                 keyMapper, valueMapper, valueSetFunction);
     }
 
@@ -2495,6 +2579,7 @@ public final class ConstraintCollectors {
                 () -> new ToSimpleMapResultContainer<>((IntFunction<HashMap<Key, Value>>) HashMap::new, mergeFunction),
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
                 ToSimpleMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_MAP,
                 keyMapper, valueMapper, mergeFunction);
     }
 
@@ -2520,6 +2605,7 @@ public final class ConstraintCollectors {
                 () -> new ToMultiMapResultContainer<>((Supplier<TreeMap<Key, ValueSet>>) TreeMap::new, valueSetFunction),
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
                 ToMultiMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_SORTED_MAP,
                 keyMapper, valueMapper, valueSetFunction);
     }
 
@@ -2535,6 +2621,7 @@ public final class ConstraintCollectors {
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
                 ToSimpleMapResultContainer::getResult,
+                ConstraintCollectorKind.TO_SORTED_MAP,
                 keyMapper, valueMapper, mergeFunction);
     }
 
@@ -2570,6 +2657,7 @@ public final class ConstraintCollectors {
                     }
                 },
                 delegate.finisher(),
+                ConstraintCollectorKind.CONDITIONALLY,
                 condition,
                 delegate);
     }
@@ -2591,6 +2679,7 @@ public final class ConstraintCollectors {
                     }
                 },
                 delegate.finisher(),
+                ConstraintCollectorKind.CONDITIONALLY,
                 condition, delegate);
     }
 
@@ -2611,6 +2700,7 @@ public final class ConstraintCollectors {
                     }
                 },
                 delegate.finisher(),
+                ConstraintCollectorKind.CONDITIONALLY,
                 condition, delegate);
     }
 
@@ -2631,6 +2721,7 @@ public final class ConstraintCollectors {
                     }
                 },
                 delegate.finisher(),
+                ConstraintCollectorKind.CONDITIONALLY,
                 condition, delegate);
     }
 
@@ -2670,6 +2761,7 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, composeFunction);
     }
 
@@ -2733,6 +2825,7 @@ public final class ConstraintCollectors {
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
                         composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1,
                 subCollector2,
                 subCollector3,
@@ -2809,6 +2902,7 @@ public final class ConstraintCollectors {
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
                         subCollector4.finisher(), composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1,
                 subCollector2,
                 subCollector3,
@@ -2861,6 +2955,7 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, composeFunction);
     }
 
@@ -2890,6 +2985,7 @@ public final class ConstraintCollectors {
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
                         composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, subCollector3, composeFunction);
     }
 
@@ -2924,6 +3020,7 @@ public final class ConstraintCollectors {
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
                         subCollector4.finisher(), composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, subCollector3, subCollector4, composeFunction);
     }
 
@@ -2947,6 +3044,7 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, composeFunction);
     }
 
@@ -2976,6 +3074,7 @@ public final class ConstraintCollectors {
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
                         composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, subCollector3, composeFunction);
     }
 
@@ -3010,6 +3109,7 @@ public final class ConstraintCollectors {
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
                         subCollector4.finisher(), composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, subCollector3, subCollector4, composeFunction);
     }
 
@@ -3033,6 +3133,7 @@ public final class ConstraintCollectors {
                     return compose(undo1, undo2);
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, composeFunction);
     }
 
@@ -3062,6 +3163,7 @@ public final class ConstraintCollectors {
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
                         composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, subCollector3, composeFunction);
     }
 
@@ -3096,6 +3198,7 @@ public final class ConstraintCollectors {
                 },
                 createComposedFinisher(subCollector1.finisher(), subCollector2.finisher(), subCollector3.finisher(),
                         subCollector4.finisher(), composeFunction),
+                ConstraintCollectorKind.COMPOSE,
                 subCollector1, subCollector2, subCollector3, subCollector4, composeFunction);
     }
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultBiConstraintCollector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultBiConstraintCollector.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.api.score.stream;
 
+import java.util.Arrays;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -12,13 +13,16 @@ final class DefaultBiConstraintCollector<A, B, ResultContainer_, Result_>
     private final Supplier<ResultContainer_> supplier;
     private final TriFunction<ResultContainer_, A, B, Runnable> accumulator;
     private final Function<ResultContainer_, Result_> finisher;
+    private final Object[] equalityArgs;
 
     public DefaultBiConstraintCollector(Supplier<ResultContainer_> supplier,
             TriFunction<ResultContainer_, A, B, Runnable> accumulator,
-            Function<ResultContainer_, Result_> finisher) {
+            Function<ResultContainer_, Result_> finisher,
+            Object... equalityArgs) {
         this.supplier = supplier;
         this.accumulator = accumulator;
         this.finisher = finisher;
+        this.equalityArgs = equalityArgs;
     }
 
     @Override
@@ -36,4 +40,18 @@ final class DefaultBiConstraintCollector<A, B, ResultContainer_, Result_>
         return finisher;
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        DefaultBiConstraintCollector<?, ?, ?, ?> that = (DefaultBiConstraintCollector<?, ?, ?, ?>) object;
+        return Arrays.equals(equalityArgs, that.equalityArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(equalityArgs);
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultBiConstraintCollector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultBiConstraintCollector.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.api.score.stream;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -13,15 +14,18 @@ final class DefaultBiConstraintCollector<A, B, ResultContainer_, Result_>
     private final Supplier<ResultContainer_> supplier;
     private final TriFunction<ResultContainer_, A, B, Runnable> accumulator;
     private final Function<ResultContainer_, Result_> finisher;
+    private final ConstraintCollectors.ConstraintCollectorKind collectorKind;
     private final Object[] equalityArgs;
 
     public DefaultBiConstraintCollector(Supplier<ResultContainer_> supplier,
             TriFunction<ResultContainer_, A, B, Runnable> accumulator,
             Function<ResultContainer_, Result_> finisher,
+            ConstraintCollectors.ConstraintCollectorKind collectorKind,
             Object... equalityArgs) {
         this.supplier = supplier;
         this.accumulator = accumulator;
         this.finisher = finisher;
+        this.collectorKind = collectorKind;
         this.equalityArgs = equalityArgs;
     }
 
@@ -47,11 +51,13 @@ final class DefaultBiConstraintCollector<A, B, ResultContainer_, Result_>
         if (object == null || getClass() != object.getClass())
             return false;
         DefaultBiConstraintCollector<?, ?, ?, ?> that = (DefaultBiConstraintCollector<?, ?, ?, ?>) object;
-        return Arrays.equals(equalityArgs, that.equalityArgs);
+        return collectorKind == that.collectorKind && Arrays.equals(equalityArgs, that.equalityArgs);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(equalityArgs);
+        int result = Objects.hash(collectorKind);
+        result = 31 * result + Arrays.hashCode(equalityArgs);
+        return result;
     }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultQuadConstraintCollector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultQuadConstraintCollector.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.api.score.stream;
 
+import java.util.Arrays;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -12,13 +13,16 @@ final class DefaultQuadConstraintCollector<A, B, C, D, ResultContainer_, Result_
     private final Supplier<ResultContainer_> supplier;
     private final PentaFunction<ResultContainer_, A, B, C, D, Runnable> accumulator;
     private final Function<ResultContainer_, Result_> finisher;
+    private final Object[] equalityArgs;
 
     public DefaultQuadConstraintCollector(Supplier<ResultContainer_> supplier,
             PentaFunction<ResultContainer_, A, B, C, D, Runnable> accumulator,
-            Function<ResultContainer_, Result_> finisher) {
+            Function<ResultContainer_, Result_> finisher,
+            Object... equalityArgs) {
         this.supplier = supplier;
         this.accumulator = accumulator;
         this.finisher = finisher;
+        this.equalityArgs = equalityArgs;
     }
 
     @Override
@@ -36,4 +40,18 @@ final class DefaultQuadConstraintCollector<A, B, C, D, ResultContainer_, Result_
         return finisher;
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        DefaultQuadConstraintCollector<?, ?, ?, ?, ?, ?> that = (DefaultQuadConstraintCollector<?, ?, ?, ?, ?, ?>) object;
+        return Arrays.equals(equalityArgs, that.equalityArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(equalityArgs);
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultQuadConstraintCollector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultQuadConstraintCollector.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.api.score.stream;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -13,15 +14,18 @@ final class DefaultQuadConstraintCollector<A, B, C, D, ResultContainer_, Result_
     private final Supplier<ResultContainer_> supplier;
     private final PentaFunction<ResultContainer_, A, B, C, D, Runnable> accumulator;
     private final Function<ResultContainer_, Result_> finisher;
+    private final ConstraintCollectors.ConstraintCollectorKind collectorKind;
     private final Object[] equalityArgs;
 
     public DefaultQuadConstraintCollector(Supplier<ResultContainer_> supplier,
             PentaFunction<ResultContainer_, A, B, C, D, Runnable> accumulator,
             Function<ResultContainer_, Result_> finisher,
+            ConstraintCollectors.ConstraintCollectorKind collectorKind,
             Object... equalityArgs) {
         this.supplier = supplier;
         this.accumulator = accumulator;
         this.finisher = finisher;
+        this.collectorKind = collectorKind;
         this.equalityArgs = equalityArgs;
     }
 
@@ -47,11 +51,13 @@ final class DefaultQuadConstraintCollector<A, B, C, D, ResultContainer_, Result_
         if (object == null || getClass() != object.getClass())
             return false;
         DefaultQuadConstraintCollector<?, ?, ?, ?, ?, ?> that = (DefaultQuadConstraintCollector<?, ?, ?, ?, ?, ?>) object;
-        return Arrays.equals(equalityArgs, that.equalityArgs);
+        return collectorKind == that.collectorKind && Arrays.equals(equalityArgs, that.equalityArgs);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(equalityArgs);
+        int result = Objects.hash(collectorKind);
+        result = 31 * result + Arrays.hashCode(equalityArgs);
+        return result;
     }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultTriConstraintCollector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultTriConstraintCollector.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.api.score.stream;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -13,15 +14,18 @@ final class DefaultTriConstraintCollector<A, B, C, ResultContainer_, Result_>
     private final Supplier<ResultContainer_> supplier;
     private final QuadFunction<ResultContainer_, A, B, C, Runnable> accumulator;
     private final Function<ResultContainer_, Result_> finisher;
+    private final ConstraintCollectors.ConstraintCollectorKind collectorKind;
     private final Object[] equalityArgs;
 
     public DefaultTriConstraintCollector(Supplier<ResultContainer_> supplier,
             QuadFunction<ResultContainer_, A, B, C, Runnable> accumulator,
             Function<ResultContainer_, Result_> finisher,
+            ConstraintCollectors.ConstraintCollectorKind collectorKind,
             Object... equalityArgs) {
         this.supplier = supplier;
         this.accumulator = accumulator;
         this.finisher = finisher;
+        this.collectorKind = collectorKind;
         this.equalityArgs = equalityArgs;
     }
 
@@ -47,11 +51,13 @@ final class DefaultTriConstraintCollector<A, B, C, ResultContainer_, Result_>
         if (object == null || getClass() != object.getClass())
             return false;
         DefaultTriConstraintCollector<?, ?, ?, ?, ?> that = (DefaultTriConstraintCollector<?, ?, ?, ?, ?>) object;
-        return Arrays.equals(equalityArgs, that.equalityArgs);
+        return collectorKind == that.collectorKind && Arrays.equals(equalityArgs, that.equalityArgs);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(equalityArgs);
+        int result = Objects.hash(collectorKind);
+        result = 31 * result + Arrays.hashCode(equalityArgs);
+        return result;
     }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultTriConstraintCollector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultTriConstraintCollector.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.api.score.stream;
 
+import java.util.Arrays;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -12,13 +13,16 @@ final class DefaultTriConstraintCollector<A, B, C, ResultContainer_, Result_>
     private final Supplier<ResultContainer_> supplier;
     private final QuadFunction<ResultContainer_, A, B, C, Runnable> accumulator;
     private final Function<ResultContainer_, Result_> finisher;
+    private final Object[] equalityArgs;
 
     public DefaultTriConstraintCollector(Supplier<ResultContainer_> supplier,
             QuadFunction<ResultContainer_, A, B, C, Runnable> accumulator,
-            Function<ResultContainer_, Result_> finisher) {
+            Function<ResultContainer_, Result_> finisher,
+            Object... equalityArgs) {
         this.supplier = supplier;
         this.accumulator = accumulator;
         this.finisher = finisher;
+        this.equalityArgs = equalityArgs;
     }
 
     @Override
@@ -36,4 +40,18 @@ final class DefaultTriConstraintCollector<A, B, C, ResultContainer_, Result_>
         return finisher;
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        DefaultTriConstraintCollector<?, ?, ?, ?, ?> that = (DefaultTriConstraintCollector<?, ?, ?, ?, ?>) object;
+        return Arrays.equals(equalityArgs, that.equalityArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(equalityArgs);
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultUniConstraintCollector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultUniConstraintCollector.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.api.score.stream;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -13,16 +14,19 @@ final class DefaultUniConstraintCollector<A, ResultContainer_, Result_>
     private final Supplier<ResultContainer_> supplier;
     private final BiFunction<ResultContainer_, A, Runnable> accumulator;
     private final Function<ResultContainer_, Result_> finisher;
+    private final ConstraintCollectors.ConstraintCollectorKind collectorKind;
 
     private final Object[] equalityArgs;
 
     public DefaultUniConstraintCollector(Supplier<ResultContainer_> supplier,
             BiFunction<ResultContainer_, A, Runnable> accumulator,
             Function<ResultContainer_, Result_> finisher,
+            ConstraintCollectors.ConstraintCollectorKind collectorKind,
             Object... equalityArgs) {
         this.supplier = supplier;
         this.accumulator = accumulator;
         this.finisher = finisher;
+        this.collectorKind = collectorKind;
         this.equalityArgs = equalityArgs;
     }
 
@@ -48,11 +52,13 @@ final class DefaultUniConstraintCollector<A, ResultContainer_, Result_>
         if (object == null || getClass() != object.getClass())
             return false;
         DefaultUniConstraintCollector<?, ?, ?> that = (DefaultUniConstraintCollector<?, ?, ?>) object;
-        return Arrays.equals(equalityArgs, that.equalityArgs);
+        return collectorKind == that.collectorKind && Arrays.equals(equalityArgs, that.equalityArgs);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(equalityArgs);
+        int result = Objects.hash(collectorKind);
+        result = 31 * result + Arrays.hashCode(equalityArgs);
+        return result;
     }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultUniConstraintCollector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/DefaultUniConstraintCollector.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.api.score.stream;
 
+import java.util.Arrays;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -13,12 +14,16 @@ final class DefaultUniConstraintCollector<A, ResultContainer_, Result_>
     private final BiFunction<ResultContainer_, A, Runnable> accumulator;
     private final Function<ResultContainer_, Result_> finisher;
 
+    private final Object[] equalityArgs;
+
     public DefaultUniConstraintCollector(Supplier<ResultContainer_> supplier,
             BiFunction<ResultContainer_, A, Runnable> accumulator,
-            Function<ResultContainer_, Result_> finisher) {
+            Function<ResultContainer_, Result_> finisher,
+            Object... equalityArgs) {
         this.supplier = supplier;
         this.accumulator = accumulator;
         this.finisher = finisher;
+        this.equalityArgs = equalityArgs;
     }
 
     @Override
@@ -36,4 +41,18 @@ final class DefaultUniConstraintCollector<A, ResultContainer_, Result_>
         return finisher;
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        DefaultUniConstraintCollector<?, ?, ?> that = (DefaultUniConstraintCollector<?, ?, ?>) object;
+        return Arrays.equals(equalityArgs, that.equalityArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(equalityArgs);
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/uni/UniConstraintStream.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/uni/UniConstraintStream.java
@@ -23,6 +23,7 @@ import ai.timefold.solver.core.api.score.stream.bi.BiConstraintStream;
 import ai.timefold.solver.core.api.score.stream.bi.BiJoiner;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintStream;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintStream;
+import ai.timefold.solver.core.impl.util.ConstantLambdaUtils;
 
 /**
  * A {@link ConstraintStream} that matches one fact.
@@ -31,7 +32,6 @@ import ai.timefold.solver.core.api.score.stream.tri.TriConstraintStream;
  * @see ConstraintStream
  */
 public interface UniConstraintStream<A> extends ConstraintStream {
-
     // ************************************************************************
     // Filter
     // ************************************************************************
@@ -452,8 +452,9 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      * @param otherClass never null
      * @return never null, a stream that matches every A where a different A exists
      */
+    @SuppressWarnings("unchecked")
     default UniConstraintStream<A> ifExistsOther(Class<A> otherClass) {
-        return ifExists(otherClass, Joiners.filtering((a, b) -> !Objects.equals(a, b)));
+        return ifExists(otherClass, Joiners.filtering((BiPredicate<A, A>) ConstantLambdaUtils.NOT_EQUALS));
     }
 
     /**
@@ -537,7 +538,10 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      *         are true
      */
     default UniConstraintStream<A> ifExistsOther(Class<A> otherClass, BiJoiner<A, A>... joiners) {
-        BiJoiner<A, A> otherness = Joiners.filtering((a, b) -> !Objects.equals(a, b));
+        @SuppressWarnings("unchecked")
+        BiJoiner<A, A> otherness = Joiners.filtering((BiPredicate<A, A>) ConstantLambdaUtils.NOT_EQUALS);
+
+        @SuppressWarnings("unchecked")
         BiJoiner<A, A>[] allJoiners = Stream.concat(Arrays.stream(joiners), Stream.of(otherness))
                 .toArray(BiJoiner[]::new);
         return ifExists(otherClass, allJoiners);
@@ -636,7 +640,10 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      *         are true
      */
     default UniConstraintStream<A> ifExistsOtherIncludingNullVars(Class<A> otherClass, BiJoiner<A, A>... joiners) {
-        BiJoiner<A, A> otherness = Joiners.filtering((a, b) -> !Objects.equals(a, b));
+        @SuppressWarnings("unchecked")
+        BiJoiner<A, A> otherness = Joiners.filtering((BiPredicate<A, A>) ConstantLambdaUtils.NOT_EQUALS);
+
+        @SuppressWarnings("unchecked")
         BiJoiner<A, A>[] allJoiners = Stream.concat(Arrays.stream(joiners), Stream.of(otherness))
                 .toArray(BiJoiner[]::new);
         return ifExistsIncludingNullVars(otherClass, allJoiners);
@@ -825,8 +832,9 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      * @param otherClass never null
      * @return never null, a stream that matches every A where a different A does not exist
      */
+    @SuppressWarnings("unchecked")
     default UniConstraintStream<A> ifNotExistsOther(Class<A> otherClass) {
-        return ifNotExists(otherClass, Joiners.filtering((a, b) -> !Objects.equals(a, b)));
+        return ifNotExists(otherClass, Joiners.filtering((BiPredicate<A, A>) ConstantLambdaUtils.NOT_EQUALS));
     }
 
     /**
@@ -911,7 +919,10 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      *         {@link BiJoiner}s are true
      */
     default UniConstraintStream<A> ifNotExistsOther(Class<A> otherClass, BiJoiner<A, A>... joiners) {
-        BiJoiner<A, A> otherness = Joiners.filtering((a, b) -> !Objects.equals(a, b));
+        @SuppressWarnings("unchecked")
+        BiJoiner<A, A> otherness = Joiners.filtering((BiPredicate<A, A>) ConstantLambdaUtils.NOT_EQUALS);
+
+        @SuppressWarnings("unchecked")
         BiJoiner<A, A>[] allJoiners = Stream.concat(Arrays.stream(joiners), Stream.of(otherness))
                 .toArray(BiJoiner[]::new);
         return ifNotExists(otherClass, allJoiners);
@@ -1010,7 +1021,10 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      *         {@link BiJoiner}s are true
      */
     default UniConstraintStream<A> ifNotExistsOtherIncludingNullVars(Class<A> otherClass, BiJoiner<A, A>... joiners) {
-        BiJoiner<A, A> otherness = Joiners.filtering((a, b) -> !Objects.equals(a, b));
+        @SuppressWarnings("unchecked")
+        BiJoiner<A, A> otherness = Joiners.filtering((BiPredicate<A, A>) ConstantLambdaUtils.NOT_EQUALS);
+
+        @SuppressWarnings("unchecked")
         BiJoiner<A, A>[] allJoiners = Stream.concat(Arrays.stream(joiners), Stream.of(otherness))
                 .toArray(BiJoiner[]::new);
         return ifNotExistsIncludingNullVars(otherClass, allJoiners);
@@ -1620,8 +1634,9 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      *
      * @return never null
      */
+    @SuppressWarnings("unchecked")
     default <Score_ extends Score<Score_>> UniConstraintBuilder<A, Score_> penalize(Score_ constraintWeight) {
-        return penalize(constraintWeight, a -> 1);
+        return penalize(constraintWeight, (ToIntFunction<A>) ConstantLambdaUtils.UNI_CONSTANT_ONE);
     }
 
     /**
@@ -1663,8 +1678,9 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      *
      * @return never null
      */
+    @SuppressWarnings("unchecked")
     default UniConstraintBuilder<A, ?> penalizeConfigurable() {
-        return penalizeConfigurable(a -> 1);
+        return penalizeConfigurable((ToIntFunction<A>) ConstantLambdaUtils.UNI_CONSTANT_ONE);
     }
 
     /**
@@ -1701,8 +1717,9 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      *
      * @return never null
      */
+    @SuppressWarnings("unchecked")
     default <Score_ extends Score<Score_>> UniConstraintBuilder<A, Score_> reward(Score_ constraintWeight) {
-        return reward(constraintWeight, a -> 1);
+        return reward(constraintWeight, (ToIntFunction<A>) ConstantLambdaUtils.UNI_CONSTANT_ONE);
     }
 
     /**
@@ -1744,8 +1761,9 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      *
      * @return never null
      */
+    @SuppressWarnings("unchecked")
     default UniConstraintBuilder<A, ?> rewardConfigurable() {
-        return rewardConfigurable(a -> 1);
+        return rewardConfigurable((ToIntFunction<A>) ConstantLambdaUtils.UNI_CONSTANT_ONE);
     }
 
     /**
@@ -1787,8 +1805,9 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      * @param constraintWeight never null
      * @return never null
      */
+    @SuppressWarnings("unchecked")
     default <Score_ extends Score<Score_>> UniConstraintBuilder<A, Score_> impact(Score_ constraintWeight) {
-        return impact(constraintWeight, a -> 1);
+        return impact(constraintWeight, (ToIntFunction<A>) ConstantLambdaUtils.UNI_CONSTANT_ONE);
     }
 
     /**
@@ -1828,8 +1847,9 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      *
      * @return never null
      */
+    @SuppressWarnings("unchecked")
     default UniConstraintBuilder<A, ?> impactConfigurable() {
-        return impactConfigurable(a -> 1);
+        return impactConfigurable((ToIntFunction<A>) ConstantLambdaUtils.UNI_CONSTANT_ONE);
     }
 
     /**

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/ConstantLambdaUtils.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/ConstantLambdaUtils.java
@@ -1,0 +1,59 @@
+package ai.timefold.solver.core.impl.util;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.ToIntBiFunction;
+import java.util.function.ToIntFunction;
+
+import ai.timefold.solver.core.api.function.QuadFunction;
+import ai.timefold.solver.core.api.function.ToIntQuadFunction;
+import ai.timefold.solver.core.api.function.ToIntTriFunction;
+import ai.timefold.solver.core.api.function.TriFunction;
+
+public final class ConstantLambdaUtils {
+    @SuppressWarnings("rawtypes")
+    public static final Function IDENTITY = Function.identity();
+    @SuppressWarnings("rawtypes")
+    public static final BiPredicate NOT_EQUALS = (a, b) -> !Objects.equals(a, b);
+
+    @SuppressWarnings("rawtypes")
+    public static final BiFunction BI_PICK_FIRST = (a, b) -> a;
+
+    @SuppressWarnings("rawtypes")
+    public static final TriFunction TRI_PICK_FIRST = (a, b, c) -> a;
+
+    @SuppressWarnings("rawtypes")
+    public static final QuadFunction QUAD_PICK_FIRST = (a, b, c, d) -> a;
+
+    @SuppressWarnings("rawtypes")
+    public static final BiFunction BI_PICK_SECOND = (a, b) -> b;
+
+    @SuppressWarnings("rawtypes")
+    public static final TriFunction TRI_PICK_SECOND = (a, b, c) -> b;
+
+    @SuppressWarnings("rawtypes")
+    public static final QuadFunction QUAD_PICK_SECOND = (a, b, c, d) -> b;
+
+    @SuppressWarnings("rawtypes")
+    public static final TriFunction TRI_PICK_THIRD = (a, b, c) -> c;
+
+    @SuppressWarnings("rawtypes")
+    public static final QuadFunction QUAD_PICK_THIRD = (a, b, c, d) -> c;
+
+    @SuppressWarnings("rawtypes")
+    public static final QuadFunction QUAD_PICK_FOURTH = (a, b, c, d) -> d;
+
+    @SuppressWarnings("rawtypes")
+    public static final ToIntFunction UNI_CONSTANT_ONE = (a) -> 1;
+
+    @SuppressWarnings("rawtypes")
+    public static final ToIntBiFunction BI_CONSTANT_ONE = (a, b) -> 1;
+
+    @SuppressWarnings("rawtypes")
+    public static final ToIntTriFunction TRI_CONSTANT_ONE = (a, b, c) -> 1;
+
+    @SuppressWarnings("rawtypes")
+    public static final ToIntQuadFunction QUAD_CONSTANT_ONE = (a, b, c, d) -> 1;
+}


### PR DESCRIPTION
- Created a class ConstantLambdaUtils to store common lambdas used in CS methods so we are guaratee to get the same instance and not depending on JDK specific behaviour.

- DefaultConstraintCollector now supports hashCode and equality. It takes an ConstraintCollectors.ConstraintCollectorKind  and Object[] equalityArgs in its constructor. If the kind and equalityArgs in two different DefaultConstraintCollectors are equal, the two DefaultConstraintCollectors are considered equal.

- groupBy checks reference equality of keyMappers and object equality of constraint collectors.

- ifExists and ifNotExists use the same logic as join

- expand and map check reference equality of passed functions.