### PR TITLE
fix: Do not fail-fast in spring boot extension if there no @PlanningSolution or @PlanningEntity classes

### DIFF
--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfiguration.java
@@ -42,7 +42,6 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -108,7 +107,6 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean({ SolverConfig.class })
     public <Solution_> SolverFactory<Solution_> solverFactory(SolverConfig solverConfig) {
         if (solverConfig == null) {
             return null;
@@ -118,7 +116,6 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean({ SolverFactory.class })
     public <Solution_, ProblemId_> SolverManager<Solution_, ProblemId_> solverManager(SolverFactory solverFactory) {
         // TODO supply ThreadFactory
         if (solverFactory == null) {
@@ -137,7 +134,6 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
     @Deprecated(forRemoval = true)
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean({ SolverFactory.class })
     public <Solution_, Score_ extends Score<Score_>> ScoreManager<Solution_, Score_> scoreManager(
             SolverFactory solverFactory) {
         if (solverFactory == null) {
@@ -148,7 +144,6 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean({ SolverFactory.class })
     public <Solution_, Score_ extends Score<Score_>> SolutionManager<Solution_, Score_> solutionManager(
             SolverFactory solverFactory) {
         if (solverFactory == null) {
@@ -176,8 +171,8 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
         @SuppressWarnings("unchecked")
         <ConstraintProvider_ extends ConstraintProvider, SolutionClass_>
                 ConstraintVerifier<ConstraintProvider_, SolutionClass_> constraintVerifier() {
-            // @ConditionalOnBean({ SolverConfig.class }) does not work here,
-            // so we need to try to fetch SolverConfig via context to check for its presence/absence
+            // Using SolverConfig as an injected parameter here leads to an injection failure on an empty app,
+            // so we need to get the SolverConfig from context
             SolverConfig solverConfig;
             try {
                 solverConfig = context.getBean(SolverConfig.class);

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfiguration.java
@@ -35,11 +35,14 @@ import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
 import ai.timefold.solver.test.api.score.stream.MultiConstraintVerification;
 import ai.timefold.solver.test.api.score.stream.SingleConstraintVerification;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -81,41 +84,6 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
 
     @Bean
     @ConditionalOnMissingBean
-    public <Solution_, ProblemId_> SolverManager<Solution_, ProblemId_> solverManager(SolverFactory solverFactory) {
-        // TODO supply ThreadFactory
-        SolverManagerConfig solverManagerConfig = new SolverManagerConfig();
-        SolverManagerProperties solverManagerProperties = timefoldProperties.getSolverManager();
-        if (solverManagerProperties != null) {
-            if (solverManagerProperties.getParallelSolverCount() != null) {
-                solverManagerConfig.setParallelSolverCount(solverManagerProperties.getParallelSolverCount());
-            }
-        }
-        return SolverManager.create(solverFactory, solverManagerConfig);
-    }
-
-    @Deprecated(forRemoval = true)
-    @Bean
-    @ConditionalOnMissingBean
-    public <Solution_, Score_ extends Score<Score_>> ScoreManager<Solution_, Score_> scoreManager(
-            SolverFactory solverFactory) {
-        return ScoreManager.create(solverFactory);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public <Solution_, Score_ extends Score<Score_>> SolutionManager<Solution_, Score_> solutionManager(
-            SolverFactory solverFactory) {
-        return SolutionManager.create(solverFactory);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public <Solution_> SolverFactory<Solution_> solverFactory(SolverConfig solverConfig) {
-        return SolverFactory.create(solverConfig);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
     public SolverConfig solverConfig() {
         String solverConfigXml = timefoldProperties.getSolverConfigXml();
         SolverConfig solverConfig;
@@ -132,26 +100,100 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
             solverConfig = new SolverConfig(beanClassLoader);
         }
 
-        applySolverProperties(solverConfig);
+        if (!applySolverProperties(solverConfig)) {
+            return null;
+        }
         return solverConfig;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean({ SolverConfig.class })
+    public <Solution_> SolverFactory<Solution_> solverFactory(SolverConfig solverConfig) {
+        if (solverConfig == null) {
+            return null;
+        }
+        return SolverFactory.create(solverConfig);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean({ SolverFactory.class })
+    public <Solution_, ProblemId_> SolverManager<Solution_, ProblemId_> solverManager(SolverFactory solverFactory) {
+        // TODO supply ThreadFactory
+        if (solverFactory == null) {
+            return null;
+        }
+        SolverManagerConfig solverManagerConfig = new SolverManagerConfig();
+        SolverManagerProperties solverManagerProperties = timefoldProperties.getSolverManager();
+        if (solverManagerProperties != null) {
+            if (solverManagerProperties.getParallelSolverCount() != null) {
+                solverManagerConfig.setParallelSolverCount(solverManagerProperties.getParallelSolverCount());
+            }
+        }
+        return SolverManager.create(solverFactory, solverManagerConfig);
+    }
+
+    @Deprecated(forRemoval = true)
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean({ SolverFactory.class })
+    public <Solution_, Score_ extends Score<Score_>> ScoreManager<Solution_, Score_> scoreManager(
+            SolverFactory solverFactory) {
+        if (solverFactory == null) {
+            return null;
+        }
+        return ScoreManager.create(solverFactory);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean({ SolverFactory.class })
+    public <Solution_, Score_ extends Score<Score_>> SolutionManager<Solution_, Score_> solutionManager(
+            SolverFactory solverFactory) {
+        if (solverFactory == null) {
+            return null;
+        }
+        return SolutionManager.create(solverFactory);
     }
 
     // @Bean wrapped by static class to avoid classloading issues if dependencies are absent
     @ConditionalOnClass({ ConstraintVerifier.class })
     @ConditionalOnMissingBean({ ConstraintVerifier.class })
-    static class TimefoldConstraintVerifierConfiguration {
+    @AutoConfigureAfter(TimefoldAutoConfiguration.class)
+    class TimefoldConstraintVerifierConfiguration {
+
+        private final ApplicationContext context;
+        private final TimefoldProperties timefoldProperties;
+
+        protected TimefoldConstraintVerifierConfiguration(ApplicationContext context,
+                TimefoldProperties timefoldProperties) {
+            this.context = context;
+            this.timefoldProperties = timefoldProperties;
+        }
 
         @Bean
         @SuppressWarnings("unchecked")
         <ConstraintProvider_ extends ConstraintProvider, SolutionClass_>
-                ConstraintVerifier<ConstraintProvider_, SolutionClass_> constraintVerifier(SolverConfig solverConfig) {
-            ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = solverConfig.getScoreDirectorFactoryConfig();
-            if (scoreDirectorFactoryConfig.getConstraintProviderClass() == null) {
+                ConstraintVerifier<ConstraintProvider_, SolutionClass_> constraintVerifier() {
+            // @ConditionalOnBean({ SolverConfig.class }) does not work here,
+            // so we need to try to fetch SolverConfig via context to check for its presence/absence
+            SolverConfig solverConfig;
+            try {
+                solverConfig = context.getBean(SolverConfig.class);
+            } catch (BeansException exception) {
+                solverConfig = null;
+            }
+
+            ScoreDirectorFactoryConfig scoreDirectorFactoryConfig =
+                    (solverConfig != null) ? solverConfig.getScoreDirectorFactoryConfig() : null;
+            if (scoreDirectorFactoryConfig == null || scoreDirectorFactoryConfig.getConstraintProviderClass() == null) {
                 // Return a mock ConstraintVerifier so not having ConstraintProvider doesn't crash tests
                 // (Cannot create custom condition that checks SolverConfig, since that
                 //  requires TimefoldAutoConfiguration to have a no-args constructor)
-                final String noConstraintProviderErrorMsg =
-                        "Cannot provision a ConstraintVerifier because there is no ConstraintProvider class.";
+                final String noConstraintProviderErrorMsg = (scoreDirectorFactoryConfig != null)
+                        ? "Cannot provision a ConstraintVerifier because there is no ConstraintProvider class."
+                        : "Cannot provision a ConstraintVerifier because there is no PlanningSolution or PlanningEntity classes.";
                 return new ConstraintVerifier<>() {
                     @Override
                     public ConstraintVerifier<ConstraintProvider_, SolutionClass_>
@@ -176,8 +218,11 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
         }
     }
 
-    private void applySolverProperties(SolverConfig solverConfig) {
+    private boolean applySolverProperties(SolverConfig solverConfig) {
         IncludeAbstractClassesEntityScanner entityScanner = new IncludeAbstractClassesEntityScanner(this.context);
+        if (!hasSolutionOrEntityClasses(entityScanner)) {
+            return false;
+        }
         if (solverConfig.getSolutionClass() == null) {
             solverConfig.setSolutionClass(findSolutionClass(entityScanner));
         }
@@ -209,6 +254,17 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
                 solverConfig.setMoveThreadCount(solverProperties.getMoveThreadCount());
             }
             applyTerminationProperties(solverConfig, solverProperties.getTermination());
+        }
+        return true;
+    }
+
+    private boolean hasSolutionOrEntityClasses(IncludeAbstractClassesEntityScanner entityScanner) {
+        try {
+            return !entityScanner.scan(PlanningSolution.class).isEmpty() || !entityScanner.scan(PlanningSolution.class)
+                    .isEmpty();
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Scanning for @" + PlanningSolution.class.getSimpleName()
+                    + " and @" + PlanningEntity.class.getSimpleName() + " annotations failed.", e);
         }
     }
 

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldBenchmarkAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldBenchmarkAutoConfiguration.java
@@ -16,6 +16,7 @@ import ai.timefold.solver.spring.boot.autoconfigure.config.TimefoldProperties;
 
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -38,7 +39,11 @@ public class TimefoldBenchmarkAutoConfiguration
     }
 
     @Bean
+    @ConditionalOnBean({ SolverConfig.class })
     public PlannerBenchmarkConfig plannerBenchmarkConfig(SolverConfig solverConfig) {
+        if (solverConfig == null) {
+            return null;
+        }
         PlannerBenchmarkConfig benchmarkConfig;
         if (timefoldProperties.getBenchmark() != null
                 && timefoldProperties.getBenchmark().getSolverBenchmarkConfigXml() != null) {
@@ -120,7 +125,11 @@ public class TimefoldBenchmarkAutoConfiguration
     }
 
     @Bean
+    @ConditionalOnBean({ PlannerBenchmarkConfig.class })
     public PlannerBenchmarkFactory plannerBenchmarkFactory(PlannerBenchmarkConfig benchmarkConfig) {
+        if (benchmarkConfig == null) {
+            return null;
+        }
         return PlannerBenchmarkFactory.create(benchmarkConfig);
     }
 

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldBenchmarkAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldBenchmarkAutoConfiguration.java
@@ -16,7 +16,6 @@ import ai.timefold.solver.spring.boot.autoconfigure.config.TimefoldProperties;
 
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -39,7 +38,6 @@ public class TimefoldBenchmarkAutoConfiguration
     }
 
     @Bean
-    @ConditionalOnBean({ SolverConfig.class })
     public PlannerBenchmarkConfig plannerBenchmarkConfig(SolverConfig solverConfig) {
         if (solverConfig == null) {
             return null;
@@ -125,7 +123,6 @@ public class TimefoldBenchmarkAutoConfiguration
     }
 
     @Bean
-    @ConditionalOnBean({ PlannerBenchmarkConfig.class })
     public PlannerBenchmarkFactory plannerBenchmarkFactory(PlannerBenchmarkConfig benchmarkConfig) {
         if (benchmarkConfig == null) {
             return null;

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfigurationTest.java
@@ -34,6 +34,7 @@ import ai.timefold.solver.spring.boot.autoconfigure.chained.domain.TestdataChain
 import ai.timefold.solver.spring.boot.autoconfigure.config.TimefoldProperties;
 import ai.timefold.solver.spring.boot.autoconfigure.gizmo.GizmoSpringTestConfiguration;
 import ai.timefold.solver.spring.boot.autoconfigure.multimodule.MultiModuleSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.normal.EmptySpringTestConfiguration;
 import ai.timefold.solver.spring.boot.autoconfigure.normal.NoConstraintsSpringTestConfiguration;
 import ai.timefold.solver.spring.boot.autoconfigure.normal.NormalSpringTestConfiguration;
 import ai.timefold.solver.spring.boot.autoconfigure.normal.constraints.TestdataSpringConstraintProvider;
@@ -55,6 +56,7 @@ import org.springframework.test.context.TestExecutionListeners;
 class TimefoldAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner;
+    private final ApplicationContextRunner emptyContextRunner;
     private final ApplicationContextRunner benchmarkContextRunner;
     private final ApplicationContextRunner noConstraintsContextRunner;
     private final ApplicationContextRunner chainedContextRunner;
@@ -68,6 +70,9 @@ class TimefoldAutoConfigurationTest {
         contextRunner = new ApplicationContextRunner()
                 .withConfiguration(AutoConfigurations.of(TimefoldAutoConfiguration.class))
                 .withUserConfiguration(NormalSpringTestConfiguration.class);
+        emptyContextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(TimefoldAutoConfiguration.class))
+                .withUserConfiguration(EmptySpringTestConfiguration.class);
         benchmarkContextRunner = new ApplicationContextRunner()
                 .withConfiguration(
                         AutoConfigurations.of(TimefoldAutoConfiguration.class, TimefoldBenchmarkAutoConfiguration.class))
@@ -93,6 +98,14 @@ class TimefoldAutoConfigurationTest {
         noGizmoFilteredClassLoader = new FilteredClassLoader(FilteredClassLoader.PackageFilter.of("io.quarkus.gizmo"),
                 FilteredClassLoader.ClassPathResourceFilter.of(
                         new ClassPathResource(TimefoldProperties.DEFAULT_SOLVER_CONFIG_URL)));
+    }
+
+    @Test
+    void noSolutionOrEntityClasses() {
+        emptyContextRunner
+                .run(context -> {
+                    assertThat(context.getStartupFailure()).isNull();
+                });
     }
 
     @Test

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/normal/EmptySpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/normal/EmptySpringTestConfiguration.java
@@ -1,0 +1,9 @@
+package ai.timefold.solver.spring.boot.autoconfigure.normal;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan(basePackages = "ai.timefold.solver.spring.boot.autoconfigure.empty")
+public class EmptySpringTestConfiguration {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/normal/empty/EmptyBean.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/normal/empty/EmptyBean.java
@@ -1,0 +1,4 @@
+package ai.timefold.solver.spring.boot.autoconfigure.normal.empty;
+
+public class EmptyBean {
+}


### PR DESCRIPTION
Fixes #388.

Note: order matters when evaluating conditional expressions, so solverConfig and solverFactory MUST be first since they are used in the conditional expressions for the other beans.