### PR TITLE
perf: reduce allocations in CS

### DIFF
--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractIfExistsNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractIfExistsNode.java
@@ -123,10 +123,10 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends AbstractTuple, Rig
 
     protected ElementAwareList<FilteringTracker<LeftTuple_>> updateRightTrackerList(UniTuple<Right_> rightTuple) {
         ElementAwareList<FilteringTracker<LeftTuple_>> rightTrackerList = rightTuple.getStore(inputStoreIndexRightTrackerList);
-        rightTrackerList.forEach(filteringTacker -> {
-            decrementCounterRight(filteringTacker.counter);
-            filteringTacker.remove();
-        });
+        for (FilteringTracker<LeftTuple_> tuple : rightTrackerList) {
+            decrementCounterRight(tuple.counter);
+            tuple.remove();
+        }
         return rightTrackerList;
     }
 

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractJoinNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractJoinNode.java
@@ -143,6 +143,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends AbstractTuple, Right_,
             ElementAwareListEntry<OutTuple_> outEntry = outTuple.getStore(outputStoreIndexOutEntry);
             ElementAwareList<OutTuple_> outEntryList = outEntry.getList();
             if (outList == outEntryList) {
+                outTupleList.prematurelyTerminateIterator(); // Performance optimization.
                 return outTuple;
             }
         }

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractUnindexedIfExistsNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractUnindexedIfExistsNode.java
@@ -52,7 +52,9 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends AbstractT
             counter.countRight = rightTupleList.size();
         } else {
             ElementAwareList<FilteringTracker<LeftTuple_>> leftTrackerList = new ElementAwareList<>();
-            rightTupleList.forEach(rightTuple -> updateCounterFromLeft(leftTuple, rightTuple, counter, leftTrackerList));
+            for (UniTuple<Right_> tuple : rightTupleList) {
+                updateCounterFromLeft(leftTuple, tuple, counter, leftTrackerList);
+            }
             leftTuple.setStore(inputStoreIndexLeftTrackerList, leftTrackerList);
         }
         initCounterLeft(counter);
@@ -75,7 +77,9 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends AbstractT
             ElementAwareList<FilteringTracker<LeftTuple_>> leftTrackerList = leftTuple.getStore(inputStoreIndexLeftTrackerList);
             leftTrackerList.forEach(FilteringTracker::remove);
             counter.countRight = 0;
-            rightTupleList.forEach(rightTuple -> updateCounterFromLeft(leftTuple, rightTuple, counter, leftTrackerList));
+            for (UniTuple<Right_> tuple : rightTupleList) {
+                updateCounterFromLeft(leftTuple, tuple, counter, leftTrackerList);
+            }
             updateCounterLeft(counter);
         }
     }
@@ -108,7 +112,9 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends AbstractT
             leftCounterList.forEach(this::incrementCounterRight);
         } else {
             ElementAwareList<FilteringTracker<LeftTuple_>> rightTrackerList = new ElementAwareList<>();
-            leftCounterList.forEach(counter -> updateCounterFromRight(rightTuple, counter, rightTrackerList));
+            for (ExistsCounter<LeftTuple_> tuple : leftCounterList) {
+                updateCounterFromRight(rightTuple, tuple, rightTrackerList);
+            }
             rightTuple.setStore(inputStoreIndexRightTrackerList, rightTrackerList);
         }
     }
@@ -123,7 +129,9 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends AbstractT
         }
         if (isFiltering) {
             ElementAwareList<FilteringTracker<LeftTuple_>> rightTrackerList = updateRightTrackerList(rightTuple);
-            leftCounterList.forEach(counter -> updateCounterFromRight(rightTuple, counter, rightTrackerList));
+            for (ExistsCounter<LeftTuple_> tuple : leftCounterList) {
+                updateCounterFromRight(rightTuple, tuple, rightTrackerList);
+            }
         }
     }
 

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
@@ -44,7 +44,9 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
         leftTuple.setStore(inputStoreIndexLeftEntry, leftEntry);
         ElementAwareList<OutTuple_> outTupleListLeft = new ElementAwareList<>();
         leftTuple.setStore(inputStoreIndexLeftOutTupleList, outTupleListLeft);
-        rightTupleList.forEach(rightTuple -> insertOutTupleFiltered(leftTuple, rightTuple));
+        for (UniTuple<Right_> tuple : rightTupleList) {
+            insertOutTupleFiltered(leftTuple, tuple);
+        }
     }
 
     @Override
@@ -80,7 +82,9 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
         rightTuple.setStore(inputStoreIndexRightEntry, rightEntry);
         ElementAwareList<OutTuple_> outTupleListRight = new ElementAwareList<>();
         rightTuple.setStore(inputStoreIndexRightOutTupleList, outTupleListRight);
-        leftTupleList.forEach(leftTuple -> insertOutTupleFiltered(leftTuple, rightTuple));
+        for (LeftTuple_ tuple : leftTupleList) {
+            insertOutTupleFiltered(tuple, rightTuple);
+        }
     }
 
     @Override

--- a/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/EqualsIndexer.java
+++ b/core/constraint-streams/src/main/java/ai/timefold/solver/constraint/streams/bavet/common/index/EqualsIndexer.java
@@ -70,7 +70,7 @@ final class EqualsIndexer<T, Key_> implements Indexer<T> {
     public void forEach(IndexProperties indexProperties, Consumer<T> tupleConsumer) {
         Key_ indexKey = indexProperties.toKey(propertyIndex);
         Indexer<T> downstreamIndexer = downstreamIndexerMap.get(indexKey);
-        if (downstreamIndexer == null || downstreamIndexer.isEmpty()) {
+        if (downstreamIndexer == null) {
             return;
         }
         downstreamIndexer.forEach(indexProperties, tupleConsumer);

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/ElementAwareList.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/ElementAwareList.java
@@ -7,14 +7,21 @@ import java.util.function.Consumer;
 /**
  * Linked list that allows to add and remove an element in O(1) time.
  * Ideal for incremental operations with frequent undo.
+ * <p>
+ * This class is not thread-safe.
  *
  * @param <T> The element type. Often a tuple.
  */
 public final class ElementAwareList<T> implements Iterable<T> {
 
+    private ElementAwareListIterator sharedIterator;
+
     private int size = 0;
     private ElementAwareListEntry<T> first = null;
     private ElementAwareListEntry<T> last = null;
+
+    public ElementAwareList() {
+    }
 
     public ElementAwareListEntry<T> add(T tuple) {
         ElementAwareListEntry<T> entry = new ElementAwareListEntry<>(this, tuple, last);
@@ -56,6 +63,50 @@ public final class ElementAwareList<T> implements Iterable<T> {
         return size;
     }
 
+    /**
+     * Convenience method for where it is easy to use a non-capturing lambda.
+     * If a capturing lambda consumer were to be created for this method, use {@link #iterator()} instead,
+     * which will consume less memory.
+     * <p>
+     *
+     * For example, the following code is perfectly fine:
+     *
+     * <code>
+     *     for (int i = 0; i &lt; 3; i++) {
+     *         elementAwareList.forEach(entry -&gt; doSomething(entry));
+     *     }
+     * </code>
+     *
+     * It will create only one lambda instance, regardless of the number of iterations;
+     * it doesn't need to capture any state.
+     * On the contrary, the following code will create three instances of a capturing lambda,
+     * one for each iteration of the for loop:
+     *
+     * <code>
+     *     for (int a: List.of(1, 2, 3)) {
+     *         elementAwareList.forEach(entry -&gt; doSomething(entry, a));
+     *     }
+     * </code>
+     *
+     * In this case, the lambda would need to capture "a" which is different in every iteration.
+     * Therefore, it will generally be better to use the iterator variant,
+     * as that will only ever create one instance of the iterator,
+     * regardless of the number of iterations:
+     *
+     * <code>
+     *     for (int a: List.of(1, 2, 3)) {
+     *         for (var entry: elementAwareList) {
+     *             doSomething(entry, a);
+     *         }
+     *     }
+     * </code>
+     *
+     * This is only an issue on the hot path,
+     * where this method can create quite a large garbage collector pressure
+     * on account of creating throw-away instances of capturing lambdas.
+     *
+     * @param tupleConsumer The action to be performed for each element
+     */
     @Override
     public void forEach(Consumer<? super T> tupleConsumer) {
         ElementAwareListEntry<T> entry = first;
@@ -67,31 +118,34 @@ public final class ElementAwareList<T> implements Iterable<T> {
         }
     }
 
+    /**
+     * See {@link #forEach(Consumer)} for a discussion on the correct use of this method.
+     *
+     * @return never null
+     */
     @Override
     public Iterator<T> iterator() {
-        return new Iterator<>() {
+        if (sharedIterator == null || sharedIterator.nextEntry != null) {
+            // Create a new instance on first access, or when the previous one is still in use (not fully consumed).
+            sharedIterator = new ElementAwareListIterator();
+        } else {
+            // Otherwise the instance is reused, significantly reducing garbage collector pressure when on the hot path.
+            sharedIterator.nextEntry = first;
+        }
+        return sharedIterator;
+    }
 
-            private ElementAwareListEntry<T> nextEntry = first;
-
-            @Override
-            public boolean hasNext() {
-                if (size == 0) {
-                    return false;
-                }
-                return nextEntry != null;
-            }
-
-            @Override
-            public T next() {
-                if (!hasNext()) {
-                    throw new NoSuchElementException();
-                }
-                T element = nextEntry.getElement();
-                nextEntry = nextEntry.next;
-                return element;
-            }
-
-        };
+    /**
+     * In order for iterator sharing to work properly,
+     * each iterator must be fully consumed.
+     * For iterators which are not fully consumed,
+     * this method can be used to free the iterator to be used by another iteration operation.
+     * This technically breaks the abstraction of this class,
+     * but the measured benefit of this change is +5% to 10% of score calculation speed
+     * on account of not creating gigabytes of iterators per minute.
+     */
+    public void prematurelyTerminateIterator() {
+        sharedIterator.nextEntry = null;
     }
 
     @Override
@@ -114,4 +168,27 @@ public final class ElementAwareList<T> implements Iterable<T> {
         }
     }
 
+    private final class ElementAwareListIterator implements Iterator<T> {
+
+        private ElementAwareListEntry<T> nextEntry = first;
+
+        @Override
+        public boolean hasNext() {
+            if (size == 0) {
+                return false;
+            }
+            return nextEntry != null;
+        }
+
+        @Override
+        public T next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            T element = nextEntry.getElement();
+            nextEntry = nextEntry.next;
+            return element;
+        }
+
+    }
 }


### PR DESCRIPTION
Various CS nodes could allocate gigabytes of `ElementAwareListIterator` per minute.
We refactor the code so that iterator instances are shared, removing this needless source of GC pressure.
Improves performance of some benchmarks by up to 6 %, while reducing their memory consumption by ~20 %.