### PR TITLE
feat: Adding penalty methods for `long` and `BigDecimal` values without match weighter

### DIFF
--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/ConstraintStreamFunctionalTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/ConstraintStreamFunctionalTest.java
@@ -194,6 +194,10 @@ public interface ConstraintStreamFunctionalTest {
 
     void penalizeUnweighted();
 
+    void penalizeUnweightedLong();
+
+    void penalizeUnweightedBigDecimal();
+
     void penalize();
 
     void penalizeLong();

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/bi/AbstractBiConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/bi/AbstractBiConstraintStreamTest.java
@@ -2341,6 +2341,42 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
         assertDefaultJustifications(scoreDirector, solution.getEntityList());
     }
 
+    @Override
+    @TestTemplate
+    public void penalizeUnweightedLong() {
+        TestdataSimpleLongScoreSolution solution = TestdataSimpleLongScoreSolution.generateSolution();
+
+        InnerScoreDirector<TestdataSimpleLongScoreSolution, SimpleLongScore> scoreDirector = buildScoreDirector(
+                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(),
+                factory -> new Constraint[] {
+                        factory.forEachUniquePair(TestdataEntity.class)
+                                .penalizeLong(SimpleLongScore.ONE)
+                                .asConstraint(TEST_CONSTRAINT_NAME)
+                });
+
+        scoreDirector.setWorkingSolution(solution);
+        scoreDirector.calculateScore();
+        assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleLongScore.of(-21));
+    }
+
+    @Override
+    @TestTemplate
+    public void penalizeUnweightedBigDecimal() {
+        TestdataSimpleBigDecimalScoreSolution solution = TestdataSimpleBigDecimalScoreSolution.generateSolution();
+
+        InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution, SimpleBigDecimalScore> scoreDirector =
+                buildScoreDirector(TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEachUniquePair(TestdataEntity.class)
+                                        .penalizeBigDecimal(SimpleBigDecimalScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_NAME)
+                        });
+
+        scoreDirector.setWorkingSolution(solution);
+        scoreDirector.calculateScore();
+        assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleBigDecimalScore.of(BigDecimal.valueOf(-21)));
+    }
+
     private <Score_ extends Score<Score_>, Solution_, Entity_> void assertDefaultJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList) {
         if (!implSupport.isConstreamMatchEnabled())

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/quad/AbstractQuadConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/quad/AbstractQuadConstraintStreamTest.java
@@ -2028,6 +2028,48 @@ public abstract class AbstractQuadConstraintStreamTest
         assertDefaultJustifications(scoreDirector, solution.getEntityList(), solution.getValueList());
     }
 
+    @Override
+    @TestTemplate
+    public void penalizeUnweightedLong() {
+        TestdataSimpleLongScoreSolution solution = TestdataSimpleLongScoreSolution.generateSolution();
+
+        InnerScoreDirector<TestdataSimpleLongScoreSolution, SimpleLongScore> scoreDirector = buildScoreDirector(
+                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(),
+                factory -> new Constraint[] {
+                        factory.forEachUniquePair(TestdataEntity.class, equal(TestdataEntity::getValue))
+                                .join(TestdataValue.class, equal((entity, entity2) -> entity.getValue(), identity()))
+                                .join(TestdataValue.class, equal((entity, entity2, value) -> value, identity()))
+                                .penalizeLong(SimpleLongScore.ONE)
+                                .asConstraint(TEST_CONSTRAINT_NAME)
+                });
+
+        scoreDirector.setWorkingSolution(solution);
+        scoreDirector.calculateScore();
+        assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleLongScore.of(-2));
+        assertDefaultJustifications(scoreDirector, solution.getEntityList(), solution.getValueList());
+    }
+
+    @Override
+    @TestTemplate
+    public void penalizeUnweightedBigDecimal() {
+        TestdataSimpleBigDecimalScoreSolution solution = TestdataSimpleBigDecimalScoreSolution.generateSolution();
+
+        InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution, SimpleBigDecimalScore> scoreDirector =
+                buildScoreDirector(TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEachUniquePair(TestdataEntity.class, equal(TestdataEntity::getValue))
+                                        .join(TestdataValue.class, equal((entity, entity2) -> entity.getValue(), identity()))
+                                        .join(TestdataValue.class, equal((entity, entity2, value) -> value, identity()))
+                                        .penalizeBigDecimal(SimpleBigDecimalScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_NAME)
+                        });
+
+        scoreDirector.setWorkingSolution(solution);
+        scoreDirector.calculateScore();
+        assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleBigDecimalScore.of(BigDecimal.valueOf(-2)));
+        assertDefaultJustifications(scoreDirector, solution.getEntityList(), solution.getValueList());
+    }
+
     private <Score_ extends Score<Score_>, Solution_, Entity_, Value_> void assertDefaultJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList, List<Value_> valueList) {
         if (!implSupport.isConstreamMatchEnabled())

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/tri/AbstractTriConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/tri/AbstractTriConstraintStreamTest.java
@@ -2322,6 +2322,46 @@ public abstract class AbstractTriConstraintStreamTest
         assertDefaultJustifications(scoreDirector, solution.getEntityList(), solution.getValueList());
     }
 
+    @Override
+    @TestTemplate
+    public void penalizeUnweightedLong() {
+        TestdataSimpleLongScoreSolution solution = TestdataSimpleLongScoreSolution.generateSolution();
+
+        InnerScoreDirector<TestdataSimpleLongScoreSolution, SimpleLongScore> scoreDirector = buildScoreDirector(
+                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(),
+                factory -> new Constraint[] {
+                        factory.forEachUniquePair(TestdataEntity.class, equal(TestdataEntity::getValue))
+                                .join(TestdataValue.class, equal((entity, entity2) -> entity.getValue(), identity()))
+                                .penalizeLong(SimpleLongScore.ONE)
+                                .asConstraint(TEST_CONSTRAINT_NAME)
+                });
+
+        scoreDirector.setWorkingSolution(solution);
+        scoreDirector.calculateScore();
+        assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleLongScore.of(-2));
+        assertDefaultJustifications(scoreDirector, solution.getEntityList(), solution.getValueList());
+    }
+
+    @Override
+    @TestTemplate
+    public void penalizeUnweightedBigDecimal() {
+        TestdataSimpleBigDecimalScoreSolution solution = TestdataSimpleBigDecimalScoreSolution.generateSolution();
+
+        InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution, SimpleBigDecimalScore> scoreDirector =
+                buildScoreDirector(TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEachUniquePair(TestdataEntity.class, equal(TestdataEntity::getValue))
+                                        .join(TestdataValue.class, equal((entity, entity2) -> entity.getValue(), identity()))
+                                        .penalizeBigDecimal(SimpleBigDecimalScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_NAME)
+                        });
+
+        scoreDirector.setWorkingSolution(solution);
+        scoreDirector.calculateScore();
+        assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleBigDecimalScore.of(BigDecimal.valueOf(-2)));
+        assertDefaultJustifications(scoreDirector, solution.getEntityList(), solution.getValueList());
+    }
+
     private <Score_ extends Score<Score_>, Solution_, Entity_, Value_> void assertDefaultJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList, List<Value_> valueList) {
         if (!implSupport.isConstreamMatchEnabled())

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/uni/AbstractUniConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/uni/AbstractUniConstraintStreamTest.java
@@ -2668,6 +2668,42 @@ public abstract class AbstractUniConstraintStreamTest
         assertDefaultJustifications(scoreDirector, solution.getEntityList());
     }
 
+    @Override
+    @TestTemplate
+    public void penalizeUnweightedLong() {
+        TestdataSimpleLongScoreSolution solution = TestdataSimpleLongScoreSolution.generateSolution();
+
+        InnerScoreDirector<TestdataSimpleLongScoreSolution, SimpleLongScore> scoreDirector = buildScoreDirector(
+                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(),
+                factory -> new Constraint[] {
+                        factory.forEach(TestdataEntity.class)
+                                .penalizeLong(SimpleLongScore.ONE)
+                                .asConstraint(TEST_CONSTRAINT_NAME)
+                });
+
+        scoreDirector.setWorkingSolution(solution);
+        scoreDirector.calculateScore();
+        assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleLongScore.of(-7));
+        assertDefaultJustifications(scoreDirector, solution.getEntityList());
+    }
+
+    @Override
+    @TestTemplate
+    public void penalizeUnweightedBigDecimal() {
+        TestdataSimpleBigDecimalScoreSolution solution = TestdataSimpleBigDecimalScoreSolution.generateSolution();
+
+        InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution, SimpleBigDecimalScore> scoreDirector =
+                buildScoreDirector(TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] { factory.forEach(TestdataEntity.class)
+                                .penalizeBigDecimal(SimpleBigDecimalScore.ONE)
+                                .asConstraint(TEST_CONSTRAINT_NAME) });
+
+        scoreDirector.setWorkingSolution(solution);
+        scoreDirector.calculateScore();
+        assertThat(scoreDirector.calculateScore()).isEqualTo(SimpleBigDecimalScore.of(BigDecimal.valueOf(-7)));
+        assertDefaultJustifications(scoreDirector, solution.getEntityList());
+    }
+
     private <Score_ extends Score<Score_>, Solution_, Entity_> void assertDefaultJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList) {
         if (!implSupport.isConstreamMatchEnabled())

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/bi/BiConstraintStream.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/bi/BiConstraintStream.java
@@ -1176,6 +1176,24 @@ public interface BiConstraintStream<A, B> extends ConstraintStream {
     }
 
     /**
+     * As defined by {@link #penalizeLong(Score, ToLongBiFunction)}, where the match weight is one (1).
+     *
+     * @return never null
+     */
+    default <Score_ extends Score<Score_>> BiConstraintBuilder<A, B, Score_> penalizeLong(Score_ constraintWeight) {
+        return penalizeLong(constraintWeight, ConstantLambdaUtils.biConstantOneLong());
+    }
+
+    /**
+     * As defined by {@link #penalizeBigDecimal(Score, BiFunction)}, where the match weight is one (1).
+     *
+     * @return never null
+     */
+    default <Score_ extends Score<Score_>> BiConstraintBuilder<A, B, Score_> penalizeBigDecimal(Score_ constraintWeight) {
+        return penalizeBigDecimal(constraintWeight, ConstantLambdaUtils.biConstantOneBigDecimal());
+    }
+
+    /**
      * Applies a negative {@link Score} impact,
      * subtracting the constraintWeight multiplied by the match weight,
      * and returns a builder to apply optional constraint properties.

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/quad/QuadConstraintStream.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/quad/QuadConstraintStream.java
@@ -935,7 +935,8 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      *
      * @return never null
      */
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeBigDecimal(Score_ constraintWeight) {
+    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_>
+            penalizeBigDecimal(Score_ constraintWeight) {
         return penalizeBigDecimal(constraintWeight, ConstantLambdaUtils.quadConstantOneBigDecimal());
     }
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/quad/QuadConstraintStream.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/quad/QuadConstraintStream.java
@@ -922,6 +922,24 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
     }
 
     /**
+     * As defined by {@link #penalizeLong(Score, ToLongQuadFunction)}, where the match weight is one (1).
+     *
+     * @return never null
+     */
+    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeLong(Score_ constraintWeight) {
+        return penalizeLong(constraintWeight, ConstantLambdaUtils.quadConstantOneLong());
+    }
+
+    /**
+     * As defined by {@link #penalizeBigDecimal(Score, QuadFunction)}, where the match weight is one (1).
+     *
+     * @return never null
+     */
+    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeBigDecimal(Score_ constraintWeight) {
+        return penalizeBigDecimal(constraintWeight, ConstantLambdaUtils.quadConstantOneBigDecimal());
+    }
+
+    /**
      * Applies a negative {@link Score} impact,
      * subtracting the constraintWeight multiplied by the match weight,
      * and returns a builder to apply optional constraint properties.

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/tri/TriConstraintStream.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/tri/TriConstraintStream.java
@@ -1152,6 +1152,24 @@ public interface TriConstraintStream<A, B, C> extends ConstraintStream {
     }
 
     /**
+     * As defined by {@link #penalizeLong(Score, ToLongTriFunction)}, where the match weight is one (1).
+     *
+     * @return never null
+     */
+    default <Score_ extends Score<Score_>> TriConstraintBuilder<A, B, C, Score_> penalizeLong(Score_ constraintWeight) {
+        return penalizeLong(constraintWeight, ConstantLambdaUtils.triConstantOneLong());
+    }
+
+    /**
+     * As defined by {@link #penalizeBigDecimal(Score, TriFunction)}, where the match weight is one (1).
+     *
+     * @return never null
+     */
+    default <Score_ extends Score<Score_>> TriConstraintBuilder<A, B, C, Score_> penalizeBigDecimal(Score_ constraintWeight) {
+        return penalizeBigDecimal(constraintWeight, ConstantLambdaUtils.triConstantOneBigDecimal());
+    }
+
+    /**
      * Applies a negative {@link Score} impact,
      * subtracting the constraintWeight multiplied by the match weight,
      * and returns a builder to apply optional constraint properties.

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/uni/UniConstraintStream.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/api/score/stream/uni/UniConstraintStream.java
@@ -1634,6 +1634,24 @@ public interface UniConstraintStream<A> extends ConstraintStream {
     }
 
     /**
+     * As defined by {@link #penalizeLong(Score, ToLongFunction)}, where the match weight is one (1).
+     *
+     * @return never null
+     */
+    default <Score_ extends Score<Score_>> UniConstraintBuilder<A, Score_> penalizeLong(Score_ constraintWeight) {
+        return penalizeLong(constraintWeight, ConstantLambdaUtils.uniConstantOneLong());
+    }
+
+    /**
+     * As defined by {@link #penalizeBigDecimal(Score, Function)}, where the match weight is one (1).
+     *
+     * @return never null
+     */
+    default <Score_ extends Score<Score_>> UniConstraintBuilder<A, Score_> penalizeBigDecimal(Score_ constraintWeight) {
+        return penalizeBigDecimal(constraintWeight, ConstantLambdaUtils.uniConstantOneBigDecimal());
+    }
+
+    /**
      * Applies a negative {@link Score} impact,
      * subtracting the constraintWeight multiplied by the match weight,
      * and returns a builder to apply optional constraint properties.

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/ConstantLambdaUtils.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/ConstantLambdaUtils.java
@@ -64,13 +64,13 @@ public final class ConstantLambdaUtils {
     private static final QuadFunction QUAD_PICK_FOURTH = (a, b, c, d) -> d;
 
     @SuppressWarnings("rawtypes")
-    private static final ToIntFunction UNI_CONSTANT_ONE = (a) -> 1;
+    private static final ToIntFunction UNI_CONSTANT_ONE = a -> 1;
 
     @SuppressWarnings("rawtypes")
-    private static final ToLongFunction UNI_CONSTANT_ONE_LONG = (a) -> 1L;
+    private static final ToLongFunction UNI_CONSTANT_ONE_LONG = a -> 1L;
 
     @SuppressWarnings("rawtypes")
-    private static final Function UNI_CONSTANT_ONE_BIG_DECIMAL = (a) -> BigDecimal.ONE;
+    private static final Function UNI_CONSTANT_ONE_BIG_DECIMAL = a -> BigDecimal.ONE;
 
     @SuppressWarnings("rawtypes")
     private static final ToIntBiFunction BI_CONSTANT_ONE = (a, b) -> 1;

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/ConstantLambdaUtils.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/util/ConstantLambdaUtils.java
@@ -1,15 +1,20 @@
 package ai.timefold.solver.core.impl.util;
 
+import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.ToIntBiFunction;
 import java.util.function.ToIntFunction;
+import java.util.function.ToLongBiFunction;
+import java.util.function.ToLongFunction;
 
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.api.function.ToIntQuadFunction;
 import ai.timefold.solver.core.api.function.ToIntTriFunction;
+import ai.timefold.solver.core.api.function.ToLongQuadFunction;
+import ai.timefold.solver.core.api.function.ToLongTriFunction;
 import ai.timefold.solver.core.api.function.TriFunction;
 
 /**
@@ -62,13 +67,37 @@ public final class ConstantLambdaUtils {
     private static final ToIntFunction UNI_CONSTANT_ONE = (a) -> 1;
 
     @SuppressWarnings("rawtypes")
+    private static final ToLongFunction UNI_CONSTANT_ONE_LONG = (a) -> 1L;
+
+    @SuppressWarnings("rawtypes")
+    private static final Function UNI_CONSTANT_ONE_BIG_DECIMAL = (a) -> BigDecimal.ONE;
+
+    @SuppressWarnings("rawtypes")
     private static final ToIntBiFunction BI_CONSTANT_ONE = (a, b) -> 1;
+
+    @SuppressWarnings("rawtypes")
+    private static final ToLongBiFunction BI_CONSTANT_ONE_LONG = (a, b) -> 1L;
+
+    @SuppressWarnings("rawtypes")
+    private static final BiFunction BI_CONSTANT_ONE_BIG_DECIMAL = (a, b) -> BigDecimal.ONE;
 
     @SuppressWarnings("rawtypes")
     private static final ToIntTriFunction TRI_CONSTANT_ONE = (a, b, c) -> 1;
 
     @SuppressWarnings("rawtypes")
+    private static final ToLongTriFunction TRI_CONSTANT_ONE_LONG = (a, b, c) -> 1L;
+
+    @SuppressWarnings("rawtypes")
+    private static final TriFunction TRI_CONSTANT_ONE_BIG_DECIMAL = (a, b, c) -> BigDecimal.ONE;
+
+    @SuppressWarnings("rawtypes")
     private static final ToIntQuadFunction QUAD_CONSTANT_ONE = (a, b, c, d) -> 1;
+
+    @SuppressWarnings("rawtypes")
+    private static final ToLongQuadFunction QUAD_CONSTANT_ONE_LONG = (a, b, c, d) -> 1L;
+
+    @SuppressWarnings("rawtypes")
+    private static final QuadFunction QUAD_CONSTANT_ONE_BIG_DECiMAL = (a, b, c, d) -> BigDecimal.ONE;
 
     /**
      * Returns a {@link Runnable} that does nothing.
@@ -201,6 +230,26 @@ public final class ConstantLambdaUtils {
     }
 
     /**
+     * Returns a {@link ToLongFunction} that returns the constant 1.
+     *
+     * @return never null
+     */
+    @SuppressWarnings("unchecked")
+    public static <A> ToLongFunction<A> uniConstantOneLong() {
+        return UNI_CONSTANT_ONE_LONG;
+    }
+
+    /**
+     * Returns a {@link Function} that returns the constant 1.
+     *
+     * @return never null
+     */
+    @SuppressWarnings("unchecked")
+    public static <A> Function<A, BigDecimal> uniConstantOneBigDecimal() {
+        return UNI_CONSTANT_ONE_BIG_DECIMAL;
+    }
+
+    /**
      * Returns a {@link ToIntBiFunction} that returns the constant 1.
      *
      * @return never null
@@ -208,6 +257,26 @@ public final class ConstantLambdaUtils {
     @SuppressWarnings("unchecked")
     public static <A, B> ToIntBiFunction<A, B> biConstantOne() {
         return BI_CONSTANT_ONE;
+    }
+
+    /**
+     * Returns a {@link ToLongBiFunction} that returns the constant 1.
+     *
+     * @return never null
+     */
+    @SuppressWarnings("unchecked")
+    public static <A, B> ToLongBiFunction<A, B> biConstantOneLong() {
+        return BI_CONSTANT_ONE_LONG;
+    }
+
+    /**
+     * Returns a {@link BiFunction} that returns the constant 1.
+     *
+     * @return never null
+     */
+    @SuppressWarnings("unchecked")
+    public static <A, B> BiFunction<A, B, BigDecimal> biConstantOneBigDecimal() {
+        return BI_CONSTANT_ONE_BIG_DECIMAL;
     }
 
     /**
@@ -221,6 +290,26 @@ public final class ConstantLambdaUtils {
     }
 
     /**
+     * Returns a {@link ToLongTriFunction} that returns the constant 1.
+     *
+     * @return never null
+     */
+    @SuppressWarnings("unchecked")
+    public static <A, B, C> ToLongTriFunction<A, B, C> triConstantOneLong() {
+        return TRI_CONSTANT_ONE_LONG;
+    }
+
+    /**
+     * Returns a {@link TriFunction} that returns the constant 1.
+     *
+     * @return never null
+     */
+    @SuppressWarnings("unchecked")
+    public static <A, B, C> TriFunction<A, B, C, BigDecimal> triConstantOneBigDecimal() {
+        return TRI_CONSTANT_ONE_BIG_DECIMAL;
+    }
+
+    /**
      * Returns a {@link ToIntQuadFunction} that returns the constant 1.
      *
      * @return never null
@@ -228,6 +317,26 @@ public final class ConstantLambdaUtils {
     @SuppressWarnings("unchecked")
     public static <A, B, C, D> ToIntQuadFunction<A, B, C, D> quadConstantOne() {
         return QUAD_CONSTANT_ONE;
+    }
+
+    /**
+     * Returns a {@link ToLongQuadFunction} that returns the constant 1.
+     *
+     * @return never null
+     */
+    @SuppressWarnings("unchecked")
+    public static <A, B, C, D> ToLongQuadFunction<A, B, C, D> quadConstantOneLong() {
+        return QUAD_CONSTANT_ONE_LONG;
+    }
+
+    /**
+     * Returns a {@link QuadFunction} that returns the constant 1.
+     *
+     * @return never null
+     */
+    @SuppressWarnings("unchecked")
+    public static <A, B, C, D> QuadFunction<A, B, C, D, BigDecimal> quadConstantOneBigDecimal() {
+        return QUAD_CONSTANT_ONE_BIG_DECiMAL;
     }
 
     private ConstantLambdaUtils() {


### PR DESCRIPTION
This pull request introduces two new penalty methods for `long` and `BigDecimal` values without a match weighter.