### PR TITLE
fix: Do not set shadow variables to null when calculating from scratch in TRACED_FULL_ASSERT

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
@@ -236,15 +236,6 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
         triggerVariableListenersInNotificationQueues();
     }
 
-    /**
-     * Sets all shadow variables to null and then force triggers all variable listeners.
-     * This effectively recalculates the shadow variables from scratch.
-     */
-    public void recalculateAllShadowVariablesFromScratch(Solution_ workingSolution) {
-        scoreDirector.getSolutionDescriptor().visitAllEntities(workingSolution, this::resetShadowVariables);
-        forceTriggerAllVariableListeners(workingSolution);
-    }
-
     private void simulateGenuineVariableChange(Object entity) {
         var entityDescriptor = scoreDirector.getSolutionDescriptor()
                 .findEntityDescriptorOrFail(entity.getClass());
@@ -260,17 +251,6 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
             } else {
                 // Triggering before...() is enough, as that will add the after...() call to the queue automatically.
                 beforeVariableChanged(variableDescriptor, entity);
-            }
-        }
-    }
-
-    private void resetShadowVariables(Object entity) {
-        var entityDescriptor = scoreDirector.getSolutionDescriptor()
-                .findEntityDescriptorOrFail(entity.getClass());
-
-        for (var variableDescriptor : entityDescriptor.getShadowVariableDescriptors()) {
-            if (!variableDescriptor.getVariablePropertyType().isPrimitive()) {
-                variableDescriptor.setValue(entity, null);
             }
         }
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -695,14 +695,18 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             assertShadowVariablesAreNotStale(undoScore, undoMoveText);
             String corruptionDiagnosis = "";
             if (trackingWorkingSolution) {
-                // Recalculate all shadow variables from scratch
-                variableListenerSupport.recalculateAllShadowVariablesFromScratch(workingSolution);
+                // Recalculate all shadow variables from scratch.
+                // We cannot set all shadow variables to null, since some variable listeners
+                // may expect them to be non-null.
+                //
+                // Instead, we just simulate a change to all genuine variables.
+                variableListenerSupport.forceTriggerAllVariableListeners(workingSolution);
                 solutionTracker.setUndoFromScratchSolution(workingSolution);
 
                 // Also calculate from scratch for the before solution, since it might
                 // have been corrupted but was only detected now
                 solutionTracker.restoreBeforeSolution();
-                variableListenerSupport.recalculateAllShadowVariablesFromScratch(workingSolution);
+                variableListenerSupport.forceTriggerAllVariableListeners(workingSolution);
                 solutionTracker.setBeforeFromScratchSolution(workingSolution);
 
                 corruptionDiagnosis = solutionTracker.buildScoreCorruptionMessage();

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -698,7 +698,6 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
                 // Recalculate all shadow variables from scratch.
                 // We cannot set all shadow variables to null, since some variable listeners
                 // may expect them to be non-null.
-                //
                 // Instead, we just simulate a change to all genuine variables.
                 variableListenerSupport.forceTriggerAllVariableListeners(workingSolution);
                 solutionTracker.setUndoFromScratchSolution(workingSolution);

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/EnvironmentModeTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/EnvironmentModeTest.java
@@ -173,7 +173,7 @@ class EnvironmentModeTest {
             }
             case FULL_ASSERT,
                     FAST_ASSERT -> {
-                // FAST_ASSERT does not create snapshots since it does not intrusive, and hence it can only
+                // FAST_ASSERT does not create snapshots since it is not intrusive, and hence it can only
                 // detect the undo corruption and not what caused it
                 var e1 = new CorruptedUndoShadowEntity("e1");
                 var e2 = new CorruptedUndoShadowEntity("e2");

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowEntity.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowEntity.java
@@ -8,14 +8,37 @@ import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
 @PlanningEntity
 public class CorruptedUndoShadowEntity {
     @PlanningId
-    String id = CorruptedUndoShadowEntity.class.getSimpleName();
+    String id;
 
     @PlanningVariable
-    String value;
+    CorruptedUndoShadowValue value;
 
     @ShadowVariable(sourceVariableName = "value",
             variableListenerClass = CorruptedUndoShadowVariableListener.class)
-    String valueClone;
+    CorruptedUndoShadowValue valueClone;
+
+    public CorruptedUndoShadowEntity() {
+    }
+
+    public CorruptedUndoShadowEntity(String id) {
+        this.id = id;
+    }
+
+    public CorruptedUndoShadowValue getValue() {
+        return value;
+    }
+
+    public void setValue(CorruptedUndoShadowValue value) {
+        this.value = value;
+    }
+
+    public CorruptedUndoShadowValue getValueClone() {
+        return valueClone;
+    }
+
+    public void setValueClone(CorruptedUndoShadowValue valueClone) {
+        this.valueClone = valueClone;
+    }
 
     @Override
     public String toString() {

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowSolution.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowSolution.java
@@ -13,8 +13,9 @@ public class CorruptedUndoShadowSolution {
     @PlanningEntityCollectionProperty
     List<CorruptedUndoShadowEntity> entityList;
 
+    @PlanningEntityCollectionProperty
     @ValueRangeProvider
-    List<String> valueList;
+    List<CorruptedUndoShadowValue> valueList;
 
     @PlanningScore
     SimpleScore score;
@@ -22,7 +23,7 @@ public class CorruptedUndoShadowSolution {
     public CorruptedUndoShadowSolution() {
     }
 
-    public CorruptedUndoShadowSolution(List<CorruptedUndoShadowEntity> entityList, List<String> valueList) {
+    public CorruptedUndoShadowSolution(List<CorruptedUndoShadowEntity> entityList, List<CorruptedUndoShadowValue> valueList) {
         this.entityList = entityList;
         this.valueList = valueList;
     }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowValue.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowValue.java
@@ -1,0 +1,47 @@
+package ai.timefold.solver.core.config.solver.testutil.corruptedundoshadow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.lookup.PlanningId;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+
+@PlanningEntity
+public class CorruptedUndoShadowValue {
+    @PlanningId
+    String value;
+
+    @InverseRelationShadowVariable(sourceVariableName = "value")
+    List<CorruptedUndoShadowEntity> entities;
+
+    public CorruptedUndoShadowValue() {
+    }
+
+    public CorruptedUndoShadowValue(String value) {
+        this.value = value;
+        this.entities = new ArrayList<>();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public List<CorruptedUndoShadowEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(
+            List<CorruptedUndoShadowEntity> entities) {
+        this.entities = entities;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowVariableListener.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowVariableListener.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.config.solver.testutil.corruptedundoshadow;
 
+import java.util.Objects;
+
 import ai.timefold.solver.core.api.domain.variable.VariableListener;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 
@@ -43,7 +45,7 @@ public class CorruptedUndoShadowVariableListener
 
     private void update(ScoreDirector<CorruptedUndoShadowSolution> scoreDirector,
             CorruptedUndoShadowEntity corruptedUndoShadowEntity) {
-        if (corruptedUndoShadowEntity.value != null) {
+        if (corruptedUndoShadowEntity.valueClone == null || !Objects.equals("v1", corruptedUndoShadowEntity.value.value)) {
             scoreDirector.beforeVariableChanged(corruptedUndoShadowEntity, "valueClone");
             corruptedUndoShadowEntity.valueClone = corruptedUndoShadowEntity.value;
             scoreDirector.afterVariableChanged(corruptedUndoShadowEntity, "valueClone");


### PR DESCRIPTION
Some variable listeners, such as CollectionInverseVariableListener, expect their shadow not to be null. The same can also be true for user's own variable listeners. Thus, we cannot set shadow variables to null and can only simulate changes to geninue variables in order to recalculate from scratch.

Fixes #478