### PR TITLE
fix: Support repeatable annotations like @ShadowVariable in Quarkus

### DIFF
--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -405,7 +405,7 @@ class TimefoldProcessor {
         Collection<AnnotationInstance> timefoldFieldAnnotations = new HashSet<>();
 
         for (DotName annotationName : DotNames.PLANNING_ENTITY_FIELD_ANNOTATIONS) {
-            timefoldFieldAnnotations.addAll(indexView.getAnnotations(annotationName));
+            timefoldFieldAnnotations.addAll(indexView.getAnnotationsWithRepeatable(annotationName, indexView));
         }
 
         for (AnnotationInstance annotationInstance : timefoldFieldAnnotations) {
@@ -444,7 +444,7 @@ class TimefoldProcessor {
     private void registerClassesFromAnnotations(IndexView indexView, Set<Class<?>> reflectiveClassSet) {
         for (DotNames.BeanDefiningAnnotations beanDefiningAnnotation : DotNames.BeanDefiningAnnotations.values()) {
             for (AnnotationInstance annotationInstance : indexView
-                    .getAnnotations(beanDefiningAnnotation.getAnnotationDotName())) {
+                    .getAnnotationsWithRepeatable(beanDefiningAnnotation.getAnnotationDotName(), indexView)) {
                 for (String parameterName : beanDefiningAnnotation.getParameterNames()) {
                     AnnotationValue value = annotationInstance.value(parameterName);
 
@@ -559,7 +559,7 @@ class TimefoldProcessor {
             // Every entity and solution gets scanned for annotations.
             // Annotated members get their accessors generated.
             for (DotName dotName : DotNames.GIZMO_MEMBER_ACCESSOR_ANNOTATIONS) {
-                membersToGeneratedAccessorsFor.addAll(indexView.getAnnotations(dotName));
+                membersToGeneratedAccessorsFor.addAll(indexView.getAnnotationsWithRepeatable(dotName, indexView));
             }
             membersToGeneratedAccessorsFor.removeIf(this::shouldIgnoreMember);
 

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorShadowVariableSolveTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorShadowVariableSolveTest.java
@@ -1,0 +1,82 @@
+package ai.timefold.solver.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import jakarta.inject.Inject;
+
+import ai.timefold.solver.core.api.score.ScoreManager;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
+import ai.timefold.solver.core.api.solver.SolverFactory;
+import ai.timefold.solver.core.api.solver.SolverJob;
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.core.impl.solver.DefaultSolutionManager;
+import ai.timefold.solver.core.impl.solver.DefaultSolverFactory;
+import ai.timefold.solver.core.impl.solver.DefaultSolverManager;
+import ai.timefold.solver.quarkus.testdata.shadowvariable.constraints.TestdataQuarkusShadowVariableConstraintProvider;
+import ai.timefold.solver.quarkus.testdata.shadowvariable.domain.TestdataQuarkusShadowVariableEntity;
+import ai.timefold.solver.quarkus.testdata.shadowvariable.domain.TestdataQuarkusShadowVariableListener;
+import ai.timefold.solver.quarkus.testdata.shadowvariable.domain.TestdataQuarkusShadowVariableSolution;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldProcessorShadowVariableSolveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusShadowVariableEntity.class,
+                            TestdataQuarkusShadowVariableSolution.class,
+                            TestdataQuarkusShadowVariableConstraintProvider.class,
+                            TestdataQuarkusShadowVariableListener.class));
+
+    @Inject
+    SolverFactory<TestdataQuarkusShadowVariableSolution> solverFactory;
+    @Inject
+    SolverManager<TestdataQuarkusShadowVariableSolution, Long> solverManager;
+    @Inject
+    ScoreManager<TestdataQuarkusShadowVariableSolution, SimpleScore> scoreManager;
+    @Inject
+    SolutionManager<TestdataQuarkusShadowVariableSolution, SimpleScore> solutionManager;
+
+    @Test
+    void singletonSolverFactory() {
+        assertNotNull(solverFactory);
+        assertSame(((DefaultSolverFactory<TestdataQuarkusShadowVariableSolution>) solverFactory).getScoreDirectorFactory(),
+                ((DefaultSolutionManager<TestdataQuarkusShadowVariableSolution, SimpleScore>) solutionManager)
+                        .getScoreDirectorFactory());
+        assertNotNull(solverManager);
+        // There is only one SolverFactory instance
+        assertSame(solverFactory,
+                ((DefaultSolverManager<TestdataQuarkusShadowVariableSolution, Long>) solverManager).getSolverFactory());
+        assertNotNull(solutionManager);
+    }
+
+    @Test
+    void solve() throws ExecutionException, InterruptedException {
+        TestdataQuarkusShadowVariableSolution problem = new TestdataQuarkusShadowVariableSolution();
+        problem.setValueList(IntStream.range(1, 3)
+                .mapToObj(i -> "v" + i)
+                .collect(Collectors.toList()));
+        problem.setEntityList(IntStream.range(1, 3)
+                .mapToObj(i -> new TestdataQuarkusShadowVariableEntity())
+                .collect(Collectors.toList()));
+        SolverJob<TestdataQuarkusShadowVariableSolution, Long> solverJob = solverManager.solve(1L, problem);
+        TestdataQuarkusShadowVariableSolution solution = solverJob.getFinalBestSolution();
+        assertNotNull(solution);
+        assertTrue(solution.getScore().score() >= 0);
+    }
+
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/shadowvariable/constraints/TestdataQuarkusShadowVariableConstraintProvider.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/shadowvariable/constraints/TestdataQuarkusShadowVariableConstraintProvider.java
@@ -1,0 +1,25 @@
+package ai.timefold.solver.quarkus.testdata.shadowvariable.constraints;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.api.score.stream.Joiners;
+import ai.timefold.solver.quarkus.testdata.shadowvariable.domain.TestdataQuarkusShadowVariableEntity;
+
+public class TestdataQuarkusShadowVariableConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.forEach(TestdataQuarkusShadowVariableEntity.class)
+                        .join(TestdataQuarkusShadowVariableEntity.class,
+                                Joiners.equal(TestdataQuarkusShadowVariableEntity::getValue1,
+                                        TestdataQuarkusShadowVariableEntity::getValue2))
+                        .filter((a, b) -> a.getValue1AndValue2().equals(b.getValue1AndValue2()))
+                        .penalize(SimpleScore.ONE)
+                        .asConstraint("Don't assign 2 entities the same value.")
+        };
+    }
+
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/shadowvariable/domain/TestdataQuarkusShadowVariableEntity.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/shadowvariable/domain/TestdataQuarkusShadowVariableEntity.java
@@ -1,0 +1,44 @@
+package ai.timefold.solver.quarkus.testdata.shadowvariable.domain;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+
+@PlanningEntity
+public class TestdataQuarkusShadowVariableEntity {
+
+    private String value1;
+    private String value2;
+    private String value1AndValue2;
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue1() {
+        return value1;
+    }
+
+    public void setValue1(String value1) {
+        this.value1 = value1;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue2() {
+        return value2;
+    }
+
+    public void setValue2(String value2) {
+        this.value2 = value2;
+    }
+
+    @ShadowVariable(variableListenerClass = TestdataQuarkusShadowVariableListener.class,
+            sourceVariableName = "value1")
+    @ShadowVariable(variableListenerClass = TestdataQuarkusShadowVariableListener.class,
+            sourceVariableName = "value2")
+    public String getValue1AndValue2() {
+        return value1AndValue2;
+    }
+
+    public void setValue1AndValue2(String value1AndValue2) {
+        this.value1AndValue2 = value1AndValue2;
+    }
+
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/shadowvariable/domain/TestdataQuarkusShadowVariableListener.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/shadowvariable/domain/TestdataQuarkusShadowVariableListener.java
@@ -1,0 +1,50 @@
+package ai.timefold.solver.quarkus.testdata.shadowvariable.domain;
+
+import ai.timefold.solver.core.api.domain.variable.VariableListener;
+import ai.timefold.solver.core.api.score.director.ScoreDirector;
+
+public class TestdataQuarkusShadowVariableListener
+        implements VariableListener<TestdataQuarkusShadowVariableSolution, TestdataQuarkusShadowVariableEntity> {
+    @Override
+    public void beforeEntityAdded(ScoreDirector<TestdataQuarkusShadowVariableSolution> scoreDirector,
+            TestdataQuarkusShadowVariableEntity testdataQuarkusShadowVariableEntity) {
+
+    }
+
+    @Override
+    public void afterEntityAdded(ScoreDirector<TestdataQuarkusShadowVariableSolution> scoreDirector,
+            TestdataQuarkusShadowVariableEntity testdataQuarkusShadowVariableEntity) {
+        update(scoreDirector, testdataQuarkusShadowVariableEntity);
+    }
+
+    @Override
+    public void beforeEntityRemoved(ScoreDirector<TestdataQuarkusShadowVariableSolution> scoreDirector,
+            TestdataQuarkusShadowVariableEntity testdataQuarkusShadowVariableEntity) {
+
+    }
+
+    @Override
+    public void afterEntityRemoved(ScoreDirector<TestdataQuarkusShadowVariableSolution> scoreDirector,
+            TestdataQuarkusShadowVariableEntity testdataQuarkusShadowVariableEntity) {
+
+    }
+
+    @Override
+    public void beforeVariableChanged(ScoreDirector<TestdataQuarkusShadowVariableSolution> scoreDirector,
+            TestdataQuarkusShadowVariableEntity testdataQuarkusShadowVariableEntity) {
+
+    }
+
+    @Override
+    public void afterVariableChanged(ScoreDirector<TestdataQuarkusShadowVariableSolution> scoreDirector,
+            TestdataQuarkusShadowVariableEntity testdataQuarkusShadowVariableEntity) {
+        update(scoreDirector, testdataQuarkusShadowVariableEntity);
+    }
+
+    void update(ScoreDirector<TestdataQuarkusShadowVariableSolution> scoreDirector,
+            TestdataQuarkusShadowVariableEntity entity) {
+        scoreDirector.beforeVariableChanged(entity, "value1AndValue2");
+        entity.setValue1AndValue2(entity.getValue1() + entity.getValue2());
+        scoreDirector.afterVariableChanged(entity, "value1AndValue2");
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/shadowvariable/domain/TestdataQuarkusShadowVariableSolution.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/shadowvariable/domain/TestdataQuarkusShadowVariableSolution.java
@@ -1,0 +1,48 @@
+package ai.timefold.solver.quarkus.testdata.shadowvariable.domain;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataQuarkusShadowVariableSolution {
+
+    private List<String> valueList;
+    private List<TestdataQuarkusShadowVariableEntity> entityList;
+
+    private SimpleScore score;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataQuarkusShadowVariableEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataQuarkusShadowVariableEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}


### PR DESCRIPTION
Jandex, being Jandex, likes to fails sliently without telling you anything. The culprit in this case is IndexView::getAnnotations. IndexView::getAnnotations will appear to work, returning a collection of AnnotationInstances. But it will sliently fail and return an empty list when the annotation repeats on a target. The fix is to use IndexView::getAnnotationsWithRepeatable instead.

Also did some cleanup in the generated Gizmo code, removing meaningless try blocks, and not doing reflection to generate the method descriptors.