### PR TITLE
feat: Support multiple SolverManager instances (Spring-boot)

### DIFF
--- a/quarkus-integration/quarkus-benchmark/deployment/src/main/java/ai/timefold/solver/benchmark/quarkus/deployment/TimefoldBenchmarkProcessor.java
+++ b/quarkus-integration/quarkus-benchmark/deployment/src/main/java/ai/timefold/solver/benchmark/quarkus/deployment/TimefoldBenchmarkProcessor.java
@@ -47,8 +47,7 @@ class TimefoldBenchmarkProcessor {
         if (solverConfigBuildItem.getSolvetConfigMap().size() > 1) {
             throw new ConfigurationException("""
                     When defining multiple solvers, the benchmark feature is not enabled.
-                    Consider using separate <solverBenchmark> instances for evaluating different solver configurations.
-                    """);
+                    Consider using separate <solverBenchmark> instances for evaluating different solver configurations.""");
         }
         if (solverConfigBuildItem.getGeneratedGizmoClasses() == null) {
             log.warn("Skipping Timefold Benchmark extension because the Timefold extension was skipped.");

--- a/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMultipleSolversConfigTest.java
+++ b/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMultipleSolversConfigTest.java
@@ -30,10 +30,10 @@ class TimefoldBenchmarkProcessorMultipleSolversConfigTest {
                             TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class))
             .assertException(t -> assertThat(t)
                     .isInstanceOf(ConfigurationException.class)
-                    .hasMessageContaining("""
-                            When defining multiple solvers, the benchmark feature is not enabled.
-                            Consider using separate <solverBenchmark> instances for evaluating different solver configurations.
-                            """));
+                    .hasMessageContaining(
+                            """
+                                    When defining multiple solvers, the benchmark feature is not enabled.
+                                    Consider using separate <solverBenchmark> instances for evaluating different solver configurations."""));
 
     @Test
     void benchmark() throws ExecutionException, InterruptedException {

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -476,13 +476,11 @@ class TimefoldProcessor {
     }
 
     private void assertEmptyInstances(IndexView indexView, DotName dotName) {
-        // Validate the solution class
         Collection<AnnotationInstance> annotationInstanceCollection = indexView.getAnnotations(dotName);
-        // No solution class
         if (annotationInstanceCollection.isEmpty()) {
             try {
                 throw new IllegalStateException(
-                        "No classes found with a @%s annotation.".formatted(Class.forName(dotName.local()).getSimpleName()));
+                        "No classes were found with a @%s annotation.".formatted(Class.forName(dotName.local()).getSimpleName()));
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
             }
@@ -517,7 +515,7 @@ class TimefoldProcessor {
                                 .formatted(solverUrl);
                 if (!solverName.equals(TimefoldBuildTimeConfig.DEFAULT_SOLVER_NAME)) {
                     message =
-                            "Invalid quarkus.timefold.\"%s\".solverConfigXML property (%s): that classpath resource does not exist."
+                            "Invalid quarkus.timefold.solver.\"%s\".solverConfigXML property (%s): that classpath resource does not exist."
                                     .formatted(solverName, solverUrl);
                 }
                 throw new ConfigurationException(message);

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -480,7 +480,8 @@ class TimefoldProcessor {
         if (annotationInstanceCollection.isEmpty()) {
             try {
                 throw new IllegalStateException(
-                        "No classes were found with a @%s annotation.".formatted(Class.forName(dotName.local()).getSimpleName()));
+                        "No classes were found with a @%s annotation."
+                                .formatted(Class.forName(dotName.local()).getSimpleName()));
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
             }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidEntityClassTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidEntityClassTest.java
@@ -24,7 +24,7 @@ class TimefoldProcessorMultipleSolversInvalidEntityClassTest {
             .assertException(t -> assertThat(t)
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining(
-                            "No classes found with a @PlanningEntity annotation."));
+                            "No classes were found with a @PlanningEntity annotation."));
 
     @Test
     void test() {

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidSolutionClassTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidSolutionClassTest.java
@@ -31,7 +31,7 @@ class TimefoldProcessorMultipleSolversInvalidSolutionClassTest {
             .assertException(t -> assertThat(t)
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining(
-                            "No classes found with a @PlanningSolution annotation."));
+                            "No classes were found with a @PlanningSolution annotation."));
 
     // Multiple classes
     @RegisterExtension

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSolverInvalidEntityClassTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSolverInvalidEntityClassTest.java
@@ -23,7 +23,7 @@ class TimefoldProcessorSolverInvalidEntityClassTest {
             .assertException(t -> assertThat(t)
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining(
-                            "No classes found with a @PlanningEntity annotation."));
+                            "No classes were found with a @PlanningEntity annotation."));
 
     @Test
     void test() {

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSolverInvalidSolutionClassTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSolverInvalidSolutionClassTest.java
@@ -26,7 +26,7 @@ class TimefoldProcessorSolverInvalidSolutionClassTest {
             .assertException(t -> assertThat(t)
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining(
-                            "No classes found with a @PlanningSolution annotation."));
+                            "No classes were found with a @PlanningSolution annotation."));
 
     // Multiple classes
     @RegisterExtension

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/IncludeAbstractClassesEntityScanner.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/IncludeAbstractClassesEntityScanner.java
@@ -1,0 +1,115 @@
+package ai.timefold.solver.spring.boot.autoconfigure;
+
+import static java.util.Collections.emptyList;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.boot.autoconfigure.domain.EntityScanPackages;
+import org.springframework.boot.autoconfigure.domain.EntityScanner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.util.ClassUtils;
+
+public class IncludeAbstractClassesEntityScanner extends EntityScanner {
+
+    private final ApplicationContext context;
+
+    public IncludeAbstractClassesEntityScanner(ApplicationContext context) {
+        super(context);
+        this.context = context;
+    }
+
+    public <T> Class<? extends T> findFirstImplementingClass(Class<T> targetClass) {
+        return Optional.ofNullable(findImplementingClassList(targetClass)).filter(classes -> !classes.isEmpty())
+                .map(classes -> classes.get(0)).orElse(null);
+    }
+
+    public <T> List<Class<? extends T>> findImplementingClassList(Class<T> targetClass) {
+        if (!AutoConfigurationPackages.has(context)) {
+            return emptyList();
+        }
+        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
+        scanner.setEnvironment(context.getEnvironment());
+        scanner.setResourceLoader(context);
+        scanner.addIncludeFilter(new AssignableTypeFilter(targetClass));
+
+        EntityScanPackages entityScanPackages = EntityScanPackages.get(context);
+
+        Set<String> packages = new HashSet<>();
+        packages.addAll(AutoConfigurationPackages.get(context));
+        packages.addAll(entityScanPackages.getPackageNames());
+        return packages.stream()
+                .flatMap(basePackage -> scanner.findCandidateComponents(basePackage).stream())
+                // findCandidateComponents can return the same package for different base packages
+                .distinct()
+                .sorted(Comparator.comparing(BeanDefinition::getBeanClassName))
+                .map(candidate -> {
+                    try {
+                        return (Class<? extends T>) ClassUtils.forName(candidate.getBeanClassName(), context.getClassLoader())
+                                .asSubclass(targetClass);
+                    } catch (ClassNotFoundException e) {
+                        throw new IllegalStateException("The " + targetClass.getSimpleName() + " class ("
+                                + candidate.getBeanClassName() + ") cannot be found.", e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    public boolean hasSolutionOrEntityClasses() {
+        try {
+            return !scan(PlanningSolution.class).isEmpty() || !scan(PlanningEntity.class).isEmpty();
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Scanning for @" + PlanningSolution.class.getSimpleName()
+                    + " and @" + PlanningEntity.class.getSimpleName() + " annotations failed.", e);
+        }
+    }
+
+    public Class<?> findFirstSolutionClass() {
+        Set<Class<?>> solutionClassSet;
+        try {
+            solutionClassSet = scan(PlanningSolution.class);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Scanning for @" + PlanningSolution.class.getSimpleName()
+                    + " annotations failed.", e);
+        }
+        return solutionClassSet.iterator().next();
+    }
+
+    public List<Class<?>> findEntityClassList() {
+        Set<Class<?>> entityClassSet;
+        try {
+            entityClassSet = scan(PlanningEntity.class);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Scanning for @" + PlanningEntity.class.getSimpleName() + " failed.", e);
+        }
+        return new ArrayList<>(entityClassSet);
+    }
+
+    @Override
+    protected ClassPathScanningCandidateComponentProvider
+            createClassPathScanningCandidateComponentProvider(ApplicationContext context) {
+        return new ClassPathScanningCandidateComponentProvider(false) {
+            @Override
+            protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
+                AnnotationMetadata metadata = beanDefinition.getMetadata();
+                // Do not exclude abstract classes nor interfaces
+                return metadata.isIndependent();
+            }
+        };
+    }
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/IncludeAbstractClassesEntityScanner.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/IncludeAbstractClassesEntityScanner.java
@@ -83,7 +83,7 @@ public class IncludeAbstractClassesEntityScanner extends EntityScanner {
     }
 
     @SafeVarargs
-    public final List<Class<?>> findAnnotationsWithRepeatable(Class<? extends Annotation>... annotations) {
+    public final List<Class<?>> findClassesWithAnnotation(Class<? extends Annotation>... annotations) {
         if (!AutoConfigurationPackages.has(context)) {
             return emptyList();
         }

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfiguration.java
@@ -328,7 +328,7 @@ public class TimefoldAutoConfiguration
     private void assertSolverConfigEntityClasses(IncludeAbstractClassesEntityScanner entityScanner) {
         // No Entity class
         String emptyListErrorMessage = """
-                No classes found with a @%s annotation.
+                No classes were found with a @%s annotation.
                 Maybe your @%s annotated class(es) are not in a subpackage of your @%s annotated class's package.
                 Maybe move your planning entity classes to your application class's (sub)package(or use @%s)."""
                 .formatted(

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfiguration.java
@@ -1,10 +1,14 @@
 package ai.timefold.solver.spring.boot.autoconfigure;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
+import static java.util.stream.Collectors.joining;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -35,27 +39,29 @@ import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
 import ai.timefold.solver.test.api.score.stream.MultiConstraintVerification;
 import ai.timefold.solver.test.api.score.stream.SingleConstraintVerification;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
-import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
-import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.autoconfigure.domain.EntityScanPackages;
-import org.springframework.boot.autoconfigure.domain.EntityScanner;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-import org.springframework.util.ClassUtils;
 
 import com.fasterxml.jackson.databind.Module;
 
@@ -64,16 +70,16 @@ import com.fasterxml.jackson.databind.Module;
 @ConditionalOnMissingBean({ SolverConfig.class, SolverFactory.class, ScoreManager.class, SolutionManager.class,
         SolverManager.class })
 @EnableConfigurationProperties({ TimefoldProperties.class })
-public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
+public class TimefoldAutoConfiguration
+        implements BeanClassLoaderAware, ApplicationContextAware, EnvironmentAware, BeanFactoryPostProcessor {
 
-    private final ApplicationContext context;
-    private final TimefoldProperties timefoldProperties;
+    private static final Log LOG = LogFactory.getLog(TimefoldAutoConfiguration.class);
+    private static String DEFAULT_SOLVER_CONFIG_NAME = "getSolverConfig";
+    private ApplicationContext context;
     private ClassLoader beanClassLoader;
+    private TimefoldProperties timefoldProperties;
 
-    protected TimefoldAutoConfiguration(ApplicationContext context,
-            TimefoldProperties timefoldProperties) {
-        this.context = context;
-        this.timefoldProperties = timefoldProperties;
+    protected TimefoldAutoConfiguration() {
     }
 
     @Override
@@ -81,45 +87,405 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
         this.beanClassLoader = beanClassLoader;
     }
 
+    @Override
+    public void setApplicationContext(ApplicationContext context) throws BeansException {
+        this.context = context;
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        // postProcessBeanFactory runs before creating any bean, but we need TimefoldProperties. Therefore, we use the
+        // Environment to load the properties
+        BindResult<TimefoldProperties> result = Binder.get(environment).bind("timefold", TimefoldProperties.class);
+        this.timefoldProperties = result.orElseGet(TimefoldProperties::new);
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        IncludeAbstractClassesEntityScanner entityScanner = new IncludeAbstractClassesEntityScanner(this.context);
+        if (!entityScanner.hasSolutionOrEntityClasses()) {
+            LOG.warn(
+                    """
+                            Skipping Timefold loading because there are no @%s  or @%s annotated classes.
+                            Maybe your annotated classes are not in a subpackage of your @%s annotated class's package.
+                            Maybe move your planning solution and entity classes to your application class's (sub)package (or use @%s)."""
+                            .formatted(PlanningSolution.class.getSimpleName(), PlanningEntity.class.getSimpleName(),
+                                    SpringBootApplication.class.getSimpleName(), EntityScan.class.getSimpleName()));
+            beanFactory.registerSingleton(DEFAULT_SOLVER_CONFIG_NAME, new SolverConfig(beanClassLoader));
+            return;
+        }
+        Map<String, SolverConfig> solverConfigMap = new HashMap<>();
+        // Step 1 - create all SolverConfig
+        // If the config map is empty, we build the config using the default solver name
+        if (timefoldProperties.getSolver() == null || timefoldProperties.getSolver().isEmpty()) {
+            solverConfigMap.put(TimefoldProperties.DEFAULT_SOLVER_NAME,
+                    createSolverConfig(timefoldProperties, TimefoldProperties.DEFAULT_SOLVER_NAME));
+        } else {
+            timefoldProperties.getSolver().keySet()
+                    .forEach(solverName -> solverConfigMap.put(solverName, createSolverConfig(timefoldProperties, solverName)));
+        }
+        // Step 2 - validate all SolverConfig definitions
+        // TODO - Should we assert planning members belongs to a PlanningEntity Quarkus#assertNoMemberAnnotationWithoutClassAnnotation?
+        assertSolverConfigSolutionClasses(entityScanner, solverConfigMap);
+        assertSolverConfigEntityClasses(entityScanner);
+        assertSolverConfigConstraintClasses(entityScanner, solverConfigMap);
+
+        // Step 3 - load all additional information per SolverConfig
+        solverConfigMap.forEach(
+                (solverName, solverConfig) -> loadSolverConfig(entityScanner, timefoldProperties, solverName, solverConfig));
+
+        if (timefoldProperties.getSolver() == null || timefoldProperties.getSolver().size() == 1) {
+            beanFactory.registerSingleton(DEFAULT_SOLVER_CONFIG_NAME, solverConfigMap.values().iterator().next());
+        } else {
+            // Only SolverManager can be injected for multiple solver configurations
+            solverConfigMap.forEach((solverName, solverConfig) -> {
+                SolverFactory<?> solverFactory = SolverFactory.create(solverConfig);
+
+                SolverManagerConfig solverManagerConfig = new SolverManagerConfig();
+                SolverManagerProperties solverManagerProperties = timefoldProperties.getSolverManager();
+                if (solverManagerProperties != null && solverManagerProperties.getParallelSolverCount() != null) {
+                    solverManagerConfig.setParallelSolverCount(solverManagerProperties.getParallelSolverCount());
+                }
+                beanFactory.registerSingleton(solverName, SolverManager.create(solverFactory, solverManagerConfig));
+            });
+        }
+    }
+
+    private SolverConfig createSolverConfig(TimefoldProperties timefoldProperties, String solverName) {
+        // 1 - The solver configuration takes precedence over root and default settings
+        Optional<String> solverConfigXml = timefoldProperties.getSolverConfig(solverName)
+                .map(SolverProperties::getSolverConfigXml);
+
+        // 2 - Root settings
+        if (solverConfigXml.isEmpty()) {
+            solverConfigXml = Optional.ofNullable(timefoldProperties.getSolverConfigXml());
+        }
+
+        SolverConfig solverConfig;
+        if (solverConfigXml.isPresent()) {
+            String solverUrl = solverConfigXml.get();
+            if (beanClassLoader.getResource(solverUrl) == null) {
+                String message =
+                        "\"Invalid timefold.solverConfigXml property (%s): that classpath resource does not exist."
+                                .formatted(solverUrl);
+                if (!solverName.equals(TimefoldProperties.DEFAULT_SOLVER_NAME)) {
+                    message =
+                            "Invalid timefold.solver.\"%s\".solverConfigXML property (%s): that classpath resource does not exist."
+                                    .formatted(solverName, solverUrl);
+                }
+                throw new IllegalStateException(message);
+            }
+            solverConfig = SolverConfig.createFromXmlResource(solverUrl);
+        } else if (beanClassLoader.getResource(TimefoldProperties.DEFAULT_SOLVER_CONFIG_URL) != null) {
+            // 3 - Default file URL
+            solverConfig = SolverConfig.createFromXmlResource(
+                    TimefoldProperties.DEFAULT_SOLVER_CONFIG_URL);
+        } else {
+            solverConfig = new SolverConfig(beanClassLoader);
+        }
+
+        return solverConfig;
+    }
+
+    private void loadSolverConfig(IncludeAbstractClassesEntityScanner entityScanner, TimefoldProperties timefoldProperties,
+            String solverName, SolverConfig solverConfig) {
+        if (solverConfig.getSolutionClass() == null) {
+            solverConfig.setSolutionClass(entityScanner.findFirstSolutionClass());
+        }
+        if (solverConfig.getEntityClassList() == null) {
+            solverConfig.setEntityClassList(entityScanner.findEntityClassList());
+        } else {
+            long entityClassCount = solverConfig.getEntityClassList().stream()
+                    .filter(Objects::nonNull)
+                    .count();
+            if (entityClassCount == 0L) {
+                throw new IllegalStateException(
+                        """
+                                The solverConfig's entityClassList (%s) does not contain any non-null entries.
+                                Maybe the classes listed there do not actually exist and therefore deserialization turned them to null?"""
+                                .formatted(solverConfig.getEntityClassList().stream().map(Class::getSimpleName)
+                                        .collect(joining(", "))));
+            }
+        }
+        applyScoreDirectorFactoryProperties(entityScanner, solverConfig);
+        Optional<SolverProperties> solverProperties = timefoldProperties.getSolverConfig(solverName);
+        if (solverProperties.isPresent()) {
+            if (solverProperties.get().getEnvironmentMode() != null) {
+                solverConfig.setEnvironmentMode(solverProperties.get().getEnvironmentMode());
+            }
+            if (solverProperties.get().getDomainAccessType() != null) {
+                solverConfig.setDomainAccessType(solverProperties.get().getDomainAccessType());
+            }
+            if (solverProperties.get().getDaemon() != null) {
+                solverConfig.setDaemon(solverProperties.get().getDaemon());
+            }
+            if (solverProperties.get().getMoveThreadCount() != null) {
+                solverConfig.setMoveThreadCount(solverProperties.get().getMoveThreadCount());
+            }
+            applyTerminationProperties(solverConfig, solverProperties.get().getTermination());
+        }
+    }
+
+    protected void applyScoreDirectorFactoryProperties(IncludeAbstractClassesEntityScanner entityScanner,
+            SolverConfig solverConfig) {
+        if (solverConfig.getScoreDirectorFactoryConfig() == null) {
+            solverConfig.setScoreDirectorFactoryConfig(defaultScoreDirectoryFactoryConfig(entityScanner));
+        }
+    }
+
+    private ScoreDirectorFactoryConfig defaultScoreDirectoryFactoryConfig(IncludeAbstractClassesEntityScanner entityScanner) {
+        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
+        scoreDirectorFactoryConfig
+                .setEasyScoreCalculatorClass(entityScanner.findFirstImplementingClass(EasyScoreCalculator.class));
+        scoreDirectorFactoryConfig
+                .setConstraintProviderClass(entityScanner.findFirstImplementingClass(ConstraintProvider.class));
+        scoreDirectorFactoryConfig
+                .setIncrementalScoreCalculatorClass(entityScanner.findFirstImplementingClass(IncrementalScoreCalculator.class));
+
+        return scoreDirectorFactoryConfig;
+    }
+
+    static void applyTerminationProperties(SolverConfig solverConfig, TerminationProperties terminationProperties) {
+        TerminationConfig terminationConfig = solverConfig.getTerminationConfig();
+        if (terminationConfig == null) {
+            terminationConfig = new TerminationConfig();
+            solverConfig.setTerminationConfig(terminationConfig);
+        }
+        if (terminationProperties != null) {
+            if (terminationProperties.getSpentLimit() != null) {
+                terminationConfig.overwriteSpentLimit(terminationProperties.getSpentLimit());
+            }
+            if (terminationProperties.getUnimprovedSpentLimit() != null) {
+                terminationConfig.overwriteUnimprovedSpentLimit(terminationProperties.getUnimprovedSpentLimit());
+            }
+            if (terminationProperties.getBestScoreLimit() != null) {
+                terminationConfig.setBestScoreLimit(terminationProperties.getBestScoreLimit());
+            }
+        }
+    }
+
+    private void failInjectionWithMultipleSolvers(String resourceName) {
+        if (timefoldProperties.getSolver() != null && timefoldProperties.getSolver().size() > 1) {
+            throw new BeanCreationException(
+                    "No qualifying bean of type '%s' available".formatted(resourceName));
+        }
+    }
+
+    private void assertSolverConfigSolutionClasses(IncludeAbstractClassesEntityScanner entityScanner,
+            Map<String, SolverConfig> solverConfigMap) {
+        // Validate the solution class
+        // No solution class
+        String emptyListErrorMessage = """
+                No classes were found with a @%s annotation.
+                Maybe your @%s annotated class is not in a subpackage of your @%s annotated class's package.
+                Maybe move your planning solution class to your application class's (sub)package (or use @%s).""".formatted(
+                PlanningSolution.class.getSimpleName(), PlanningSolution.class.getSimpleName(),
+                SpringBootApplication.class.getSimpleName(), EntityScan.class.getSimpleName());
+        assertEmptyInstances(entityScanner, PlanningSolution.class, emptyListErrorMessage);
+        // Multiple classes and single solver
+        try {
+            Set<Class<?>> annotationInstanceSet = entityScanner.scan(PlanningSolution.class);
+            if (annotationInstanceSet.size() > 1 && solverConfigMap.size() == 1) {
+                throw new IllegalStateException(
+                        "Multiple classes ([%s]) found in the classpath with a @%s annotation.".formatted(
+                                annotationInstanceSet.stream().map(Class::getSimpleName).collect(joining(", ")),
+                                PlanningSolution.class.getSimpleName()));
+            }
+            // Multiple classes and at least one solver config does not specify the solution class
+            List<String> solverConfigWithoutSolutionClassList = solverConfigMap.entrySet().stream()
+                    .filter(e -> e.getValue().getSolutionClass() == null)
+                    .map(Map.Entry::getKey)
+                    .toList();
+            if (annotationInstanceSet.size() > 1 && !solverConfigWithoutSolutionClassList.isEmpty()) {
+                throw new IllegalStateException(
+                        """
+                                Some solver configs (%s) don't specify a %s class, yet there are multiple available (%s) on the classpath.
+                                Maybe set the XML config file to the related solver configs, or add the missing solution classes to the XML files,
+                                or remove the unnecessary solution classes from the classpath."""
+                                .formatted(String.join(", ", solverConfigWithoutSolutionClassList),
+                                        PlanningSolution.class.getSimpleName(),
+                                        annotationInstanceSet.stream().map(Class::getSimpleName).collect(joining(", "))));
+            }
+            // Unused solution classes
+            List<String> unusedSolutionClassList = annotationInstanceSet.stream()
+                    .map(Class::getName)
+                    .filter(planningClassName -> solverConfigMap.values().stream().filter(c -> c.getSolutionClass() != null)
+                            .noneMatch(c -> c.getSolutionClass().getName().equals(planningClassName)))
+                    .toList();
+            if (annotationInstanceSet.size() > 1 && !unusedSolutionClassList.isEmpty()) {
+                throw new IllegalStateException(
+                        "Unused classes ([%s]) found with a @%s annotation.".formatted(
+                                String.join(", ", unusedSolutionClassList),
+                                PlanningSolution.class.getSimpleName()));
+            }
+            // TODO - Should we validate target types?
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(
+                    "Scanning for @%s annotations failed.".formatted(PlanningSolution.class.getSimpleName()), e);
+        }
+    }
+
+    private void assertSolverConfigEntityClasses(IncludeAbstractClassesEntityScanner entityScanner) {
+        // No Entity class
+        String emptyListErrorMessage = """
+                No classes found with a @%s annotation.
+                Maybe your @%s annotated class(es) are not in a subpackage of your @%s annotated class's package.
+                Maybe move your planning entity classes to your application class's (sub)package(or use @%s)."""
+                .formatted(
+                        PlanningEntity.class.getSimpleName(), PlanningEntity.class.getSimpleName(),
+                        SpringBootApplication.class.getSimpleName(), EntityScan.class.getSimpleName());
+        assertEmptyInstances(entityScanner, PlanningEntity.class, emptyListErrorMessage);
+        // TODO - Should we validate target types?
+    }
+
+    private void assertSolverConfigConstraintClasses(
+            IncludeAbstractClassesEntityScanner entityScanner, Map<String, SolverConfig> solverConfigMap) {
+        List<Class<? extends EasyScoreCalculator>> simpleScoreClassList =
+                entityScanner.findImplementingClassList(EasyScoreCalculator.class);
+        List<Class<? extends ConstraintProvider>> constraintScoreClassList =
+                entityScanner.findImplementingClassList(ConstraintProvider.class);
+        List<Class<? extends IncrementalScoreCalculator>> incrementalScoreClassList =
+                entityScanner.findImplementingClassList(IncrementalScoreCalculator.class);
+        // No score classes
+        if (simpleScoreClassList.isEmpty() && constraintScoreClassList.isEmpty()
+                && incrementalScoreClassList.isEmpty()) {
+            throw new IllegalStateException(
+                    """
+                            No classes found that implement %s, %s, or %s.
+                            Maybe your %s class is not in a subpackage of your @%s annotated class's package."
+                            Maybe move your %s class to your application class's (sub)package (or use @%s)."""
+                            .formatted(EasyScoreCalculator.class.getSimpleName(),
+                                    ConstraintProvider.class.getSimpleName(), IncrementalScoreCalculator.class.getSimpleName(),
+                                    ConstraintProvider.class.getSimpleName(), SpringBootApplication.class.getSimpleName(),
+                                    ConstraintProvider.class.getSimpleName(), EntityScan.class.getSimpleName()));
+        }
+        // Multiple classes and single solver
+        String errorMessage = "Multiple score classes classes (%s) that implements %s were found in the classpath.";
+        if (simpleScoreClassList.size() > 1 && solverConfigMap.size() == 1) {
+            throw new IllegalStateException(errorMessage.formatted(
+                    simpleScoreClassList.stream().map(Class::getSimpleName).collect(Collectors.joining(", ")),
+                    EasyScoreCalculator.class.getSimpleName()));
+        }
+        if (constraintScoreClassList.size() > 1 && solverConfigMap.size() == 1) {
+            throw new IllegalStateException(errorMessage.formatted(
+                    constraintScoreClassList.stream().map(Class::getSimpleName).collect(Collectors.joining(", ")),
+                    ConstraintProvider.class.getSimpleName()));
+        }
+        if (incrementalScoreClassList.size() > 1 && solverConfigMap.size() == 1) {
+            throw new IllegalStateException(errorMessage.formatted(
+                    incrementalScoreClassList.stream().map(Class::getSimpleName).collect(Collectors.joining(", ")),
+                    IncrementalScoreCalculator.class.getSimpleName()));
+        }
+        // Multiple classes and at least one solver config does not specify the score class
+        errorMessage = """
+                Some solver configs (%s) don't specify a %s score class, yet there are multiple available (%s) on the classpath.
+                Maybe set the XML config file to the related solver configs, or add the missing score classes to the XML files,
+                or remove the unnecessary score classes from the classpath.""";
+        List<String> solverConfigWithoutConstraintClassList = solverConfigMap.entrySet().stream()
+                .filter(e -> e.getValue().getScoreDirectorFactoryConfig() == null
+                        || e.getValue().getScoreDirectorFactoryConfig().getEasyScoreCalculatorClass() == null)
+                .map(Map.Entry::getKey)
+                .toList();
+        if (simpleScoreClassList.size() > 1 && !solverConfigWithoutConstraintClassList.isEmpty()) {
+            throw new IllegalStateException(errorMessage.formatted(
+                    String.join(", ", solverConfigWithoutConstraintClassList),
+                    EasyScoreCalculator.class.getSimpleName(),
+                    simpleScoreClassList.stream().map(Class::getSimpleName).collect(Collectors.joining(", "))));
+        }
+        solverConfigWithoutConstraintClassList = solverConfigMap.entrySet().stream()
+                .filter(e -> e.getValue().getScoreDirectorFactoryConfig() == null
+                        || e.getValue().getScoreDirectorFactoryConfig().getConstraintProviderClass() == null)
+                .map(Map.Entry::getKey)
+                .toList();
+        if (constraintScoreClassList.size() > 1 && !solverConfigWithoutConstraintClassList.isEmpty()) {
+            throw new IllegalStateException(errorMessage.formatted(
+                    String.join(", ", solverConfigWithoutConstraintClassList),
+                    ConstraintProvider.class.getSimpleName(),
+                    constraintScoreClassList.stream().map(Class::getSimpleName).collect(Collectors.joining(", "))));
+        }
+        solverConfigWithoutConstraintClassList = solverConfigMap.entrySet().stream()
+                .filter(e -> e.getValue().getScoreDirectorFactoryConfig() == null
+                        || e.getValue().getScoreDirectorFactoryConfig().getIncrementalScoreCalculatorClass() == null)
+                .map(Map.Entry::getKey)
+                .toList();
+        if (incrementalScoreClassList.size() > 1 && !solverConfigWithoutConstraintClassList.isEmpty()) {
+            throw new IllegalStateException(errorMessage.formatted(
+                    String.join(", ", solverConfigWithoutConstraintClassList),
+                    IncrementalScoreCalculator.class.getSimpleName(),
+                    incrementalScoreClassList.stream().map(Class::getSimpleName).collect(Collectors.joining(", "))));
+        }
+        // Unused score classes
+        List<String> solverConfigWithUnusedSolutionClassList = simpleScoreClassList.stream()
+                .map(Class::getName)
+                .filter(className -> solverConfigMap.values().stream()
+                        .filter(c -> c.getScoreDirectorFactoryConfig() != null
+                                && c.getScoreDirectorFactoryConfig().getEasyScoreCalculatorClass() != null)
+                        .noneMatch(c -> c.getScoreDirectorFactoryConfig().getEasyScoreCalculatorClass().getName()
+                                .equals(className)))
+                .toList();
+        errorMessage = "Unused classes ([%s]) that implements %s were found.";
+        if (simpleScoreClassList.size() > 1 && !solverConfigWithUnusedSolutionClassList.isEmpty()) {
+            throw new IllegalStateException(errorMessage.formatted(String.join(", ", solverConfigWithUnusedSolutionClassList),
+                    EasyScoreCalculator.class.getSimpleName()));
+        }
+        solverConfigWithUnusedSolutionClassList = constraintScoreClassList.stream()
+                .map(Class::getName)
+                .filter(className -> solverConfigMap.values().stream()
+                        .filter(c -> c.getScoreDirectorFactoryConfig() != null
+                                && c.getScoreDirectorFactoryConfig().getConstraintProviderClass() != null)
+                        .noneMatch(c -> c.getScoreDirectorFactoryConfig().getConstraintProviderClass().getName()
+                                .equals(className)))
+                .toList();
+        if (constraintScoreClassList.size() > 1 && !solverConfigWithUnusedSolutionClassList.isEmpty()) {
+            throw new IllegalStateException(errorMessage.formatted(String.join(", ", solverConfigWithUnusedSolutionClassList),
+                    ConstraintProvider.class.getSimpleName()));
+        }
+        solverConfigWithUnusedSolutionClassList = incrementalScoreClassList.stream()
+                .map(Class::getName)
+                .filter(className -> solverConfigMap.values().stream()
+                        .filter(c -> c.getScoreDirectorFactoryConfig() != null
+                                && c.getScoreDirectorFactoryConfig().getIncrementalScoreCalculatorClass() != null)
+                        .noneMatch(c -> c.getScoreDirectorFactoryConfig().getIncrementalScoreCalculatorClass().getName()
+                                .equals(className)))
+                .toList();
+        if (incrementalScoreClassList.size() > 1 && !solverConfigWithUnusedSolutionClassList.isEmpty()) {
+            throw new IllegalStateException(errorMessage.formatted(String.join(", ", solverConfigWithUnusedSolutionClassList),
+                    IncrementalScoreCalculator.class.getSimpleName()));
+        }
+    }
+
+    private void assertEmptyInstances(IncludeAbstractClassesEntityScanner entityScanner, Class<? extends Annotation> clazz,
+            String errorMessage) {
+        try {
+            Collection<Class<?>> classInstanceCollection = entityScanner.scan(clazz);
+            if (classInstanceCollection.isEmpty()) {
+                throw new IllegalStateException(errorMessage);
+            }
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Scanning for @%s annotations failed.".formatted(clazz.getSimpleName()), e);
+        }
+    }
+
     @Bean
+    @Lazy
     public TimefoldSolverBannerBean getBanner() {
         return new TimefoldSolverBannerBean();
     }
 
     @Bean
+    @Lazy
     @ConditionalOnMissingBean
-    public SolverConfig solverConfig() {
-        String solverConfigXml = timefoldProperties.getSolverConfigXml();
-        SolverConfig solverConfig;
-        if (solverConfigXml != null) {
-            if (beanClassLoader.getResource(solverConfigXml) == null) {
-                throw new IllegalStateException("Invalid timefold.solverConfigXml property (" + solverConfigXml
-                        + "): that classpath resource does not exist.");
-            }
-            solverConfig = SolverConfig.createFromXmlResource(solverConfigXml, beanClassLoader);
-        } else if (beanClassLoader.getResource(TimefoldProperties.DEFAULT_SOLVER_CONFIG_URL) != null) {
-            solverConfig = SolverConfig.createFromXmlResource(
-                    TimefoldProperties.DEFAULT_SOLVER_CONFIG_URL, beanClassLoader);
-        } else {
-            solverConfig = new SolverConfig(beanClassLoader);
-        }
-
-        if (!applySolverProperties(solverConfig)) {
-            return null;
-        }
-        return solverConfig;
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public <Solution_> SolverFactory<Solution_> solverFactory(SolverConfig solverConfig) {
-        if (solverConfig == null) {
+    public <Solution_> SolverFactory<Solution_> getSolverFactory() {
+        failInjectionWithMultipleSolvers(SolverFactory.class.getName());
+        SolverConfig solverConfig = context.getBean(SolverConfig.class);
+        if (solverConfig == null || solverConfig.getSolutionClass() == null) {
             return null;
         }
         return SolverFactory.create(solverConfig);
     }
 
     @Bean
+    @Lazy
     @ConditionalOnMissingBean
     public <Solution_, ProblemId_> SolverManager<Solution_, ProblemId_> solverManager(SolverFactory solverFactory) {
         // TODO supply ThreadFactory
@@ -128,19 +494,19 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
         }
         SolverManagerConfig solverManagerConfig = new SolverManagerConfig();
         SolverManagerProperties solverManagerProperties = timefoldProperties.getSolverManager();
-        if (solverManagerProperties != null) {
-            if (solverManagerProperties.getParallelSolverCount() != null) {
-                solverManagerConfig.setParallelSolverCount(solverManagerProperties.getParallelSolverCount());
-            }
+        if (solverManagerProperties != null && solverManagerProperties.getParallelSolverCount() != null) {
+            solverManagerConfig.setParallelSolverCount(solverManagerProperties.getParallelSolverCount());
         }
         return SolverManager.create(solverFactory, solverManagerConfig);
     }
 
-    @Deprecated(forRemoval = true)
     @Bean
+    @Lazy
     @ConditionalOnMissingBean
-    public <Solution_, Score_ extends Score<Score_>> ScoreManager<Solution_, Score_> scoreManager(
-            SolverFactory solverFactory) {
+    @Deprecated(forRemoval = true)
+    public <Solution_, Score_ extends Score<Score_>> ScoreManager<Solution_, Score_> scoreManager() {
+        failInjectionWithMultipleSolvers(ScoreManager.class.getName());
+        SolverFactory solverFactory = context.getBean(SolverFactory.class);
         if (solverFactory == null) {
             return null;
         }
@@ -148,9 +514,11 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
     }
 
     @Bean
+    @Lazy
     @ConditionalOnMissingBean
-    public <Solution_, Score_ extends Score<Score_>> SolutionManager<Solution_, Score_> solutionManager(
-            SolverFactory solverFactory) {
+    public <Solution_, Score_ extends Score<Score_>> SolutionManager<Solution_, Score_> solutionManager() {
+        failInjectionWithMultipleSolvers(SolutionManager.class.getName());
+        SolverFactory solverFactory = context.getBean(SolverFactory.class);
         if (solverFactory == null) {
             return null;
         }
@@ -164,20 +532,19 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
     class TimefoldConstraintVerifierConfiguration {
 
         private final ApplicationContext context;
-        private final TimefoldProperties timefoldProperties;
 
-        protected TimefoldConstraintVerifierConfiguration(ApplicationContext context,
-                TimefoldProperties timefoldProperties) {
+        protected TimefoldConstraintVerifierConfiguration(ApplicationContext context) {
             this.context = context;
-            this.timefoldProperties = timefoldProperties;
         }
 
         @Bean
+        @Lazy
         @SuppressWarnings("unchecked")
         <ConstraintProvider_ extends ConstraintProvider, SolutionClass_>
                 ConstraintVerifier<ConstraintProvider_, SolutionClass_> constraintVerifier() {
             // Using SolverConfig as an injected parameter here leads to an injection failure on an empty app,
             // so we need to get the SolverConfig from context
+            failInjectionWithMultipleSolvers(ConstraintProvider.class.getName());
             SolverConfig solverConfig;
             try {
                 solverConfig = context.getBean(SolverConfig.class);
@@ -218,188 +585,6 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
         }
     }
 
-    private boolean applySolverProperties(SolverConfig solverConfig) {
-        IncludeAbstractClassesEntityScanner entityScanner = new IncludeAbstractClassesEntityScanner(this.context);
-        if (!hasSolutionOrEntityClasses(entityScanner)) {
-            return false;
-        }
-        if (solverConfig.getSolutionClass() == null) {
-            solverConfig.setSolutionClass(findSolutionClass(entityScanner));
-        }
-        if (solverConfig.getEntityClassList() == null) {
-            solverConfig.setEntityClassList(findEntityClassList(entityScanner));
-        } else {
-            long entityClassCount = solverConfig.getEntityClassList().stream()
-                    .filter(Objects::nonNull)
-                    .count();
-            if (entityClassCount == 0L) {
-                throw new IllegalStateException("The solverConfig's entityClassList (" + solverConfig.getEntityClassList()
-                        + ") does not contain any non-null entries.\n"
-                        + "Maybe the classes listed there do not actually exist and therefore deserialization turned them to null?\n");
-            }
-        }
-        applyScoreDirectorFactoryProperties(solverConfig);
-        SolverProperties solverProperties = timefoldProperties.getSolver();
-        if (solverProperties != null) {
-            if (solverProperties.getEnvironmentMode() != null) {
-                solverConfig.setEnvironmentMode(solverProperties.getEnvironmentMode());
-            }
-            if (solverProperties.getDomainAccessType() != null) {
-                solverConfig.setDomainAccessType(solverProperties.getDomainAccessType());
-            }
-            if (solverProperties.getDaemon() != null) {
-                solverConfig.setDaemon(solverProperties.getDaemon());
-            }
-            if (solverProperties.getMoveThreadCount() != null) {
-                solverConfig.setMoveThreadCount(solverProperties.getMoveThreadCount());
-            }
-            applyTerminationProperties(solverConfig, solverProperties.getTermination());
-        }
-        return true;
-    }
-
-    private boolean hasSolutionOrEntityClasses(IncludeAbstractClassesEntityScanner entityScanner) {
-        try {
-            return !entityScanner.scan(PlanningSolution.class).isEmpty() || !entityScanner.scan(PlanningEntity.class)
-                    .isEmpty();
-        } catch (ClassNotFoundException e) {
-            throw new IllegalStateException("Scanning for @" + PlanningSolution.class.getSimpleName()
-                    + " and @" + PlanningEntity.class.getSimpleName() + " annotations failed.", e);
-        }
-    }
-
-    private Class<?> findSolutionClass(IncludeAbstractClassesEntityScanner entityScanner) {
-        Set<Class<?>> solutionClassSet;
-        try {
-            solutionClassSet = entityScanner.scan(PlanningSolution.class);
-        } catch (ClassNotFoundException e) {
-            throw new IllegalStateException("Scanning for @" + PlanningSolution.class.getSimpleName()
-                    + " annotations failed.", e);
-        }
-        if (solutionClassSet.size() > 1) {
-            throw new IllegalStateException("Multiple classes (" + solutionClassSet
-                    + ") found with a @" + PlanningSolution.class.getSimpleName() + " annotation.");
-        }
-        if (solutionClassSet.isEmpty()) {
-            throw new IllegalStateException("No classes (" + solutionClassSet
-                    + ") found with a @" + PlanningSolution.class.getSimpleName() + " annotation.\n"
-                    + "Maybe your @" + PlanningSolution.class.getSimpleName() + " annotated class "
-                    + " is not in a subpackage of your @" + SpringBootApplication.class.getSimpleName()
-                    + " annotated class's package.\n"
-                    + "Maybe move your planning solution class to your application class's (sub)package"
-                    + " (or use @" + EntityScan.class.getSimpleName() + ").");
-        }
-        return solutionClassSet.iterator().next();
-    }
-
-    private List<Class<?>> findEntityClassList(IncludeAbstractClassesEntityScanner entityScanner) {
-        Set<Class<?>> entityClassSet;
-        try {
-            entityClassSet = entityScanner.scan(PlanningEntity.class);
-        } catch (ClassNotFoundException e) {
-            throw new IllegalStateException("Scanning for @" + PlanningEntity.class.getSimpleName() + " failed.", e);
-        }
-        if (entityClassSet.isEmpty()) {
-            throw new IllegalStateException("No classes (" + entityClassSet
-                    + ") found with a @" + PlanningEntity.class.getSimpleName() + " annotation.\n"
-                    + "Maybe your @" + PlanningEntity.class.getSimpleName() + " annotated class(es) "
-                    + " are not in a subpackage of your @" + SpringBootApplication.class.getSimpleName()
-                    + " annotated class's package.\n"
-                    + "Maybe move your planning entity classes to your application class's (sub)package"
-                    + " (or use @" + EntityScan.class.getSimpleName() + ").");
-        }
-        return new ArrayList<>(entityClassSet);
-    }
-
-    protected void applyScoreDirectorFactoryProperties(SolverConfig solverConfig) {
-        if (solverConfig.getScoreDirectorFactoryConfig() == null) {
-            solverConfig.setScoreDirectorFactoryConfig(defaultScoreDirectoryFactoryConfig());
-        }
-    }
-
-    private ScoreDirectorFactoryConfig defaultScoreDirectoryFactoryConfig() {
-        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
-        scoreDirectorFactoryConfig.setEasyScoreCalculatorClass(findImplementingClass(EasyScoreCalculator.class));
-        scoreDirectorFactoryConfig.setConstraintProviderClass(findImplementingClass(ConstraintProvider.class));
-        scoreDirectorFactoryConfig
-                .setIncrementalScoreCalculatorClass(findImplementingClass(IncrementalScoreCalculator.class));
-
-        if (scoreDirectorFactoryConfig.getEasyScoreCalculatorClass() == null
-                && scoreDirectorFactoryConfig.getConstraintProviderClass() == null
-                && scoreDirectorFactoryConfig.getIncrementalScoreCalculatorClass() == null) {
-            throw new IllegalStateException("No classes found that implement "
-                    + EasyScoreCalculator.class.getSimpleName() + ", "
-                    + ConstraintProvider.class.getSimpleName() + " or "
-                    + IncrementalScoreCalculator.class.getSimpleName() + ".\n"
-                    + "Maybe your " + ConstraintProvider.class.getSimpleName() + " class "
-                    + " is not in a subpackage of your @" + SpringBootApplication.class.getSimpleName()
-                    + " annotated class's package.\n"
-                    + "Maybe move your " + ConstraintProvider.class.getSimpleName()
-                    + " class to your application class's (sub)package"
-                    + " (or use @" + EntityScan.class.getSimpleName() + ").");
-        }
-        return scoreDirectorFactoryConfig;
-    }
-
-    private <T> Class<? extends T> findImplementingClass(Class<T> targetClass) {
-        if (!AutoConfigurationPackages.has(context)) {
-            return null;
-        }
-        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
-        scanner.setEnvironment(context.getEnvironment());
-        scanner.setResourceLoader(context);
-        scanner.addIncludeFilter(new AssignableTypeFilter(targetClass));
-
-        EntityScanPackages entityScanPackages = EntityScanPackages.get(context);
-
-        Set<String> packages = new HashSet<>();
-        packages.addAll(AutoConfigurationPackages.get(context));
-        packages.addAll(entityScanPackages.getPackageNames());
-        List<Class<? extends T>> classList = packages.stream()
-                .flatMap(basePackage -> scanner.findCandidateComponents(basePackage).stream())
-                // findCandidateComponents can return the same package for different base packages
-                .distinct()
-                .sorted(Comparator.comparing(BeanDefinition::getBeanClassName))
-                .map(candidate -> {
-                    try {
-                        Class<? extends T> clazz = ClassUtils.forName(candidate.getBeanClassName(), context.getClassLoader())
-                                .asSubclass(targetClass);
-                        return clazz;
-                    } catch (ClassNotFoundException e) {
-                        throw new IllegalStateException("The " + targetClass.getSimpleName() + " class ("
-                                + candidate.getBeanClassName() + ") cannot be found.", e);
-                    }
-                })
-                .collect(Collectors.toList());
-        if (classList.size() > 1) {
-            throw new IllegalStateException("Multiple classes (" + classList
-                    + ") found that implement the interface " + targetClass.getSimpleName() + ".");
-        }
-        if (classList.isEmpty()) {
-            return null;
-        }
-        return classList.get(0);
-    }
-
-    static void applyTerminationProperties(SolverConfig solverConfig, TerminationProperties terminationProperties) {
-        TerminationConfig terminationConfig = solverConfig.getTerminationConfig();
-        if (terminationConfig == null) {
-            terminationConfig = new TerminationConfig();
-            solverConfig.setTerminationConfig(terminationConfig);
-        }
-        if (terminationProperties != null) {
-            if (terminationProperties.getSpentLimit() != null) {
-                terminationConfig.overwriteSpentLimit(terminationProperties.getSpentLimit());
-            }
-            if (terminationProperties.getUnimprovedSpentLimit() != null) {
-                terminationConfig.overwriteUnimprovedSpentLimit(terminationProperties.getUnimprovedSpentLimit());
-            }
-            if (terminationProperties.getBestScoreLimit() != null) {
-                terminationConfig.setBestScoreLimit(terminationProperties.getBestScoreLimit());
-            }
-        }
-    }
-
     // @Bean wrapped by static class to avoid classloading issues if dependencies are absent
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({ Jackson2ObjectMapperBuilder.class, Score.class })
@@ -411,26 +596,4 @@ public class TimefoldAutoConfiguration implements BeanClassLoaderAware {
         }
 
     }
-
-    private static class IncludeAbstractClassesEntityScanner extends EntityScanner {
-
-        public IncludeAbstractClassesEntityScanner(ApplicationContext context) {
-            super(context);
-        }
-
-        @Override
-        protected ClassPathScanningCandidateComponentProvider
-                createClassPathScanningCandidateComponentProvider(ApplicationContext context) {
-            return new ClassPathScanningCandidateComponentProvider(false) {
-                @Override
-                protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
-                    AnnotationMetadata metadata = beanDefinition.getMetadata();
-                    // Do not exclude abstract classes nor interfaces
-                    return metadata.isIndependent();
-                }
-            };
-        }
-
-    }
-
 }

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldBenchmarkAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldBenchmarkAutoConfiguration.java
@@ -79,6 +79,12 @@ public class TimefoldBenchmarkAutoConfiguration implements BeanClassLoaderAware,
             benchmarkConfig.setBenchmarkDirectory(new File(BenchmarkProperties.DEFAULT_BENCHMARK_RESULT_DIRECTORY));
         }
 
+        if (benchmarkConfig.getInheritedSolverBenchmarkConfig() == null) {
+            SolverBenchmarkConfig inheritedBenchmarkConfig = new SolverBenchmarkConfig();
+            benchmarkConfig.setInheritedSolverBenchmarkConfig(inheritedBenchmarkConfig);
+            inheritedBenchmarkConfig.setSolverConfig(solverConfig.copyConfig());
+        }
+
         if (timefoldProperties.getBenchmark() != null && timefoldProperties.getBenchmark().getSolver() != null) {
             TimefoldAutoConfiguration
                     .applyTerminationProperties(benchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig(),

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperties.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperties.java
@@ -1,5 +1,8 @@
 package ai.timefold.solver.spring.boot.autoconfigure.config;
 
+import java.util.Map;
+import java.util.Set;
+
 import ai.timefold.solver.core.api.domain.common.DomainAccessType;
 import ai.timefold.solver.core.api.score.stream.ConstraintStreamImplType;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -7,6 +10,15 @@ import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class SolverProperties {
+    public static final Set<String> VALID_FIELD_NAMES_SET =
+            Set.of("solver-config-xml", "environment-mode", "daemon", "move-thread-count", "domain-access-type",
+                    "constraint-stream-impl-type", "termination");
+
+    /**
+     * A classpath resource to read the specific solver configuration XML.
+     * If this property isn't specified, that solverConfig.xml is optional.
+     */
+    private String solverConfigXml;
 
     /**
      * Enable runtime assertions to detect common bugs in your implementation during development.
@@ -50,6 +62,14 @@ public class SolverProperties {
     // ************************************************************************
     // Getters/setters
     // ************************************************************************
+
+    public String getSolverConfigXml() {
+        return solverConfigXml;
+    }
+
+    public void setSolverConfigXml(String solverConfigXml) {
+        this.solverConfigXml = solverConfigXml;
+    }
 
     public EnvironmentMode getEnvironmentMode() {
         return environmentMode;
@@ -105,6 +125,50 @@ public class SolverProperties {
 
     public void setTermination(TerminationProperties termination) {
         this.termination = termination;
+    }
+
+    public void loadProperties(Map<String, Object> properties) {
+        properties.forEach(this::loadProperty);
+    }
+
+    private void loadProperty(String key, Object value) {
+        if (value == null) {
+            return;
+        }
+        switch (key) {
+            case "solver-config-xml":
+                setSolverConfigXml((String) value);
+                break;
+            case "environment-mode":
+                setEnvironmentMode(EnvironmentMode.valueOf((String) value));
+                break;
+            case "daemon":
+                setDaemon(Boolean.parseBoolean((String) value));
+                break;
+            case "move-thread-count":
+                setMoveThreadCount((String) value);
+                break;
+            case "domain-access-type":
+                setDomainAccessType(DomainAccessType.valueOf((String) value));
+                break;
+            case "constraint-stream-impl-type":
+                setConstraintStreamImplType(ConstraintStreamImplType.valueOf((String) value));
+                break;
+            case "termination": {
+                if (value instanceof TerminationProperties terminationProperties) {
+                    setTermination(terminationProperties);
+                } else if (value instanceof Map<?, ?>) {
+                    TerminationProperties terminationProperties = new TerminationProperties();
+                    terminationProperties.loadProperties((Map<String, Object>) value);
+                    setTermination(terminationProperties);
+                } else {
+                    throw new IllegalStateException("The termination value is not valid.");
+                }
+                break;
+            }
+            default:
+                throw new IllegalStateException("The property %s is not valid.".formatted(key));
+        }
     }
 
 }

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperties.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperties.java
@@ -10,9 +10,18 @@ import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class SolverProperties {
+
+    public static final String SOLVER_CONFIG_XML_PROPERTY_NAME = "solver-config-xml";
+    public static final String ENVIRONMENT_MODE_PROPERTY_NAME = "environment-mode";
+    public static final String DAEMON_PROPERTY_NAME = "daemon";
+    public static final String MOVE_THREAD_COUNT_PROPERTY_NAME = "move-thread-count";
+    public static final String DOMAIN_ACCESS_TYPE_PROPERTY_NAME = "domain-access-type";
+    public static final String CONSTRAINT_STREAM_IMPL_TYPE_PROPERTY_NAME = "constraint-stream-impl-type";
+    public static final String TERMINATION_PROPERTY_NAME = "termination";
     public static final Set<String> VALID_FIELD_NAMES_SET =
-            Set.of("solver-config-xml", "environment-mode", "daemon", "move-thread-count", "domain-access-type",
-                    "constraint-stream-impl-type", "termination");
+            Set.of(SOLVER_CONFIG_XML_PROPERTY_NAME, ENVIRONMENT_MODE_PROPERTY_NAME, DAEMON_PROPERTY_NAME,
+                    MOVE_THREAD_COUNT_PROPERTY_NAME, DOMAIN_ACCESS_TYPE_PROPERTY_NAME,
+                    CONSTRAINT_STREAM_IMPL_TYPE_PROPERTY_NAME, TERMINATION_PROPERTY_NAME);
 
     /**
      * A classpath resource to read the specific solver configuration XML.
@@ -136,25 +145,25 @@ public class SolverProperties {
             return;
         }
         switch (key) {
-            case "solver-config-xml":
+            case SOLVER_CONFIG_XML_PROPERTY_NAME:
                 setSolverConfigXml((String) value);
                 break;
-            case "environment-mode":
+            case ENVIRONMENT_MODE_PROPERTY_NAME:
                 setEnvironmentMode(EnvironmentMode.valueOf((String) value));
                 break;
-            case "daemon":
+            case DAEMON_PROPERTY_NAME:
                 setDaemon(Boolean.parseBoolean((String) value));
                 break;
-            case "move-thread-count":
+            case MOVE_THREAD_COUNT_PROPERTY_NAME:
                 setMoveThreadCount((String) value);
                 break;
-            case "domain-access-type":
+            case DOMAIN_ACCESS_TYPE_PROPERTY_NAME:
                 setDomainAccessType(DomainAccessType.valueOf((String) value));
                 break;
-            case "constraint-stream-impl-type":
+            case CONSTRAINT_STREAM_IMPL_TYPE_PROPERTY_NAME:
                 setConstraintStreamImplType(ConstraintStreamImplType.valueOf((String) value));
                 break;
-            case "termination": {
+            case TERMINATION_PROPERTY_NAME: {
                 if (value instanceof TerminationProperties terminationProperties) {
                     setTermination(terminationProperties);
                 } else if (value instanceof Map<?, ?>) {

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/TerminationProperties.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/TerminationProperties.java
@@ -1,9 +1,9 @@
 package ai.timefold.solver.spring.boot.autoconfigure.config;
 
-import org.springframework.boot.convert.DurationStyle;
-
 import java.time.Duration;
 import java.util.Map;
+
+import org.springframework.boot.convert.DurationStyle;
 
 public class TerminationProperties {
 

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/TerminationProperties.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/TerminationProperties.java
@@ -1,6 +1,9 @@
 package ai.timefold.solver.spring.boot.autoconfigure.config;
 
+import org.springframework.boot.convert.DurationStyle;
+
 import java.time.Duration;
+import java.util.Map;
 
 public class TerminationProperties {
 
@@ -50,6 +53,29 @@ public class TerminationProperties {
 
     public void setBestScoreLimit(String bestScoreLimit) {
         this.bestScoreLimit = bestScoreLimit;
+    }
+
+    public void loadProperties(Map<String, Object> properties) {
+        properties.forEach(this::loadProperty);
+    }
+
+    private void loadProperty(String key, Object value) {
+        if (value == null) {
+            return;
+        }
+        switch (key) {
+            case "spent-limit":
+                setSpentLimit(DurationStyle.detectAndParse((String) value));
+                break;
+            case "unimproved-spent-limit":
+                setUnimprovedSpentLimit(DurationStyle.detectAndParse((String) value));
+                break;
+            case "best-score-limit":
+                setBestScoreLimit((String) value);
+                break;
+            default:
+                throw new IllegalStateException("The property %s is not valid.".formatted(key));
+        }
     }
 
 }

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/TerminationProperties.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/TerminationProperties.java
@@ -7,6 +7,10 @@ import org.springframework.boot.convert.DurationStyle;
 
 public class TerminationProperties {
 
+    private static final String SPENT_LIMIT_PROERTY_NAME = "spent-limit";
+    private static final String UNIMPROVED_SPENT_LIMIT_PROERTY_NAME = "unimproved-spent-limit";
+    private static final String BEST_SCORE_LIMIT_PROERTY_NAME = "best-score-limit";
+
     /**
      * How long the solver can run.
      * For example: "30s" is 30 seconds. "5m" is 5 minutes. "2h" is 2 hours. "1d" is 1 day.
@@ -64,13 +68,13 @@ public class TerminationProperties {
             return;
         }
         switch (key) {
-            case "spent-limit":
+            case SPENT_LIMIT_PROERTY_NAME:
                 setSpentLimit(DurationStyle.detectAndParse((String) value));
                 break;
-            case "unimproved-spent-limit":
+            case UNIMPROVED_SPENT_LIMIT_PROERTY_NAME:
                 setUnimprovedSpentLimit(DurationStyle.detectAndParse((String) value));
                 break;
-            case "best-score-limit":
+            case BEST_SCORE_LIMIT_PROERTY_NAME:
                 setBestScoreLimit((String) value);
                 break;
             default:

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/util/LambdaUtils.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/util/LambdaUtils.java
@@ -1,0 +1,25 @@
+package ai.timefold.solver.spring.boot.autoconfigure.util;
+
+import java.util.function.Function;
+
+public class LambdaUtils {
+
+    public static <T, R> Function<T, R> rethrowFunction(ThrowingFunction<T, R> throwingFunction) {
+        return v -> {
+            try {
+                return throwingFunction.apply(v);
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        };
+    }
+
+    @FunctionalInterface
+    public interface ThrowingFunction<T, R> {
+        R apply(T t) throws Exception;
+    }
+
+    private LambdaUtils() {
+        // No external instances.
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/IncludeAbstractClassesEntityScannerTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/IncludeAbstractClassesEntityScannerTest.java
@@ -17,9 +17,9 @@ import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
 import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
-import ai.timefold.solver.spring.boot.autoconfigure.invalid.domain.InvalidFieldTestdataSpringEntity;
-import ai.timefold.solver.spring.boot.autoconfigure.invalid.domain.InvalidMethodTestdataSpringEntity;
-import ai.timefold.solver.spring.boot.autoconfigure.invalid.domain.InvalidEntitySpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.type.InvalidEntityTypeSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.type.InvalidFieldTestdataSpringEntity;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.type.InvalidMethodTestdataSpringEntity;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -45,7 +45,7 @@ class IncludeAbstractClassesEntityScannerTest {
     private final ApplicationContextRunner contextRunner;
 
     public IncludeAbstractClassesEntityScannerTest() {
-        contextRunner = new ApplicationContextRunner().withUserConfiguration(InvalidEntitySpringTestConfiguration.class);
+        contextRunner = new ApplicationContextRunner().withUserConfiguration(InvalidEntityTypeSpringTestConfiguration.class);
     }
 
     @Test
@@ -56,14 +56,14 @@ class IncludeAbstractClassesEntityScannerTest {
 
                     // Each field
                     Arrays.stream(PLANNING_ENTITY_FIELD_ANNOTATIONS).forEach(annotation -> {
-                        List<Class<?>> classes = scanner.findAnnotationsWithRepeatable(annotation);
+                        List<Class<?>> classes = scanner.findClassesWithAnnotation(annotation);
                         assertThat(classes).hasSize(2);
                         assertThat(classes).contains(InvalidFieldTestdataSpringEntity.class,
                                 InvalidMethodTestdataSpringEntity.class);
                     });
 
                     // All fields
-                    List<Class<?>> classes = scanner.findAnnotationsWithRepeatable(PLANNING_ENTITY_FIELD_ANNOTATIONS);
+                    List<Class<?>> classes = scanner.findClassesWithAnnotation(PLANNING_ENTITY_FIELD_ANNOTATIONS);
                     assertThat(classes).hasSize(2);
                     assertThat(classes).contains(InvalidFieldTestdataSpringEntity.class,
                             InvalidMethodTestdataSpringEntity.class);

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/IncludeAbstractClassesEntityScannerTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/IncludeAbstractClassesEntityScannerTest.java
@@ -1,0 +1,72 @@
+package ai.timefold.solver.spring.boot.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.variable.AnchorShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.CustomShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.IndexShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.NextElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PiggybackShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.domain.InvalidFieldTestdataSpringEntity;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.domain.InvalidMethodTestdataSpringEntity;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.domain.InvalidEntitySpringTestConfiguration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.test.context.TestExecutionListeners;
+
+@TestExecutionListeners
+class IncludeAbstractClassesEntityScannerTest {
+
+    private static final Class<? extends Annotation>[] PLANNING_ENTITY_FIELD_ANNOTATIONS = new Class[] {
+            PlanningPin.class,
+            PlanningVariable.class,
+            PlanningListVariable.class,
+            AnchorShadowVariable.class,
+            CustomShadowVariable.class,
+            IndexShadowVariable.class,
+            InverseRelationShadowVariable.class,
+            NextElementShadowVariable.class,
+            PiggybackShadowVariable.class,
+            PreviousElementShadowVariable.class,
+            ShadowVariable.class
+    };
+
+    private final ApplicationContextRunner contextRunner;
+
+    public IncludeAbstractClassesEntityScannerTest() {
+        contextRunner = new ApplicationContextRunner().withUserConfiguration(InvalidEntitySpringTestConfiguration.class);
+    }
+
+    @Test
+    void testInvalidProperties() {
+        contextRunner
+                .run(context -> {
+                    IncludeAbstractClassesEntityScanner scanner = new IncludeAbstractClassesEntityScanner(context);
+
+                    // Each field
+                    Arrays.stream(PLANNING_ENTITY_FIELD_ANNOTATIONS).forEach(annotation -> {
+                        List<Class<?>> classes = scanner.findAnnotationsWithRepeatable(annotation);
+                        assertThat(classes).hasSize(2);
+                        assertThat(classes).contains(InvalidFieldTestdataSpringEntity.class,
+                                InvalidMethodTestdataSpringEntity.class);
+                    });
+
+                    // All fields
+                    List<Class<?>> classes = scanner.findAnnotationsWithRepeatable(PLANNING_ENTITY_FIELD_ANNOTATIONS);
+                    assertThat(classes).hasSize(2);
+                    assertThat(classes).contains(InvalidFieldTestdataSpringEntity.class,
+                            InvalidMethodTestdataSpringEntity.class);
+                });
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfigurationTest.java
@@ -579,7 +579,7 @@ class TimefoldAutoConfigurationTest {
                 .withUserConfiguration(NoEntitySpringTestConfiguration.class)
                 .withPropertyValues("timefold.solver.termination.best-score-limit=0")
                 .run(context -> context.getBean("solver1")))
-                .cause().message().contains("No classes found with a @PlanningEntity annotation.");
+                .cause().message().contains("No classes were found with a @PlanningEntity annotation.");
     }
 
     @Test

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldAutoConfigurationTest.java
@@ -440,6 +440,26 @@ class TimefoldAutoConfigurationTest {
     }
 
     @Test
+    void benchmarkWithXml() {
+        benchmarkContextRunner
+                .withClassLoader(allDefaultsFilteredClassLoader)
+                .withPropertyValues("timefold.benchmark.solver.termination.spent-limit=1s")
+                .withPropertyValues(
+                        "timefold.benchmark.solver-benchmark-config-xml=ai/timefold/solver/spring/boot/autoconfigure/solverBenchmarkConfig.xml")
+                .run(context -> {
+                    PlannerBenchmarkFactory benchmarkFactory = context.getBean(PlannerBenchmarkFactory.class);
+                    TestdataSpringSolution problem = new TestdataSpringSolution();
+                    problem.setValueList(IntStream.range(1, 3)
+                            .mapToObj(i -> "v" + i)
+                            .collect(Collectors.toList()));
+                    problem.setEntityList(IntStream.range(1, 3)
+                            .mapToObj(i -> new TestdataSpringEntity())
+                            .collect(Collectors.toList()));
+                    benchmarkFactory.buildPlannerBenchmark(problem).benchmark();
+                });
+    }
+
+    @Test
     void constraintVerifier() {
         contextRunner
                 .withClassLoader(testFilteredClassLoader)

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldMultipleSolverAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldMultipleSolverAutoConfigurationTest.java
@@ -29,7 +29,9 @@ import ai.timefold.solver.spring.boot.autoconfigure.dummy.MultipleSolutionsSprin
 import ai.timefold.solver.spring.boot.autoconfigure.dummy.NoEntitySpringTestConfiguration;
 import ai.timefold.solver.spring.boot.autoconfigure.dummy.NoSolutionSpringTestConfiguration;
 import ai.timefold.solver.spring.boot.autoconfigure.gizmo.GizmoSpringTestConfiguration;
-import ai.timefold.solver.spring.boot.autoconfigure.invalid.domain.InvalidEntitySpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.entity.InvalidEntitySpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.solution.InvalidSolutionSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.type.InvalidEntityTypeSpringTestConfiguration;
 import ai.timefold.solver.spring.boot.autoconfigure.multimodule.MultiModuleSpringTestConfiguration;
 import ai.timefold.solver.spring.boot.autoconfigure.normal.EmptySpringTestConfiguration;
 import ai.timefold.solver.spring.boot.autoconfigure.normal.NoConstraintsSpringTestConfiguration;
@@ -605,11 +607,9 @@ class TimefoldMultipleSolverAutoConfigurationTest {
     @Test
     void invalidEntity() {
         assertThatCode(() -> contextRunner
-                .withUserConfiguration(InvalidEntitySpringTestConfiguration.class)
-                .withPropertyValues(
-                        "timefold.solver.solver1.solver-config-xml=solverConfig.xml")
-                .withPropertyValues(
-                        "timefold.solver.solver2.solver-config-xml=solverConfig.xml")
+                .withUserConfiguration(InvalidEntityTypeSpringTestConfiguration.class)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
                 .run(context -> context.getBean("solver1")))
                 .cause().message().contains(
                         "The classes",
@@ -617,5 +617,31 @@ class TimefoldMultipleSolverAutoConfigurationTest {
                         "InvalidFieldTestdataSpringEntity",
                         "do not have the PlanningEntity annotation, even though they contain properties reserved for planning entities.",
                         "Maybe add a @PlanningEntity annotation on the classes");
+
+        assertThatCode(() -> contextRunner
+                .withUserConfiguration(InvalidEntitySpringTestConfiguration.class)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "All classes",
+                        "InvalidRecordTestdataSpringEntity",
+                        "InvalidEnumTestdataSpringEntity",
+                        "annotated with @PlanningEntity must be a class");
+    }
+
+    @Test
+    void invalidSolution() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(InvalidSolutionSpringTestConfiguration.class)
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/invalidSolverConfig.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/invalidSolverConfig.xml")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "All classes",
+                        "InvalidRecordTestdataSpringSolution",
+                        "annotated with @PlanningSolution must be a class");
     }
 }

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldMultipleSolverAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldMultipleSolverAutoConfigurationTest.java
@@ -1,0 +1,603 @@
+package ai.timefold.solver.spring.boot.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import ai.timefold.solver.benchmark.api.PlannerBenchmarkFactory;
+import ai.timefold.solver.core.api.score.ScoreManager;
+import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
+import ai.timefold.solver.core.api.solver.SolverConfigOverride;
+import ai.timefold.solver.core.api.solver.SolverFactory;
+import ai.timefold.solver.core.api.solver.SolverJob;
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
+import ai.timefold.solver.core.impl.solver.DefaultSolverJob;
+import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.spring.boot.autoconfigure.chained.ChainedSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.config.TimefoldProperties;
+import ai.timefold.solver.spring.boot.autoconfigure.dummy.MultipleConstraintProviderSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.dummy.MultipleEasyScoreConstraintSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.dummy.MultipleIncrementalScoreConstraintSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.dummy.MultipleSolutionsSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.dummy.NoEntitySpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.dummy.NoSolutionSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.gizmo.GizmoSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.multimodule.MultiModuleSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.normal.EmptySpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.normal.NoConstraintsSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.normal.NormalSpringTestConfiguration;
+import ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity;
+import ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringSolution;
+import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.TestExecutionListeners;
+
+@TestExecutionListeners
+class TimefoldMultipleSolverAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner;
+    private final ApplicationContextRunner emptyContextRunner;
+    private final ApplicationContextRunner noUserConfigurationContextRunner;
+    private final ApplicationContextRunner benchmarkContextRunner;
+    private final ApplicationContextRunner chainedContextRunner;
+    private final ApplicationContextRunner gizmoContextRunner;
+    private final ApplicationContextRunner multimoduleRunner;
+    private final FilteredClassLoader allDefaultsFilteredClassLoader;
+
+    public TimefoldMultipleSolverAutoConfigurationTest() {
+        contextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(TimefoldAutoConfiguration.class))
+                .withUserConfiguration(NormalSpringTestConfiguration.class);
+        emptyContextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(TimefoldAutoConfiguration.class))
+                .withUserConfiguration(EmptySpringTestConfiguration.class);
+        benchmarkContextRunner = new ApplicationContextRunner()
+                .withConfiguration(
+                        AutoConfigurations.of(TimefoldAutoConfiguration.class, TimefoldBenchmarkAutoConfiguration.class))
+                .withUserConfiguration(NormalSpringTestConfiguration.class);
+        gizmoContextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(TimefoldAutoConfiguration.class))
+                .withUserConfiguration(GizmoSpringTestConfiguration.class);
+        chainedContextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(TimefoldAutoConfiguration.class))
+                .withUserConfiguration(ChainedSpringTestConfiguration.class);
+        multimoduleRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(TimefoldAutoConfiguration.class))
+                .withUserConfiguration(MultiModuleSpringTestConfiguration.class);
+        allDefaultsFilteredClassLoader =
+                new FilteredClassLoader(FilteredClassLoader.PackageFilter.of("ai.timefold.solver.test"),
+                        FilteredClassLoader.ClassPathResourceFilter
+                                .of(new ClassPathResource(TimefoldProperties.DEFAULT_SOLVER_CONFIG_URL)));
+        noUserConfigurationContextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(TimefoldAutoConfiguration.class));
+    }
+
+    @Test
+    void noSolutionOrEntityClasses() {
+        emptyContextRunner
+                .withPropertyValues("timefold.solver.solver1.termination.spent-limit=4h")
+                .withPropertyValues("timefold.solver.solver2.termination.spent-limit=4h")
+                .run(context -> {
+                    assertThat(context.getStartupFailure()).isNull();
+                });
+    }
+
+    @Test
+    void solverConfigXml_none() {
+        contextRunner
+                .withPropertyValues("timefold.solver.solver1.termination.spent-limit=10s")
+                .withPropertyValues("timefold.solver.solver2.termination.spent-limit=20s")
+                .withClassLoader(allDefaultsFilteredClassLoader)
+                .run(context -> {
+                    SolverManager<TestdataSpringSolution, Long> solver1 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver1");
+                    SolverManager<TestdataSpringSolution, Long> solver2 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver2");
+                    assertThat(solver1).isNotNull();
+                    assertThat(solver2).isNotNull();
+                    TestdataSpringSolution problem = new TestdataSpringSolution();
+                    problem.setValueList(IntStream.range(1, 3)
+                            .mapToObj(i -> "v" + i)
+                            .collect(Collectors.toList()));
+                    problem.setEntityList(IntStream.range(1, 3)
+                            .mapToObj(i -> new TestdataSpringEntity())
+                            .collect(Collectors.toList()));
+                    SolverScope<TestdataSpringSolution> customScope = new SolverScope<>() {
+                        @Override
+                        public long calculateTimeMillisSpentUpToNow() {
+                            // Return five seconds to make the time gradient predictable
+                            return 5000L;
+                        }
+                    };
+                    // We ensure the best-score limit won't take priority
+                    customScope.setStartingInitializedScore(HardSoftScore.of(-1, -1));
+                    customScope.setBestScore(HardSoftScore.of(-1, -1));
+                    double gradientTimeDefaultSolver1 =
+                            ((DefaultSolverJob<TestdataSpringSolution, Long>) solver1.solve(1L, problem)).getSolverTermination()
+                                    .calculateSolverTimeGradient(customScope);
+                    assertThat(gradientTimeDefaultSolver1).isEqualTo(0.5);
+                    double gradientTimeSolver2 =
+                            ((DefaultSolverJob<TestdataSpringSolution, Long>) solver2.solve(1L, problem)).getSolverTermination()
+                                    .calculateSolverTimeGradient(customScope);
+                    assertThat(gradientTimeSolver2).isEqualTo(0.25);
+                });
+    }
+
+    @Test
+    void solverConfigXml_property() {
+        contextRunner
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/customSolver1Config.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/customSolver2Config.xml")
+                .run(context -> {
+                    SolverManager<TestdataSpringSolution, Long> solver1 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver1");
+                    SolverManager<TestdataSpringSolution, Long> solver2 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver2");
+                    assertThat(solver1).isNotNull();
+                    assertThat(solver2).isNotNull();
+                    TestdataSpringSolution problem = new TestdataSpringSolution();
+                    problem.setValueList(IntStream.range(1, 3)
+                            .mapToObj(i -> "v" + i)
+                            .collect(Collectors.toList()));
+                    problem.setEntityList(IntStream.range(1, 3)
+                            .mapToObj(i -> new TestdataSpringEntity())
+                            .collect(Collectors.toList()));
+                    SolverScope<TestdataSpringSolution> customScope = new SolverScope<>() {
+                        @Override
+                        public long calculateTimeMillisSpentUpToNow() {
+                            // Return five seconds to make the time gradient predictable
+                            return 5000L;
+                        }
+                    };
+                    // We ensure the best-score limit won't take priority
+                    customScope.setStartingInitializedScore(HardSoftScore.of(-1, -1));
+                    customScope.setBestScore(HardSoftScore.of(-1, -1));
+                    double gradientTimeDefaultSolver1 =
+                            ((DefaultSolverJob<TestdataSpringSolution, Long>) solver1.solve(1L, problem)).getSolverTermination()
+                                    .calculateSolverTimeGradient(customScope);
+                    assertThat(gradientTimeDefaultSolver1).isEqualTo(0.5);
+                    double gradientTimeSolver2 =
+                            ((DefaultSolverJob<TestdataSpringSolution, Long>) solver2.solve(1L, problem)).getSolverTermination()
+                                    .calculateSolverTimeGradient(customScope);
+                    assertThat(gradientTimeSolver2).isEqualTo(0.25);
+                });
+    }
+
+    @Test
+    void solverConfigXml_property_noGlobalTermination() {
+        contextRunner
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/solverConfigWithoutGlobalTermination.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/solverConfigWithoutGlobalTermination.xml")
+                .run(context -> {
+                    SolverManager<TestdataSpringSolution, Long> solver1 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver1");
+                    SolverManager<TestdataSpringSolution, Long> solver2 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver2");
+                    assertThat(solver1).isNotNull();
+                    assertThat(solver2).isNotNull();
+                });
+    }
+
+    @Test
+    void solverProperties() {
+        contextRunner
+                .withPropertyValues("timefold.solver.solver1.environment-mode=FULL_ASSERT")
+                .withPropertyValues("timefold.solver.solver2.environment-mode=TRACKED_FULL_ASSERT")
+                .run(context -> {
+                    SolverManager<TestdataSpringSolution, Long> solver1 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver1");
+                    SolverManager<TestdataSpringSolution, Long> solver2 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver2");
+                    assertThat(solver1).isNotNull();
+                    assertThat(solver2).isNotNull();
+                });
+        gizmoContextRunner
+                .withPropertyValues("timefold.solver.solver1.domain-access-type=GIZMO")
+                .withPropertyValues("timefold.solver.solver2.domain-access-type=REFLECTION")
+                .run(context -> {
+                    SolverManager<TestdataSpringSolution, Long> solver1 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver1");
+                    SolverManager<TestdataSpringSolution, Long> solver2 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver2");
+                    assertThat(solver1).isNotNull();
+                    assertThat(solver2).isNotNull();
+                });
+        contextRunner
+                .withPropertyValues("timefold.solver.solver1.daemon=true")
+                .withPropertyValues("timefold.solver.solver2.daemon=false")
+                .run(context -> {
+                    SolverManager<TestdataSpringSolution, Long> solver1 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver1");
+                    SolverManager<TestdataSpringSolution, Long> solver2 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver2");
+                    assertThat(solver1).isNotNull();
+                    assertThat(solver2).isNotNull();
+                });
+        contextRunner
+                .withPropertyValues("timefold.solver.solver1.constraint-stream-impl-type=BAVET")
+                .withPropertyValues("timefold.solver.solver2.constraint-stream-impl-type=DROOLS")
+                .run(context -> {
+                    SolverManager<TestdataSpringSolution, Long> solver1 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver1");
+                    SolverManager<TestdataSpringSolution, Long> solver2 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver2");
+                    assertThat(solver1).isNotNull();
+                    assertThat(solver2).isNotNull();
+                });
+    }
+
+    @Test
+    void solve() {
+        contextRunner
+                .withClassLoader(allDefaultsFilteredClassLoader)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> {
+                    TestdataSpringSolution problem = new TestdataSpringSolution();
+                    problem.setValueList(IntStream.range(1, 3)
+                            .mapToObj(i -> "v" + i)
+                            .collect(Collectors.toList()));
+                    problem.setEntityList(IntStream.range(1, 3)
+                            .mapToObj(i -> new TestdataSpringEntity())
+                            .collect(Collectors.toList()));
+
+                    for (String solverName : List.of("solver1", "solver2")) {
+                        SolverManager<TestdataSpringSolution, Long> solver =
+                                (SolverManager<TestdataSpringSolution, Long>) context.getBean(solverName);
+                        SolverJob<TestdataSpringSolution, Long> solverJob = solver.solve(1L, problem);
+                        TestdataSpringSolution solution = solverJob.getFinalBestSolution();
+                        assertThat(solution).isNotNull();
+                        assertThat(solution.getScore().score()).isGreaterThanOrEqualTo(0);
+                    }
+                });
+    }
+
+    @Test
+    void solveWithTimeOverride() {
+        contextRunner
+                .withClassLoader(allDefaultsFilteredClassLoader)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0",
+                        "timefold.solver.solver1.termination.spent-limit=30s")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0",
+                        "timefold.solver.solver2.termination.spent-limit=30s")
+                .run(context -> {
+                    TestdataSpringSolution problem = new TestdataSpringSolution();
+                    problem.setValueList(IntStream.range(1, 3)
+                            .mapToObj(i -> "v" + i)
+                            .collect(Collectors.toList()));
+                    problem.setEntityList(IntStream.range(1, 3)
+                            .mapToObj(i -> new TestdataSpringEntity())
+                            .collect(Collectors.toList()));
+                    for (String solverName : List.of("solver1", "solver2")) {
+                        SolverManager<TestdataSpringSolution, Long> solverManager =
+                                (SolverManager<TestdataSpringSolution, Long>) context.getBean(solverName);
+                        DefaultSolverJob<TestdataSpringSolution, Long> solverJob =
+                                (DefaultSolverJob<TestdataSpringSolution, Long>) solverManager.solveBuilder()
+                                        .withProblemId(1L)
+                                        .withProblem(problem)
+                                        .withConfigOverride(
+                                                new SolverConfigOverride<TestdataSpringSolution>()
+                                                        .withTerminationConfig(new TerminationConfig()
+                                                                .withSpentLimit(Duration.ofSeconds(10L))))
+                                        .run();
+                        SolverScope<TestdataSpringSolution> customScope = new SolverScope<>() {
+                            @Override
+                            public long calculateTimeMillisSpentUpToNow() {
+                                // Return five seconds to make the time gradient predictable
+                                return 5000L;
+                            }
+                        };
+                        // We ensure the best-score limit won't take priority
+                        customScope.setStartingInitializedScore(HardSoftScore.of(-1, -1));
+                        customScope.setBestScore(HardSoftScore.of(-1, -1));
+                        double gradientTime = solverJob.getSolverTermination().calculateSolverTimeGradient(customScope);
+                        TestdataSpringSolution solution = solverJob.getFinalBestSolution();
+                        assertThat(solution).isNotNull();
+                        assertThat(solution.getScore().score()).isGreaterThanOrEqualTo(0);
+                        // Spent-time is 30s by default, but it is overridden with 10. The gradient time must be 50%
+                        assertThat(gradientTime).isEqualTo(0.5);
+                    }
+                });
+    }
+
+    @Test
+    void multimoduleSolve() {
+        multimoduleRunner
+                .withClassLoader(allDefaultsFilteredClassLoader)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> {
+                    for (String solverName : List.of("solver1", "solver2")) {
+                        SolverManager<TestdataSpringSolution, Long> solverManager =
+                                (SolverManager<TestdataSpringSolution, Long>) context.getBean(solverName);
+                        TestdataSpringSolution problem = new TestdataSpringSolution();
+                        problem.setValueList(IntStream.range(1, 3)
+                                .mapToObj(i -> "v" + i)
+                                .collect(Collectors.toList()));
+                        problem.setEntityList(IntStream.range(1, 3)
+                                .mapToObj(i -> new TestdataSpringEntity())
+                                .collect(Collectors.toList()));
+                        SolverJob<TestdataSpringSolution, Long> solverJob = solverManager.solve(1L, problem);
+                        TestdataSpringSolution solution = solverJob.getFinalBestSolution();
+                        assertThat(solution).isNotNull();
+                        assertThat(solution.getScore().score()).isGreaterThanOrEqualTo(0);
+                    }
+                });
+    }
+
+    @Test
+    void resoucesInjectionFailure() {
+        assertThatCode(() -> contextRunner
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean(SolverConfig.class)))
+                .hasMessageContaining(
+                        "No qualifying bean of type 'ai.timefold.solver.core.config.solver.SolverConfig' available");
+        assertThatCode(() -> contextRunner
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean(SolverFactory.class)))
+                .hasRootCauseMessage(
+                        "No qualifying bean of type 'ai.timefold.solver.core.api.solver.SolverFactory' available");
+        assertThatCode(() -> contextRunner
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean(SolverManager.class)))
+                .hasMessageContaining(
+                        "No qualifying bean of type 'ai.timefold.solver.core.api.solver.SolverManager' available");
+        assertThatCode(() -> contextRunner
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean(ScoreManager.class)))
+                .hasMessageContaining(
+                        "No qualifying bean of type 'ai.timefold.solver.core.api.score.ScoreManager' available");
+        assertThatCode(() -> contextRunner
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean(SolutionManager.class)))
+                .hasMessageContaining(
+                        "No qualifying bean of type 'ai.timefold.solver.core.api.solver.SolutionManager' available");
+        assertThatCode(() -> contextRunner
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean(ConstraintVerifier.class)))
+                .hasMessageContaining(
+                        "No qualifying bean of type 'ai.timefold.solver.core.api.score.stream.ConstraintProvider' available");
+        assertThatCode(() -> benchmarkContextRunner
+                .withClassLoader(allDefaultsFilteredClassLoader)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .withPropertyValues("timefold.benchmark.solver.termination.spent-limit=1s")
+                .run(context -> {
+                    context.getBean(PlannerBenchmarkFactory.class);
+                }))
+                .hasRootCauseMessage("""
+                        When defining multiple solvers, the benchmark feature is not enabled.
+                        Consider using separate <solverBenchmark> instances for evaluating different solver configurations.""");
+    }
+
+    @Test
+    void chained_solverConfigXml_none() {
+        chainedContextRunner
+                .withClassLoader(allDefaultsFilteredClassLoader)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> {
+                    SolverManager<TestdataSpringSolution, Long> solver1 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver1");
+                    SolverManager<TestdataSpringSolution, Long> solver2 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver2");
+                    assertThat(solver1).isNotNull();
+                    assertThat(solver2).isNotNull();
+                });
+    }
+
+    @Test
+    void noSolutionClass() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(NoSolutionSpringTestConfiguration.class)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains("No classes were found with a @PlanningSolution annotation.");
+    }
+
+    @Test
+    void multipleSolutionClasses() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleSolutionsSpringTestConfiguration.class)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Some solver configs", "solver2", "solver1",
+                        "don't specify a PlanningSolution class, yet there are multiple available",
+                        "TestdataSpringSolution", "TestdataChainedSpringSolution",
+                        "on the classpath.");
+    }
+
+    @Test
+    void unusedSolutionClass() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleSolutionsSpringTestConfiguration.class)
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/normalSolverConfig.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/normalSolverConfig.xml")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Unused classes ([ai.timefold.solver.spring.boot.autoconfigure.chained.domain.TestdataChainedSpringSolution]) found with a @PlanningSolution annotation.");
+    }
+
+    @Test
+    void noEntityClass() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(NoEntitySpringTestConfiguration.class)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains("No classes found with a @PlanningEntity annotation.");
+    }
+
+    @Test
+    void noConstraintClass() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(NoConstraintsSpringTestConfiguration.class)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "No classes found that implement EasyScoreCalculator, ConstraintProvider, or IncrementalScoreCalculator.");
+    }
+
+    @Test
+    void multipleEasyScoreConstraints() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleEasyScoreConstraintSpringTestConfiguration.class)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Some solver configs", "solver2", "solver1",
+                        "don't specify a EasyScoreCalculator score class, yet there are multiple available",
+                        "DummyTestdataChainedSpringEasyScore",
+                        "DummyTestdataSpringEasyScore",
+                        "on the classpath.");
+    }
+
+    @Test
+    void multipleConstraintProviderConstraints() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleConstraintProviderSpringTestConfiguration.class)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Some solver configs", "solver2", "solver1",
+                        "don't specify a ConstraintProvider score class, yet there are multiple available",
+                        "TestdataSpringConstraintProvider",
+                        "TestdataChainedSpringConstraintProvider",
+                        "on the classpath.");
+    }
+
+    @Test
+    void multipleIncrementalScoreConstraints() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleIncrementalScoreConstraintSpringTestConfiguration.class)
+                .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
+                .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Some solver configs", "solver2", "solver1",
+                        "don't specify a IncrementalScoreCalculator score class, yet there are multiple available",
+                        "DummyTestdataSpringIncrementalScore",
+                        "DummyTestdataChainedSpringIncrementalScore",
+                        "on the classpath.");
+    }
+
+    @Test
+    void multipleEasyScoreConstraintsXml_property() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleEasyScoreConstraintSpringTestConfiguration.class)
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=solverConfig.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=solverConfig.xml")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Some solver configs", "solver2", "solver1",
+                        "don't specify a EasyScoreCalculator score class, yet there are multiple available",
+                        "DummyTestdataChainedSpringEasyScore",
+                        "DummyTestdataSpringEasyScore",
+                        "on the classpath.");
+    }
+
+    @Test
+    void multipleConstraintProviderConstraintsXml_property() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleConstraintProviderSpringTestConfiguration.class)
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=solverConfig.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=solverConfig.xml")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Some solver configs", "solver2", "solver1",
+                        "don't specify a ConstraintProvider score class, yet there are multiple available",
+                        "TestdataSpringConstraintProvider",
+                        "TestdataChainedSpringConstraintProvider",
+                        "on the classpath.");
+    }
+
+    @Test
+    void multipleIncrementalScoreConstraintsXml_property() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleIncrementalScoreConstraintSpringTestConfiguration.class)
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=solverConfig.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=solverConfig.xml")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Some solver configs", "solver2", "solver1",
+                        "don't specify a IncrementalScoreCalculator score class, yet there are multiple available",
+                        "DummyTestdataSpringIncrementalScore",
+                        "DummyTestdataChainedSpringIncrementalScore",
+                        "on the classpath.");
+    }
+
+    @Test
+    void unusedEasyScoreConstraints() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleEasyScoreConstraintSpringTestConfiguration.class)
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/easyScoreSolverConfig.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/easyScoreSolverConfig.xml")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Unused classes ([ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.easyScoreConstraints.DummyTestdataSpringEasyScore]) that implements EasyScoreCalculator were found.");
+    }
+
+    @Test
+    void unusedConstraintProviderConstraints() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleConstraintProviderSpringTestConfiguration.class)
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/normalSolverConfig.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/normalSolverConfig.xml")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Unused classes ([ai.timefold.solver.spring.boot.autoconfigure.chained.constraints.TestdataChainedSpringConstraintProvider]) that implements ConstraintProvider were found.");
+    }
+
+    @Test
+    void unusedIncrementalScoreConstraints() {
+        assertThatCode(() -> noUserConfigurationContextRunner
+                .withUserConfiguration(MultipleIncrementalScoreConstraintSpringTestConfiguration.class)
+                .withPropertyValues(
+                        "timefold.solver.solver1.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/incrementalScoreSolverConfig.xml")
+                .withPropertyValues(
+                        "timefold.solver.solver2.solver-config-xml=ai/timefold/solver/spring/boot/autoconfigure/incrementalScoreSolverConfig.xml")
+                .run(context -> context.getBean("solver1")))
+                .cause().message().contains(
+                        "Unused classes ([ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.incrementalScoreConstraints.DummyTestdataSpringIncrementalScore]) that implements IncrementalScoreCalculator were found.");
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldMultipleSolverAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldMultipleSolverAutoConfigurationTest.java
@@ -452,7 +452,7 @@ class TimefoldMultipleSolverAutoConfigurationTest {
                 .withPropertyValues("timefold.solver.solver1.termination.best-score-limit=0")
                 .withPropertyValues("timefold.solver.solver2.termination.best-score-limit=0")
                 .run(context -> context.getBean("solver1")))
-                .cause().message().contains("No classes found with a @PlanningEntity annotation.");
+                .cause().message().contains("No classes were found with a @PlanningEntity annotation.");
     }
 
     @Test

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/MultipleConstraintProviderSpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/MultipleConstraintProviderSpringTestConfiguration.java
@@ -1,0 +1,11 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigurationPackage(basePackages = { "ai.timefold.solver.spring.boot.autoconfigure.normal.domain",
+        "ai.timefold.solver.spring.boot.autoconfigure.normal.constraints",
+        "ai.timefold.solver.spring.boot.autoconfigure.chained.constraints" })
+public class MultipleConstraintProviderSpringTestConfiguration {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/MultipleEasyScoreConstraintSpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/MultipleEasyScoreConstraintSpringTestConfiguration.java
@@ -1,0 +1,11 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigurationPackage(basePackages = { "ai.timefold.solver.spring.boot.autoconfigure.normal.domain",
+        "ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.easyScoreConstraints",
+        "ai.timefold.solver.spring.boot.autoconfigure.dummy.chained.easyScoreConstraints" })
+public class MultipleEasyScoreConstraintSpringTestConfiguration {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/MultipleIncrementalScoreConstraintSpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/MultipleIncrementalScoreConstraintSpringTestConfiguration.java
@@ -1,0 +1,11 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigurationPackage(basePackages = { "ai.timefold.solver.spring.boot.autoconfigure.normal.domain",
+        "ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.incrementalScoreConstraints",
+        "ai.timefold.solver.spring.boot.autoconfigure.dummy.chained.incrementalScoreConstraints" })
+public class MultipleIncrementalScoreConstraintSpringTestConfiguration {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/MultipleSolutionsSpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/MultipleSolutionsSpringTestConfiguration.java
@@ -1,0 +1,10 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan(basePackages = { "ai.timefold.solver.spring.boot.autoconfigure.normal.domain",
+        "ai.timefold.solver.spring.boot.autoconfigure.chained.domain" })
+public class MultipleSolutionsSpringTestConfiguration {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/NoEntitySpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/NoEntitySpringTestConfiguration.java
@@ -1,0 +1,9 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan(basePackages = "ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.noEntity")
+public class NoEntitySpringTestConfiguration {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/NoSolutionSpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/NoSolutionSpringTestConfiguration.java
@@ -1,0 +1,9 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan(basePackages = "ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.noSolution")
+public class NoSolutionSpringTestConfiguration {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/chained/easyScoreConstraints/DummyTestdataChainedSpringEasyScore.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/chained/easyScoreConstraints/DummyTestdataChainedSpringEasyScore.java
@@ -1,0 +1,12 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy.chained.easyScoreConstraints;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
+import ai.timefold.solver.spring.boot.autoconfigure.chained.domain.TestdataChainedSpringSolution;
+
+public class DummyTestdataChainedSpringEasyScore implements EasyScoreCalculator<TestdataChainedSpringSolution, SimpleScore> {
+    @Override
+    public SimpleScore calculateScore(TestdataChainedSpringSolution testdataSpringSolution) {
+        return null;
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/chained/incrementalScoreConstraints/DummyTestdataChainedSpringIncrementalScore.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/chained/incrementalScoreConstraints/DummyTestdataChainedSpringIncrementalScore.java
@@ -1,0 +1,46 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy.chained.incrementalScoreConstraints;
+
+import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.api.score.calculator.IncrementalScoreCalculator;
+
+public class DummyTestdataChainedSpringIncrementalScore implements IncrementalScoreCalculator {
+    @Override
+    public void resetWorkingSolution(Object workingSolution) {
+
+    }
+
+    @Override
+    public void beforeEntityAdded(Object entity) {
+
+    }
+
+    @Override
+    public void afterEntityAdded(Object entity) {
+
+    }
+
+    @Override
+    public void beforeVariableChanged(Object entity, String variableName) {
+
+    }
+
+    @Override
+    public void afterVariableChanged(Object entity, String variableName) {
+
+    }
+
+    @Override
+    public void beforeEntityRemoved(Object entity) {
+
+    }
+
+    @Override
+    public void afterEntityRemoved(Object entity) {
+
+    }
+
+    @Override
+    public Score calculateScore() {
+        return null;
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/normal/easyScoreConstraints/DummyTestdataSpringEasyScore.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/normal/easyScoreConstraints/DummyTestdataSpringEasyScore.java
@@ -1,0 +1,12 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.easyScoreConstraints;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
+import ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringSolution;
+
+public class DummyTestdataSpringEasyScore implements EasyScoreCalculator<TestdataSpringSolution, SimpleScore> {
+    @Override
+    public SimpleScore calculateScore(TestdataSpringSolution testdataSpringSolution) {
+        return null;
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/normal/incrementalScoreConstraints/DummyTestdataSpringIncrementalScore.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/normal/incrementalScoreConstraints/DummyTestdataSpringIncrementalScore.java
@@ -1,0 +1,46 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.incrementalScoreConstraints;
+
+import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.api.score.calculator.IncrementalScoreCalculator;
+
+public class DummyTestdataSpringIncrementalScore implements IncrementalScoreCalculator {
+    @Override
+    public void resetWorkingSolution(Object workingSolution) {
+
+    }
+
+    @Override
+    public void beforeEntityAdded(Object entity) {
+
+    }
+
+    @Override
+    public void afterEntityAdded(Object entity) {
+
+    }
+
+    @Override
+    public void beforeVariableChanged(Object entity, String variableName) {
+
+    }
+
+    @Override
+    public void afterVariableChanged(Object entity, String variableName) {
+
+    }
+
+    @Override
+    public void beforeEntityRemoved(Object entity) {
+
+    }
+
+    @Override
+    public void afterEntityRemoved(Object entity) {
+
+    }
+
+    @Override
+    public Score calculateScore() {
+        return null;
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/normal/noEntity/DummyTestdataSpringSolution.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/normal/noEntity/DummyTestdataSpringSolution.java
@@ -1,0 +1,52 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.noEntity;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity;
+
+@PlanningSolution
+public class DummyTestdataSpringSolution {
+
+    @ProblemFactCollectionProperty
+    @ValueRangeProvider(id = "valueRange")
+    private List<String> valueList;
+    @PlanningEntityCollectionProperty
+    private List<TestdataSpringEntity> entityList;
+
+    @PlanningScore
+    private SimpleScore score;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    public List<TestdataSpringEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataSpringEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/normal/noSolution/DummyTestdataSpringEntity.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/dummy/normal/noSolution/DummyTestdataSpringEntity.java
@@ -1,0 +1,24 @@
+package ai.timefold.solver.spring.boot.autoconfigure.dummy.normal.noSolution;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class DummyTestdataSpringEntity {
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    private String value;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/VariableListener.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/VariableListener.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.spring.boot.autoconfigure.invalid.domain;
+package ai.timefold.solver.spring.boot.autoconfigure.invalid;
 
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/domain/InvalidEntitySpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/domain/InvalidEntitySpringTestConfiguration.java
@@ -1,0 +1,10 @@
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.domain;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigurationPackage
+public class InvalidEntitySpringTestConfiguration {
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/domain/InvalidFieldTestdataSpringEntity.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/domain/InvalidFieldTestdataSpringEntity.java
@@ -1,0 +1,143 @@
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.domain;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.variable.AnchorShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.CustomShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.IndexShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.NextElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PiggybackShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+
+public class InvalidFieldTestdataSpringEntity {
+
+    @PlanningPin
+    private boolean pin;
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    private String value;
+
+    @PlanningListVariable
+    private List<String> values;
+
+    @AnchorShadowVariable(sourceVariableName = "source")
+    private String anchorShadow;
+
+    @CustomShadowVariable
+    private String custom;
+
+    @IndexShadowVariable(sourceVariableName = "source")
+    private int indexShadow;
+
+    @InverseRelationShadowVariable(sourceVariableName = "source")
+    private String inverse;
+
+    @NextElementShadowVariable(sourceVariableName = "source")
+    private String next;
+
+    @PiggybackShadowVariable(shadowVariableName = "variable")
+    private String piggy;
+
+    @PreviousElementShadowVariable(sourceVariableName = "source")
+    private String previous;
+
+    @ShadowVariable(sourceVariableName = "source", variableListenerClass = VariableListener.class)
+    private String shadow;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public boolean isPin() {
+        return pin;
+    }
+
+    public void setPin(boolean pin) {
+        this.pin = pin;
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+
+    public String getAnchorShadow() {
+        return anchorShadow;
+    }
+
+    public void setAnchorShadow(String anchorShadow) {
+        this.anchorShadow = anchorShadow;
+    }
+
+    public String getCustom() {
+        return custom;
+    }
+
+    public void setCustom(String custom) {
+        this.custom = custom;
+    }
+
+    public int getIndexShadow() {
+        return indexShadow;
+    }
+
+    public void setIndexShadow(int indexShadow) {
+        this.indexShadow = indexShadow;
+    }
+
+    public String getInverse() {
+        return inverse;
+    }
+
+    public void setInverse(String inverse) {
+        this.inverse = inverse;
+    }
+
+    public String getNext() {
+        return next;
+    }
+
+    public void setNext(String next) {
+        this.next = next;
+    }
+
+    public String getPiggy() {
+        return piggy;
+    }
+
+    public void setPiggy(String piggy) {
+        this.piggy = piggy;
+    }
+
+    public String getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(String previous) {
+        this.previous = previous;
+    }
+
+    public String getShadow() {
+        return shadow;
+    }
+
+    public void setShadow(String shadow) {
+        this.shadow = shadow;
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/domain/InvalidMethodTestdataSpringEntity.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/domain/InvalidMethodTestdataSpringEntity.java
@@ -1,0 +1,142 @@
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.domain;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.variable.AnchorShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.CustomShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.IndexShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.NextElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PiggybackShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+
+public class InvalidMethodTestdataSpringEntity {
+
+    private boolean pin;
+
+    private String value;
+
+    private List<String> values;
+
+    private String anchorShadow;
+
+    private String custom;
+
+    private int indexShadow;
+
+    private String inverse;
+
+    private String next;
+
+    private String piggy;
+
+    private String previous;
+
+    private String shadow;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+    @PlanningPin
+    public boolean isPin() {
+        return pin;
+    }
+
+    public void setPin(boolean pin) {
+        this.pin = pin;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @PlanningListVariable
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+
+    @AnchorShadowVariable(sourceVariableName = "source")
+    public String getAnchorShadow() {
+        return anchorShadow;
+    }
+
+    public void setAnchorShadow(String anchorShadow) {
+        this.anchorShadow = anchorShadow;
+    }
+
+    @CustomShadowVariable
+    public String getCustom() {
+        return custom;
+    }
+
+    public void setCustom(String custom) {
+        this.custom = custom;
+    }
+
+    @IndexShadowVariable(sourceVariableName = "source")
+    public int getIndexShadow() {
+        return indexShadow;
+    }
+
+    public void setIndexShadow(int indexShadow) {
+        this.indexShadow = indexShadow;
+    }
+
+    @InverseRelationShadowVariable(sourceVariableName = "source")
+    public String getInverse() {
+        return inverse;
+    }
+
+    public void setInverse(String inverse) {
+        this.inverse = inverse;
+    }
+
+    @NextElementShadowVariable(sourceVariableName = "source")
+    public String getNext() {
+        return next;
+    }
+
+    public void setNext(String next) {
+        this.next = next;
+    }
+
+    @PiggybackShadowVariable(shadowVariableName = "variable")
+    public String getPiggy() {
+        return piggy;
+    }
+
+    public void setPiggy(String piggy) {
+        this.piggy = piggy;
+    }
+
+    @PreviousElementShadowVariable(sourceVariableName = "source")
+    public String getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(String previous) {
+        this.previous = previous;
+    }
+
+    @ShadowVariable(sourceVariableName = "source", variableListenerClass = VariableListener.class)
+    public String getShadow() {
+        return shadow;
+    }
+
+    public void setShadow(String shadow) {
+        this.shadow = shadow;
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/domain/VariableListener.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/domain/VariableListener.java
@@ -1,0 +1,35 @@
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.domain;
+
+import ai.timefold.solver.core.api.score.director.ScoreDirector;
+
+public class VariableListener implements ai.timefold.solver.core.api.domain.variable.VariableListener {
+    @Override
+    public void beforeEntityAdded(ScoreDirector scoreDirector, Object o) {
+
+    }
+
+    @Override
+    public void afterEntityAdded(ScoreDirector scoreDirector, Object o) {
+
+    }
+
+    @Override
+    public void beforeEntityRemoved(ScoreDirector scoreDirector, Object o) {
+
+    }
+
+    @Override
+    public void afterEntityRemoved(ScoreDirector scoreDirector, Object o) {
+
+    }
+
+    @Override
+    public void beforeVariableChanged(ScoreDirector scoreDirector, Object o) {
+
+    }
+
+    @Override
+    public void afterVariableChanged(ScoreDirector scoreDirector, Object o) {
+
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/entity/InvalidEntitySpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/entity/InvalidEntitySpringTestConfiguration.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.spring.boot.autoconfigure.invalid.domain;
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.entity;
 
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.context.annotation.Configuration;

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/entity/InvalidEnumTestdataSpringEntity.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/entity/InvalidEnumTestdataSpringEntity.java
@@ -1,0 +1,7 @@
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.entity;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+
+@PlanningEntity
+public enum InvalidEnumTestdataSpringEntity {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/entity/InvalidRecordTestdataSpringEntity.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/entity/InvalidRecordTestdataSpringEntity.java
@@ -1,0 +1,7 @@
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.entity;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+
+@PlanningEntity
+public record InvalidRecordTestdataSpringEntity() {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/solution/InvalidRecordTestdataSpringSolution.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/solution/InvalidRecordTestdataSpringSolution.java
@@ -1,0 +1,7 @@
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.solution;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+
+@PlanningSolution
+public record InvalidRecordTestdataSpringSolution() {
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/solution/InvalidSolutionSpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/solution/InvalidSolutionSpringTestConfiguration.java
@@ -1,0 +1,10 @@
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.solution;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigurationPackage
+public class InvalidSolutionSpringTestConfiguration {
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/type/InvalidEntityTypeSpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/type/InvalidEntityTypeSpringTestConfiguration.java
@@ -1,0 +1,10 @@
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.type;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigurationPackage
+public class InvalidEntityTypeSpringTestConfiguration {
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/type/InvalidFieldTestdataSpringEntity.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/type/InvalidFieldTestdataSpringEntity.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.spring.boot.autoconfigure.invalid.domain;
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.type;
 
 import java.util.List;
 
@@ -13,6 +13,7 @@ import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
 import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.VariableListener;
 
 public class InvalidFieldTestdataSpringEntity {
 

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/type/InvalidMethodTestdataSpringEntity.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/invalid/type/InvalidMethodTestdataSpringEntity.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.spring.boot.autoconfigure.invalid.domain;
+package ai.timefold.solver.spring.boot.autoconfigure.invalid.type;
 
 import java.util.List;
 
@@ -13,6 +13,7 @@ import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
 import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.spring.boot.autoconfigure.invalid.VariableListener;
 
 public class InvalidMethodTestdataSpringEntity {
 

--- a/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/customSolver1Config.xml
+++ b/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/customSolver1Config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://timefold.ai/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://timefold.ai/xsd/solver https://timefold.ai/xsd/solver/solver.xsd">
+  <termination>
+    <secondsSpentLimit>10</secondsSpentLimit>
+  </termination>
+</solver>

--- a/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/customSolver2Config.xml
+++ b/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/customSolver2Config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://timefold.ai/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://timefold.ai/xsd/solver https://timefold.ai/xsd/solver/solver.xsd">
+  <termination>
+    <secondsSpentLimit>20</secondsSpentLimit>
+  </termination>
+</solver>

--- a/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/easyScoreSolverConfig.xml
+++ b/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/easyScoreSolverConfig.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://timefold.ai/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://timefold.ai/xsd/solver https://timefold.ai/xsd/solver/solver.xsd">
+    <solutionClass>ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringSolution</solutionClass>
+    <entityClass>ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity</entityClass>
+    <scoreDirectorFactory>
+        <easyScoreCalculatorClass>
+            ai.timefold.solver.spring.boot.autoconfigure.dummy.chained.easyScoreConstraints.DummyTestdataChainedSpringEasyScore
+        </easyScoreCalculatorClass>
+    </scoreDirectorFactory>
+</solver>

--- a/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/incrementalScoreSolverConfig.xml
+++ b/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/incrementalScoreSolverConfig.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://timefold.ai/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://timefold.ai/xsd/solver https://timefold.ai/xsd/solver/solver.xsd">
+    <solutionClass>ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringSolution</solutionClass>
+    <entityClass>ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity</entityClass>
+    <scoreDirectorFactory>
+        <incrementalScoreCalculatorClass>
+            ai.timefold.solver.spring.boot.autoconfigure.dummy.chained.incrementalScoreConstraints.DummyTestdataChainedSpringIncrementalScore
+        </incrementalScoreCalculatorClass>
+    </scoreDirectorFactory>
+</solver>

--- a/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/invalidSolverConfig.xml
+++ b/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/invalidSolverConfig.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://timefold.ai/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://timefold.ai/xsd/solver https://timefold.ai/xsd/solver/solver.xsd">
+    <solutionClass>ai.timefold.solver.spring.boot.autoconfigure.invalid.solution.InvalidRecordTestdataSpringSolution</solutionClass>
+    <entityClass>ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity</entityClass>
+    <scoreDirectorFactory>
+        <constraintProviderClass>
+            ai.timefold.solver.spring.boot.autoconfigure.normal.constraints.TestdataSpringConstraintProvider
+        </constraintProviderClass>
+    </scoreDirectorFactory>
+</solver>

--- a/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/normalSolverConfig.xml
+++ b/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/normalSolverConfig.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://timefold.ai/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://timefold.ai/xsd/solver https://timefold.ai/xsd/solver/solver.xsd">
+    <solutionClass>ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringSolution</solutionClass>
+    <entityClass>ai.timefold.solver.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity</entityClass>
+    <scoreDirectorFactory>
+        <constraintProviderClass>
+            ai.timefold.solver.spring.boot.autoconfigure.normal.constraints.TestdataSpringConstraintProvider
+        </constraintProviderClass>
+    </scoreDirectorFactory>
+</solver>

--- a/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/solverBenchmarkConfig.xml
+++ b/spring-integration/spring-boot-autoconfigure/src/test/resources/ai/timefold/solver/spring/boot/autoconfigure/solverBenchmarkConfig.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plannerBenchmark xmlns="https://timefold.ai/xsd/benchmark" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://timefold.ai/xsd/benchmark https://timefold.ai/xsd/benchmark/benchmark.xsd">
+    <solverBenchmarkBluePrint>
+        <solverBenchmarkBluePrintType>EVERY_LOCAL_SEARCH_TYPE</solverBenchmarkBluePrintType>
+    </solverBenchmarkBluePrint>
+</plannerBenchmark>


### PR DESCRIPTION
This pull request updates the Spring boot extension to support multiple instances of Solver in an application. The new logic utilizes a map to keep track of the configurations, and nothing changes for the current behavior for single solvers, which are mapped by default to the key name `default`.
