### PR TITLE
fix: Updating the School Timetabling quickstarts documentation

### DIFF
--- a/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -124,7 +124,7 @@ If you choose Maven, your `pom.xml` file has the following content:
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.3</version>
+        <version>1.4.14</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -155,7 +155,7 @@ If you choose Maven, your `pom.xml` file has the following content:
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
-          <mainClass>org.acme.schooltimetabling.TimeTableApp</mainClass>
+          <mainClass>org.acme.schooltimetabling.TimetableApp</mainClass>
         </configuration>
       </plugin>
     </plugins>
@@ -177,7 +177,7 @@ plugins {
 }
 
 def timefoldSolverVersion = "{timefold-solver-version}"
-def logbackVersion = "1.4.7"
+def logbackVersion = "1.4.14"
 
 group = "org.acme"
 version = "1.0-SNAPSHOT"
@@ -209,7 +209,7 @@ compileTestJava {
 }
 
 application {
-    mainClass = "org.acme.schooltimetabling.TimeTableApp"
+    mainClass = "org.acme.schooltimetabling.TimetableApp"
 }
 
 test {
@@ -241,7 +241,7 @@ to build a new `Solver` instance for each problem dataset to solve.
 A `SolverFactory` is thread-safe, but a `Solver` is not.
 In this case, there is only one dataset, so only one `Solver` instance.
 
-Create the `src/main/java/org/acme/schooltimetabling/TimeTableApp.java` class:
+Create the `src/main/java/org/acme/schooltimetabling/TimetableApp.java` class:
 
 [source,java]
 ----
@@ -254,44 +254,45 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.acme.schooltimetabling.domain.Lesson;
-import org.acme.schooltimetabling.domain.Room;
-import org.acme.schooltimetabling.domain.TimeTable;
-import org.acme.schooltimetabling.domain.Timeslot;
-import org.acme.schooltimetabling.solver.TimeTableConstraintProvider;
 import ai.timefold.solver.core.api.solver.Solver;
 import ai.timefold.solver.core.api.solver.SolverFactory;
 import ai.timefold.solver.core.config.solver.SolverConfig;
+import org.acme.schooltimetabling.domain.Lesson;
+import org.acme.schooltimetabling.domain.Room;
+import org.acme.schooltimetabling.domain.Timeslot;
+import org.acme.schooltimetabling.domain.Timetable;
+import org.acme.schooltimetabling.solver.TimetableConstraintProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TimeTableApp {
+public class TimetableApp {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TimeTableApp.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimetableApp.class);
 
     public static void main(String[] args) {
-        SolverFactory<TimeTable> solverFactory = SolverFactory.create(new SolverConfig()
-                .withSolutionClass(TimeTable.class)
+        SolverFactory<Timetable> solverFactory = SolverFactory.create(new SolverConfig()
+                .withSolutionClass(Timetable.class)
                 .withEntityClasses(Lesson.class)
-                .withConstraintProviderClass(TimeTableConstraintProvider.class)
+                .withConstraintProviderClass(TimetableConstraintProvider.class)
                 // The solver runs only for 5 seconds on this small dataset.
                 // It's recommended to run for at least 5 minutes ("5m") otherwise.
                 .withTerminationSpentLimit(Duration.ofSeconds(5)));
 
         // Load the problem
-        TimeTable problem = generateDemoData();
+        Timetable problem = generateDemoData();
 
         // Solve the problem
-        Solver<TimeTable> solver = solverFactory.buildSolver();
-        TimeTable solution = solver.solve(problem);
+        Solver<Timetable> solver = solverFactory.buildSolver();
+        Timetable solution = solver.solve(problem);
 
         // Visualize the solution
         printTimetable(solution);
     }
 
-    public static TimeTable generateDemoData() {
+    public static Timetable generateDemoData() {
         List<Timeslot> timeslotList = new ArrayList<>(10);
         timeslotList.add(new Timeslot(DayOfWeek.MONDAY, LocalTime.of(8, 30), LocalTime.of(9, 30)));
         timeslotList.add(new Timeslot(DayOfWeek.MONDAY, LocalTime.of(9, 30), LocalTime.of(10, 30)));
@@ -311,34 +312,34 @@ public class TimeTableApp {
         roomList.add(new Room("Room C"));
 
         List<Lesson> lessonList = new ArrayList<>();
-        long id = 0;
-        lessonList.add(new Lesson(id++, "Math", "A. Turing", "9th grade"));
-        lessonList.add(new Lesson(id++, "Math", "A. Turing", "9th grade"));
-        lessonList.add(new Lesson(id++, "Physics", "M. Curie", "9th grade"));
-        lessonList.add(new Lesson(id++, "Chemistry", "M. Curie", "9th grade"));
-        lessonList.add(new Lesson(id++, "Biology", "C. Darwin", "9th grade"));
-        lessonList.add(new Lesson(id++, "History", "I. Jones", "9th grade"));
-        lessonList.add(new Lesson(id++, "English", "I. Jones", "9th grade"));
-        lessonList.add(new Lesson(id++, "English", "I. Jones", "9th grade"));
-        lessonList.add(new Lesson(id++, "Spanish", "P. Cruz", "9th grade"));
-        lessonList.add(new Lesson(id++, "Spanish", "P. Cruz", "9th grade"));
+        long nextLessonId = 0L;
+        lessonList.add(new Lesson(nextLessonId++, "Math", "A. Turing", "9th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Math", "A. Turing", "9th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Physics", "M. Curie", "9th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Chemistry", "M. Curie", "9th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Biology", "C. Darwin", "9th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "History", "I. Jones", "9th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "English", "I. Jones", "9th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "English", "I. Jones", "9th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Spanish", "P. Cruz", "9th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Spanish", "P. Cruz", "9th grade"));
 
-        lessonList.add(new Lesson(id++, "Math", "A. Turing", "10th grade"));
-        lessonList.add(new Lesson(id++, "Math", "A. Turing", "10th grade"));
-        lessonList.add(new Lesson(id++, "Math", "A. Turing", "10th grade"));
-        lessonList.add(new Lesson(id++, "Physics", "M. Curie", "10th grade"));
-        lessonList.add(new Lesson(id++, "Chemistry", "M. Curie", "10th grade"));
-        lessonList.add(new Lesson(id++, "French", "M. Curie", "10th grade"));
-        lessonList.add(new Lesson(id++, "Geography", "C. Darwin", "10th grade"));
-        lessonList.add(new Lesson(id++, "History", "I. Jones", "10th grade"));
-        lessonList.add(new Lesson(id++, "English", "P. Cruz", "10th grade"));
-        lessonList.add(new Lesson(id++, "Spanish", "P. Cruz", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Math", "A. Turing", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Math", "A. Turing", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Math", "A. Turing", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Physics", "M. Curie", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Chemistry", "M. Curie", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "French", "M. Curie", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Geography", "C. Darwin", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "History", "I. Jones", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "English", "P. Cruz", "10th grade"));
+        lessonList.add(new Lesson(nextLessonId++, "Spanish", "P. Cruz", "10th grade"));
 
-        return new TimeTable(timeslotList, roomList, lessonList);
+        return new Timetable(timeslotList, roomList, lessonList);
     }
 
-    private static void printTimetable(TimeTable timeTable) {
-        LOGGER.info("");
+    private static void printTimetable(Timetable timeTable) {
+               LOGGER.info("");
         List<Room> roomList = timeTable.getRooms();
         List<Lesson> lessonList = timeTable.getLessons();
         Map<Timeslot, Map<Room, List<Lesson>>> lessonMap = lessonList.stream()
@@ -355,12 +356,8 @@ public class TimeTableApp {
                             return Collections.<Lesson>emptyList();
                         }
                         List<Lesson> cellLessonList = byRoomMap.get(room);
-                        if (cellLessonList == null) {
-                            return Collections.<Lesson>emptyList();
-                        }
-                        return cellLessonList;
-                    })
-                    .collect(Collectors.toList());
+                        return Objects.requireNonNullElse(cellLessonList, Collections.<Lesson>emptyList());
+                    }).toList();
 
             LOGGER.info("| " + String.format("%-10s",
                     timeslot.getDayOfWeek().toString().substring(0, 3) + " " + timeslot.getStartTime()) + " | "
@@ -382,7 +379,7 @@ public class TimeTableApp {
         }
         List<Lesson> unassignedLessons = lessonList.stream()
                 .filter(lesson -> lesson.getTimeslot() == null || lesson.getRoom() == null)
-                .collect(Collectors.toList());
+                .toList();
         if (!unassignedLessons.isEmpty()) {
             LOGGER.info("");
             LOGGER.info("Unassigned lessons");
@@ -399,10 +396,10 @@ The `main()` method first creates the `SolverFactory`:
 
 [source,java]
 ----
-SolverFactory<TimeTable> solverFactory = SolverFactory.create(new SolverConfig()
-        .withSolutionClass(TimeTable.class)
+SolverFactory<Timetable> solverFactory = SolverFactory.create(new SolverConfig()
+        .withSolutionClass(Timetable.class)
         .withEntityClasses(Lesson.class)
-        .withConstraintProviderClass(TimeTableConstraintProvider.class)
+        .withConstraintProviderClass(TimetableConstraintProvider.class)
         // The solver runs only for 5 seconds on this small dataset.
         // It's recommended to run for at least 5 minutes ("5m") otherwise.
         .withTerminationSpentLimit(Duration.ofSeconds(5)));
@@ -419,11 +416,11 @@ After five seconds, the `main()` method loads the problem, solves it, and prints
 [source,java]
 ----
         // Load the problem
-        TimeTable problem = generateDemoData();
+        Timetable problem = generateDemoData();
 
         // Solve the problem
-        Solver<TimeTable> solver = solverFactory.buildSolver();
-        TimeTable solution = solver.solve(problem);
+        Solver<Timetable> solver = solverFactory.buildSolver();
+        Timetable solution = solver.solve(problem);
 
         // Visualize the solution
         printTimetable(solution);
@@ -472,7 +469,7 @@ Create the `src/main/resource/logback.xml` file:
 
 === Run the application in IDE
 
-Run that `TimeTableApp` class as the main class of a normal Java application:
+Run that `TimetableApp` class as the main class of a normal Java application:
 
 ----
 ...
@@ -489,7 +486,7 @@ INFO  |            | 9th grade  | 10th grade |            |
 ----
 
 Verify the console output. Does it conform to all hard constraints?
-What happens if you comment out the `roomConflict` constraint in `TimeTableConstraintProvider`?
+What happens if you comment out the `roomConflict` constraint in `TimetableConstraintProvider`?
 
 The `info` log shows what Timefold Solver did in those five seconds:
 
@@ -511,7 +508,7 @@ To test each constraint in isolation, use a `ConstraintVerifier` in unit tests.
 This tests each constraint's corner cases in isolation from the other tests,
 which lowers maintenance when adding a new constraint with proper test coverage.
 
-Create the `src/test/java/org/acme/schooltimetabling/solver/TimeTableConstraintProviderTest.java` class:
+Create the `src/test/java/org/acme/schooltimetabling/solver/TimetableConstraintProviderTest.java` class:
 
 [source,java]
 ----
@@ -522,26 +519,26 @@ import java.time.LocalTime;
 
 import org.acme.schooltimetabling.domain.Lesson;
 import org.acme.schooltimetabling.domain.Room;
-import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.domain.Timetable;
 import org.acme.schooltimetabling.domain.Timeslot;
 import org.junit.jupiter.api.Test;
 import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
 
-class TimeTableConstraintProviderTest {
+class TimetableConstraintProviderTest {
 
     private static final Room ROOM1 = new Room("Room1");
     private static final Timeslot TIMESLOT1 = new Timeslot(DayOfWeek.MONDAY, LocalTime.NOON);
     private static final Timeslot TIMESLOT2 = new Timeslot(DayOfWeek.TUESDAY, LocalTime.NOON);
 
-    ConstraintVerifier<TimeTableConstraintProvider, TimeTable> constraintVerifier = ConstraintVerifier.build(
-            new TimeTableConstraintProvider(), TimeTable.class, Lesson.class);
+    ConstraintVerifier<TimetableConstraintProvider, Timetable> constraintVerifier = ConstraintVerifier.build(
+            new TimetableConstraintProvider(), Timetable.class, Lesson.class);
 
     @Test
     void roomConflict() {
         Lesson firstLesson = new Lesson(1, "Subject1", "Teacher1", "Group1", TIMESLOT1, ROOM1);
         Lesson conflictingLesson = new Lesson(2, "Subject2", "Teacher2", "Group2", TIMESLOT1, ROOM1);
         Lesson nonConflictingLesson = new Lesson(3, "Subject3", "Teacher3", "Group3", TIMESLOT2, ROOM1);
-        constraintVerifier.verifyThat(TimeTableConstraintProvider::roomConflict)
+        constraintVerifier.verifyThat(TimetableConstraintProvider::roomConflict)
                 .given(firstLesson, conflictingLesson, nonConflictingLesson)
                 .penalizesBy(1);
     }
@@ -549,7 +546,7 @@ class TimeTableConstraintProviderTest {
 }
 ----
 
-This test verifies that the constraint `TimeTableConstraintProvider::roomConflict` penalizes with a match weight of `1`
+This test verifies that the constraint `TimetableConstraintProvider::roomConflict` penalizes with a match weight of `1`
 when given three lessons in the same room, where two lessons have the same timeslot.
 Therefore, a constraint weight of `10hard` would reduce the score by `-10hard`.
 
@@ -604,7 +601,7 @@ In Maven, add the following to your `pom.xml`:
   ...
   <build>
     <plugins>
-      <plugin>
+       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>${version.assembly.plugin}</version>
@@ -616,7 +613,7 @@ In Maven, add the following to your `pom.xml`:
           </descriptors>
           <archive>
             <manifestEntries>
-              <Main-Class>org.acme.schooltimetabling.TimeTableApp</Main-Class>
+              <Main-Class>org.acme.schooltimetabling.TimetableApp</Main-Class>
               <Multi-Release>true</Multi-Release>
             </manifestEntries>
           </archive>
@@ -671,7 +668,7 @@ This enables the https://maven.apache.org/plugins/maven-assembly-plugin/[Maven A
 * Take all dependencies of your project and put their classes and resources into a new JAR.
 ** If any of the dependencies use https://docs.oracle.com/javase/tutorial/ext/basics/spi.html[Java SPI], it properly bundles all the service descriptors.
 ** If any of the dependencies are https://openjdk.org/jeps/238[multi-release JARs], it takes that into account.
-* Set that JAR's main class to be `org.acme.schooltimetabling.TimeTableApp`.
+* Set that JAR's main class to be `org.acme.schooltimetabling.TimetableApp`.
 * Make that JAR available as `hello-world-run.jar` in your project's build directory, most likely `target/`.
 
 This executable JAR can be run like any other JAR:
@@ -690,7 +687,7 @@ In Gradle, add the following to your `build.gradle`:
 [source,gradle,options="nowrap"]
 ----
 application {
-    mainClass = "org.acme.schooltimetabling.TimeTableApp"
+    mainClass = "org.acme.schooltimetabling.TimetableApp"
 }
 ----
 

--- a/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -411,7 +411,7 @@ and the `ConstraintProvider` class, all of which you created earlier.
 Without a termination setting or a `terminationEarly()` event, the solver runs forever.
 To avoid that, the solver limits the solving time to five seconds.
 
-After five seconds, the `main()` method loads the problem, solves it, and prints the solution:
+The `main()` method loads the problem, solves it, and prints the solution after just over five seconds.
 
 [source,java]
 ----
@@ -601,7 +601,7 @@ In Maven, add the following to your `pom.xml`:
   ...
   <build>
     <plugins>
-       <plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>${version.assembly.plugin}</version>

--- a/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -338,17 +338,17 @@ public class TimetableApp {
         return new Timetable(timeslotList, roomList, lessonList);
     }
 
-    private static void printTimetable(Timetable timeTable) {
+    private static void printTimetable(Timetable timetable) {
                LOGGER.info("");
-        List<Room> roomList = timeTable.getRooms();
-        List<Lesson> lessonList = timeTable.getLessons();
+        List<Room> roomList = timetable.getRooms();
+        List<Lesson> lessonList = timetable.getLessons();
         Map<Timeslot, Map<Room, List<Lesson>>> lessonMap = lessonList.stream()
                 .filter(lesson -> lesson.getTimeslot() != null && lesson.getRoom() != null)
                 .collect(Collectors.groupingBy(Lesson::getTimeslot, Collectors.groupingBy(Lesson::getRoom)));
         LOGGER.info("|            | " + roomList.stream()
                 .map(room -> String.format("%-10s", room.getName())).collect(Collectors.joining(" | ")) + " |");
         LOGGER.info("|" + "------------|".repeat(roomList.size() + 1));
-        for (Timeslot timeslot : timeTable.getTimeslots()) {
+        for (Timeslot timeslot : timetable.getTimeslots()) {
             List<List<Lesson>> cellList = roomList.stream()
                     .map(room -> {
                         Map<Room, List<Lesson>> byRoomMap = lessonMap.get(timeslot);

--- a/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -140,17 +140,6 @@ If you choose Maven, your `pom.xml` file has the following content:
       <groupId>ai.timefold.solver</groupId>
       <artifactId>timefold-solver-quarkus-jackson</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ai.timefold.solver</groupId>
-      <artifactId>timefold-solver-test</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -367,10 +356,22 @@ Add a `timefold-solver-test` dependency in your `pom.xml`:
 [source,xml]
 ----
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ai.timefold.solver</groupId>
       <artifactId>timefold-solver-test</artifactId>
       <scope>test</scope>
     </dependency>
+----
+
+For Gradle, add the subsequent dependencies to your `build.gradle`:
+[source,groovy,subs=attributes+]
+----
+    testImplementation "io.quarkus:quarkus-junit5"
+    testImplementation "ai.timefold.solver:timefold-solver-test"
 ----
 
 Create the `src/test/java/org/acme/schooltimetabling/solver/TimetableConstraintProviderTest.java` class:

--- a/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -722,4 +722,4 @@ public class TimetableResourceTest {
 
 . Build an attractive web UI on top of these REST methods to visualize the timetable.
 
-For an implementation with UI-integrated and in-memory storage, check out {quarkus-quickstart-url}[the Quarkus quickstart source code].
+For a full implementation with a web UI and in-memory storage, check out {quarkus-quickstart-url}[the Quarkus quickstart source code].

--- a/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -242,7 +242,7 @@ Therefore, the Quarkus extension injects a `SolverManager` instance,
 which runs solvers in a separate thread pool
 and can solve multiple datasets in parallel.
 
-Create the `src/main/java/org/acme/schooltimetabling/rest/TimeTableResource.java` class:
+Create the `src/main/java/org/acme/schooltimetabling/rest/TimetableResource.java` class:
 
 [source,java]
 ----
@@ -254,23 +254,23 @@ import javax.inject.Inject;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
-import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.domain.Timetable;
 import ai.timefold.solver.core.api.solver.SolverJob;
 import ai.timefold.solver.core.api.solver.SolverManager;
 
-@Path("/timeTable")
-public class TimeTableResource {
+@Path("/timetables")
+public class TimetableResource {
 
     @Inject
-    SolverManager<TimeTable, UUID> solverManager;
+    SolverManager<Timetable, UUID> solverManager;
 
     @POST
     @Path("/solve")
-    public TimeTable solve(TimeTable problem) {
+    public Timetable solve(Timetable problem) {
         UUID problemId = UUID.randomUUID();
         // Submit the problem to start solving
-        SolverJob<TimeTable, UUID> solverJob = solverManager.solve(problemId, problem);
-        TimeTable solution;
+        SolverJob<Timetable, UUID> solverJob = solverManager.solve(problemId, problem);
+        Timetable solution;
         try {
             // Wait until the solving ends
             solution = solverJob.getFinalBestSolution();
@@ -324,7 +324,7 @@ The following example uses the Linux command `curl` to send a POST request:
 
 [source,shell]
 ----
-$ curl -i -X POST http://localhost:8080/timeTable/solve -H "Content-Type:application/json" -d '{"timeslots":[{"dayOfWeek":"MONDAY","startTime":"08:30:00","endTime":"09:30:00"},{"dayOfWeek":"MONDAY","startTime":"09:30:00","endTime":"10:30:00"}],"rooms":[{"name":"Room A"},{"name":"Room B"}],"lessons":[{"id":1,"subject":"Math","teacher":"A. Turing","studentGroup":"9th grade"},{"id":2,"subject":"Chemistry","teacher":"M. Curie","studentGroup":"9th grade"},{"id":3,"subject":"French","teacher":"M. Curie","studentGroup":"10th grade"},{"id":4,"subject":"History","teacher":"I. Jones","studentGroup":"10th grade"}]}'
+$ curl -i -X POST http://localhost:8080/timetables/solve -H "Content-Type:application/json" -d '{"timeslots":[{"dayOfWeek":"MONDAY","startTime":"08:30:00","endTime":"09:30:00"},{"dayOfWeek":"MONDAY","startTime":"09:30:00","endTime":"10:30:00"}],"rooms":[{"name":"Room A"},{"name":"Room B"}],"lessons":[{"id":1,"subject":"Math","teacher":"A. Turing","studentGroup":"9th grade"},{"id":2,"subject":"Chemistry","teacher":"M. Curie","studentGroup":"9th grade"},{"id":3,"subject":"French","teacher":"M. Curie","studentGroup":"10th grade"},{"id":4,"subject":"History","teacher":"I. Jones","studentGroup":"10th grade"}]}'
 ----
 
 After about five seconds, according to the termination spent time defined in your `application.properties`,
@@ -373,7 +373,7 @@ Add a `timefold-solver-test` dependency in your `pom.xml`:
     </dependency>
 ----
 
-Create the `src/test/java/org/acme/schooltimetabling/solver/TimeTableConstraintProviderTest.java` class:
+Create the `src/test/java/org/acme/schooltimetabling/solver/TimetableConstraintProviderTest.java` class:
 
 [source,java]
 ----
@@ -387,37 +387,27 @@ import javax.inject.Inject;
 import io.quarkus.test.junit.QuarkusTest;
 import org.acme.schooltimetabling.domain.Lesson;
 import org.acme.schooltimetabling.domain.Room;
-import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.domain.Timetable;
 import org.acme.schooltimetabling.domain.Timeslot;
 import org.junit.jupiter.api.Test;
 import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
 
 @QuarkusTest
-class TimeTableConstraintProviderTest {
+class TimetableConstraintProviderTest {
 
     private static final Room ROOM = new Room("Room1");
     private static final Timeslot TIMESLOT1 = new Timeslot(DayOfWeek.MONDAY, LocalTime.of(9,0), LocalTime.NOON);
     private static final Timeslot TIMESLOT2 = new Timeslot(DayOfWeek.TUESDAY, LocalTime.of(9,0), LocalTime.NOON);
 
     @Inject
-    ConstraintVerifier<TimeTableConstraintProvider, TimeTable> constraintVerifier;
+    ConstraintVerifier<TimetableConstraintProvider, Timetable> constraintVerifier;
 
     @Test
     void roomConflict() {
-        Lesson firstLesson = new Lesson(1, "Subject1", "Teacher1", "Group1");
-        Lesson conflictingLesson = new Lesson(2, "Subject2", "Teacher2", "Group2");
-        Lesson nonConflictingLesson = new Lesson(3, "Subject3", "Teacher3", "Group3");
-
-        firstLesson.setRoom(ROOM);
-        firstLesson.setTimeslot(TIMESLOT1);
-
-        conflictingLesson.setRoom(ROOM);
-        conflictingLesson.setTimeslot(TIMESLOT1);
-
-        nonConflictingLesson.setRoom(ROOM);
-        nonConflictingLesson.setTimeslot(TIMESLOT2);
-
-        constraintVerifier.verifyThat(TimeTableConstraintProvider::roomConflict)
+        Lesson firstLesson = new Lesson(1, "Subject1", "Teacher1", "Group1", TIMESLOT1, ROOM1);
+        Lesson conflictingLesson = new Lesson(2, "Subject2", "Teacher2", "Group2", TIMESLOT1, ROOM1);
+        Lesson nonConflictingLesson = new Lesson(3, "Subject3", "Teacher3", "Group3", TIMESLOT2, ROOM1);
+        constraintVerifier.verifyThat(TimetableConstraintProvider::roomConflict)
                 .given(firstLesson, conflictingLesson, nonConflictingLesson)
                 .penalizesBy(1);
     }
@@ -425,7 +415,7 @@ class TimeTableConstraintProviderTest {
 }
 ----
 
-This test verifies that the constraint `TimeTableConstraintProvider::roomConflict`,
+This test verifies that the constraint `TimetableConstraintProvider::roomConflict`,
 when given three lessons in the same room, where two lessons have the same timeslot,
 it penalizes with a match weight of `1`.
 So with a constraint weight of `10hard` it would reduce the score by `-10hard`.
@@ -437,9 +427,9 @@ This way, constraint weight tweaking does not break the unit tests.
 
 ==== Test the solver
 
-In a JUnit test, generate a test dataset and send it to the `TimeTableResource` to solve.
+In a JUnit test, generate a test dataset and send it to the `TimetableResource` to solve.
 
-Create the `src/test/java/org/acme/schooltimetabling/rest/TimeTableResourceTest.java` class:
+Create the `src/test/java/org/acme/schooltimetabling/rest/TimetableResourceTest.java` class:
 
 [source,java]
 ----
@@ -456,8 +446,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.acme.schooltimetabling.domain.Room;
 import org.acme.schooltimetabling.domain.Timeslot;
 import org.acme.schooltimetabling.domain.Lesson;
-import org.acme.schooltimetabling.domain.TimeTable;
-import org.acme.schooltimetabling.rest.TimeTableResource;
+import org.acme.schooltimetabling.domain.Timetable;
+import org.acme.schooltimetabling.rest.TimetableResource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -466,16 +456,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-public class TimeTableResourceTest {
+public class TimetableResourceTest {
 
     @Inject
-    TimeTableResource timeTableResource;
+    TimetableResource timetableResource;
 
     @Test
     @Timeout(600_000)
     public void solve() {
-        TimeTable problem = generateProblem();
-        TimeTable solution = timeTableResource.solve(problem);
+        Timetable problem = generateProblem();
+        Timetable solution = timetableResource.solve(problem);
         assertFalse(solution.getLessons().isEmpty());
         for (Lesson lesson : solution.getLessons()) {
             assertNotNull(lesson.getTimeslot());
@@ -484,7 +474,7 @@ public class TimeTableResourceTest {
         assertTrue(solution.getScore().isFeasible());
     }
 
-    private TimeTable generateProblem() {
+    private Timetable generateProblem() {
         List<Timeslot> timeslots = new ArrayList<>();
         timeslots.add(new Timeslot(DayOfWeek.MONDAY, LocalTime.of(8, 30), LocalTime.of(9, 30)));
         timeslots.add(new Timeslot(DayOfWeek.MONDAY, LocalTime.of(9, 30), LocalTime.of(10, 30)));
@@ -509,7 +499,7 @@ public class TimeTableResourceTest {
         lessons.add(new Lesson(203L, "History", "I. Jones", "10th grade"));
         lessons.add(new Lesson(204L, "English", "P. Cruz", "10th grade"));
         lessons.add(new Lesson(205L, "French", "M. Curie", "10th grade"));
-        return new TimeTable(timeslots, rooms, lessons);
+        return new Timetable(timeslots, rooms, lessons);
     }
 
 }
@@ -580,7 +570,7 @@ Now try adding database and UI integration:
 
 . https://quarkus.io/guides/rest-json[Expose them through REST].
 
-. Adjust the `TimeTableResource` to read and write a `TimeTable` instance in a single transaction
+. Adjust the `TimetableResource` to read and write a `Timetable` instance in a single transaction
 and use those accordingly:
 +
 [source,java]
@@ -596,30 +586,30 @@ import javax.ws.rs.Path;
 import io.quarkus.panache.common.Sort;
 import org.acme.schooltimetabling.domain.Lesson;
 import org.acme.schooltimetabling.domain.Room;
-import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.domain.Timetable;
 import org.acme.schooltimetabling.domain.Timeslot;
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.api.solver.SolverManager;
 import ai.timefold.solver.core.api.solver.SolverStatus;
 
-@Path("/timeTable")
-public class TimeTableResource {
+@Path("/timetable")
+public class TimetableResource {
 
     public static final Long SINGLETON_TIME_TABLE_ID = 1L;
 
     @Inject
-    SolverManager<TimeTable, Long> solverManager;
+    SolverManager<Timetable, Long> solverManager;
     @Inject
-    SolutionManager<TimeTable, HardSoftScore> solutionManager;
+    SolutionManager<Timetable, HardSoftScore> solutionManager;
 
-    // To try, open http://localhost:8080/timeTable
+    // To try, open http://localhost:8080/timetable
     @GET
-    public TimeTable getTimeTable() {
+    public Timetable getTimetable() {
         // Get the solver status before loading the solution
         // to avoid the race condition that the solver terminates between them
         SolverStatus solverStatus = getSolverStatus();
-        TimeTable solution = findById(SINGLETON_TIME_TABLE_ID);
+        Timetable solution = findById(SINGLETON_TIME_TABLE_ID);
         solutionManager.update(solution); // Sets the score
         solution.setSolverStatus(solverStatus);
         return solution;
@@ -644,21 +634,21 @@ public class TimeTableResource {
     }
 
     @Transactional
-    protected TimeTable findById(Long id) {
+    protected Timetable findById(Long id) {
         if (!SINGLETON_TIME_TABLE_ID.equals(id)) {
-            throw new IllegalStateException("There is no timeTable with id (" + id + ").");
+            throw new IllegalStateException("There is no timetable with id (" + id + ").");
         }
         // Occurs in a single transaction, so each initialized lesson references the same timeslot/room instance
-        // that is contained by the timeTable's timeslots/rooms.
-        return new TimeTable(
+        // that is contained by the timetable's timeslots/rooms.
+        return new Timetable(
                 Timeslot.listAll(Sort.by("dayOfWeek").and("startTime").and("endTime").and("id")),
                 Room.listAll(Sort.by("name").and("id")),
                 Lesson.listAll(Sort.by("subject").and("teacher").and("studentGroup").and("id")));
     }
 
     @Transactional
-    protected void save(TimeTable timeTable) {
-        for (Lesson lesson : timeTable.getLessons()) {
+    protected void save(Timetable timetable) {
+        for (Lesson lesson : timetable.getLessons()) {
             // TODO this is awfully naive: optimistic locking causes issues if called by the SolverManager
             Lesson attachedLesson = Lesson.findById(lesson.getId());
             attachedLesson.setTimeslot(lesson.getTimeslot());
@@ -669,10 +659,10 @@ public class TimeTableResource {
 }
 ----
 +
-For simplicity's sake, this code handles only one `TimeTable` instance,
-but it is straightforward to enable multi-tenancy and handle multiple `TimeTable` instances of different high schools in parallel.
+For simplicity's sake, this code handles only one `Timetable` instance,
+but it is straightforward to enable multi-tenancy and handle multiple `Timetable` instances of different high schools in parallel.
 +
-The `getTimeTable()` method returns the latest timetable from the database.
+The `getTimetable()` method returns the latest timetable from the database.
 It uses the `SolutionManager` (which is automatically injected)
 to calculate the score of that timetable, so the UI can show the score.
 +
@@ -681,7 +671,7 @@ It uses the `SolverManager.solveAndListen()` method to listen to intermediate be
 and update the database accordingly.
 This enables the UI to show progress while the backend is still solving.
 
-. Adjust the `TimeTableResourceTest` instance accordingly, now that the `solve()` method returns immediately.
+. Adjust the `TimetableResourceTest` instance accordingly, now that the `solve()` method returns immediately.
 Poll for the latest solution until the solver finishes solving:
 +
 [source,java]
@@ -692,7 +682,7 @@ import javax.inject.Inject;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.acme.schooltimetabling.domain.Lesson;
-import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.domain.Timetable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import ai.timefold.solver.core.api.solver.SolverStatus;
@@ -702,28 +692,28 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-public class TimeTableResourceTest {
+public class TimetableResourceTest {
 
     @Inject
-    TimeTableResource timeTableResource;
+    TimetableResource timetableResource;
 
     @Test
     @Timeout(600_000)
     public void solveDemoDataUntilFeasible() throws InterruptedException {
-        timeTableResource.solve();
-        TimeTable timeTable = timeTableResource.getTimeTable();
-        while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING) {
+        timetableResource.solve();
+        Timetable timetable = timetableResource.getTimetable();
+        while (timetable.getSolverStatus() != SolverStatus.NOT_SOLVING) {
             // Quick polling (not a Test Thread Sleep anti-pattern)
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L);
-            timeTable = timeTableResource.getTimeTable();
+            timetable = timetableResource.getTimetable();
         }
-        assertFalse(timeTable.getLessons().isEmpty());
-        for (Lesson lesson : timeTable.getLessons()) {
+        assertFalse(timetable.getLessons().isEmpty());
+        for (Lesson lesson : timetable.getLessons()) {
             assertNotNull(lesson.getTimeslot());
             assertNotNull(lesson.getRoom());
         }
-        assertTrue(timeTable.getScore().isFeasible());
+        assertTrue(timetable.getScore().isFeasible());
     }
 
 }
@@ -731,4 +721,4 @@ public class TimeTableResourceTest {
 
 . Build an attractive web UI on top of these REST methods to visualize the timetable.
 
-Take a look at {quarkus-quickstart-url}[the quickstart source code] to see how this all turns out.
+For an implementation with UI-integrated and in-memory storage, check out {quarkus-quickstart-url}[the Quarkus quickstart source code].

--- a/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-constraints.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-constraints.adoc
@@ -23,8 +23,8 @@ To calculate the score, you could implement an `EasyScoreCalculator` class:
 public class TimetableEasyScoreCalculator implements EasyScoreCalculator<Timetable, HardSoftScore> {
 
     @Override
-    public HardSoftScore calculateScore(Timetable timeTable) {
-        List<Lesson> lessons = timeTable.getLessons();
+    public HardSoftScore calculateScore(Timetable timetable) {
+        List<Lesson> lessons = timetable.getLessons();
         int hardScore = 0;
         for (Lesson a : lessons) {
             for (Lesson b : lessons) {

--- a/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-constraints.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-constraints.adoc
@@ -20,10 +20,10 @@ To calculate the score, you could implement an `EasyScoreCalculator` class:
 
 [source,java]
 ----
-public class TimeTableEasyScoreCalculator implements EasyScoreCalculator<TimeTable, HardSoftScore> {
+public class TimetableEasyScoreCalculator implements EasyScoreCalculator<Timetable, HardSoftScore> {
 
     @Override
-    public HardSoftScore calculateScore(TimeTable timeTable) {
+    public HardSoftScore calculateScore(Timetable timeTable) {
         List<Lesson> lessons = timeTable.getLessons();
         int hardScore = 0;
         for (Lesson a : lessons) {
@@ -57,7 +57,7 @@ Unfortunately **that does not scale well**, because it is non-incremental:
 every time a lesson is assigned to a different time slot or room,
 all lessons are re-evaluated to calculate the new score.
 
-Instead, create a `src/main/java/org/acme/schooltimetabling/solver/TimeTableConstraintProvider.java` class
+Instead, create a `src/main/java/org/acme/schooltimetabling/solver/TimetableConstraintProvider.java` class
 to perform incremental score calculation.
 It uses Timefold Solver's xref:constraints-and-score/score-calculation.adoc[Constraint Streams API]
 which is inspired by Java Streams and SQL:
@@ -73,7 +73,7 @@ import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
 import ai.timefold.solver.core.api.score.stream.Joiners;
 
-public class TimeTableConstraintProvider implements ConstraintProvider {
+public class TimetableConstraintProvider implements ConstraintProvider {
 
     @Override
     public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
@@ -88,41 +88,34 @@ public class TimeTableConstraintProvider implements ConstraintProvider {
 
     private Constraint roomConflict(ConstraintFactory constraintFactory) {
         // A room can accommodate at most one lesson at the same time.
-
-        // Select a lesson ...
         return constraintFactory
-                .forEach(Lesson.class)
-                // ... and pair it with another lesson ...
-                .join(Lesson.class,
+                // Select each pair of 2 different lessons ...
+                .forEachUniquePair(Lesson.class,
                         // ... in the same timeslot ...
                         Joiners.equal(Lesson::getTimeslot),
                         // ... in the same room ...
-                        Joiners.equal(Lesson::getRoom),
-                        // ... and the pair is unique (different id, no reverse pairs) ...
-                        Joiners.lessThan(Lesson::getId))
-                // ... then penalize each pair with a hard weight.
+                        Joiners.equal(Lesson::getRoom))
+                // ... and penalize each pair with a hard weight.
                 .penalize(HardSoftScore.ONE_HARD)
                 .asConstraint("Room conflict");
     }
 
     private Constraint teacherConflict(ConstraintFactory constraintFactory) {
         // A teacher can teach at most one lesson at the same time.
-        return constraintFactory.forEach(Lesson.class)
-                .join(Lesson.class,
+        return constraintFactory
+                .forEachUniquePair(Lesson.class,
                         Joiners.equal(Lesson::getTimeslot),
-                        Joiners.equal(Lesson::getTeacher),
-                        Joiners.lessThan(Lesson::getId))
+                        Joiners.equal(Lesson::getTeacher))
                 .penalize(HardSoftScore.ONE_HARD)
                 .asConstraint("Teacher conflict");
     }
 
     private Constraint studentGroupConflict(ConstraintFactory constraintFactory) {
         // A student can attend at most one lesson at the same time.
-        return constraintFactory.forEach(Lesson.class)
-                .join(Lesson.class,
+        return constraintFactory
+                .forEachUniquePair(Lesson.class,
                         Joiners.equal(Lesson::getTimeslot),
-                        Joiners.equal(Lesson::getStudentGroup),
-                        Joiners.lessThan(Lesson::getId))
+                        Joiners.equal(Lesson::getStudentGroup))
                 .penalize(HardSoftScore.ONE_HARD)
                 .asConstraint("Student group conflict");
     }

--- a/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-model.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-model.adoc
@@ -61,7 +61,6 @@ public class Timeslot {
 ----
 
 Because no `Timeslot` instances change during solving, a `Timeslot` is called a _problem fact_.
-Such classes do not require any Timefold Solver specific annotations.
 
 Notice the `toString()` method keeps the output short,
 so it is easier to read Timefold Solver's `DEBUG` or `TRACE` log, as shown later.

--- a/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-model.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-model.adoc
@@ -61,6 +61,7 @@ public class Timeslot {
 ----
 
 Because no `Timeslot` instances change during solving, a `Timeslot` is called a _problem fact_.
+Such classes do not require any Timefold Solver specific annotations.
 
 Notice the `toString()` method keeps the output short,
 so it is easier to read Timefold Solver's `DEBUG` or `TRACE` log, as shown later.

--- a/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-solution.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-solution.adoc
@@ -1,7 +1,7 @@
 = Gather the domain objects in a planning solution
 :imagesdir: ../..
 
-A `TimeTable` wraps all `Timeslot`, `Room`, and `Lesson` instances of a single dataset.
+A `Timetable` wraps all `Timeslot`, `Room`, and `Lesson` instances of a single dataset.
 Furthermore, because it contains all lessons, each with a specific planning variable state,
 it is a _planning solution_ and it has a score:
 
@@ -12,7 +12,7 @@ for example, a solution with the score `-2hard/-3soft`.
 * If it adheres to all hard constraints, then it is a _feasible_ solution,
 for example, a solution with the score `0hard/-7soft`.
 
-Create the `src/main/java/org/acme/schooltimetabling/domain/TimeTable.java` class:
+Create the `src/main/java/org/acme/schooltimetabling/domain/Timetable.java` class:
 
 [source,java]
 ----
@@ -28,7 +28,7 @@ import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 
 @PlanningSolution
-public class TimeTable {
+public class Timetable {
 
     @ValueRangeProvider
     @ProblemFactCollectionProperty
@@ -42,10 +42,10 @@ public class TimeTable {
     @PlanningScore
     private HardSoftScore score;
 
-    public TimeTable() {
+    public Timetable() {
     }
 
-    public TimeTable(List<Timeslot> timeslots, List<Room> rooms, List<Lesson> lessons) {
+    public Timetable(List<Timeslot> timeslots, List<Room> rooms, List<Lesson> lessons) {
         this.timeslots = timeslots;
         this.rooms = rooms;
         this.lessons = lessons;
@@ -70,16 +70,16 @@ public class TimeTable {
 }
 ----
 
-The `TimeTable` class has an `@PlanningSolution` annotation,
+The `Timetable` class has an `@PlanningSolution` annotation,
 so Timefold Solver knows that this class contains all of the input and output data.
 
-Specifically, this class is the input of the problem:
+Specifically, these classes are the input of the problem:
 
-* A `timeslots` field with all time slots
+* The `timeslots` field with all time slots
 ** This is a list of problem facts, because they do not change during solving.
-* A `rooms` field with all rooms
+* The `rooms` field with all rooms
 ** This is a list of problem facts, because they do not change during solving.
-* A `lessons` field with all lessons
+* The `lessons` field with all lessons
 ** This is a list of planning entities, because they change during solving.
 ** Of each `Lesson`:
 *** The values of the `timeslot` and `room` fields are typically still `null`, so unassigned.
@@ -89,8 +89,8 @@ These fields are problem properties.
 
 However, this class is also the output of the solution:
 
-* A `lessons` field for which each `Lesson` instance has non-null `timeslot` and `room` fields after solving
-* A `score` field that represents the quality of the output solution, for example, `0hard/-5soft`
+* The `lessons` field for which each `Lesson` instance has non-null `timeslot` and `room` fields after solving.
+* The `score` field that represents the quality of the output solution, for example, `0hard/-5soft`.
 
 == The value range providers
 
@@ -105,11 +105,11 @@ Following the same logic, the `rooms` field also has an `@ValueRangeProvider` an
 
 Furthermore, Timefold Solver needs to know which `Lesson` instances it can change
 as well as how to retrieve the `Timeslot` and `Room` instances used for score calculation
-by your `TimeTableConstraintProvider`.
+by your `TimetableConstraintProvider`.
 
 The `timeslots` and `rooms` fields have an `@ProblemFactCollectionProperty` annotation,
-so your `TimeTableConstraintProvider` can select _from_ those instances.
+so your `TimetableConstraintProvider` can select _from_ those instances.
 
 The `lessons` has an `@PlanningEntityCollectionProperty` annotation,
 so Timefold Solver can change them during solving
-and your `TimeTableConstraintProvider` can select _from_ those too.
+and your `TimetableConstraintProvider` can select _from_ those too.

--- a/docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
@@ -668,4 +668,4 @@ public class TimetableControllerTest {
 
 . Build an attractive web UI on top of these REST methods to visualize the timetable.
 
-For an implementation with UI-integrated and in-memory storage, check out {spring-boot-quickstart-url}[the Spring-boot quickstart source code].
+For a full implementation with a web UI and in-memory storage, check out {spring-boot-quickstart-url}[the Spring-boot quickstart source code].

--- a/docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
@@ -114,17 +114,6 @@ If you choose Maven, your `pom.xml` file has the following content:
             <groupId>ai.timefold.solver</groupId>
             <artifactId>timefold-solver-spring-boot-starter</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ai.timefold.solver</groupId>
-            <artifactId>timefold-solver-test</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -144,7 +133,7 @@ On the other hand, in Gradle, your `build.gradle` file has this content:
 ----
 plugins {
     id "org.springframework.boot" version "{spring-boot-version}"
-    id "io.spring.dependency-management" version "1.0.11.RELEASE"
+    id "io.spring.dependency-management" version "1.1.4"
     id "java"
 }
 
@@ -161,11 +150,9 @@ repositories {
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-data-rest"
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     implementation platform("ai.timefold.solver:timefold-solver-bom:${timefoldSolverVersion}")
     implementation "ai.timefold.solver:timefold-solver-spring-boot-starter"
-    testImplementation("ai.timefold.solver:timefold-solver-test")
 }
 
 test {
@@ -185,7 +172,7 @@ Therefore, the Spring Boot starter injects a `SolverManager` instance,
 which runs solvers in a separate thread pool
 and can solve multiple datasets in parallel.
 
-Create the `src/main/java/org/acme/schooltimetabling/rest/TimeTableController.java` class:
+Create the `src/main/java/org/acme/schooltimetabling/rest/TimetableController.java` class:
 
 [source,java]
 ----
@@ -194,7 +181,7 @@ package org.acme.schooltimetabling.rest;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
-import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.domain.Timetable;
 import ai.timefold.solver.core.api.solver.SolverJob;
 import ai.timefold.solver.core.api.solver.SolverManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -204,18 +191,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/timeTable")
-public class TimeTableController {
+@RequestMapping("/timetable")
+public class TimetableController {
 
     @Autowired
-    private SolverManager<TimeTable, UUID> solverManager;
+    private SolverManager<Timetable, UUID> solverManager;
 
     @PostMapping("/solve")
-    public TimeTable solve(@RequestBody TimeTable problem) {
+    public Timetable solve(@RequestBody Timetable problem) {
         UUID problemId = UUID.randomUUID();
         // Submit the problem to start solving
-        SolverJob<TimeTable, UUID> solverJob = solverManager.solve(problemId, problem);
-        TimeTable solution;
+        SolverJob<Timetable, UUID> solverJob = solverManager.solve(problemId, problem);
+        Timetable solution;
         try {
             // Wait until the solving ends
             solution = solverJob.getFinalBestSolution();
@@ -257,7 +244,7 @@ Increase the termination time to potentially find a better solution.
 Package everything into a single executable JAR file driven by a standard Java `main()` method:
 
 Replace the `DemoApplication.java` class created by Spring Initializr
-with the `src/main/java/org/acme/schooltimetabling/TimeTableSpringBootApp.java` class:
+with the `src/main/java/org/acme/schooltimetabling/TimetableSpringBootApp.java` class:
 
 [source,java]
 ----
@@ -267,16 +254,16 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class TimeTableSpringBootApp {
+public class TimetableSpringBootApp {
 
     public static void main(String[] args) {
-        SpringApplication.run(TimeTableSpringBootApp.class, args);
+        SpringApplication.run(TimetableSpringBootApp.class, args);
     }
 
 }
 ----
 
-Run that `TimeTableSpringBootApp` class as the main class of a normal Java application.
+Run that `TimetableSpringBootApp` class as the main class of a normal Java application.
 
 === Try the application
 
@@ -286,7 +273,7 @@ The following example uses the Linux command `curl` to send a POST request:
 
 [source,shell]
 ----
-$ curl -i -X POST http://localhost:8080/timeTable/solve -H "Content-Type:application/json" -d '{"timeslotList":[{"dayOfWeek":"MONDAY","startTime":"08:30:00","endTime":"09:30:00"},{"dayOfWeek":"MONDAY","startTime":"09:30:00","endTime":"10:30:00"}],"roomList":[{"name":"Room A"},{"name":"Room B"}],"lessonList":[{"id":1,"subject":"Math","teacher":"A. Turing","studentGroup":"9th grade"},{"id":2,"subject":"Chemistry","teacher":"M. Curie","studentGroup":"9th grade"},{"id":3,"subject":"French","teacher":"M. Curie","studentGroup":"10th grade"},{"id":4,"subject":"History","teacher":"I. Jones","studentGroup":"10th grade"}]}'
+$ curl -i -X POST http://localhost:8080/timetable/solve -H "Content-Type:application/json" -d '{"timeslotList":[{"dayOfWeek":"MONDAY","startTime":"08:30:00","endTime":"09:30:00"},{"dayOfWeek":"MONDAY","startTime":"09:30:00","endTime":"10:30:00"}],"roomList":[{"name":"Room A"},{"name":"Room B"}],"lessonList":[{"id":1,"subject":"Math","teacher":"A. Turing","studentGroup":"9th grade"},{"id":2,"subject":"Chemistry","teacher":"M. Curie","studentGroup":"9th grade"},{"id":3,"subject":"French","teacher":"M. Curie","studentGroup":"10th grade"},{"id":4,"subject":"History","teacher":"I. Jones","studentGroup":"10th grade"}]}'
 ----
 
 After about five seconds, according to the termination spent time defined in your `application.properties`,
@@ -326,17 +313,30 @@ It tests each constraint's corner cases in isolation from the other tests,
 which lowers maintenance when adding a new constraint with proper test coverage.
 
 
-Add a `timefold-solver-test` dependency in your `pom.xml`:
+Add the folllowing dependencies to your `pom.xml`:
 [source,xml]
 ----
     <dependency>
-      <groupId>ai.timefold.solver</groupId>
-      <artifactId>timefold-solver-test</artifactId>
-      <scope>test</scope>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>ai.timefold.solver</groupId>
+        <artifactId>timefold-solver-test</artifactId>
+        <scope>test</scope>
     </dependency>
 ----
 
-Create the `src/test/java/org/acme/schooltimetabling/solver/TimeTableConstraintProviderTest.java` class:
+For Gradle, add the subsequent dependencies to your `build.gradle`:
+[source,groovy,subs=attributes+]
+----
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("ai.timefold.solver:timefold-solver-test")
+----
+
+
+Create the `src/test/java/org/acme/schooltimetabling/solver/TimetableConstraintProviderTest.java` class:
 
 [source,java]
 ----
@@ -347,7 +347,7 @@ import java.time.LocalTime;
 import javax.inject.Inject;
 import org.acme.schooltimetabling.domain.Lesson;
 import org.acme.schooltimetabling.domain.Room;
-import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.domain.Timetable;
 import org.acme.schooltimetabling.domain.Timeslot;
 import org.junit.jupiter.api.Test;
 import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
@@ -356,41 +356,53 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class TimeTableConstraintProviderTest {
+class TimetableConstraintProviderTest {
 
     private static final Room ROOM = new Room("Room1");
     private static final Timeslot TIMESLOT1 = new Timeslot(DayOfWeek.MONDAY, LocalTime.of(9,0), LocalTime.NOON);
     private static final Timeslot TIMESLOT2 = new Timeslot(DayOfWeek.TUESDAY, LocalTime.of(9,0), LocalTime.NOON);
 
     @Autowired
-    ConstraintVerifier<TimeTableConstraintProvider, TimeTable> constraintVerifier;
+    ConstraintVerifier<TimetableConstraintProvider, Timetable> constraintVerifier;
 
     @Test
     void roomConflict() {
-        Lesson firstLesson = new Lesson(1, "Subject1", "Teacher1", "Group1");
-        Lesson conflictingLesson = new Lesson(2, "Subject2", "Teacher2", "Group2");
-        Lesson nonConflictingLesson = new Lesson(3, "Subject3", "Teacher3", "Group3");
-
-        firstLesson.setRoom(ROOM);
-        firstLesson.setTimeslot(TIMESLOT1);
-
-        conflictingLesson.setRoom(ROOM);
-        conflictingLesson.setTimeslot(TIMESLOT1);
-
-        nonConflictingLesson.setRoom(ROOM);
-        nonConflictingLesson.setTimeslot(TIMESLOT2);
-
-        constraintVerifier.verifyThat(TimeTableConstraintProvider::roomConflict)
+        Lesson firstLesson = new Lesson(1, "Subject1", "Teacher1", "Group1", TIMESLOT1, ROOM1);
+        Lesson conflictingLesson = new Lesson(2, "Subject2", "Teacher2", "Group2", TIMESLOT1, ROOM1);
+        Lesson nonConflictingLesson = new Lesson(3, "Subject3", "Teacher3", "Group3", TIMESLOT2, ROOM1);
+        constraintVerifier.verifyThat(TimetableConstraintProvider::roomConflict)
                 .given(firstLesson, conflictingLesson, nonConflictingLesson)
                 .penalizesBy(1);
     }
 }
 ----
 
-This test verifies that the constraint `TimeTableConstraintProvider::roomConflict`,
+This test verifies that the constraint `TimetableConstraintProvider::roomConflict`,
 when given three lessons in the same room, where two lessons have the same timeslot,
 it penalizes with a match weight of `1`.
 So with a constraint weight of `10hard` it would reduce the score by `-10hard`.
+
+In order to inject managed `ConstraintVerifier<TimetableConstraintProvider, Timetable>` instances, we need a bean definition source class.
+[source,java]
+----
+package org.acme.schooltimetabling.config;
+
+import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
+import org.acme.schooltimetabling.domain.Lesson;
+import org.acme.schooltimetabling.domain.Timetable;
+import org.acme.schooltimetabling.solver.TimetableConstraintProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class ConstraintConfig {
+
+    @Bean
+    public ConstraintVerifier<TimetableConstraintProvider, Timetable> buildConstraintVerifier() {
+        return ConstraintVerifier.build(new TimetableConstraintProvider(), Timetable.class, Lesson.class);
+    }
+}
+----
 
 Notice how `ConstraintVerifier` ignores the constraint weight during testing - even
 if those constraint weights are hard coded in the `ConstraintProvider` - because
@@ -399,9 +411,9 @@ This way, constraint weight tweaking does not break the unit tests.
 
 ==== Test the solver
 
-In a JUnit test, generate a test dataset and send it to the `TimeTableController` to solve.
+In a JUnit test, generate a test dataset and send it to the `TimetableController` to solve.
 
-Create the `src/test/java/org/acme/schooltimetabling/rest/TimeTableControllerTest.java` class:
+Create the `src/test/java/org/acme/schooltimetabling/rest/TimetableControllerTest.java` class:
 
 [source,java]
 ----
@@ -414,7 +426,7 @@ import java.util.List;
 
 import org.acme.schooltimetabling.domain.Lesson;
 import org.acme.schooltimetabling.domain.Room;
-import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.domain.Timetable;
 import org.acme.schooltimetabling.domain.Timeslot;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -429,16 +441,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         // Effectively disable spent-time termination in favor of the best-score-limit
         "timefold.solver.termination.spent-limit=1h",
         "timefold.solver.termination.best-score-limit=0hard/*soft"})
-public class TimeTableControllerTest {
+public class TimetableControllerTest {
 
     @Autowired
-    private TimeTableController timeTableController;
+    private TimetableController timetableController;
 
     @Test
     @Timeout(600_000)
     public void solve() {
-        TimeTable problem = generateProblem();
-        TimeTable solution = timeTableController.solve(problem);
+        Timetable problem = generateProblem();
+        Timetable solution = timetableController.solve(problem);
         assertFalse(solution.getLessonList().isEmpty());
         for (Lesson lesson : solution.getLessonList()) {
             assertNotNull(lesson.getTimeslot());
@@ -447,7 +459,7 @@ public class TimeTableControllerTest {
         assertTrue(solution.getScore().isFeasible());
     }
 
-    private TimeTable generateProblem() {
+    private Timetable generateProblem() {
         List<Timeslot> timeslotList = new ArrayList<>();
         timeslotList.add(new Timeslot(DayOfWeek.MONDAY, LocalTime.of(8, 30), LocalTime.of(9, 30)));
         timeslotList.add(new Timeslot(DayOfWeek.MONDAY, LocalTime.of(9, 30), LocalTime.of(10, 30)));
@@ -472,7 +484,7 @@ public class TimeTableControllerTest {
         lessonList.add(new Lesson(203L, "History", "I. Jones", "10th grade"));
         lessonList.add(new Lesson(204L, "English", "P. Cruz", "10th grade"));
         lessonList.add(new Lesson(205L, "French", "M. Curie", "10th grade"));
-        return new TimeTable(timeslotList, roomList, lessonList);
+        return new Timetable(timeslotList, roomList, lessonList);
     }
 
 }
@@ -532,16 +544,16 @@ Now try adding database and UI integration:
 
 . https://spring.io/guides/gs/accessing-data-rest/[Expose them through REST].
 
-. Build a `TimeTableRepository` facade to read and write a `TimeTable` instance in a single transaction.
+. Build a `TimetableRepository` facade to read and write a `Timetable` instance in a single transaction.
 
-. Adjust the `TimeTableController` accordingly:
+. Adjust the `TimetableController` accordingly:
 +
 [source,java]
 ----
 package org.acme.schooltimetabling.rest;
 
-import org.acme.schooltimetabling.domain.TimeTable;
-import org.acme.schooltimetabling.persistence.TimeTableRepository;
+import org.acme.schooltimetabling.domain.Timetable;
+import org.acme.schooltimetabling.persistence.TimetableRepository;
 import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.api.solver.SolverManager;
 import ai.timefold.solver.core.api.solver.SolverStatus;
@@ -552,23 +564,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/timeTable")
-public class TimeTableController {
+@RequestMapping("/timetable")
+public class TimetableController {
 
     @Autowired
-    private TimeTableRepository timeTableRepository;
+    private TimetableRepository timetableRepository;
     @Autowired
-    private SolverManager<TimeTable, Long> solverManager;
+    private SolverManager<Timetable, Long> solverManager;
     @Autowired
-    private SolutionManager<TimeTable, HardSoftScore> solutionManager;
+    private SolutionManager<Timetable, HardSoftScore> solutionManager;
 
-    // To try, GET http://localhost:8080/timeTable
+    // To try, GET http://localhost:8080/timetable
     @GetMapping()
-    public TimeTable getTimeTable() {
+    public Timetable getTimetable() {
         // Get the solver status before loading the solution
         // to avoid the race condition that the solver terminates between them
         SolverStatus solverStatus = getSolverStatus();
-        TimeTable solution = timeTableRepository.findById(TimeTableRepository.SINGLETON_TIME_TABLE_ID);
+        Timetable solution = timetableRepository.findById(TimetableRepository.SINGLETON_TIME_TABLE_ID);
         solutionManager.update(solution); // Sets the score
         solution.setSolverStatus(solverStatus);
         return solution;
@@ -576,27 +588,27 @@ public class TimeTableController {
 
     @PostMapping("/solve")
     public void solve() {
-        solverManager.solveAndListen(TimeTableRepository.SINGLETON_TIME_TABLE_ID,
-                timeTableRepository::findById,
-                timeTableRepository::save);
+        solverManager.solveAndListen(TimetableRepository.SINGLETON_TIME_TABLE_ID,
+                timetableRepository::findById,
+                timetableRepository::save);
     }
 
     public SolverStatus getSolverStatus() {
-        return solverManager.getSolverStatus(TimeTableRepository.SINGLETON_TIME_TABLE_ID);
+        return solverManager.getSolverStatus(TimetableRepository.SINGLETON_TIME_TABLE_ID);
     }
 
     @PostMapping("/stopSolving")
     public void stopSolving() {
-        solverManager.terminateEarly(TimeTableRepository.SINGLETON_TIME_TABLE_ID);
+        solverManager.terminateEarly(TimetableRepository.SINGLETON_TIME_TABLE_ID);
     }
 
 }
 ----
 +
-For simplicity's sake, this code handles only one `TimeTable` instance,
-but it is straightforward to enable multi-tenancy and handle multiple `TimeTable` instances of different high schools in parallel.
+For simplicity's sake, this code handles only one `Timetable` instance,
+but it is straightforward to enable multi-tenancy and handle multiple `Timetable` instances of different high schools in parallel.
 +
-The `getTimeTable()` method returns the latest timetable from the database.
+The `getTimetable()` method returns the latest timetable from the database.
 It uses the `SolutionManager` (which is automatically injected)
 to calculate the score of that timetable, so the UI can show the score.
 +
@@ -605,7 +617,7 @@ It uses the `SolverManager.solveAndListen()` method to listen to intermediate be
 and update the database accordingly.
 This enables the UI to show progress while the backend is still solving.
 
-. Adjust the `TimeTableControllerTest` instance accordingly, now that the `solve()` method returns immediately.
+. Adjust the `TimetableControllerTest` instance accordingly, now that the `solve()` method returns immediately.
 Poll for the latest solution until the solver finishes solving:
 +
 [source,java]
@@ -613,7 +625,7 @@ Poll for the latest solution until the solver finishes solving:
 package org.acme.schooltimetabling.rest;
 
 import org.acme.schooltimetabling.domain.Lesson;
-import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.domain.Timetable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import ai.timefold.solver.core.api.solver.SolverStatus;
@@ -627,28 +639,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest(properties = {
         "timefold.solver.termination.spent-limit=1h", // Effectively disable this termination in favor of the best-score-limit
         "timefold.solver.termination.best-score-limit=0hard/*soft"})
-public class TimeTableControllerTest {
+public class TimetableControllerTest {
 
     @Autowired
-    private TimeTableController timeTableController;
+    private TimetableController timetableController;
 
     @Test
     @Timeout(600_000)
     public void solveDemoDataUntilFeasible() throws InterruptedException {
-        timeTableController.solve();
-        TimeTable timeTable = timeTableController.getTimeTable();
-        while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING) {
+        timetableController.solve();
+        Timetable timetable = timetableController.getTimetable();
+        while (timetable.getSolverStatus() != SolverStatus.NOT_SOLVING) {
             // Quick polling (not a Test Thread Sleep anti-pattern)
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L);
-            timeTable = timeTableController.getTimeTable();
+            timetable = timetableController.getTimetable();
         }
-        assertFalse(timeTable.getLessonList().isEmpty());
-        for (Lesson lesson : timeTable.getLessonList()) {
+        assertFalse(timetable.getLessonList().isEmpty());
+        for (Lesson lesson : timetable.getLessonList()) {
             assertNotNull(lesson.getTimeslot());
             assertNotNull(lesson.getRoom());
         }
-        assertTrue(timeTable.getScore().isFeasible());
+        assertTrue(timetable.getScore().isFeasible());
     }
 
 }
@@ -656,4 +668,4 @@ public class TimeTableControllerTest {
 
 . Build an attractive web UI on top of these REST methods to visualize the timetable.
 
-Take a look at {spring-boot-quickstart-url}[the quickstart source code] to see how this all turns out.
+For an implementation with UI-integrated and in-memory storage, check out {spring-boot-quickstart-url}[the Spring-boot quickstart source code].


### PR DESCRIPTION
This pull request contains updates related to the School Timetabling quickstart. Here are some important points:

- The field `id` was not included in the problem facts to keep them simple.
- The OpenAPI dependencies were not included to keep things simple.
- The justification models were not included to keep things simple.
- The initial Maven and Gradle files were modified to remove test dependencies and then add them in the test Section.

Issue #98 