### PR TITLE
chore: Enabling SonarCloud for forks

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
-  # PRs from forks are unsupported, therefore this is pointless.
-  # pull_request:
-  #  types: [opened, synchronize, reopened]
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
 jobs:
   build:
     name: Build and analyze
@@ -14,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -37,4 +40,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B -Psonarcloud-analysis validate org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.organization=timefold -Dsonar.projectKey=ai.timefold:timefold-solver -Dsonar.host.url=https://sonarcloud.io
+        run: mvn -B -Psonarcloud-analysis validate org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.organization=timefold -Dsonar.projectKey=ai.timefold:timefold-solver -Dsonar.host.url=https://sonarcloud.io -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This pull request modifies the SonarCloud workflow to function with forked repositories as well. The `pull_request_target` event works similarly to `pull_request`, but runs on the base branch and allows using secrets. Therefore, the PR ref version needs to be specified in the workflow script.