### PR TITLE
fix: fail fast when @DeepPlanningClone on a record

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/DeepCloningUtils.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/DeepCloningUtils.java
@@ -95,7 +95,15 @@ public final class DeepCloningUtils {
     }
 
     static boolean isImmutable(Class<?> clz) {
-        if (clz.isPrimitive() || clz.isEnum() || clz.isRecord() || Score.class.isAssignableFrom(clz)) {
+        if (clz.isPrimitive() || Score.class.isAssignableFrom(clz)) {
+            return true;
+        } else if (clz.isRecord() || clz.isEnum()) {
+            if (clz.isAnnotationPresent(DeepPlanningClone.class)) {
+                throw new IllegalStateException("""
+                        The class (%s) is annotated with @%s, but it is immutable.
+                        Deep-cloning enums and records is not supported."""
+                        .formatted(clz.getName(), DeepPlanningClone.class.getSimpleName()));
+            }
             return true;
         }
         return IMMUTABLE_CLASSES.contains(clz);


### PR DESCRIPTION
The docs already say this is impossible, so we're only bringing the impl up to date with the spec.