### PR TITLE
fix: Recommended Fit API needs to ignore any unassigned entities/values

### DIFF
--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/EntityPlacer.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/EntityPlacer.java
@@ -1,7 +1,10 @@
 package ai.timefold.solver.core.impl.constructionheuristic.placer;
 
+import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListener;
 
 public interface EntityPlacer<Solution_> extends Iterable<Placement<Solution_>>, PhaseLifecycleListener<Solution_> {
+
+    EntityPlacer<Solution_> rebuildWithFilter(SelectionFilter<Solution_, Object> filter);
 
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/PooledEntityPlacer.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/PooledEntityPlacer.java
@@ -3,8 +3,10 @@ package ai.timefold.solver.core.impl.constructionheuristic.placer;
 import java.util.Iterator;
 
 import ai.timefold.solver.core.impl.heuristic.move.Move;
+import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.UpcomingSelectionIterator;
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector;
+import ai.timefold.solver.core.impl.heuristic.selector.move.decorator.FilteringMoveSelector;
 
 public class PooledEntityPlacer<Solution_> extends AbstractEntityPlacer<Solution_> implements EntityPlacer<Solution_> {
 
@@ -20,6 +22,11 @@ public class PooledEntityPlacer<Solution_> extends AbstractEntityPlacer<Solution
         return new PooledEntityPlacingIterator();
     }
 
+    @Override
+    public EntityPlacer<Solution_> rebuildWithFilter(SelectionFilter<Solution_, Object> filter) {
+        return new PooledEntityPlacer<>(FilteringMoveSelector.of(moveSelector, filter::accept));
+    }
+
     private class PooledEntityPlacingIterator extends UpcomingSelectionIterator<Placement<Solution_>> {
 
         private PooledEntityPlacingIterator() {
@@ -31,7 +38,7 @@ public class PooledEntityPlacer<Solution_> extends AbstractEntityPlacer<Solution
             if (!moveIterator.hasNext()) {
                 return noUpcomingSelection();
             }
-            return new Placement<Solution_>(moveIterator);
+            return new Placement<>(moveIterator);
         }
 
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/QueuedEntityPlacer.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/QueuedEntityPlacer.java
@@ -5,8 +5,10 @@ import java.util.Iterator;
 import java.util.List;
 
 import ai.timefold.solver.core.impl.heuristic.move.Move;
+import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.UpcomingSelectionIterator;
 import ai.timefold.solver.core.impl.heuristic.selector.entity.EntitySelector;
+import ai.timefold.solver.core.impl.heuristic.selector.entity.decorator.FilteringEntitySelector;
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector;
 
 public class QueuedEntityPlacer<Solution_> extends AbstractEntityPlacer<Solution_> implements EntityPlacer<Solution_> {
@@ -26,6 +28,11 @@ public class QueuedEntityPlacer<Solution_> extends AbstractEntityPlacer<Solution
     @Override
     public Iterator<Placement<Solution_>> iterator() {
         return new QueuedEntityPlacingIterator(entitySelector.iterator());
+    }
+
+    @Override
+    public EntityPlacer<Solution_> rebuildWithFilter(SelectionFilter<Solution_, Object> filter) {
+        return new QueuedEntityPlacer<>(FilteringEntitySelector.of(entitySelector, filter), moveSelectorList);
     }
 
     private class QueuedEntityPlacingIterator extends UpcomingSelectionIterator<Placement<Solution_>> {

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/QueuedValuePlacer.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/placer/QueuedValuePlacer.java
@@ -3,10 +3,12 @@ package ai.timefold.solver.core.impl.constructionheuristic.placer;
 import java.util.Collections;
 import java.util.Iterator;
 
-import ai.timefold.solver.core.impl.heuristic.move.Move;
+import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.UpcomingSelectionIterator;
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector;
 import ai.timefold.solver.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+import ai.timefold.solver.core.impl.heuristic.selector.value.decorator.EntityIndependentFilteringValueSelector;
+import ai.timefold.solver.core.impl.heuristic.selector.value.decorator.FilteringValueSelector;
 
 public class QueuedValuePlacer<Solution_> extends AbstractEntityPlacer<Solution_> implements EntityPlacer<Solution_> {
 
@@ -44,7 +46,7 @@ public class QueuedValuePlacer<Solution_> extends AbstractEntityPlacer<Solution_
                 }
             }
             valueIterator.next();
-            Iterator<Move<Solution_>> moveIterator = moveSelector.iterator();
+            var moveIterator = moveSelector.iterator();
             // Because the valueSelector is entity independent, there is always a move if there's still an entity
             if (!moveIterator.hasNext()) {
                 return noUpcomingSelection();
@@ -52,6 +54,13 @@ public class QueuedValuePlacer<Solution_> extends AbstractEntityPlacer<Solution_
             return new Placement<>(moveIterator);
         }
 
+    }
+
+    @Override
+    public EntityPlacer<Solution_> rebuildWithFilter(SelectionFilter<Solution_, Object> filter) {
+        return new QueuedValuePlacer<>(
+                (EntityIndependentFilteringValueSelector<Solution_>) FilteringValueSelector.of(valueSelector, filter),
+                moveSelector);
     }
 
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/decorator/CompositeSelectionFilter.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/decorator/CompositeSelectionFilter.java
@@ -2,29 +2,22 @@ package ai.timefold.solver.core.impl.heuristic.selector.common.decorator;
 
 import java.util.Arrays;
 
-import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 
 /**
  * Combines several {@link SelectionFilter}s into one.
  * Does a logical AND over the accept status of its filters.
  *
- * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
- * @param <T> the selection type
  */
-final class CompositeSelectionFilter<Solution_, T> implements SelectionFilter<Solution_, T> {
+record CompositeSelectionFilter<Solution_, T>(SelectionFilter<Solution_, T>[] selectionFilterArray)
+        implements
+            SelectionFilter<Solution_, T> {
 
     static final SelectionFilter NOOP = (scoreDirector, selection) -> true;
 
-    final SelectionFilter<Solution_, T>[] selectionFilterArray;
-
-    CompositeSelectionFilter(SelectionFilter<Solution_, T>[] selectionFilterArray) {
-        this.selectionFilterArray = selectionFilterArray;
-    }
-
     @Override
     public boolean accept(ScoreDirector<Solution_> scoreDirector, T selection) {
-        for (SelectionFilter<Solution_, T> selectionFilter : selectionFilterArray) {
+        for (var selectionFilter : selectionFilterArray) {
             if (!selectionFilter.accept(scoreDirector, selection)) {
                 return false;
             }
@@ -34,17 +27,18 @@ final class CompositeSelectionFilter<Solution_, T> implements SelectionFilter<So
 
     @Override
     public boolean equals(Object other) {
-        if (this == other)
-            return true;
-        if (other == null || getClass() != other.getClass())
-            return false;
-        CompositeSelectionFilter<?, ?> that = (CompositeSelectionFilter<?, ?>) other;
-        return Arrays.equals(selectionFilterArray, that.selectionFilterArray);
+        return other instanceof CompositeSelectionFilter<?, ?> otherCompositeSelectionFilter
+                && Arrays.equals(selectionFilterArray, otherCompositeSelectionFilter.selectionFilterArray);
     }
 
     @Override
     public int hashCode() {
         return Arrays.hashCode(selectionFilterArray);
+    }
+
+    @Override
+    public String toString() {
+        return "CompositeSelectionFilter[" + Arrays.toString(selectionFilterArray) + ']';
     }
 
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/EntitySelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/EntitySelectorFactory.java
@@ -197,7 +197,7 @@ public class EntitySelectorFactory<Solution_> extends AbstractSelectorFactory<So
             }
             // Do not filter out initialized entities here for CH and ES, because they can be partially initialized
             // Instead, ValueSelectorConfig.applyReinitializeVariableFiltering() does that.
-            entitySelector = new FilteringEntitySelector<>(entitySelector, filterList);
+            entitySelector = FilteringEntitySelector.of(entitySelector, SelectionFilter.compose(filterList));
         }
         return entitySelector;
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/AbstractMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/AbstractMoveSelectorFactory.java
@@ -147,9 +147,9 @@ public abstract class AbstractMoveSelectorFactory<Solution_, MoveSelectorConfig_
                     ConfigUtils.newInstance(config, "filterClass", config.getFilterClass());
             SelectionFilter<Solution_, Move<Solution_>> finalFilter =
                     baseFilter == null ? selectionFilter : SelectionFilter.compose(baseFilter, selectionFilter);
-            return new FilteringMoveSelector<>(moveSelector, finalFilter);
+            return FilteringMoveSelector.of(moveSelector, finalFilter);
         } else if (baseFilter != null) {
-            return new FilteringMoveSelector<>(moveSelector, baseFilter);
+            return FilteringMoveSelector.of(moveSelector, baseFilter);
         } else {
             return moveSelector;
         }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelector.java
@@ -12,13 +12,22 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 
 public final class FilteringMoveSelector<Solution_> extends AbstractMoveSelector<Solution_> {
 
+    public static <Solution_> FilteringMoveSelector<Solution_> of(MoveSelector<Solution_> moveSelector,
+            SelectionFilter<Solution_, Move<Solution_>> filter) {
+        if (moveSelector instanceof FilteringMoveSelector<Solution_> filteringMoveSelector) {
+            return new FilteringMoveSelector<>(filteringMoveSelector.childMoveSelector,
+                    SelectionFilter.compose(filteringMoveSelector.filter, filter));
+        }
+        return new FilteringMoveSelector<>(moveSelector, filter);
+    }
+
     private final MoveSelector<Solution_> childMoveSelector;
     private final SelectionFilter<Solution_, Move<Solution_>> filter;
     private final boolean bailOutEnabled;
 
     private ScoreDirector<Solution_> scoreDirector = null;
 
-    public FilteringMoveSelector(MoveSelector<Solution_> childMoveSelector,
+    private FilteringMoveSelector(MoveSelector<Solution_> childMoveSelector,
             SelectionFilter<Solution_, Move<Solution_>> filter) {
         this.childMoveSelector = childMoveSelector;
         this.filter = filter;

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelector.java
@@ -57,7 +57,7 @@ public class ListChangeMoveSelector<Solution_> extends GenericMoveSelector<Solut
             // Don't incur the overhead of filtering values if there is no pinning support.
             return sourceValueSelector;
         }
-        return (EntityIndependentValueSelector<Solution_>) FilteringValueSelector.create(sourceValueSelector,
+        return (EntityIndependentValueSelector<Solution_>) FilteringValueSelector.of(sourceValueSelector,
                 (scoreDirector, selection) -> {
                     var entity = inverseVariableSupply.getInverseSingleton(selection);
                     if (entity == null) { // Unassigned.

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/ValueSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/ValueSelectorFactory.java
@@ -242,7 +242,7 @@ public class ValueSelectorFactory<Solution_>
             if (variableDescriptor.hasMovableChainedTrailingValueFilter()) {
                 filterList.add(variableDescriptor.getMovableChainedTrailingValueFilter());
             }
-            valueSelector = FilteringValueSelector.create(valueSelector, filterList);
+            valueSelector = FilteringValueSelector.of(valueSelector, SelectionFilter.compose(filterList));
         }
         return valueSelector;
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/EntityIndependentFilteringValueSelector.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/EntityIndependentFilteringValueSelector.java
@@ -1,7 +1,6 @@
 package ai.timefold.solver.core.impl.heuristic.selector.value.decorator;
 
 import java.util.Iterator;
-import java.util.List;
 
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import ai.timefold.solver.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
@@ -10,9 +9,9 @@ public final class EntityIndependentFilteringValueSelector<Solution_>
         extends FilteringValueSelector<Solution_>
         implements EntityIndependentValueSelector<Solution_> {
 
-    public EntityIndependentFilteringValueSelector(EntityIndependentValueSelector<Solution_> childValueSelector,
-            List<SelectionFilter<Solution_, Object>> filterList) {
-        super(childValueSelector, filterList);
+    EntityIndependentFilteringValueSelector(EntityIndependentValueSelector<Solution_> childValueSelector,
+            SelectionFilter<Solution_, Object> filter) {
+        super(childValueSelector, filter);
     }
 
     @Override
@@ -26,7 +25,7 @@ public final class EntityIndependentFilteringValueSelector<Solution_>
                 determineBailOutSize());
     }
 
-    protected long determineBailOutSize() {
+    private long determineBailOutSize() {
         if (!bailOutEnabled) {
             return -1L;
         }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/solver/FitProcessor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/solver/FitProcessor.java
@@ -38,7 +38,8 @@ public final class FitProcessor<Solution_, In_, Out_, Score_ extends Score<Score
 
     @Override
     public List<RecommendedFit<Out_, Score_>> apply(InnerScoreDirector<Solution_, Score_> scoreDirector) {
-        var entityPlacer = buildEntityPlacer();
+        var entityPlacer = buildEntityPlacer()
+                .rebuildWithFilter((solution, selection) -> selection == clonedElement);
 
         var solverScope = new SolverScope<Solution_>();
         solverScope.setWorkingRandom(new Random(0)); // We will evaluate every option; random does not matter.

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/solver/FitProcessor.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/solver/FitProcessor.java
@@ -38,6 +38,9 @@ public final class FitProcessor<Solution_, In_, Out_, Score_ extends Score<Score
 
     @Override
     public List<RecommendedFit<Out_, Score_>> apply(InnerScoreDirector<Solution_, Score_> scoreDirector) {
+        // The placers needs to be filtered.
+        // If anything else than the cloned element is unassigned, we want to keep it unassigned.
+        // Otherwise the solution would have to explicitly pin everything other than the cloned element.
         var entityPlacer = buildEntityPlacer()
                 .rebuildWithFilter((solution, selection) -> selection == clonedElement);
 

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntitySelectorTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntitySelectorTest.java
@@ -8,8 +8,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionOrder;
 import ai.timefold.solver.core.impl.heuristic.selector.SelectorTestUtils;
@@ -68,7 +66,7 @@ class FilteringEntitySelectorTest {
                 new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3"), new TestdataEntity("e4"));
 
         SelectionFilter<TestdataSolution, TestdataEntity> filter = (scoreDirector, entity) -> !entity.getCode().equals("e3");
-        EntitySelector entitySelector = new FilteringEntitySelector(childEntitySelector, List.of(filter));
+        EntitySelector entitySelector = FilteringEntitySelector.of(childEntitySelector, (SelectionFilter) filter);
         if (cacheType.isCached()) {
             entitySelector = new CachingEntitySelector(entitySelector, cacheType, false);
         }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
@@ -46,7 +46,7 @@ class FilteringMoveSelectorTest {
                 new DummyMove("a1"), new DummyMove("a2"), new DummyMove("a3"), new DummyMove("a4"));
 
         SelectionFilter<TestdataSolution, DummyMove> filter = (scoreDirector, move) -> !move.getCode().equals("a3");
-        MoveSelector moveSelector = new FilteringMoveSelector(childMoveSelector, filter);
+        MoveSelector moveSelector = FilteringMoveSelector.of(childMoveSelector, (SelectionFilter) filter);
         if (cacheType.isCached()) {
             moveSelector = new CachingMoveSelector(moveSelector, cacheType, false);
         }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/PillarDemandTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/PillarDemandTest.java
@@ -32,7 +32,7 @@ class PillarDemandTest {
                 new FromSolutionEntitySelector<>(entityDescriptor, SelectionCacheType.JUST_IN_TIME, true);
         SelectionFilter<TestdataSolution, Object> selectionFilter = (scoreDirector, selection) -> true;
         FilteringEntitySelector<TestdataSolution> filteringEntitySelector =
-                new FilteringEntitySelector<>(entitySelector, List.of(selectionFilter));
+                FilteringEntitySelector.of(entitySelector, selectionFilter);
 
         PillarDemand<TestdataSolution> pillarDemand =
                 new PillarDemand<>(filteringEntitySelector, variableDescriptorList, subPillarConfigPolicy);
@@ -46,8 +46,7 @@ class PillarDemandTest {
                 new PillarDemand<>(filteringEntitySelector, new ArrayList<>(variableDescriptorList), subPillarConfigPolicy);
         Assertions.assertThat(samePillarDemandCopiedList).isEqualTo(pillarDemand);
 
-        EntitySelector<TestdataSolution> sameEntitySelector =
-                new FilteringEntitySelector<>(entitySelector, List.of(selectionFilter));
+        EntitySelector<TestdataSolution> sameEntitySelector = FilteringEntitySelector.of(entitySelector, selectionFilter);
         PillarDemand<TestdataSolution> samePillarDemandCopiedSelector =
                 new PillarDemand<>(sameEntitySelector, new ArrayList<>(variableDescriptorList), subPillarConfigPolicy);
         Assertions.assertThat(samePillarDemandCopiedSelector).isEqualTo(pillarDemand);

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/EntityIndependentFilteringValueSelectorTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/EntityIndependentFilteringValueSelectorTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-
 import ai.timefold.solver.core.impl.heuristic.selector.SelectorTestUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import ai.timefold.solver.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
@@ -30,8 +28,7 @@ class EntityIndependentFilteringValueSelectorTest {
                 new TestdataValue("v1"), new TestdataValue("v2"), new TestdataValue("v3"), new TestdataValue("v4"));
 
         SelectionFilter<TestdataSolution, TestdataValue> filter = (scoreDirector, value) -> !value.getCode().equals("v3");
-        EntityIndependentValueSelector valueSelector =
-                new EntityIndependentFilteringValueSelector(childValueSelector, List.of(filter));
+        EntityIndependentValueSelector valueSelector = new EntityIndependentFilteringValueSelector(childValueSelector, filter);
 
         SolverScope solverScope = mock(SolverScope.class);
         valueSelector.solvingStarted(solverScope);

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueSelectorTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueSelectorTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-
 import ai.timefold.solver.core.impl.heuristic.selector.SelectorTestUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import ai.timefold.solver.core.impl.heuristic.selector.value.ValueSelector;
@@ -31,7 +29,7 @@ class FilteringValueSelectorTest {
                 new TestdataValue("v1"), new TestdataValue("v2"), new TestdataValue("v3"), new TestdataValue("v4"));
 
         SelectionFilter<TestdataSolution, TestdataValue> filter = (scoreDirector, value) -> !value.getCode().equals("v3");
-        ValueSelector valueSelector = new FilteringValueSelector(childValueSelector, List.of(filter));
+        ValueSelector valueSelector = new FilteringValueSelector(childValueSelector, filter);
 
         SolverScope solverScope = mock(SolverScope.class);
         valueSelector.solvingStarted(solverScope);

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/list/pinned/index/TestdataPinnedWithIndexListCMAIncrementalScoreCalculator.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/list/pinned/index/TestdataPinnedWithIndexListCMAIncrementalScoreCalculator.java
@@ -1,0 +1,106 @@
+package ai.timefold.solver.core.impl.testdata.domain.list.pinned.index;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.calculator.ConstraintMatchAwareIncrementalScoreCalculator;
+import ai.timefold.solver.core.api.score.constraint.ConstraintMatchTotal;
+import ai.timefold.solver.core.api.score.constraint.ConstraintRef;
+import ai.timefold.solver.core.api.score.constraint.Indictment;
+import ai.timefold.solver.core.impl.score.constraint.DefaultConstraintMatchTotal;
+import ai.timefold.solver.core.impl.score.constraint.DefaultIndictment;
+
+public class TestdataPinnedWithIndexListCMAIncrementalScoreCalculator
+        implements ConstraintMatchAwareIncrementalScoreCalculator<TestdataPinnedWithIndexListSolution, SimpleScore> {
+
+    private TestdataPinnedWithIndexListSolution workingSolution;
+    private Map<Object, Indictment<SimpleScore>> indictmentMap;
+
+    @Override
+    public void resetWorkingSolution(TestdataPinnedWithIndexListSolution workingSolution) {
+        resetWorkingSolution(workingSolution, true);
+    }
+
+    @Override
+    public void resetWorkingSolution(TestdataPinnedWithIndexListSolution workingSolution, boolean constraintMatchEnabled) {
+        this.workingSolution = workingSolution;
+        this.indictmentMap = null;
+    }
+
+    @Override
+    public void beforeEntityAdded(Object entity) {
+
+    }
+
+    @Override
+    public void afterEntityAdded(Object entity) {
+
+    }
+
+    @Override
+    public void beforeVariableChanged(Object entity, String variableName) {
+
+    }
+
+    @Override
+    public void afterVariableChanged(Object entity, String variableName) {
+
+    }
+
+    @Override
+    public void beforeEntityRemoved(Object entity) {
+
+    }
+
+    @Override
+    public void afterEntityRemoved(Object entity) {
+
+    }
+
+    @Override
+    public SimpleScore calculateScore() {
+        return update().getScore();
+    }
+
+    private DefaultConstraintMatchTotal<SimpleScore> update() {
+        var constraintMatchTotal = new DefaultConstraintMatchTotal<>(
+                ConstraintRef.of(getClass().getPackageName(), "testConstraint"),
+                SimpleScore.ONE);
+        this.indictmentMap = new HashMap<>();
+        for (TestdataPinnedWithIndexListValue left : workingSolution.getValueList()) {
+            TestdataPinnedWithIndexListEntity entity = left.getEntity();
+            if (entity == null) {
+                continue;
+            }
+            for (TestdataPinnedWithIndexListValue right : workingSolution.getValueList()) {
+                if (Objects.equals(right.getEntity(), entity)) {
+                    var constraintMatch =
+                            constraintMatchTotal.addConstraintMatch(List.of(left, right), SimpleScore.ONE.negate());
+                    Stream.of(left, right)
+                            .forEach(value -> indictmentMap
+                                    .computeIfAbsent(value, key -> new DefaultIndictment<>(key, SimpleScore.ZERO))
+                                    .getConstraintMatchSet()
+                                    .add(constraintMatch));
+                }
+            }
+        }
+        return constraintMatchTotal;
+    }
+
+    @Override
+    public Collection<ConstraintMatchTotal<SimpleScore>> getConstraintMatchTotals() {
+        return Collections.singleton(update());
+    }
+
+    @Override
+    public Map<Object, Indictment<SimpleScore>> getIndictmentMap() {
+        update();
+        return indictmentMap;
+    }
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/list/pinned/index/TestdataPinnedWithIndexListValue.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/list/pinned/index/TestdataPinnedWithIndexListValue.java
@@ -26,6 +26,7 @@ public class TestdataPinnedWithIndexListValue extends TestdataObject {
                 .getShadowVariableDescriptor("index");
     }
 
+    // Index shadow var intentionally missing, to test that the supply can deal with that.
     @InverseRelationShadowVariable(sourceVariableName = "valueList")
     private TestdataPinnedWithIndexListEntity entity;
 

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/nullable/TestdataNullableIncrementalScoreCalculator.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/nullable/TestdataNullableIncrementalScoreCalculator.java
@@ -10,7 +10,6 @@ import java.util.stream.Stream;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.calculator.ConstraintMatchAwareIncrementalScoreCalculator;
-import ai.timefold.solver.core.api.score.constraint.ConstraintMatch;
 import ai.timefold.solver.core.api.score.constraint.ConstraintMatchTotal;
 import ai.timefold.solver.core.api.score.constraint.ConstraintRef;
 import ai.timefold.solver.core.api.score.constraint.Indictment;
@@ -18,42 +17,21 @@ import ai.timefold.solver.core.impl.score.constraint.DefaultConstraintMatchTotal
 import ai.timefold.solver.core.impl.score.constraint.DefaultIndictment;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 
-public final class TestdataNullableIncrementalScoreCalculator
+public class TestdataNullableIncrementalScoreCalculator
         implements ConstraintMatchAwareIncrementalScoreCalculator<TestdataNullableSolution, SimpleScore> {
 
-    private int score = 0;
-    private DefaultConstraintMatchTotal<SimpleScore> constraintMatchTotal;
+    private TestdataNullableSolution workingSolution;
     private Map<Object, Indictment<SimpleScore>> indictmentMap;
 
     @Override
     public void resetWorkingSolution(TestdataNullableSolution workingSolution) {
-        score = 0;
-        constraintMatchTotal = new DefaultConstraintMatchTotal<>(
-                ConstraintRef.of("ai.timefold.solver.core.impl.testdata.domain.shadow", "testConstraint"), SimpleScore.ONE);
-        indictmentMap = new HashMap<>();
-        for (TestdataNullableEntity left : workingSolution.getEntityList()) {
-            TestdataValue value = left.getValue();
-            if (value == null) {
-                continue;
-            }
-            for (TestdataNullableEntity right : workingSolution.getEntityList()) {
-                if (Objects.equals(right.getValue(), value)) {
-                    score -= 1;
-                    ConstraintMatch<SimpleScore> constraintMatch =
-                            constraintMatchTotal.addConstraintMatch(List.of(left, right), SimpleScore.ONE);
-                    Stream.of(left, right)
-                            .forEach(entity -> indictmentMap
-                                    .computeIfAbsent(entity, key -> new DefaultIndictment<>(key, SimpleScore.ZERO))
-                                    .getConstraintMatchSet()
-                                    .add(constraintMatch));
-                }
-            }
-        }
+        resetWorkingSolution(workingSolution, true);
     }
 
     @Override
     public void resetWorkingSolution(TestdataNullableSolution workingSolution, boolean constraintMatchEnabled) {
-        resetWorkingSolution(workingSolution);
+        this.workingSolution = workingSolution;
+        this.indictmentMap = null;
     }
 
     @Override
@@ -88,16 +66,39 @@ public final class TestdataNullableIncrementalScoreCalculator
 
     @Override
     public SimpleScore calculateScore() {
-        return SimpleScore.of(score);
+        return update().getScore();
+    }
+
+    private DefaultConstraintMatchTotal<SimpleScore> update() {
+        var constraintMatchTotal = new DefaultConstraintMatchTotal<>(
+                ConstraintRef.of(getClass().getPackageName(), "testConstraint"),
+                SimpleScore.ONE);
+        this.indictmentMap = new HashMap<>();
+        for (TestdataNullableEntity left : workingSolution.getEntityList()) {
+            TestdataValue value = left.getValue();
+            for (TestdataNullableEntity right : workingSolution.getEntityList()) {
+                if (Objects.equals(right.getValue(), value)) {
+                    var constraintMatch =
+                            constraintMatchTotal.addConstraintMatch(List.of(left, right), SimpleScore.ONE.negate());
+                    Stream.of(left, right)
+                            .forEach(entity -> indictmentMap
+                                    .computeIfAbsent(entity, key -> new DefaultIndictment<>(key, SimpleScore.ZERO))
+                                    .getConstraintMatchSet()
+                                    .add(constraintMatch));
+                }
+            }
+        }
+        return constraintMatchTotal;
     }
 
     @Override
     public Collection<ConstraintMatchTotal<SimpleScore>> getConstraintMatchTotals() {
-        return Collections.singleton(constraintMatchTotal);
+        return Collections.singleton(update());
     }
 
     @Override
     public Map<Object, Indictment<SimpleScore>> getIndictmentMap() {
+        update();
         return indictmentMap;
     }
 }


### PR DESCRIPTION
With nullable vars, the solution may contain many unassigned entities/values.
But the user only wants recommendations for the one that they specified.
Therefore we need to ignore every other one.

I also marginally improve composite filters, deduplicating and decomposing where possible.

Closes #581. 