### PR TITLE
fix: Avoid eager initialization of the Benchmark resources

### DIFF
--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldBenchmarkAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldBenchmarkAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 @Configuration
 @AutoConfigureAfter(TimefoldAutoConfiguration.class)
@@ -46,6 +47,7 @@ public class TimefoldBenchmarkAutoConfiguration implements BeanClassLoaderAware,
     }
 
     @Bean
+    @Lazy
     public PlannerBenchmarkConfig plannerBenchmarkConfig() {
         assertSingleSolver();
         SolverConfig solverConfig = context.getBean(SolverConfig.class);
@@ -139,6 +141,7 @@ public class TimefoldBenchmarkAutoConfiguration implements BeanClassLoaderAware,
     }
 
     @Bean
+    @Lazy
     public PlannerBenchmarkFactory plannerBenchmarkFactory(PlannerBenchmarkConfig benchmarkConfig) {
         if (benchmarkConfig == null) {
             return null;

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldMultipleSolverAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldMultipleSolverAutoConfigurationTest.java
@@ -246,6 +246,22 @@ class TimefoldMultipleSolverAutoConfigurationTest {
     }
 
     @Test
+    void solverPropertiesWithoutLoadingBenchmark() {
+        contextRunner
+                .withPropertyValues("timefold.solver.solver1.environment-mode=FULL_ASSERT")
+                .withPropertyValues("timefold.solver.solver2.environment-mode=TRACKED_FULL_ASSERT")
+                .withUserConfiguration(TimefoldBenchmarkAutoConfiguration.class) // We load the configuration, but get no bean
+                .run(context -> {
+                    SolverManager<TestdataSpringSolution, Long> solver1 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver1");
+                    SolverManager<TestdataSpringSolution, Long> solver2 =
+                            (SolverManager<TestdataSpringSolution, Long>) context.getBean("solver2");
+                    assertThat(solver1).isNotNull();
+                    assertThat(solver2).isNotNull();
+                });
+    }
+
+    @Test
     void solve() {
         contextRunner
                 .withClassLoader(allDefaultsFilteredClassLoader)


### PR DESCRIPTION
This pull request fixes an initialization error that occurs when multiple resources are being used. The error occurs because the Benchmark resources are created in an eager way.