### PR TITLE
perf: Change records back to classes for GraalVM native image performance

### DIFF
--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/ManyIndexProperties.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/ManyIndexProperties.java
@@ -2,7 +2,12 @@ package ai.timefold.solver.constraint.streams.bavet.common.index;
 
 import java.util.Arrays;
 
-record ManyIndexProperties(Object... properties) implements IndexProperties {
+final class ManyIndexProperties implements IndexProperties {
+    private final Object[] properties;
+
+    public ManyIndexProperties(Object... properties) {
+        this.properties = properties;
+    }
 
     @Override
     public <Type_> Type_ toKey(int id) {

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/SingleIndexProperties.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/SingleIndexProperties.java
@@ -1,6 +1,18 @@
 package ai.timefold.solver.constraint.streams.bavet.common.index;
 
-record SingleIndexProperties<A>(A property) implements IndexProperties {
+import java.util.Objects;
+
+final class SingleIndexProperties<A> implements IndexProperties {
+
+    private final A property;
+
+    public SingleIndexProperties(A property) {
+        this.property = property;
+    }
+
+    public A property() {
+        return property;
+    }
 
     @Override
     public <Type_> Type_ toKey(int id) {
@@ -10,4 +22,18 @@ record SingleIndexProperties<A>(A property) implements IndexProperties {
         return (Type_) property;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        SingleIndexProperties<?> that = (SingleIndexProperties<?>) o;
+        return Objects.equals(property, that.property);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(property);
+    }
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/ThreeIndexProperties.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/ThreeIndexProperties.java
@@ -1,6 +1,18 @@
 package ai.timefold.solver.constraint.streams.bavet.common.index;
 
-record ThreeIndexProperties<A, B, C>(A propertyA, B propertyB, C propertyC) implements IndexProperties {
+import java.util.Objects;
+
+final class ThreeIndexProperties<A, B, C> implements IndexProperties {
+
+    private final A propertyA;
+    private final B propertyB;
+    private final C propertyC;
+
+    public ThreeIndexProperties(A propertyA, B propertyB, C propertyC) {
+        this.propertyA = propertyA;
+        this.propertyB = propertyB;
+        this.propertyC = propertyC;
+    }
 
     @Override
     public <Type_> Type_ toKey(int id) {
@@ -12,4 +24,31 @@ record ThreeIndexProperties<A, B, C>(A propertyA, B propertyB, C propertyC) impl
         };
     }
 
+    public A propertyA() {
+        return propertyA;
+    }
+
+    public B propertyB() {
+        return propertyB;
+    }
+
+    public C propertyC() {
+        return propertyC;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ThreeIndexProperties<?, ?, ?> that = (ThreeIndexProperties<?, ?, ?>) o;
+        return Objects.equals(propertyA, that.propertyA) && Objects.equals(propertyB,
+                that.propertyB) && Objects.equals(propertyC, that.propertyC);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(propertyA, propertyB, propertyC);
+    }
 }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/TwoIndexProperties.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/TwoIndexProperties.java
@@ -1,6 +1,15 @@
 package ai.timefold.solver.constraint.streams.bavet.common.index;
 
-record TwoIndexProperties<A, B>(A propertyA, B propertyB) implements IndexProperties {
+import java.util.Objects;
+
+public final class TwoIndexProperties<A, B> implements IndexProperties {
+    private final A propertyA;
+    private final B propertyB;
+
+    public TwoIndexProperties(A propertyA, B propertyB) {
+        this.propertyA = propertyA;
+        this.propertyB = propertyB;
+    }
 
     @Override
     public <Type_> Type_ toKey(int id) {
@@ -11,4 +20,26 @@ record TwoIndexProperties<A, B>(A propertyA, B propertyB) implements IndexProper
         };
     }
 
+    public A propertyA() {
+        return propertyA;
+    }
+
+    public B propertyB() {
+        return propertyB;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        TwoIndexProperties<?, ?> that = (TwoIndexProperties<?, ?>) o;
+        return Objects.equals(propertyA, that.propertyA) && Objects.equals(propertyB, that.propertyB);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(propertyA, propertyB);
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/constraint/ConstraintRef.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/constraint/ConstraintRef.java
@@ -20,11 +20,13 @@ import ai.timefold.solver.core.api.domain.constraintweight.ConstraintWeight;
  *        it is equal to the {@link ConstraintWeight#value()}.
  * @param constraintId Always derived from {@code packageName} and {@code constraintName}.
  */
-public record ConstraintRef(String packageName, String constraintName, String constraintId)
-        implements
-            Comparable<ConstraintRef> {
+public class ConstraintRef implements Comparable<ConstraintRef> {
 
     private static final char PACKAGE_SEPARATOR = '/';
+
+    private final String packageName;
+    private final String constraintName;
+    private final String constraintId;
 
     public static ConstraintRef of(String packageName, String constraintName) {
         return new ConstraintRef(packageName, constraintName, null);
@@ -47,16 +49,16 @@ public record ConstraintRef(String packageName, String constraintName, String co
         return packageName + PACKAGE_SEPARATOR + constraintName;
     }
 
-    public ConstraintRef {
-        packageName = validate(packageName, "constraint package");
-        constraintName = validate(constraintName, "constraint name");
+    public ConstraintRef(String packageName, String constraintName, String constraintId) {
+        this.packageName = validate(packageName, "constraint package");
+        this.constraintName = validate(constraintName, "constraint name");
         var expectedConstraintId = composeConstraintId(packageName, constraintName);
         if (constraintId != null && !constraintId.equals(expectedConstraintId)) {
             throw new IllegalArgumentException(
                     "Specifying custom constraintId (%s) is not allowed."
                             .formatted(constraintId));
         }
-        constraintId = expectedConstraintId;
+        this.constraintId = expectedConstraintId;
     }
 
     private static String validate(String identifier, String type) {
@@ -71,6 +73,18 @@ public record ConstraintRef(String packageName, String constraintName, String co
         return sanitized;
     }
 
+    public String packageName() {
+        return packageName;
+    }
+
+    public String constraintName() {
+        return constraintName;
+    }
+
+    public String constraintId() {
+        return constraintId;
+    }
+
     @Override
     public String toString() {
         return constraintId;
@@ -81,4 +95,19 @@ public record ConstraintRef(String packageName, String constraintName, String co
         return constraintId.compareTo(other.constraintId);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ConstraintRef that = (ConstraintRef) o;
+        return Objects.equals(packageName, that.packageName) && Objects.equals(constraintName,
+                that.constraintName) && Objects.equals(constraintId, that.constraintId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(packageName, constraintName, constraintId);
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/Pair.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/Pair.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.util;
 
+import java.util.Objects;
+
 /**
  * An immutable key-value tuple.
  * Two instances {@link Object#equals(Object) are equal} if both values in the first instance
@@ -8,6 +10,35 @@ package ai.timefold.solver.core.impl.util;
  * @param <Key_>
  * @param <Value_>
  */
-public record Pair<Key_, Value_>(Key_ key, Value_ value) {
+public class Pair<Key_, Value_> {
+    private final Key_ key;
+    private final Value_ value;
 
+    public Pair(Key_ key, Value_ value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public Key_ key() {
+        return key;
+    }
+
+    public Value_ value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Pair<?, ?> pair = (Pair<?, ?>) o;
+        return Objects.equals(key, pair.key) && Objects.equals(value, pair.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/Quadruple.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/Quadruple.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.util;
 
+import java.util.Objects;
+
 /**
  * An immutable tuple of four values.
  * Two instances {@link Object#equals(Object) are equal} if all four values in the first instance
@@ -10,6 +12,48 @@ package ai.timefold.solver.core.impl.util;
  * @param <C>
  * @param <D>
  */
-public record Quadruple<A, B, C, D>(A a, B b, C c, D d) {
+public class Quadruple<A, B, C, D> {
+    private final A a;
+    private final B b;
+    private final C c;
+    private final D d;
 
+    public Quadruple(A a, B b, C c, D d) {
+        this.a = a;
+        this.b = b;
+        this.c = c;
+        this.d = d;
+    }
+
+    public A a() {
+        return a;
+    }
+
+    public B b() {
+        return b;
+    }
+
+    public C c() {
+        return c;
+    }
+
+    public D d() {
+        return d;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Quadruple<?, ?, ?, ?> quadruple = (Quadruple<?, ?, ?, ?>) o;
+        return Objects.equals(a, quadruple.a) && Objects.equals(b, quadruple.b) && Objects.equals(c,
+                quadruple.c) && Objects.equals(d, quadruple.d);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(a, b, c, d);
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/Triple.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/Triple.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.util;
 
+import java.util.Objects;
+
 /**
  * An immutable tuple of three values.
  * Two instances {@link Object#equals(Object) are equal} if all three values in the first instance
@@ -9,6 +11,42 @@ package ai.timefold.solver.core.impl.util;
  * @param <B>
  * @param <C>
  */
-public record Triple<A, B, C>(A a, B b, C c) {
+public class Triple<A, B, C> {
+    private final A a;
+    private final B b;
+    private final C c;
 
+    public Triple(A a, B b, C c) {
+        this.a = a;
+        this.b = b;
+        this.c = c;
+    }
+
+    public A a() {
+        return a;
+    }
+
+    public B b() {
+        return b;
+    }
+
+    public C c() {
+        return c;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Triple<?, ?, ?> triple = (Triple<?, ?, ?>) o;
+        return Objects.equals(a, triple.a) && Objects.equals(b, triple.b) && Objects.equals(c,
+                triple.c);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(a, b, c);
+    }
 }


### PR DESCRIPTION
GraalVM uses reflection!!! for records equals and hashCode (see https://github.com/oracle/graal/issues/4348), degrading performance by 100x compared to normal classes. Use normal classes instead of records for classes used during solving.

Draft as there some test failures and some improvements still to be made.