### PR TITLE
fix: Ensuring the spent termination property is read in the Quarkus environment

### DIFF
--- a/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorBenchmarkEmptyTerminationConfigTest.java
+++ b/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorBenchmarkEmptyTerminationConfigTest.java
@@ -1,0 +1,48 @@
+package ai.timefold.solver.benchmark.quarkus;
+
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import jakarta.inject.Inject;
+
+import ai.timefold.solver.benchmark.api.PlannerBenchmarkFactory;
+import ai.timefold.solver.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import ai.timefold.solver.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import ai.timefold.solver.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldBenchmarkProcessorBenchmarkEmptyTerminationConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.benchmark.solver.termination.spent-limit", "3s")
+            .overrideConfigKey("quarkus.timefold.benchmark.solver-benchmark-config-xml",
+                    "emptySolverBenchmarkConfig.xml")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("emptySolverBenchmarkConfig.xml")
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
+
+    @Inject
+    PlannerBenchmarkFactory benchmarkFactory;
+
+    @Test
+    void benchmark() throws ExecutionException, InterruptedException {
+        TestdataQuarkusSolution problem = new TestdataQuarkusSolution();
+        problem.setValueList(IntStream.range(1, 3)
+                .mapToObj(i -> "v" + i)
+                .collect(Collectors.toList()));
+        problem.setEntityList(IntStream.range(1, 3)
+                .mapToObj(i -> new TestdataQuarkusEntity())
+                .collect(Collectors.toList()));
+        benchmarkFactory.buildPlannerBenchmark(problem).benchmark();
+    }
+
+}

--- a/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest.java
+++ b/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest {
 
     @RegisterExtension
@@ -26,11 +28,12 @@ class TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest {
 
     @Test
     void benchmark() throws InterruptedException {
-        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
-            new TimefoldBenchmarkRecorder().benchmarkConfigSupplier(new PlannerBenchmarkConfig(), null).get();
-        });
-        Assertions.assertEquals(
-                "At least one of the properties quarkus.timefold.benchmark.solver.termination.spent-limit, quarkus.timefold.benchmark.solver.termination.best-score-limit, quarkus.timefold.benchmark.solver.termination.unimproved-spent-limit is required if termination is not configured in the inherited solver benchmark config and solverBenchmarkBluePrint is used.",
-                exception.getMessage());
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
+                () -> new TimefoldBenchmarkRecorder().benchmarkConfigSupplier(new PlannerBenchmarkConfig(), null).get());
+        assertThat(exception.getMessage()).contains("At least one of the properties",
+                "quarkus.timefold.benchmark.solver.termination.spent-limit",
+                "quarkus.timefold.benchmark.solver.termination.best-score-limit",
+                "quarkus.timefold.benchmark.solver.termination.unimproved-spent-limit",
+                "is required if termination is not configured");
     }
 }

--- a/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest.java
+++ b/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest.java
@@ -1,0 +1,36 @@
+package ai.timefold.solver.benchmark.quarkus;
+
+import ai.timefold.solver.benchmark.config.PlannerBenchmarkConfig;
+import ai.timefold.solver.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import ai.timefold.solver.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import ai.timefold.solver.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.benchmark.solver-benchmark-config-xml",
+                    "emptySolverBenchmarkConfig.xml")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("emptySolverBenchmarkConfig.xml")
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
+
+    @Test
+    void benchmark() throws InterruptedException {
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
+            new TimefoldBenchmarkRecorder().benchmarkConfigSupplier(new PlannerBenchmarkConfig(), null).get();
+        });
+        Assertions.assertEquals(
+                "At least one of the properties quarkus.timefold.benchmark.solver.termination.spent-limit, quarkus.timefold.benchmark.solver.termination.best-score-limit, quarkus.timefold.benchmark.solver.termination.unimproved-spent-limit is required if termination is not configured in the inherited solver benchmark config and solverBenchmarkBluePrint is used.",
+                exception.getMessage());
+    }
+}

--- a/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest.java
+++ b/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.benchmark.quarkus;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import ai.timefold.solver.benchmark.config.PlannerBenchmarkConfig;
 import ai.timefold.solver.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import ai.timefold.solver.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
@@ -12,8 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class TimefoldBenchmarkProcessorMissingSpentLimitWithXmlTest {
 

--- a/quarkus-integration/quarkus-benchmark/deployment/src/test/resources/emptySolverBenchmarkConfig.xml
+++ b/quarkus-integration/quarkus-benchmark/deployment/src/test/resources/emptySolverBenchmarkConfig.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plannerBenchmark xmlns="https://timefold.ai/xsd/benchmark" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://timefold.ai/xsd/benchmark https://timefold.ai/xsd/benchmark/benchmark.xsd">
+</plannerBenchmark>

--- a/quarkus-integration/quarkus-benchmark/runtime/src/main/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkRecorder.java
+++ b/quarkus-integration/quarkus-benchmark/runtime/src/main/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkRecorder.java
@@ -24,6 +24,12 @@ public class TimefoldBenchmarkRecorder {
         return () -> {
             SolverConfig solverConfig =
                     Arc.container().instance(SolverConfig.class).get();
+            // If the termination configuration is set and the created benchmark configuration has no configuration item,
+            // we need to add at least one configuration; otherwise, we will fail to recognize the runtime termination setting.
+            if (benchmarkConfig != null && benchmarkConfig.getSolverBenchmarkConfigList() == null &&
+                    timefoldRuntimeConfig != null && timefoldRuntimeConfig.termination() != null) {
+                benchmarkConfig.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
+            }
             return updateBenchmarkConfigWithRuntimeProperties(benchmarkConfig, timefoldRuntimeConfig, solverConfig);
         };
     }


### PR DESCRIPTION
This pull request fixes a bug in the Quarkus Benchmark extension that was causing the termination properties to be ignored.