### PR TITLE
feat: Report shadow variables that differ after recalculating from scratch when undo corruption occurs

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/violation/ShadowVariablesAssert.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/violation/ShadowVariablesAssert.java
@@ -35,6 +35,15 @@ public final class ShadowVariablesAssert {
         return new ShadowVariablesAssert(shadowVariableSnapshots);
     }
 
+    public static <Solution_> void resetShadowVariables(
+            SolutionDescriptor<Solution_> solutionDescriptor,
+            Solution_ workingSolution) {
+        solutionDescriptor.visitAllEntities(workingSolution,
+                entity -> solutionDescriptor.findEntityDescriptorOrFail(entity.getClass())
+                        .getShadowVariableDescriptors()
+                        .forEach(descriptor -> descriptor.setValue(entity, null)));
+    }
+
     /**
      * Takes a look at the shadow variables of all entities and compares them against the recorded state. Every difference
      * is added to the violation message. The first N differences up to the {@code violationDisplayLimit} are displayed

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowEasyScoreCalculator.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowEasyScoreCalculator.java
@@ -1,0 +1,19 @@
+package ai.timefold.solver.core.config.solver.testutil.corruptedundoshadow;
+
+import java.util.Objects;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
+
+public class CorruptedUndoShadowEasyScoreCalculator implements EasyScoreCalculator<CorruptedUndoShadowSolution, SimpleScore> {
+    @Override
+    public SimpleScore calculateScore(CorruptedUndoShadowSolution corruptedUndoShadowSolution) {
+        int score = 0;
+        for (CorruptedUndoShadowEntity entity : corruptedUndoShadowSolution.entityList) {
+            if (Objects.equals(entity.value, entity.valueClone)) {
+                score++;
+            }
+        }
+        return SimpleScore.of(score);
+    }
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowEntity.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowEntity.java
@@ -1,0 +1,20 @@
+package ai.timefold.solver.core.config.solver.testutil.corruptedundoshadow;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+
+@PlanningEntity
+public class CorruptedUndoShadowEntity {
+    @PlanningVariable
+    String value;
+
+    @ShadowVariable(sourceVariableName = "value",
+            variableListenerClass = CorruptedUndoShadowVariableListener.class)
+    String valueClone;
+
+    @Override
+    public String toString() {
+        return CorruptedUndoShadowEntity.class.getSimpleName();
+    }
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowSolution.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowSolution.java
@@ -1,0 +1,29 @@
+package ai.timefold.solver.core.config.solver.testutil.corruptedundoshadow;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class CorruptedUndoShadowSolution {
+    @PlanningEntityCollectionProperty
+    List<CorruptedUndoShadowEntity> entityList;
+
+    @ValueRangeProvider
+    List<String> valueList;
+
+    @PlanningScore
+    SimpleScore score;
+
+    public CorruptedUndoShadowSolution() {
+    }
+
+    public CorruptedUndoShadowSolution(List<CorruptedUndoShadowEntity> entityList, List<String> valueList) {
+        this.entityList = entityList;
+        this.valueList = valueList;
+    }
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowVariableListener.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowVariableListener.java
@@ -1,0 +1,52 @@
+package ai.timefold.solver.core.config.solver.testutil.corruptedundoshadow;
+
+import ai.timefold.solver.core.api.domain.variable.VariableListener;
+import ai.timefold.solver.core.api.score.director.ScoreDirector;
+
+public class CorruptedUndoShadowVariableListener
+        implements VariableListener<CorruptedUndoShadowSolution, CorruptedUndoShadowEntity> {
+    @Override
+    public void beforeEntityAdded(ScoreDirector<CorruptedUndoShadowSolution> scoreDirector,
+            CorruptedUndoShadowEntity corruptedUndoShadowEntity) {
+
+    }
+
+    @Override
+    public void afterEntityAdded(ScoreDirector<CorruptedUndoShadowSolution> scoreDirector,
+            CorruptedUndoShadowEntity corruptedUndoShadowEntity) {
+        update(scoreDirector, corruptedUndoShadowEntity);
+    }
+
+    @Override
+    public void beforeEntityRemoved(ScoreDirector<CorruptedUndoShadowSolution> scoreDirector,
+            CorruptedUndoShadowEntity corruptedUndoShadowEntity) {
+
+    }
+
+    @Override
+    public void afterEntityRemoved(ScoreDirector<CorruptedUndoShadowSolution> scoreDirector,
+            CorruptedUndoShadowEntity corruptedUndoShadowEntity) {
+
+    }
+
+    @Override
+    public void beforeVariableChanged(ScoreDirector<CorruptedUndoShadowSolution> scoreDirector,
+            CorruptedUndoShadowEntity corruptedUndoShadowEntity) {
+
+    }
+
+    @Override
+    public void afterVariableChanged(ScoreDirector<CorruptedUndoShadowSolution> scoreDirector,
+            CorruptedUndoShadowEntity corruptedUndoShadowEntity) {
+        update(scoreDirector, corruptedUndoShadowEntity);
+    }
+
+    private void update(ScoreDirector<CorruptedUndoShadowSolution> scoreDirector,
+            CorruptedUndoShadowEntity corruptedUndoShadowEntity) {
+        if (corruptedUndoShadowEntity.value != null) {
+            scoreDirector.beforeVariableChanged(corruptedUndoShadowEntity, "valueClone");
+            corruptedUndoShadowEntity.valueClone = corruptedUndoShadowEntity.value;
+            scoreDirector.afterVariableChanged(corruptedUndoShadowEntity, "valueClone");
+        }
+    }
+}


### PR DESCRIPTION
Example message:

```
UndoMove corruption (-1): the beforeMoveScore (-1init/1) is not the undoScore (-1init/0) which is the uncorruptedScore (-1init/0) of the workingSolution.
Shadow variables have different values when recalculated from scratch after undo:
    The entity (CorruptedUndoShadowEntity)'s shadow variable (CorruptedUndoShadowEntity.valueClone)'s corrupted value (v1) changed to uncorrupted value (null) after all variable listeners were triggered without changes to the genuine variables.
      Maybe one of the listeners ([CorruptedUndoShadowVariableListener]) for that shadow variable (CorruptedUndoShadowEntity.valueClone) forgot to update it when one of its sourceVariables ([CorruptedUndoShadowEntity.value]) changed.
      Or vice versa, maybe one of the listeners computes this shadow variable using a planning variable that is not declared as its source. Use the repeatable @ShadowVariable annotation for each source variable that is used to compute this shadow variable.

  1) Enable EnvironmentMode FULL_ASSERT (if you haven't already) to fail-faster in case there's a score corruption or variable listener corruption.
  2) Check the Move.createUndoMove(...) method of the moveClass (class ai.timefold.solver.core.impl.heuristic.selector.move.generic.ChangeMove). The move (CorruptedUndoShadowEntity {null -> v1}) might have a corrupted undoMove (CorruptedUndoShadowEntity {v1 -> null}).
  3) Check your custom VariableListeners (if you have any) for shadow variables that are used by score constraints that could cause the scoreDifference (-1).
```