### PR TITLE
fix: Pass all subclasses of Throwable to the exception handler in SolverManager

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
@@ -111,7 +111,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
             final Solution_ finalBestSolution = solver.solve(problem);
             consumerSupport.consumeFinalBestSolution(finalBestSolution);
             return finalBestSolution;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             exceptionHandler.accept(problemId, e);
             bestSolutionHolder.cancelPendingChanges();
             throw new IllegalStateException("Solving failed for problemId (" + problemId + ").", e);


### PR DESCRIPTION
Previously, if a part of solving throws an Error (an unchecked exception that normally should not be caught), the SolverManager will not pass the error to the exception handler (nor will it log it to the console), making the solver appear to be hanging.

Now, all subclasses of Throwable are passed to the exception handler.

Fixes #603 