### PR TITLE
test: do not create a new entity in EnvironmentMode test

### DIFF
--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedmove/TestdataCorruptedEntityUndoMove.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedmove/TestdataCorruptedEntityUndoMove.java
@@ -7,14 +7,16 @@ import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 
 public class TestdataCorruptedEntityUndoMove extends AbstractTestdataMove {
+    TestdataEntity undoEntity;
 
-    public TestdataCorruptedEntityUndoMove(TestdataEntity entity, TestdataValue toValue) {
+    public TestdataCorruptedEntityUndoMove(TestdataEntity entity, TestdataEntity undoEntity, TestdataValue toValue) {
         super(entity, toValue);
+        this.undoEntity = undoEntity;
     }
 
     @Override
     protected AbstractMove<TestdataSolution> createUndoMove(ScoreDirector<TestdataSolution> scoreDirector) {
-        // Corrupts the undo move by creating a new entity and not undo-ing the value
-        return new TestdataCorruptedEntityUndoMove(new TestdataEntity("corrupted"), toValue);
+        // Corrupts the undo move by using a different entity and not undo-ing the value
+        return new TestdataCorruptedEntityUndoMove(undoEntity, entity, toValue);
     }
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedmove/TestdataCorruptedUndoMove.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedmove/TestdataCorruptedUndoMove.java
@@ -15,6 +15,6 @@ public class TestdataCorruptedUndoMove extends AbstractTestdataMove {
     @Override
     protected AbstractMove<TestdataSolution> createUndoMove(ScoreDirector<TestdataSolution> scoreDirector) {
         // Corrupts the undo move by not undo-ing the value
-        return new TestdataCorruptedEntityUndoMove(entity, toValue);
+        return new TestdataCorruptedUndoMove(entity, toValue);
     }
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedmove/factory/AbstractTestdataCorruptedUndoMoveTotalMappingFactory.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedmove/factory/AbstractTestdataCorruptedUndoMoveTotalMappingFactory.java
@@ -27,7 +27,12 @@ public class AbstractTestdataCorruptedUndoMoveTotalMappingFactory implements Mov
         for (TestdataEntity entity : solution.getEntityList()) {
             for (TestdataValue value : solution.getValueList()) {
                 if (corruptEntityAsWell) {
-                    moveList.add(new TestdataCorruptedEntityUndoMove(entity, value));
+                    for (TestdataEntity undoEntity : solution.getEntityList()) {
+                        if (entity == undoEntity) {
+                            continue;
+                        }
+                        moveList.add(new TestdataCorruptedEntityUndoMove(entity, undoEntity, value));
+                    }
                 } else {
                     moveList.add(new TestdataCorruptedUndoMove(entity, value));
                 }


### PR DESCRIPTION
When the test creates a new entity in its undo move and assigns it, it increases the init score from 0 to 1, an impossible state that should never occur in correctly implemented move(s). This could result in a fail-fast in the future that is not related to the EnvironmentMode being tested. Now the test use an existing but different entity to achieve the desired corruption.