### PR TITLE
feat: Enabling Nearby Selection for non-empty move selectors configuration

### DIFF
--- a/benchmark/src/main/resources/benchmark.xsd
+++ b/benchmark/src/main/resources/benchmark.xsd
@@ -1196,7 +1196,7 @@
     <xs:complexContent>
                   
       
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                         
         
         <xs:sequence>
@@ -1220,13 +1220,34 @@
   </xs:complexType>
       
   
-  <xs:complexType name="kOptListMoveSelectorConfig">
+  <xs:complexType abstract="true" name="nearbyAutoConfigurationMoveSelectorConfig">
             
     
     <xs:complexContent>
                   
       
       <xs:extension base="tns:moveSelectorConfig">
+                        
+        
+        <xs:sequence/>
+                      
+      
+      </xs:extension>
+                
+    
+    </xs:complexContent>
+          
+  
+  </xs:complexType>
+      
+  
+  <xs:complexType name="kOptListMoveSelectorConfig">
+            
+    
+    <xs:complexContent>
+                  
+      
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                         
         
         <xs:sequence>
@@ -1262,7 +1283,7 @@
     <xs:complexContent>
                   
       
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                         
         
         <xs:sequence>
@@ -1325,7 +1346,7 @@
     <xs:complexContent>
                   
       
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                         
         
         <xs:sequence>
@@ -1739,7 +1760,7 @@
     <xs:complexContent>
                   
       
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                         
         
         <xs:sequence>
@@ -1790,7 +1811,7 @@
     <xs:complexContent>
                   
       
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                         
         
         <xs:sequence>
@@ -1820,7 +1841,7 @@
     <xs:complexContent>
                   
       
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                         
         
         <xs:sequence>

--- a/core/core-impl/src/build/revapi-differences.json
+++ b/core/core-impl/src/build/revapi-differences.json
@@ -13,6 +13,62 @@
           "oldValue": "{\"environmentMode\", \"daemon\", \"randomType\", \"randomSeed\", \"randomFactoryClass\", \"moveThreadCount\", \"moveThreadBufferSize\", \"threadFactoryClass\", \"monitoringConfig\", \"solutionClass\", \"entityClassList\", \"domainAccessType\", \"scoreDirectorFactoryConfig\", \"terminationConfig\", \"phaseConfigList\"}",
           "newValue": "{\"environmentMode\", \"daemon\", \"randomType\", \"randomSeed\", \"randomFactoryClass\", \"moveThreadCount\", \"moveThreadBufferSize\", \"threadFactoryClass\", \"monitoringConfig\", \"solutionClass\", \"entityClassList\", \"domainAccessType\", \"scoreDirectorFactoryConfig\", \"terminationConfig\", \"nearbyDistanceMeterClass\", \"phaseConfigList\"}",
           "justification": "Adding new Nearby root property"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.nonFinalClassInheritsFromNewClass",
+          "old": "class ai.timefold.solver.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig",
+          "new": "class ai.timefold.solver.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig",
+          "superClass": "ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig<ai.timefold.solver.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig>",
+          "justification": "Adding support for Nearby Selection autoconfiguration"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.nonFinalClassInheritsFromNewClass",
+          "old": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig",
+          "new": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig",
+          "superClass": "ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig<ai.timefold.solver.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig>",
+          "justification": "Adding support for Nearby Selection autoconfiguration"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.nonFinalClassInheritsFromNewClass",
+          "old": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig",
+          "new": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig",
+          "superClass": "ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig<ai.timefold.solver.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig>",
+          "justification": "Adding support for Nearby Selection autoconfiguration"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.nonFinalClassInheritsFromNewClass",
+          "old": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig",
+          "new": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig",
+          "superClass": "ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig<ai.timefold.solver.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig>",
+          "justification": "Adding support for Nearby Selection autoconfiguration"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.nonFinalClassInheritsFromNewClass",
+          "old": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig",
+          "new": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig",
+          "superClass": "ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig<ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig>",
+          "justification": "Adding support for Nearby Selection autoconfiguration"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.nonFinalClassInheritsFromNewClass",
+          "old": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListSwapMoveSelectorConfig",
+          "new": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListSwapMoveSelectorConfig",
+          "superClass": "ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig<ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListSwapMoveSelectorConfig>",
+          "justification": "Adding support for Nearby Selection autoconfiguration"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.nonFinalClassInheritsFromNewClass",
+          "old": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.list.kopt.KOptListMoveSelectorConfig",
+          "new": "class ai.timefold.solver.core.config.heuristic.selector.move.generic.list.kopt.KOptListMoveSelectorConfig",
+          "superClass": "ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig<ai.timefold.solver.core.config.heuristic.selector.move.generic.list.kopt.KOptListMoveSelectorConfig>",
+          "justification": "Adding support for Nearby Selection autoconfiguration"
         }
       ]
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/SelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/SelectorConfig.java
@@ -10,4 +10,8 @@ import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConf
  */
 public abstract class SelectorConfig<Config_ extends SelectorConfig<Config_>> extends AbstractConfig<Config_> {
 
+    /**
+     * Verifies if the current configuration has any Nearby Selection settings.
+     */
+    public abstract boolean hasNearbySelectionConfig();
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
@@ -343,4 +343,8 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
         classVisitor.accept(nearbyDistanceMeterClass);
     }
 
+    @Override
+    public boolean hasNearbySelectionConfig() {
+        return true;
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/entity/EntitySelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/entity/EntitySelectorConfig.java
@@ -362,4 +362,8 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
         }
     }
 
+    @Override
+    public boolean hasNearbySelectionConfig() {
+        return nearbySelectionConfig != null;
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/entity/pillar/PillarSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/entity/pillar/PillarSelectorConfig.java
@@ -91,4 +91,9 @@ public class PillarSelectorConfig extends SelectorConfig<PillarSelectorConfig> {
     public String toString() {
         return getClass().getSimpleName() + "(" + entitySelectorConfig + ")";
     }
+
+    @Override
+    public boolean hasNearbySelectionConfig() {
+        return entitySelectorConfig != null && entitySelectorConfig.hasNearbySelectionConfig();
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/list/DestinationSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/list/DestinationSelectorConfig.java
@@ -111,4 +111,11 @@ public class DestinationSelectorConfig extends SelectorConfig<DestinationSelecto
     public String toString() {
         return getClass().getSimpleName() + "(" + entitySelectorConfig + ", " + valueSelectorConfig + ")";
     }
+
+    @Override
+    public boolean hasNearbySelectionConfig() {
+        return nearbySelectionConfig != null
+                || (entitySelectorConfig != null && entitySelectorConfig.hasNearbySelectionConfig())
+                || (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig());
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/list/SubListSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/list/SubListSelectorConfig.java
@@ -156,6 +156,11 @@ public class SubListSelectorConfig extends SelectorConfig<SubListSelectorConfig>
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return nearbySelectionConfig != null || (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig());
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + valueSelectorConfig + ")";
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.config.heuristic.selector.move;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Random;
 import java.util.function.Consumer;
 
 import jakarta.xml.bind.annotation.XmlSeeAlso;
@@ -32,6 +33,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.Selectio
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionProbabilityWeightFactory;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionSorter;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionSorterWeightFactory;
+import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 
 /**
  * General superclass for {@link ChangeMoveSelectorConfig}, etc.
@@ -279,5 +281,34 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
         fixedProbabilityWeight = ConfigUtils.inheritOverwritableProperty(
                 fixedProbabilityWeight, inheritedConfig.getFixedProbabilityWeight());
     }
+
+    protected String addRandomSuffix(String name, Random random) {
+        StringBuilder value = new StringBuilder(name);
+        value.append("-");
+        random.ints(97, 122) // ['a', 'z']
+                .limit(4) // 4 letters
+                .forEach(value::appendCodePoint);
+        return value.toString();
+    }
+
+    /**
+     * Check if the selector factory accepts Nearby selection autoconfiguration.
+     *
+     * @return false by default
+     */
+    public boolean acceptNearbySelectionAutoConfiguration() {
+        return false;
+    }
+
+    /**
+     * Enables the Nearby Selection autoconfiguration.
+     *
+     * @return new instance with the Nearby Selection settings properly configured
+     */
+    public Config_ enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter, Random random) {
+        throw new UnsupportedOperationException();
+    }
+
+    public abstract boolean hasNearbySelectionConfig();
 
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -292,7 +292,7 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
     }
 
     /**
-     * Check if the selector factory accepts Nearby selection autoconfiguration.
+     * Check if the move selector accepts Nearby autoconfiguration.
      *
      * @return false by default
      */
@@ -309,6 +309,9 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Verifies if the current configuration has any Nearby Selection settings.
+     */
     public abstract boolean hasNearbySelectionConfig();
 
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -280,9 +280,4 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
                 fixedProbabilityWeight, inheritedConfig.getFixedProbabilityWeight());
     }
 
-    /**
-     * Verifies if the current configuration has any Nearby Selection settings.
-     */
-    public abstract boolean hasNearbySelectionConfig();
-
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -305,7 +305,7 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
      *
      * @return new instance with the Nearby Selection settings properly configured
      */
-    public Config_ enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter, Random random) {
+    public Config_ enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, Random random) {
         throw new UnsupportedOperationException();
     }
 

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -2,7 +2,6 @@ package ai.timefold.solver.core.config.heuristic.selector.move;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Random;
 import java.util.function.Consumer;
 
 import jakarta.xml.bind.annotation.XmlSeeAlso;
@@ -33,7 +32,6 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.Selectio
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionProbabilityWeightFactory;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionSorter;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionSorterWeightFactory;
-import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 
 /**
  * General superclass for {@link ChangeMoveSelectorConfig}, etc.
@@ -280,33 +278,6 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
 
         fixedProbabilityWeight = ConfigUtils.inheritOverwritableProperty(
                 fixedProbabilityWeight, inheritedConfig.getFixedProbabilityWeight());
-    }
-
-    protected String addRandomSuffix(String name, Random random) {
-        StringBuilder value = new StringBuilder(name);
-        value.append("-");
-        random.ints(97, 122) // ['a', 'z']
-                .limit(4) // 4 letters
-                .forEach(value::appendCodePoint);
-        return value.toString();
-    }
-
-    /**
-     * Check if the move selector accepts Nearby autoconfiguration.
-     *
-     * @return false by default
-     */
-    public boolean acceptNearbySelectionAutoConfiguration() {
-        return false;
-    }
-
-    /**
-     * Enables the Nearby Selection autoconfiguration.
-     *
-     * @return new instance with the Nearby Selection settings properly configured
-     */
-    public Config_ enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, Random random) {
-        throw new UnsupportedOperationException();
     }
 
     /**

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/NearbyAutoConfigurationMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/NearbyAutoConfigurationMoveSelectorConfig.java
@@ -1,0 +1,28 @@
+package ai.timefold.solver.core.config.heuristic.selector.move;
+
+import java.util.Random;
+
+import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
+
+/**
+ * General superclass for move selectors that support Nearby Selection autoconfiguration.
+ */
+public abstract class NearbyAutoConfigurationMoveSelectorConfig<Config_ extends MoveSelectorConfig<Config_>>
+        extends MoveSelectorConfig<Config_> {
+
+    /**
+     * Enables the Nearby Selection autoconfiguration.
+     *
+     * @return new instance with the Nearby Selection settings properly configured
+     */
+    public abstract Config_ enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, Random random);
+
+    protected static String addRandomSuffix(String name, Random random) {
+        StringBuilder value = new StringBuilder(name);
+        value.append("-");
+        random.ints(97, 122) // ['a', 'z']
+                .limit(4) // 4 letters
+                .forEach(value::appendCodePoint);
+        return value.toString();
+    }
+}

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
@@ -160,7 +160,8 @@ public class CartesianProductMoveSelectorConfig extends MoveSelectorConfig<Carte
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return moveSelectorConfigList.stream().anyMatch(MoveSelectorConfig::hasNearbySelectionConfig);
+        return moveSelectorConfigList != null
+                && moveSelectorConfigList.stream().anyMatch(MoveSelectorConfig::hasNearbySelectionConfig);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
@@ -159,6 +159,11 @@ public class CartesianProductMoveSelectorConfig extends MoveSelectorConfig<Carte
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return moveSelectorConfigList.stream().anyMatch(MoveSelectorConfig::hasNearbySelectionConfig);
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + moveSelectorConfigList + ")";
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
@@ -10,8 +10,6 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElements;
 import jakarta.xml.bind.annotation.XmlType;
 
-import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
-import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.factory.MoveIteratorFactoryConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.factory.MoveListFactoryConfig;
@@ -27,7 +25,6 @@ import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListS
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.SubListChangeMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.SubListSwapMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.kopt.KOptListMoveSelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionProbabilityWeightFactory;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -174,7 +171,7 @@ public class UnionMoveSelectorConfig extends MoveSelectorConfig<UnionMoveSelecto
     }
 
     @Override
-    public UnionMoveSelectorConfig enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter,
+    public UnionMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
             Random random) {
         UnionMoveSelectorConfig nearbyConfig = copyConfig();
         List<MoveSelectorConfig> updatedMoveSelectorList = new LinkedList<>(moveSelectorConfigList);
@@ -189,7 +186,8 @@ public class UnionMoveSelectorConfig extends MoveSelectorConfig<UnionMoveSelecto
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return moveSelectorConfigList.stream().anyMatch(MoveSelectorConfig::hasNearbySelectionConfig);
+        return moveSelectorConfigList != null
+                && moveSelectorConfigList.stream().anyMatch(MoveSelectorConfig::hasNearbySelectionConfig);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
@@ -174,10 +174,15 @@ public class UnionMoveSelectorConfig extends MoveSelectorConfig<UnionMoveSelecto
     public UnionMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
             Random random) {
         UnionMoveSelectorConfig nearbyConfig = copyConfig();
-        List<MoveSelectorConfig> updatedMoveSelectorList = new LinkedList<>(moveSelectorConfigList);
-        for (MoveSelectorConfig selectorConfig : moveSelectorConfigList) {
+        List<MoveSelectorConfig> updatedMoveSelectorList = new LinkedList<>();
+        for (MoveSelectorConfig<?> selectorConfig : moveSelectorConfigList) {
             if (selectorConfig.acceptNearbySelectionAutoConfiguration()) {
-                updatedMoveSelectorList.add(selectorConfig.enableNearbySelection(distanceMeter, random));
+                if (UnionMoveSelectorConfig.class.isAssignableFrom(selectorConfig.getClass())) {
+                    updatedMoveSelectorList.add(selectorConfig.enableNearbySelection(distanceMeter, random));
+                } else {
+                    updatedMoveSelectorList.add(selectorConfig.copyConfig());
+                    updatedMoveSelectorList.add(selectorConfig.enableNearbySelection(distanceMeter, random));
+                }
             }
         }
         nearbyConfig.withMoveSelectorList(updatedMoveSelectorList);

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
@@ -170,8 +170,8 @@ public class UnionMoveSelectorConfig extends NearbyAutoConfigurationMoveSelector
     public UnionMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
             Random random) {
         UnionMoveSelectorConfig nearbyConfig = copyConfig();
-        List<MoveSelectorConfig> updatedMoveSelectorList = new LinkedList<>();
-        for (MoveSelectorConfig<?> selectorConfig : moveSelectorConfigList) {
+        var updatedMoveSelectorList = new LinkedList<MoveSelectorConfig>();
+        for (var selectorConfig : moveSelectorConfigList) {
             if (selectorConfig instanceof NearbyAutoConfigurationMoveSelectorConfig<?> nearbySelectorConfig) {
                 if (UnionMoveSelectorConfig.class.isAssignableFrom(nearbySelectorConfig.getClass())) {
                     updatedMoveSelectorList.add(nearbySelectorConfig.enableNearbySelection(distanceMeter, random));
@@ -180,7 +180,7 @@ public class UnionMoveSelectorConfig extends NearbyAutoConfigurationMoveSelector
                     updatedMoveSelectorList.add(nearbySelectorConfig.enableNearbySelection(distanceMeter, random));
                 }
             } else {
-                updatedMoveSelectorList.add(selectorConfig.copyConfig());
+                updatedMoveSelectorList.add((MoveSelectorConfig<?>) selectorConfig.copyConfig());
             }
         }
         nearbyConfig.withMoveSelectorList(updatedMoveSelectorList);

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
@@ -171,14 +171,16 @@ public class UnionMoveSelectorConfig extends NearbyAutoConfigurationMoveSelector
             Random random) {
         UnionMoveSelectorConfig nearbyConfig = copyConfig();
         List<MoveSelectorConfig> updatedMoveSelectorList = new LinkedList<>();
-        for (NearbyAutoConfigurationMoveSelectorConfig<?> selectorConfig : moveSelectorConfigList.stream()
-                .filter(s -> NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(s.getClass()))
-                .map(s -> (NearbyAutoConfigurationMoveSelectorConfig<?>) s).toList()) {
-            if (UnionMoveSelectorConfig.class.isAssignableFrom(selectorConfig.getClass())) {
-                updatedMoveSelectorList.add(selectorConfig.enableNearbySelection(distanceMeter, random));
+        for (MoveSelectorConfig<?> selectorConfig : moveSelectorConfigList) {
+            if (selectorConfig instanceof NearbyAutoConfigurationMoveSelectorConfig<?> nearbySelectorConfig) {
+                if (UnionMoveSelectorConfig.class.isAssignableFrom(nearbySelectorConfig.getClass())) {
+                    updatedMoveSelectorList.add(nearbySelectorConfig.enableNearbySelection(distanceMeter, random));
+                } else {
+                    updatedMoveSelectorList.add(nearbySelectorConfig.copyConfig());
+                    updatedMoveSelectorList.add(nearbySelectorConfig.enableNearbySelection(distanceMeter, random));
+                }
             } else {
                 updatedMoveSelectorList.add(selectorConfig.copyConfig());
-                updatedMoveSelectorList.add(selectorConfig.enableNearbySelection(distanceMeter, random));
             }
         }
         nearbyConfig.withMoveSelectorList(updatedMoveSelectorList);

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/factory/MoveIteratorFactoryConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/factory/MoveIteratorFactoryConfig.java
@@ -78,6 +78,11 @@ public class MoveIteratorFactoryConfig extends MoveSelectorConfig<MoveIteratorFa
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + moveIteratorFactoryClass + ")";
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/factory/MoveListFactoryConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/factory/MoveListFactoryConfig.java
@@ -80,6 +80,11 @@ public class MoveListFactoryConfig extends MoveSelectorConfig<MoveListFactoryCon
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + moveListFactoryClass + ")";
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/AbstractPillarMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/AbstractPillarMoveSelectorConfig.java
@@ -85,4 +85,8 @@ public abstract class AbstractPillarMoveSelectorConfig<Config_ extends AbstractP
         }
     }
 
+    @Override
+    public boolean hasNearbySelectionConfig() {
+        return pillarSelectorConfig != null && pillarSelectorConfig.hasNearbySelectionConfig();
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
@@ -8,7 +8,7 @@ import jakarta.xml.bind.annotation.XmlType;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -17,7 +17,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDista
         "entitySelectorConfig",
         "valueSelectorConfig"
 })
-public class ChangeMoveSelectorConfig extends MoveSelectorConfig<ChangeMoveSelectorConfig> {
+public class ChangeMoveSelectorConfig extends NearbyAutoConfigurationMoveSelectorConfig<ChangeMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "changeMoveSelector";
 
@@ -107,11 +107,6 @@ public class ChangeMoveSelectorConfig extends MoveSelectorConfig<ChangeMoveSelec
         nearbyConfig.withEntitySelectorConfig(entityConfig)
                 .withValueSelectorConfig(valueConfig);
         return nearbyConfig;
-    }
-
-    @Override
-    public boolean acceptNearbySelectionAutoConfiguration() {
-        return true;
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
@@ -111,8 +111,8 @@ public class ChangeMoveSelectorConfig extends NearbyAutoConfigurationMoveSelecto
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (entitySelectorConfig != null && entitySelectorConfig.getNearbySelectionConfig() != null)
-                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
+        return (entitySelectorConfig != null && entitySelectorConfig.hasNearbySelectionConfig())
+                || (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
@@ -86,7 +86,7 @@ public class ChangeMoveSelectorConfig extends MoveSelectorConfig<ChangeMoveSelec
     }
 
     @Override
-    public ChangeMoveSelectorConfig enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter,
+    public ChangeMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
             Random random) {
         ChangeMoveSelectorConfig nearbyConfig = copyConfig();
         EntitySelectorConfig entityConfig = nearbyConfig.getEntitySelectorConfig();
@@ -116,8 +116,8 @@ public class ChangeMoveSelectorConfig extends MoveSelectorConfig<ChangeMoveSelec
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return entitySelectorConfig.getNearbySelectionConfig() != null
-                || valueSelectorConfig.getNearbySelectionConfig() != null;
+        return (entitySelectorConfig != null && entitySelectorConfig.getNearbySelectionConfig() != null)
+                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
@@ -57,9 +57,8 @@ public class PillarChangeMoveSelectorConfig extends AbstractPillarMoveSelectorCo
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (pillarSelectorConfig != null && pillarSelectorConfig.getEntitySelectorConfig() != null
-                && pillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null)
-                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
+        return (pillarSelectorConfig != null && pillarSelectorConfig.hasNearbySelectionConfig())
+                || (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
@@ -56,6 +56,12 @@ public class PillarChangeMoveSelectorConfig extends AbstractPillarMoveSelectorCo
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return pillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null ||
+                valueSelectorConfig.getNearbySelectionConfig() != null;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + pillarSelectorConfig + ", " + valueSelectorConfig + ")";
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
@@ -57,8 +57,9 @@ public class PillarChangeMoveSelectorConfig extends AbstractPillarMoveSelectorCo
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return pillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null ||
-                valueSelectorConfig.getNearbySelectionConfig() != null;
+        return (pillarSelectorConfig != null && pillarSelectorConfig.getEntitySelectorConfig() != null
+                && pillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null)
+                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
@@ -84,6 +84,12 @@ public class PillarSwapMoveSelectorConfig extends AbstractPillarMoveSelectorConf
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return pillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null
+                || secondaryPillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + pillarSelectorConfig
                 + (secondaryPillarSelectorConfig == null ? "" : ", " + secondaryPillarSelectorConfig) + ")";

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
@@ -85,10 +85,8 @@ public class PillarSwapMoveSelectorConfig extends AbstractPillarMoveSelectorConf
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (pillarSelectorConfig != null && pillarSelectorConfig.getEntitySelectorConfig() != null
-                && pillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null)
-                || (secondaryPillarSelectorConfig != null && secondaryPillarSelectorConfig.getEntitySelectorConfig() != null
-                        && secondaryPillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null);
+        return (pillarSelectorConfig != null && pillarSelectorConfig.hasNearbySelectionConfig())
+                || (secondaryPillarSelectorConfig != null && secondaryPillarSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
@@ -85,8 +85,10 @@ public class PillarSwapMoveSelectorConfig extends AbstractPillarMoveSelectorConf
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return pillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null
-                || secondaryPillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null;
+        return (pillarSelectorConfig != null && pillarSelectorConfig.getEntitySelectorConfig() != null
+                && pillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null)
+                || (secondaryPillarSelectorConfig != null && secondaryPillarSelectorConfig.getEntitySelectorConfig() != null
+                        && secondaryPillarSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
@@ -2,15 +2,19 @@ package ai.timefold.solver.core.config.heuristic.selector.move.generic;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import java.util.function.Consumer;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlType;
 
+import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
+import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 
 @XmlType(propOrder = {
         "entitySelectorConfig",
@@ -102,6 +106,40 @@ public class SwapMoveSelectorConfig extends MoveSelectorConfig<SwapMoveSelectorC
         if (secondaryEntitySelectorConfig != null) {
             secondaryEntitySelectorConfig.visitReferencedClasses(classVisitor);
         }
+    }
+
+    @Override
+    public SwapMoveSelectorConfig enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter,
+            Random random) {
+        SwapMoveSelectorConfig nearbyConfig = copyConfig();
+        EntitySelectorConfig entityConfig = nearbyConfig.getEntitySelectorConfig();
+        if (entityConfig == null) {
+            entityConfig = new EntitySelectorConfig();
+        }
+        String entitySelectorId = addRandomSuffix("entitySelector", random);
+        entityConfig.withId(entitySelectorId);
+        EntitySelectorConfig secondaryConfig = nearbyConfig.getSecondaryEntitySelectorConfig();
+        if (secondaryConfig == null) {
+            secondaryConfig = new EntitySelectorConfig();
+        }
+        secondaryConfig.withNearbySelectionConfig(new NearbySelectionConfig()
+                .withOriginEntitySelectorConfig(new EntitySelectorConfig()
+                        .withMimicSelectorRef(entitySelectorId))
+                .withNearbyDistanceMeterClass(distanceMeter));
+        nearbyConfig.withEntitySelectorConfig(entityConfig)
+                .withSecondaryEntitySelectorConfig(secondaryConfig);
+        return nearbyConfig;
+    }
+
+    @Override
+    public boolean acceptNearbySelectionAutoConfiguration() {
+        return true;
+    }
+
+    @Override
+    public boolean hasNearbySelectionConfig() {
+        return entitySelectorConfig.getNearbySelectionConfig() != null
+                || secondaryEntitySelectorConfig.getNearbySelectionConfig() != null;
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
@@ -12,7 +12,6 @@ import jakarta.xml.bind.annotation.XmlType;
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 
@@ -109,7 +108,7 @@ public class SwapMoveSelectorConfig extends MoveSelectorConfig<SwapMoveSelectorC
     }
 
     @Override
-    public SwapMoveSelectorConfig enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter,
+    public SwapMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
             Random random) {
         SwapMoveSelectorConfig nearbyConfig = copyConfig();
         EntitySelectorConfig entityConfig = nearbyConfig.getEntitySelectorConfig();
@@ -138,8 +137,8 @@ public class SwapMoveSelectorConfig extends MoveSelectorConfig<SwapMoveSelectorC
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return entitySelectorConfig.getNearbySelectionConfig() != null
-                || secondaryEntitySelectorConfig.getNearbySelectionConfig() != null;
+        return (entitySelectorConfig != null && entitySelectorConfig.getNearbySelectionConfig() != null)
+                || (secondaryEntitySelectorConfig != null && secondaryEntitySelectorConfig.getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
@@ -132,8 +132,8 @@ public class SwapMoveSelectorConfig extends NearbyAutoConfigurationMoveSelectorC
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (entitySelectorConfig != null && entitySelectorConfig.getNearbySelectionConfig() != null)
-                || (secondaryEntitySelectorConfig != null && secondaryEntitySelectorConfig.getNearbySelectionConfig() != null);
+        return (entitySelectorConfig != null && entitySelectorConfig.hasNearbySelectionConfig())
+                || (secondaryEntitySelectorConfig != null && secondaryEntitySelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
@@ -11,7 +11,7 @@ import jakarta.xml.bind.annotation.XmlType;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 
@@ -20,7 +20,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDista
         "secondaryEntitySelectorConfig",
         "variableNameIncludeList"
 })
-public class SwapMoveSelectorConfig extends MoveSelectorConfig<SwapMoveSelectorConfig> {
+public class SwapMoveSelectorConfig extends NearbyAutoConfigurationMoveSelectorConfig<SwapMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "swapMoveSelector";
 
@@ -128,11 +128,6 @@ public class SwapMoveSelectorConfig extends MoveSelectorConfig<SwapMoveSelectorC
         nearbyConfig.withEntitySelectorConfig(entityConfig)
                 .withSecondaryEntitySelectorConfig(secondaryConfig);
         return nearbyConfig;
-    }
-
-    @Override
-    public boolean acceptNearbySelectionAutoConfiguration() {
-        return true;
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
@@ -90,6 +90,12 @@ public class KOptMoveSelectorConfig extends MoveSelectorConfig<KOptMoveSelectorC
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return entitySelectorConfig.getNearbySelectionConfig() != null
+                || valueSelectorConfig.getNearbySelectionConfig() != null;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + entitySelectorConfig + ", " + valueSelectorConfig + ")";
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
@@ -91,8 +91,8 @@ public class KOptMoveSelectorConfig extends MoveSelectorConfig<KOptMoveSelectorC
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return entitySelectorConfig.getNearbySelectionConfig() != null
-                || valueSelectorConfig.getNearbySelectionConfig() != null;
+        return (entitySelectorConfig != null && entitySelectorConfig.getNearbySelectionConfig() != null)
+                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
@@ -91,8 +91,8 @@ public class KOptMoveSelectorConfig extends MoveSelectorConfig<KOptMoveSelectorC
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (entitySelectorConfig != null && entitySelectorConfig.getNearbySelectionConfig() != null)
-                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
+        return (entitySelectorConfig != null && entitySelectorConfig.hasNearbySelectionConfig())
+                || (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorConfig.java
@@ -114,9 +114,8 @@ public class SubChainChangeMoveSelectorConfig extends MoveSelectorConfig<SubChai
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (subChainSelectorConfig != null && subChainSelectorConfig.getValueSelectorConfig() != null
-                && subChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)
-                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
+        return (subChainSelectorConfig != null && subChainSelectorConfig.hasNearbySelectionConfig())
+                || (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorConfig.java
@@ -113,6 +113,12 @@ public class SubChainChangeMoveSelectorConfig extends MoveSelectorConfig<SubChai
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return subChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
+                || valueSelectorConfig.getNearbySelectionConfig() != null;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + subChainSelectorConfig + ", " + valueSelectorConfig + ")";
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorConfig.java
@@ -114,8 +114,9 @@ public class SubChainChangeMoveSelectorConfig extends MoveSelectorConfig<SubChai
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return subChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
-                || valueSelectorConfig.getNearbySelectionConfig() != null;
+        return (subChainSelectorConfig != null && subChainSelectorConfig.getValueSelectorConfig() != null
+                && subChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)
+                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorConfig.java
@@ -114,6 +114,12 @@ public class SubChainSwapMoveSelectorConfig extends MoveSelectorConfig<SubChainS
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return subChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
+                || secondarySubChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + subChainSelectorConfig
                 + (secondarySubChainSelectorConfig == null ? "" : ", " + secondarySubChainSelectorConfig) + ")";

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorConfig.java
@@ -115,10 +115,8 @@ public class SubChainSwapMoveSelectorConfig extends MoveSelectorConfig<SubChainS
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (subChainSelectorConfig != null && subChainSelectorConfig.getValueSelectorConfig() != null
-                && subChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)
-                || (secondarySubChainSelectorConfig != null && secondarySubChainSelectorConfig.getValueSelectorConfig() != null
-                        && secondarySubChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null);
+        return (subChainSelectorConfig != null && subChainSelectorConfig.hasNearbySelectionConfig())
+                || (secondarySubChainSelectorConfig != null && secondarySubChainSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorConfig.java
@@ -115,8 +115,10 @@ public class SubChainSwapMoveSelectorConfig extends MoveSelectorConfig<SubChainS
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return subChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
-                || secondarySubChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null;
+        return (subChainSelectorConfig != null && subChainSelectorConfig.getValueSelectorConfig() != null
+                && subChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)
+                || (secondarySubChainSelectorConfig != null && secondarySubChainSelectorConfig.getValueSelectorConfig() != null
+                        && secondarySubChainSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
@@ -115,8 +115,8 @@ public class TailChainSwapMoveSelectorConfig
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (entitySelectorConfig != null && entitySelectorConfig.getNearbySelectionConfig() != null)
-                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
+        return (entitySelectorConfig != null && entitySelectorConfig.hasNearbySelectionConfig())
+                || (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
@@ -9,7 +9,6 @@ import jakarta.xml.bind.annotation.XmlType;
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -79,7 +78,7 @@ public class TailChainSwapMoveSelectorConfig extends MoveSelectorConfig<TailChai
     }
 
     @Override
-    public TailChainSwapMoveSelectorConfig enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter,
+    public TailChainSwapMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
             Random random) {
         TailChainSwapMoveSelectorConfig nearbyConfig = copyConfig();
         EntitySelectorConfig entityConfig = nearbyConfig.getEntitySelectorConfig();
@@ -120,8 +119,8 @@ public class TailChainSwapMoveSelectorConfig extends MoveSelectorConfig<TailChai
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return entitySelectorConfig.getNearbySelectionConfig() != null
-                || valueSelectorConfig.getNearbySelectionConfig() != null;
+        return (entitySelectorConfig != null && entitySelectorConfig.getNearbySelectionConfig() != null)
+                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
@@ -78,8 +78,19 @@ public class TailChainSwapMoveSelectorConfig extends MoveSelectorConfig<TailChai
     }
 
     @Override
+    public void visitReferencedClasses(Consumer<Class<?>> classVisitor) {
+        visitCommonReferencedClasses(classVisitor);
+        if (entitySelectorConfig != null) {
+            entitySelectorConfig.visitReferencedClasses(classVisitor);
+        }
+        if (valueSelectorConfig != null) {
+            valueSelectorConfig.visitReferencedClasses(classVisitor);
+        }
+    }
+
+    @Override
     public TailChainSwapMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
-            Random random) {
+                                                                 Random random) {
         TailChainSwapMoveSelectorConfig nearbyConfig = copyConfig();
         EntitySelectorConfig entityConfig = nearbyConfig.getEntitySelectorConfig();
         if (entityConfig == null) {
@@ -99,17 +110,6 @@ public class TailChainSwapMoveSelectorConfig extends MoveSelectorConfig<TailChai
         nearbyConfig.withEntitySelectorConfig(entityConfig)
                 .withValueSelectorConfig(valueConfig);
         return nearbyConfig;
-    }
-
-    @Override
-    public void visitReferencedClasses(Consumer<Class<?>> classVisitor) {
-        visitCommonReferencedClasses(classVisitor);
-        if (entitySelectorConfig != null) {
-            entitySelectorConfig.visitReferencedClasses(classVisitor);
-        }
-        if (valueSelectorConfig != null) {
-            valueSelectorConfig.visitReferencedClasses(classVisitor);
-        }
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
@@ -8,7 +8,7 @@ import jakarta.xml.bind.annotation.XmlType;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -20,7 +20,8 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDista
         "entitySelectorConfig",
         "valueSelectorConfig"
 })
-public class TailChainSwapMoveSelectorConfig extends MoveSelectorConfig<TailChainSwapMoveSelectorConfig> {
+public class TailChainSwapMoveSelectorConfig
+        extends NearbyAutoConfigurationMoveSelectorConfig<TailChainSwapMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "tailChainSwapMoveSelector";
 
@@ -90,7 +91,7 @@ public class TailChainSwapMoveSelectorConfig extends MoveSelectorConfig<TailChai
 
     @Override
     public TailChainSwapMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
-                                                                 Random random) {
+            Random random) {
         TailChainSwapMoveSelectorConfig nearbyConfig = copyConfig();
         EntitySelectorConfig entityConfig = nearbyConfig.getEntitySelectorConfig();
         if (entityConfig == null) {
@@ -110,11 +111,6 @@ public class TailChainSwapMoveSelectorConfig extends MoveSelectorConfig<TailChai
         nearbyConfig.withEntitySelectorConfig(entityConfig)
                 .withValueSelectorConfig(valueConfig);
         return nearbyConfig;
-    }
-
-    @Override
-    public boolean acceptNearbySelectionAutoConfiguration() {
-        return true;
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
@@ -111,12 +111,8 @@ public class ListChangeMoveSelectorConfig extends NearbyAutoConfigurationMoveSel
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null)
-                || (destinationSelectorConfig != null && ((destinationSelectorConfig.getNearbySelectionConfig() != null)
-                        || (destinationSelectorConfig.getEntitySelectorConfig() != null
-                                && destinationSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null)
-                        || (destinationSelectorConfig.getValueSelectorConfig() != null
-                                && destinationSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)));
+        return (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig())
+                || (destinationSelectorConfig != null && destinationSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
@@ -8,7 +8,7 @@ import jakarta.xml.bind.annotation.XmlType;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import ai.timefold.solver.core.config.heuristic.selector.list.DestinationSelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -17,7 +17,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDista
         "valueSelectorConfig",
         "destinationSelectorConfig"
 })
-public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeMoveSelectorConfig> {
+public class ListChangeMoveSelectorConfig extends NearbyAutoConfigurationMoveSelectorConfig<ListChangeMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "listChangeMoveSelector";
 
@@ -107,11 +107,6 @@ public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeM
         nearbyConfig.withValueSelectorConfig(valueConfig)
                 .withDestinationSelectorConfig(destinationConfig);
         return nearbyConfig;
-    }
-
-    @Override
-    public boolean acceptNearbySelectionAutoConfiguration() {
-        return true;
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
@@ -7,10 +7,8 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
-import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.list.DestinationSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -89,7 +87,7 @@ public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeM
     }
 
     @Override
-    public ListChangeMoveSelectorConfig enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter,
+    public ListChangeMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
             Random random) {
         ListChangeMoveSelectorConfig nearbyConfig = copyConfig();
         ValueSelectorConfig valueConfig = nearbyConfig.getValueSelectorConfig();
@@ -118,10 +116,12 @@ public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeM
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return valueSelectorConfig.getNearbySelectionConfig() != null
-                || destinationSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null
-                || destinationSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
-                || destinationSelectorConfig.getNearbySelectionConfig() != null;
+        return (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null)
+                || (destinationSelectorConfig != null && ((destinationSelectorConfig.getNearbySelectionConfig() != null)
+                        || (destinationSelectorConfig.getEntitySelectorConfig() != null
+                                && destinationSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null)
+                        || (destinationSelectorConfig.getValueSelectorConfig() != null
+                                && destinationSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)));
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
@@ -7,7 +7,7 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -16,7 +16,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDista
         "valueSelectorConfig",
         "secondaryValueSelectorConfig"
 })
-public class ListSwapMoveSelectorConfig extends MoveSelectorConfig<ListSwapMoveSelectorConfig> {
+public class ListSwapMoveSelectorConfig extends NearbyAutoConfigurationMoveSelectorConfig<ListSwapMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "listSwapMoveSelector";
 
@@ -105,11 +105,6 @@ public class ListSwapMoveSelectorConfig extends MoveSelectorConfig<ListSwapMoveS
         nearbyConfig.withValueSelectorConfig(valueConfig)
                 .withSecondaryValueSelectorConfig(secondaryConfig);
         return nearbyConfig;
-    }
-
-    @Override
-    public boolean acceptNearbySelectionAutoConfiguration() {
-        return true;
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
@@ -109,8 +109,8 @@ public class ListSwapMoveSelectorConfig extends NearbyAutoConfigurationMoveSelec
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null)
-                || (secondaryValueSelectorConfig != null && secondaryValueSelectorConfig.getNearbySelectionConfig() != null);
+        return (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig())
+                || (secondaryValueSelectorConfig != null && secondaryValueSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
@@ -7,9 +7,7 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
-import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -87,7 +85,7 @@ public class ListSwapMoveSelectorConfig extends MoveSelectorConfig<ListSwapMoveS
     }
 
     @Override
-    public ListSwapMoveSelectorConfig enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter,
+    public ListSwapMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
             Random random) {
         ListSwapMoveSelectorConfig nearbyConfig = copyConfig();
         ValueSelectorConfig valueConfig = nearbyConfig.getValueSelectorConfig();
@@ -116,8 +114,8 @@ public class ListSwapMoveSelectorConfig extends MoveSelectorConfig<ListSwapMoveS
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return valueSelectorConfig.getNearbySelectionConfig() != null
-                || secondaryValueSelectorConfig.getNearbySelectionConfig() != null;
+        return (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null)
+                || (secondaryValueSelectorConfig != null && secondaryValueSelectorConfig.getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
@@ -156,11 +156,14 @@ public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListC
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return subListSelectorConfig.getNearbySelectionConfig() != null
-                || subListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
-                || destinationSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null
-                || destinationSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
-                || destinationSelectorConfig.getNearbySelectionConfig() != null;
+        return (subListSelectorConfig != null && ((subListSelectorConfig.getNearbySelectionConfig() != null)
+                || (subListSelectorConfig.getValueSelectorConfig() != null
+                        && subListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)))
+                || (destinationSelectorConfig != null && ((destinationSelectorConfig.getNearbySelectionConfig() != null)
+                        || (destinationSelectorConfig.getEntitySelectorConfig() != null
+                                && destinationSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null)
+                        || (destinationSelectorConfig.getValueSelectorConfig() != null
+                                && destinationSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)));
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
@@ -155,6 +155,15 @@ public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListC
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return subListSelectorConfig.getNearbySelectionConfig() != null
+                || subListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
+                || destinationSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null
+                || destinationSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
+                || destinationSelectorConfig.getNearbySelectionConfig() != null;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + subListSelectorConfig + ", " + destinationSelectorConfig + ")";
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
@@ -156,14 +156,8 @@ public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListC
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (subListSelectorConfig != null && ((subListSelectorConfig.getNearbySelectionConfig() != null)
-                || (subListSelectorConfig.getValueSelectorConfig() != null
-                        && subListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)))
-                || (destinationSelectorConfig != null && ((destinationSelectorConfig.getNearbySelectionConfig() != null)
-                        || (destinationSelectorConfig.getEntitySelectorConfig() != null
-                                && destinationSelectorConfig.getEntitySelectorConfig().getNearbySelectionConfig() != null)
-                        || (destinationSelectorConfig.getValueSelectorConfig() != null
-                                && destinationSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)));
+        return (subListSelectorConfig != null && subListSelectorConfig.hasNearbySelectionConfig())
+                || (destinationSelectorConfig != null && destinationSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
@@ -153,10 +153,14 @@ public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwa
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return subListSelectorConfig.getNearbySelectionConfig() != null
-                || subListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
-                || secondarySubListSelectorConfig.getNearbySelectionConfig() != null
-                || secondarySubListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null;
+        return (subListSelectorConfig != null && ((subListSelectorConfig.getNearbySelectionConfig() != null)
+                || (subListSelectorConfig.getValueSelectorConfig() != null
+                        && subListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)))
+                || (secondarySubListSelectorConfig != null
+                        && ((secondarySubListSelectorConfig.getNearbySelectionConfig() != null)
+                                || (secondarySubListSelectorConfig.getValueSelectorConfig() != null
+                                        && secondarySubListSelectorConfig.getValueSelectorConfig()
+                                                .getNearbySelectionConfig() != null)));
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
@@ -153,14 +153,8 @@ public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwa
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (subListSelectorConfig != null && ((subListSelectorConfig.getNearbySelectionConfig() != null)
-                || (subListSelectorConfig.getValueSelectorConfig() != null
-                        && subListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null)))
-                || (secondarySubListSelectorConfig != null
-                        && ((secondarySubListSelectorConfig.getNearbySelectionConfig() != null)
-                                || (secondarySubListSelectorConfig.getValueSelectorConfig() != null
-                                        && secondarySubListSelectorConfig.getValueSelectorConfig()
-                                                .getNearbySelectionConfig() != null)));
+        return (subListSelectorConfig != null && subListSelectorConfig.hasNearbySelectionConfig())
+                || (secondarySubListSelectorConfig != null && secondarySubListSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
@@ -152,6 +152,14 @@ public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwa
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return subListSelectorConfig.getNearbySelectionConfig() != null
+                || subListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null
+                || secondarySubListSelectorConfig.getNearbySelectionConfig() != null
+                || secondarySubListSelectorConfig.getValueSelectorConfig().getNearbySelectionConfig() != null;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + subListSelectorConfig
                 + (secondarySubListSelectorConfig == null ? "" : ", " + secondarySubListSelectorConfig) + ")";

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
@@ -144,8 +144,8 @@ public class KOptListMoveSelectorConfig extends NearbyAutoConfigurationMoveSelec
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return (originSelectorConfig != null && originSelectorConfig.getNearbySelectionConfig() != null)
-                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
+        return (originSelectorConfig != null && originSelectorConfig.hasNearbySelectionConfig())
+                || (valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig());
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
@@ -7,7 +7,7 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -18,7 +18,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDista
         "originSelectorConfig",
         "valueSelectorConfig"
 })
-public class KOptListMoveSelectorConfig extends MoveSelectorConfig<KOptListMoveSelectorConfig> {
+public class KOptListMoveSelectorConfig extends NearbyAutoConfigurationMoveSelectorConfig<KOptListMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "kOptListMoveSelector";
 
@@ -140,11 +140,6 @@ public class KOptListMoveSelectorConfig extends MoveSelectorConfig<KOptListMoveS
         nearbyConfig.withOriginSelectorConfig(originConfig)
                 .withValueSelectorConfig(valueConfig);
         return nearbyConfig;
-    }
-
-    @Override
-    public boolean acceptNearbySelectionAutoConfiguration() {
-        return true;
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
@@ -7,9 +7,7 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
-import ai.timefold.solver.core.config.heuristic.selector.list.DestinationSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -122,7 +120,7 @@ public class KOptListMoveSelectorConfig extends MoveSelectorConfig<KOptListMoveS
     }
 
     @Override
-    public KOptListMoveSelectorConfig enableNearbySelection(Class<NearbyDistanceMeter<?, ?>> distanceMeter,
+    public KOptListMoveSelectorConfig enableNearbySelection(Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
             Random random) {
         KOptListMoveSelectorConfig nearbyConfig = copyConfig();
         ValueSelectorConfig originConfig = nearbyConfig.getOriginSelectorConfig();
@@ -151,8 +149,8 @@ public class KOptListMoveSelectorConfig extends MoveSelectorConfig<KOptListMoveS
 
     @Override
     public boolean hasNearbySelectionConfig() {
-        return originSelectorConfig.getNearbySelectionConfig() != null
-                || valueSelectorConfig.getNearbySelectionConfig() != null;
+        return (originSelectorConfig != null && originSelectorConfig.getNearbySelectionConfig() != null)
+                || (valueSelectorConfig != null && valueSelectorConfig.getNearbySelectionConfig() != null);
     }
 
     @Override

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/value/ValueSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/value/ValueSelectorConfig.java
@@ -382,4 +382,8 @@ public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
         return sorter;
     }
 
+    @Override
+    public boolean hasNearbySelectionConfig() {
+        return nearbySelectionConfig != null;
+    }
 }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/value/chained/SubChainSelectorConfig.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/config/heuristic/selector/value/chained/SubChainSelectorConfig.java
@@ -91,6 +91,11 @@ public class SubChainSelectorConfig extends SelectorConfig<SubChainSelectorConfi
     }
 
     @Override
+    public boolean hasNearbySelectionConfig() {
+        return valueSelectorConfig != null && valueSelectorConfig.hasNearbySelectionConfig();
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + valueSelectorConfig + ")";
     }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorFactory.java
@@ -22,6 +22,8 @@ public class CartesianProductMoveSelectorFactory<Solution_>
             throw new IllegalArgumentException(
                     """
                             The cartesianProductMoveSelector (%s) is not compatible with using the top-level property nearbyDistanceMeterClass (%s).
+                            Enabling nearbyDistanceMeterClass will duplicate move selector configurations that accept Nearby autoconfiguration.
+                            For example, if there are four selectors (2 non-nearby + 2 nearby), it will be A×B×C×D moves, which may be expensive.
                             Specify move selectors manually or remove the top-level nearbyDistanceMeterClass from your solver config."""
                             .formatted(config, configPolicy.getNearbyDistanceMeterClass()));
         }

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorFactory.java
@@ -18,6 +18,13 @@ public class CartesianProductMoveSelectorFactory<Solution_>
     @Override
     public MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
+        if (configPolicy.getNearbyDistanceMeterClass() != null) {
+            throw new IllegalArgumentException(
+                    """
+                            The cartesianProductMoveSelector (%s) is not compatible with using the top-level property nearbyDistanceMeterClass (%s).
+                            Specify move selectors manually or remove the top-level nearbyDistanceMeterClass from your solver config."""
+                            .formatted(config, configPolicy.getNearbyDistanceMeterClass()));
+        }
         List<MoveSelector<Solution_>> moveSelectorList = buildInnerMoveSelectors(config.getMoveSelectorList(),
                 configPolicy, minimumCacheType, randomSelection);
         boolean ignoreEmptyChildIterators_ = Objects.requireNonNullElse(config.getIgnoreEmptyChildIterators(), true);

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicy;
@@ -25,8 +26,10 @@ public class UnionMoveSelectorFactory<Solution_>
             SelectionCacheType minimumCacheType, boolean randomSelection) {
         List<MoveSelectorConfig> moveSelectorConfigList = new LinkedList<>(config.getMoveSelectorList());
         if (configPolicy.getNearbyDistanceMeterClass() != null) {
-            for (MoveSelectorConfig selectorConfig : config.getMoveSelectorList().stream()
-                    .filter(MoveSelectorConfig::acceptNearbySelectionAutoConfiguration).toList()) {
+            for (NearbyAutoConfigurationMoveSelectorConfig selectorConfig : config.getMoveSelectorList().stream()
+                    .filter(s -> NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(s.getClass()))
+                    .map(s -> (NearbyAutoConfigurationMoveSelectorConfig<?>) s)
+                    .toList()) {
                 if (selectorConfig.hasNearbySelectionConfig()) {
                     throw new IllegalArgumentException(
                             """

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
@@ -26,20 +26,20 @@ public class UnionMoveSelectorFactory<Solution_>
             SelectionCacheType minimumCacheType, boolean randomSelection) {
         var moveSelectorConfigList = new LinkedList<>(config.getMoveSelectorList());
         if (configPolicy.getNearbyDistanceMeterClass() != null) {
-            for (NearbyAutoConfigurationMoveSelectorConfig selectorConfig : config.getMoveSelectorList().stream()
-                    .filter(s -> NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(s.getClass()))
-                    .map(s -> (NearbyAutoConfigurationMoveSelectorConfig<?>) s)
-                    .toList()) {
-                if (selectorConfig.hasNearbySelectionConfig()) {
-                    throw new IllegalArgumentException(
-                            """
-                                    The selector configuration (%s) already includes the Nearby Selection setting, making it incompatible with the top-level property nearbyDistanceMeterClass (%s).
-                                    Remove the Nearby setting from the selector configuration or remove the top-level nearbyDistanceMeterClass."""
-                                    .formatted(selectorConfig, configPolicy.getNearbyDistanceMeterClass()));
+            for (MoveSelectorConfig<?> selectorConfig : config.getMoveSelectorList()) {
+                if (selectorConfig instanceof NearbyAutoConfigurationMoveSelectorConfig nearbySelectorConfig) {
+                    if (nearbySelectorConfig.hasNearbySelectionConfig()) {
+                        throw new IllegalArgumentException(
+                                """
+                                        The selector configuration (%s) already includes the Nearby Selection setting, making it incompatible with the top-level property nearbyDistanceMeterClass (%s).
+                                        Remove the Nearby setting from the selector configuration or remove the top-level nearbyDistanceMeterClass."""
+                                        .formatted(nearbySelectorConfig, configPolicy.getNearbyDistanceMeterClass()));
+                    }
+                    // Add a new configuration with Nearby Selection enabled
+                    moveSelectorConfigList
+                            .add(nearbySelectorConfig.enableNearbySelection(configPolicy.getNearbyDistanceMeterClass(),
+                                    configPolicy.getRandom()));
                 }
-                // Add a new configuration with Nearby Selection enabled
-                moveSelectorConfigList.add(selectorConfig.enableNearbySelection(configPolicy.getNearbyDistanceMeterClass(),
-                        configPolicy.getRandom()));
             }
         }
         List<MoveSelector<Solution_>> moveSelectorList =

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
@@ -26,7 +26,7 @@ public class UnionMoveSelectorFactory<Solution_>
             SelectionCacheType minimumCacheType, boolean randomSelection) {
         var moveSelectorConfigList = new LinkedList<>(config.getMoveSelectorList());
         if (configPolicy.getNearbyDistanceMeterClass() != null) {
-            for (MoveSelectorConfig<?> selectorConfig : config.getMoveSelectorList()) {
+            for (var selectorConfig : config.getMoveSelectorList()) {
                 if (selectorConfig instanceof NearbyAutoConfigurationMoveSelectorConfig nearbySelectorConfig) {
                     if (nearbySelectorConfig.hasNearbySelectionConfig()) {
                         throw new IllegalArgumentException(

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
@@ -24,7 +24,7 @@ public class UnionMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
-        List<MoveSelectorConfig> moveSelectorConfigList = new LinkedList<>(config.getMoveSelectorList());
+        var moveSelectorConfigList = new LinkedList<>(config.getMoveSelectorList());
         if (configPolicy.getNearbyDistanceMeterClass() != null) {
             for (NearbyAutoConfigurationMoveSelectorConfig selectorConfig : config.getMoveSelectorList().stream()
                     .filter(s -> NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(s.getClass()))

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.move.composite;
 
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -22,8 +23,24 @@ public class UnionMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
-        List<MoveSelector<Solution_>> moveSelectorList = buildInnerMoveSelectors(config.getMoveSelectorList(),
-                configPolicy, minimumCacheType, randomSelection);
+        List<MoveSelectorConfig> moveSelectorConfigList = new LinkedList<>(config.getMoveSelectorList());
+        if (configPolicy.getNearbyDistanceMeterClass() != null) {
+            for (MoveSelectorConfig selectorConfig : config.getMoveSelectorList().stream()
+                    .filter(MoveSelectorConfig::acceptNearbySelectionAutoConfiguration).toList()) {
+                if (selectorConfig.hasNearbySelectionConfig()) {
+                    throw new IllegalArgumentException(
+                            """
+                                    The selector configuration (%s) already includes the Nearby Selection setting, making it incompatible with the top-level property nearbyDistanceMeterClass (%s).
+                                    Remove the Nearby setting from the selector configuration or remove the top-level nearbyDistanceMeterClass."""
+                                    .formatted(selectorConfig, configPolicy.getNearbyDistanceMeterClass()));
+                }
+                // Add a new configuration with Nearby Selection enabled
+                moveSelectorConfigList.add(selectorConfig.enableNearbySelection(configPolicy.getNearbyDistanceMeterClass(),
+                        configPolicy.getRandom()));
+            }
+        }
+        List<MoveSelector<Solution_>> moveSelectorList =
+                buildInnerMoveSelectors(moveSelectorConfigList, configPolicy, minimumCacheType, randomSelection);
 
         SelectionProbabilityWeightFactory<Solution_, MoveSelector<Solution_>> selectorProbabilityWeightFactory;
         if (config.getSelectorProbabilityWeightFactoryClass() != null) {
@@ -37,9 +54,9 @@ public class UnionMoveSelectorFactory<Solution_>
                     "selectorProbabilityWeightFactoryClass", config.getSelectorProbabilityWeightFactoryClass());
         } else if (randomSelection) {
             Map<MoveSelector<Solution_>, Double> fixedProbabilityWeightMap =
-                    new HashMap<>(config.getMoveSelectorList().size());
-            for (int i = 0; i < config.getMoveSelectorList().size(); i++) {
-                MoveSelectorConfig<?> innerMoveSelectorConfig = config.getMoveSelectorList().get(i);
+                    new HashMap<>(moveSelectorConfigList.size());
+            for (int i = 0; i < moveSelectorConfigList.size(); i++) {
+                MoveSelectorConfig<?> innerMoveSelectorConfig = moveSelectorConfigList.get(i);
                 MoveSelector<Solution_> moveSelector = moveSelectorList.get(i);
                 Double fixedProbabilityWeight = innerMoveSelectorConfig.getFixedProbabilityWeight();
                 if (fixedProbabilityWeight != null) {

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionOrder;
 import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.NearbyAutoConfigurationMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
@@ -187,7 +188,8 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
                     MoveSelectorFactory.create(phaseConfig.getMoveSelectorConfig());
 
             if (configPolicy.getNearbyDistanceMeterClass() != null
-                    && phaseConfig.getMoveSelectorConfig().acceptNearbySelectionAutoConfiguration()
+                    && NearbyAutoConfigurationMoveSelectorConfig.class
+                            .isAssignableFrom(phaseConfig.getMoveSelectorConfig().getClass())
                     && !UnionMoveSelectorConfig.class.isAssignableFrom(phaseConfig.getMoveSelectorConfig().getClass())) {
                 // The move selector config is not a composite selector, but it accepts Nearby autoconfiguration.
                 // We create a new UnionMoveSelectorConfig with the existing selector to enable Nearby autoconfiguration.

--- a/core/core-impl/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
+++ b/core/core-impl/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
@@ -2,13 +2,10 @@ package ai.timefold.solver.core.impl.localsearch;
 
 import java.util.Collections;
 import java.util.Objects;
-import java.util.Random;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionOrder;
-import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
-import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.list.DestinationSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.MoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
@@ -16,7 +13,6 @@ import ai.timefold.solver.core.config.heuristic.selector.move.generic.chained.Ta
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListSwapMoveSelectorConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.kopt.KOptListMoveSelectorConfig;
-import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
 import ai.timefold.solver.core.config.localsearch.LocalSearchPhaseConfig;
 import ai.timefold.solver.core.config.localsearch.LocalSearchType;
 import ai.timefold.solver.core.config.localsearch.decider.acceptor.AcceptorType;
@@ -27,6 +23,7 @@ import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.enterprise.TimefoldSolverEnterpriseService;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicy;
+import ai.timefold.solver.core.impl.heuristic.selector.move.AbstractMoveSelectorFactory;
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector;
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelectorFactory;
 import ai.timefold.solver.core.impl.heuristic.selector.move.composite.UnionMoveSelectorFactory;
@@ -186,8 +183,20 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
             moveSelector = new UnionMoveSelectorFactory<Solution_>(determineDefaultMoveSelectorConfig(configPolicy))
                     .buildMoveSelector(configPolicy, defaultCacheType, defaultSelectionOrder, true);
         } else {
-            moveSelector = MoveSelectorFactory.<Solution_> create(phaseConfig.getMoveSelectorConfig())
-                    .buildMoveSelector(configPolicy, defaultCacheType, defaultSelectionOrder, true);
+            AbstractMoveSelectorFactory<Solution_, ?> moveSelectorFactory =
+                    MoveSelectorFactory.create(phaseConfig.getMoveSelectorConfig());
+
+            if (configPolicy.getNearbyDistanceMeterClass() != null
+                    && phaseConfig.getMoveSelectorConfig().acceptNearbySelectionAutoConfiguration()
+                    && !UnionMoveSelectorConfig.class.isAssignableFrom(phaseConfig.getMoveSelectorConfig().getClass())) {
+                // The move selector config is not a composite selector, but it accepts Nearby autoconfiguration.
+                // We create a new UnionMoveSelectorConfig with the existing selector to enable Nearby autoconfiguration.
+                MoveSelectorConfig moveSelectorCopy = (MoveSelectorConfig) phaseConfig.getMoveSelectorConfig().copyConfig();
+                UnionMoveSelectorConfig updatedConfig = new UnionMoveSelectorConfig()
+                        .withMoveSelectors(moveSelectorCopy);
+                moveSelectorFactory = MoveSelectorFactory.create(updatedConfig);
+            }
+            moveSelector = moveSelectorFactory.buildMoveSelector(configPolicy, defaultCacheType, defaultSelectionOrder, true);
         }
         return moveSelector;
     }
@@ -204,10 +213,18 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
                 .anyMatch(v -> ((BasicVariableDescriptor<?>) v).isChained());
         var listVariableDescriptor = solutionDescriptor.getListVariableDescriptor();
         if (basicVariableDescriptorList.isEmpty()) { // We only have the one list variable.
-            return determineDefaultListVarMoveSelectorConfig(configPolicy);
+            return new UnionMoveSelectorConfig()
+                    .withMoveSelectors(new ListChangeMoveSelectorConfig(), new ListSwapMoveSelectorConfig(),
+                            new KOptListMoveSelectorConfig());
         } else if (listVariableDescriptor == null) { // We only have basic variables.
-            return hasChainedVariable ? determineDefaultChainedMoveSelectorConfig(configPolicy)
-                    : determineDefaultBasicVarMoveSelectorConfig(configPolicy);
+            if (hasChainedVariable) {
+                return new UnionMoveSelectorConfig()
+                        .withMoveSelectors(new ChangeMoveSelectorConfig(), new SwapMoveSelectorConfig(),
+                                new TailChainSwapMoveSelectorConfig());
+            } else {
+                return new UnionMoveSelectorConfig()
+                        .withMoveSelectors(new ChangeMoveSelectorConfig(), new SwapMoveSelectorConfig());
+            }
         } else {
             /*
              * We have a mix of basic and list variables.
@@ -229,127 +246,5 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
             return new UnionMoveSelectorConfig()
                     .withMoveSelectors(new ChangeMoveSelectorConfig(), new SwapMoveSelectorConfig());
         }
-    }
-
-    private UnionMoveSelectorConfig determineDefaultBasicVarMoveSelectorConfig(HeuristicConfigPolicy<Solution_> configPolicy) {
-        if (configPolicy.getNearbyDistanceMeterClass() == null) {
-            return new UnionMoveSelectorConfig()
-                    .withMoveSelectors(new ChangeMoveSelectorConfig(), new SwapMoveSelectorConfig());
-        } else {
-            String changeSelectorName = addRandomSuffix("changeMoveSelector", configPolicy.getRandom());
-            String swapSelectorName = addRandomSuffix("swapMoveSelector", configPolicy.getRandom());
-            return new UnionMoveSelectorConfig()
-                    .withMoveSelectors(new ChangeMoveSelectorConfig(),
-                            new SwapMoveSelectorConfig(),
-                            new ChangeMoveSelectorConfig()
-                                    .withEntitySelectorConfig(new EntitySelectorConfig().withId(changeSelectorName))
-                                    .withValueSelectorConfig(new ValueSelectorConfig()
-                                            .withNearbySelectionConfig(new NearbySelectionConfig()
-                                                    .withOriginEntitySelectorConfig(new EntitySelectorConfig()
-                                                            .withMimicSelectorRef(changeSelectorName))
-                                                    .withNearbyDistanceMeterClass(
-                                                            configPolicy.getNearbyDistanceMeterClass()))),
-                            new SwapMoveSelectorConfig()
-                                    .withEntitySelectorConfig(new EntitySelectorConfig()
-                                            .withId(swapSelectorName))
-                                    .withSecondaryEntitySelectorConfig(new EntitySelectorConfig()
-                                            .withNearbySelectionConfig(new NearbySelectionConfig()
-                                                    .withOriginEntitySelectorConfig(new EntitySelectorConfig()
-                                                            .withMimicSelectorRef(swapSelectorName))
-                                                    .withNearbyDistanceMeterClass(
-                                                            configPolicy.getNearbyDistanceMeterClass()))));
-        }
-    }
-
-    private UnionMoveSelectorConfig determineDefaultChainedMoveSelectorConfig(HeuristicConfigPolicy<Solution_> configPolicy) {
-        if (configPolicy.getNearbyDistanceMeterClass() == null) {
-            return new UnionMoveSelectorConfig()
-                    .withMoveSelectors(new ChangeMoveSelectorConfig(), new SwapMoveSelectorConfig(),
-                            new TailChainSwapMoveSelectorConfig());
-        } else {
-            String changeSelectorName = addRandomSuffix("changeMoveSelector", configPolicy.getRandom());
-            String swapSelectorName = addRandomSuffix("swapMoveSelector", configPolicy.getRandom());
-            String tailChainSelectorName = addRandomSuffix("tailChainSwapMoveSelector", configPolicy.getRandom());
-            return new UnionMoveSelectorConfig()
-                    .withMoveSelectors(new ChangeMoveSelectorConfig(),
-                            new SwapMoveSelectorConfig(),
-                            new ChangeMoveSelectorConfig()
-                                    .withEntitySelectorConfig(new EntitySelectorConfig().withId(changeSelectorName))
-                                    .withValueSelectorConfig(new ValueSelectorConfig()
-                                            .withNearbySelectionConfig(new NearbySelectionConfig()
-                                                    .withOriginEntitySelectorConfig(new EntitySelectorConfig()
-                                                            .withMimicSelectorRef(changeSelectorName))
-                                                    .withNearbyDistanceMeterClass(
-                                                            configPolicy.getNearbyDistanceMeterClass()))),
-                            new SwapMoveSelectorConfig()
-                                    .withEntitySelectorConfig(new EntitySelectorConfig()
-                                            .withId(swapSelectorName))
-                                    .withSecondaryEntitySelectorConfig(new EntitySelectorConfig()
-                                            .withNearbySelectionConfig(new NearbySelectionConfig()
-                                                    .withOriginEntitySelectorConfig(new EntitySelectorConfig()
-                                                            .withMimicSelectorRef(swapSelectorName))
-                                                    .withNearbyDistanceMeterClass(
-                                                            configPolicy.getNearbyDistanceMeterClass()))),
-                            new TailChainSwapMoveSelectorConfig()
-                                    .withEntitySelectorConfig(new EntitySelectorConfig()
-                                            .withId(tailChainSelectorName))
-                                    .withValueSelectorConfig(new ValueSelectorConfig()
-                                            .withNearbySelectionConfig(new NearbySelectionConfig()
-                                                    .withOriginEntitySelectorConfig(new EntitySelectorConfig()
-                                                            .withMimicSelectorRef(tailChainSelectorName))
-                                                    .withNearbyDistanceMeterClass(
-                                                            configPolicy.getNearbyDistanceMeterClass()))));
-        }
-    }
-
-    private UnionMoveSelectorConfig determineDefaultListVarMoveSelectorConfig(HeuristicConfigPolicy<Solution_> configPolicy) {
-        if (configPolicy.getNearbyDistanceMeterClass() == null) {
-            return new UnionMoveSelectorConfig()
-                    .withMoveSelectors(new ListChangeMoveSelectorConfig(), new ListSwapMoveSelectorConfig(),
-                            new KOptListMoveSelectorConfig());
-        } else {
-            String changeSelectorName = addRandomSuffix("changeMoveSelector", configPolicy.getRandom());
-            String swapSelectorName = addRandomSuffix("swapMoveSelector", configPolicy.getRandom());
-            String koptSelectorName = addRandomSuffix("koptMoveSelector", configPolicy.getRandom());
-            return new UnionMoveSelectorConfig()
-                    .withMoveSelectors(new ListChangeMoveSelectorConfig(),
-                            new ListSwapMoveSelectorConfig(),
-                            new ListChangeMoveSelectorConfig()
-                                    .withValueSelectorConfig(new ValueSelectorConfig()
-                                            .withId(changeSelectorName))
-                                    .withDestinationSelectorConfig(new DestinationSelectorConfig()
-                                            .withNearbySelectionConfig(new NearbySelectionConfig()
-                                                    .withOriginValueSelectorConfig(new ValueSelectorConfig()
-                                                            .withMimicSelectorRef(changeSelectorName))
-                                                    .withNearbyDistanceMeterClass(
-                                                            configPolicy.getNearbyDistanceMeterClass()))),
-                            new ListSwapMoveSelectorConfig()
-                                    .withValueSelectorConfig(new ValueSelectorConfig()
-                                            .withId(swapSelectorName))
-                                    .withSecondaryValueSelectorConfig(new ValueSelectorConfig()
-                                            .withNearbySelectionConfig(new NearbySelectionConfig()
-                                                    .withOriginValueSelectorConfig(new ValueSelectorConfig()
-                                                            .withMimicSelectorRef(swapSelectorName))
-                                                    .withNearbyDistanceMeterClass(
-                                                            configPolicy.getNearbyDistanceMeterClass()))),
-                            new KOptListMoveSelectorConfig()
-                                    .withOriginSelectorConfig(new ValueSelectorConfig()
-                                            .withId(koptSelectorName))
-                                    .withValueSelectorConfig(new ValueSelectorConfig()
-                                            .withNearbySelectionConfig(new NearbySelectionConfig()
-                                                    .withOriginValueSelectorConfig(new ValueSelectorConfig()
-                                                            .withMimicSelectorRef(koptSelectorName))
-                                                    .withNearbyDistanceMeterClass(
-                                                            configPolicy.getNearbyDistanceMeterClass()))));
-        }
-    }
-
-    private String addRandomSuffix(String name, Random random) {
-        StringBuilder value = new StringBuilder(name);
-        value.append("-");
-        random.ints(97, 122) // ['a', 'z']
-                .limit(4) // 4 letters
-                .forEach(value::appendCodePoint);
-        return value.toString();
     }
 }

--- a/core/core-impl/src/main/resources/solver.xsd
+++ b/core/core-impl/src/main/resources/solver.xsd
@@ -607,7 +607,7 @@
         
     <xs:complexContent>
             
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                 
         <xs:sequence>
                     
@@ -623,11 +623,25 @@
       
   </xs:complexType>
     
-  <xs:complexType name="kOptListMoveSelectorConfig">
+  <xs:complexType abstract="true" name="nearbyAutoConfigurationMoveSelectorConfig">
         
     <xs:complexContent>
             
       <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence/>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="kOptListMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                 
         <xs:sequence>
                     
@@ -651,7 +665,7 @@
         
     <xs:complexContent>
             
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                 
         <xs:sequence>
                     
@@ -693,7 +707,7 @@
         
     <xs:complexContent>
             
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                 
         <xs:sequence>
                     
@@ -969,7 +983,7 @@
         
     <xs:complexContent>
             
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                 
         <xs:sequence>
                     
@@ -1003,7 +1017,7 @@
         
     <xs:complexContent>
             
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                 
         <xs:sequence>
                     
@@ -1023,7 +1037,7 @@
         
     <xs:complexContent>
             
-      <xs:extension base="tns:moveSelectorConfig">
+      <xs:extension base="tns:nearbyAutoConfigurationMoveSelectorConfig">
                 
         <xs:sequence>
                     

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
@@ -268,7 +268,6 @@ class MoveSelectorConfigTest {
         nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(0);
         assertFalse(nearbyChangeConfig.hasNearbySelectionConfig());
 
-
         nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
         assertNotNull(nearbyChangeConfig.getEntitySelectorConfig());
         assertEquals(SelectionOrder.PROBABILISTIC, nearbyChangeConfig.getEntitySelectorConfig().getSelectionOrder());

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
@@ -1,10 +1,6 @@
 package ai.timefold.solver.core.config.heuristic.selector.move;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Random;
@@ -39,182 +35,192 @@ class MoveSelectorConfigTest {
     void assertEnableNearbyForChangeMoveSelectorConfig() {
         // Default configuration
         ChangeMoveSelectorConfig config = new ChangeMoveSelectorConfig();
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         ChangeMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertNotNull(nearbyConfig.getEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass()).isNotNull();
 
         // Custom configuration
         config = new ChangeMoveSelectorConfig();
         config.withEntitySelectorConfig(new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getEntitySelectorConfig().getSelectionOrder());
-        assertNotNull(nearbyConfig.getEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getEntitySelectorConfig().getSelectionOrder()).isEqualTo(SelectionOrder.PROBABILISTIC);
+        assertThat(nearbyConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass()).isNotNull();
     }
 
     @Test
     void assertEnableNearbyForSwapMoveSelectorConfig() {
         // Default configuration
         SwapMoveSelectorConfig config = new SwapMoveSelectorConfig();
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         SwapMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertNotNull(nearbyConfig.getEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
-        assertNotNull(
-                nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
 
         // Custom configuration
         config = new SwapMoveSelectorConfig();
         config.withEntitySelectorConfig(new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getEntitySelectorConfig().getSelectionOrder());
-        assertNotNull(nearbyConfig.getEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
-        assertNotNull(
-                nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getEntitySelectorConfig().getSelectionOrder()).isEqualTo(SelectionOrder.PROBABILISTIC);
+        assertThat(nearbyConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
     }
 
     @Test
     void assertEnableNearbyForTailChainMoveSelectorConfig() {
         // Default configuration
         TailChainSwapMoveSelectorConfig config = new TailChainSwapMoveSelectorConfig();
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         TailChainSwapMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertNotNull(nearbyConfig.getEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass()).isNotNull();
 
         // Custom configuration
         config = new TailChainSwapMoveSelectorConfig();
         config.withEntitySelectorConfig(new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getEntitySelectorConfig().getSelectionOrder());
-        assertNotNull(nearbyConfig.getEntitySelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getEntitySelectorConfig().getSelectionOrder()).isEqualTo(SelectionOrder.PROBABILISTIC);
+        assertThat(nearbyConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass()).isNotNull();
     }
 
     @Test
     void assertEnableNearbyForListChangeMoveSelectorConfig() {
         // Default configuration
         ListChangeMoveSelectorConfig config = new ListChangeMoveSelectorConfig();
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         ListChangeMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getDestinationSelectorConfig());
-        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getOriginValueSelectorConfig());
-        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getDestinationSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getOriginValueSelectorConfig())
+                .isNotNull();
+        assertThat(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
 
         // Custom configuration
         config = new ListChangeMoveSelectorConfig();
         config.withValueSelectorConfig(new ValueSelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getValueSelectorConfig().getSelectionOrder());
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getDestinationSelectorConfig());
-        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getOriginValueSelectorConfig());
-        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getValueSelectorConfig().getSelectionOrder()).isEqualTo(SelectionOrder.PROBABILISTIC);
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getDestinationSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getOriginValueSelectorConfig())
+                .isNotNull();
+        assertThat(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
     }
 
     @Test
     void assertEnableNearbyForListSwapMoveSelectorConfig() {
         // Default configuration
         ListSwapMoveSelectorConfig config = new ListSwapMoveSelectorConfig();
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         ListSwapMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
 
         // Custom configuration
         config = new ListSwapMoveSelectorConfig();
         config.withValueSelectorConfig(new ValueSelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getValueSelectorConfig().getSelectionOrder());
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig());
-        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getValueSelectorConfig().getSelectionOrder()).isEqualTo(SelectionOrder.PROBABILISTIC);
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
     }
 
     @Test
     void assertEnableNearbyForKoptMoveSelectorConfig() {
         // Default configuration
         KOptListMoveSelectorConfig config = new KOptListMoveSelectorConfig();
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         KOptListMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertNotNull(nearbyConfig.getOriginSelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getOriginSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass()).isNotNull();
 
         // Custom configuration
         config = new KOptListMoveSelectorConfig();
         config.withValueSelectorConfig(new ValueSelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getValueSelectorConfig().getSelectionOrder());
-        assertNotNull(nearbyConfig.getOriginSelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getValueSelectorConfig().getSelectionOrder()).isEqualTo(SelectionOrder.PROBABILISTIC);
+        assertThat(nearbyConfig.getOriginSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass()).isNotNull();
     }
 
     @Test
@@ -222,34 +228,38 @@ class MoveSelectorConfigTest {
         // Default configuration
         UnionMoveSelectorConfig config =
                 new UnionMoveSelectorConfig(List.of(new ChangeMoveSelectorConfig(), new SwapMoveSelectorConfig()));
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         UnionMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertEquals(4, nearbyConfig.getMoveSelectorList().size());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getMoveSelectorList()).hasSize(4);
 
         ChangeMoveSelectorConfig nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(0);
-        assertFalse(nearbyChangeConfig.hasNearbySelectionConfig());
+        assertThat(nearbyChangeConfig.hasNearbySelectionConfig()).isFalse();
 
         nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
-        assertNotNull(nearbyChangeConfig.getEntitySelectorConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyChangeConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
 
         SwapMoveSelectorConfig nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(2);
-        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
+        assertThat(nearbySwapConfig.hasNearbySelectionConfig()).isFalse();
 
         nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(3);
-        assertNotNull(nearbySwapConfig.getEntitySelectorConfig());
-        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig());
-        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
-        assertNotNull(
-                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(
-                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbySwapConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbySwapConfig.getSecondaryEntitySelectorConfig()).isNotNull();
+        assertThat(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
 
         // Custom configuration
         config =
@@ -257,37 +267,41 @@ class MoveSelectorConfigTest {
                         new ChangeMoveSelectorConfig().withEntitySelectorConfig(
                                 new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC)),
                         new SwapMoveSelectorConfig()));
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
 
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertEquals(4, nearbyConfig.getMoveSelectorList().size());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getMoveSelectorList()).hasSize(4);
 
         nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(0);
-        assertFalse(nearbyChangeConfig.hasNearbySelectionConfig());
+        assertThat(nearbyChangeConfig.hasNearbySelectionConfig()).isFalse();
 
         nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
-        assertNotNull(nearbyChangeConfig.getEntitySelectorConfig());
-        assertEquals(SelectionOrder.PROBABILISTIC, nearbyChangeConfig.getEntitySelectorConfig().getSelectionOrder());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyChangeConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyChangeConfig.getEntitySelectorConfig().getSelectionOrder()).isEqualTo(SelectionOrder.PROBABILISTIC);
+        assertThat(nearbyChangeConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
 
         nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(2);
-        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
+        assertThat(nearbySwapConfig.hasNearbySelectionConfig()).isFalse();
 
         nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(3);
-        assertNotNull(nearbySwapConfig.getEntitySelectorConfig());
-        assertNull(nearbySwapConfig.getSelectionOrder());
-        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig());
-        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
-        assertNotNull(
-                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(
-                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbySwapConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbySwapConfig.getSelectionOrder()).isNull();
+        assertThat(nearbySwapConfig.getSecondaryEntitySelectorConfig()).isNotNull();
+        assertThat(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
     }
 
     @Test
@@ -299,37 +313,41 @@ class MoveSelectorConfigTest {
                 new UnionMoveSelectorConfig(List.of(new SwapMoveSelectorConfig()));
         UnionMoveSelectorConfig config =
                 new UnionMoveSelectorConfig(List.of(unionChangeSelectorConfig, unionSwapSelectorConfig));
-        assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
+        assertThat(config.hasNearbySelectionConfig()).isFalse();
+        assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isTrue();
         UnionMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
-        assertTrue(nearbyConfig.hasNearbySelectionConfig());
-        assertNotNull(nearbyConfig);
-        assertEquals(2, nearbyConfig.getMoveSelectorList().size());
+        assertThat(nearbyConfig).isNotNull();
+        assertThat(nearbyConfig.hasNearbySelectionConfig()).isTrue();
+        assertThat(nearbyConfig.getMoveSelectorList()).hasSize(2);
 
         UnionMoveSelectorConfig changeConfig = (UnionMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(0);
         ChangeMoveSelectorConfig nearbyChangeConfig = (ChangeMoveSelectorConfig) changeConfig.getMoveSelectorList().get(0);
-        assertFalse(nearbyChangeConfig.hasNearbySelectionConfig());
+        assertThat(nearbyChangeConfig.hasNearbySelectionConfig()).isFalse();
 
         nearbyChangeConfig = (ChangeMoveSelectorConfig) changeConfig.getMoveSelectorList().get(1);
-        assertNotNull(nearbyChangeConfig.getEntitySelectorConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbyChangeConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig()).isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
 
         UnionMoveSelectorConfig swapConfig = (UnionMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
 
         SwapMoveSelectorConfig nearbySwapConfig = (SwapMoveSelectorConfig) swapConfig.getMoveSelectorList().get(0);
-        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
+        assertThat(nearbySwapConfig.hasNearbySelectionConfig()).isFalse();
 
         nearbySwapConfig = (SwapMoveSelectorConfig) swapConfig.getMoveSelectorList().get(1);
-        assertNotNull(nearbySwapConfig.getEntitySelectorConfig());
-        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig());
-        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
-        assertNotNull(
-                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
-        assertNotNull(
-                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+        assertThat(nearbySwapConfig.getEntitySelectorConfig()).isNotNull();
+        assertThat(nearbySwapConfig.getSecondaryEntitySelectorConfig()).isNotNull();
+        assertThat(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig()).isNotNull();
+        assertThat(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig())
+                .isNotNull();
+        assertThat(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass())
+                .isNotNull();
     }
 
     @Test
@@ -347,8 +365,8 @@ class MoveSelectorConfigTest {
                 new PillarSwapMoveSelectorConfig());
 
         for (MoveSelectorConfig<?> config : moveSelectorConfigList) {
-            assertFalse(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
-            assertFalse(config.hasNearbySelectionConfig());
+            assertThat(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass())).isFalse();
+            assertThat(config.hasNearbySelectionConfig()).isFalse();
         }
     }
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
@@ -1,0 +1,312 @@
+package ai.timefold.solver.core.config.heuristic.selector.move;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Random;
+
+import ai.timefold.solver.core.config.heuristic.selector.common.SelectionOrder;
+import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.factory.MoveIteratorFactoryConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.factory.MoveListFactoryConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.ListSwapMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.SubListChangeMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.SubListSwapMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.kopt.KOptListMoveSelectorConfig;
+import ai.timefold.solver.core.config.heuristic.selector.value.ValueSelectorConfig;
+import ai.timefold.solver.core.impl.testdata.domain.list.TestDistanceMeter;
+
+import org.junit.jupiter.api.Test;
+
+class MoveSelectorConfigTest {
+
+    @Test
+    void assertEnableNearbyForChangeMoveSelectorConfig() {
+        // Default configuration
+        ChangeMoveSelectorConfig config = new ChangeMoveSelectorConfig();
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        ChangeMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertNotNull(nearbyConfig.getEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        // Custom configuration
+        config = new ChangeMoveSelectorConfig();
+        config.withEntitySelectorConfig(new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getEntitySelectorConfig().getSelectionOrder());
+        assertNotNull(nearbyConfig.getEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+    }
+
+    @Test
+    void assertEnableNearbyForSwapMoveSelectorConfig() {
+        // Default configuration
+        SwapMoveSelectorConfig config = new SwapMoveSelectorConfig();
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        SwapMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertNotNull(nearbyConfig.getEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
+        assertNotNull(
+                nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        // Custom configuration
+        config = new SwapMoveSelectorConfig();
+        config.withEntitySelectorConfig(new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getEntitySelectorConfig().getSelectionOrder());
+        assertNotNull(nearbyConfig.getEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
+        assertNotNull(
+                nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+    }
+
+    @Test
+    void assertEnableNearbyForTailChainMoveSelectorConfig() {
+        // Default configuration
+        TailChainSwapMoveSelectorConfig config = new TailChainSwapMoveSelectorConfig();
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        TailChainSwapMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertNotNull(nearbyConfig.getEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        // Custom configuration
+        config = new TailChainSwapMoveSelectorConfig();
+        config.withEntitySelectorConfig(new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getEntitySelectorConfig().getSelectionOrder());
+        assertNotNull(nearbyConfig.getEntitySelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+    }
+
+    @Test
+    void assertEnableNearbyForListChangeMoveSelectorConfig() {
+        // Default configuration
+        ListChangeMoveSelectorConfig config = new ListChangeMoveSelectorConfig();
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        ListChangeMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getDestinationSelectorConfig());
+        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getOriginValueSelectorConfig());
+        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        // Custom configuration
+        config = new ListChangeMoveSelectorConfig();
+        config.withValueSelectorConfig(new ValueSelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getValueSelectorConfig().getSelectionOrder());
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getDestinationSelectorConfig());
+        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getOriginValueSelectorConfig());
+        assertNotNull(nearbyConfig.getDestinationSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+    }
+
+    @Test
+    void assertEnableNearbyForListSwapMoveSelectorConfig() {
+        // Default configuration
+        ListSwapMoveSelectorConfig config = new ListSwapMoveSelectorConfig();
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        ListSwapMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        // Custom configuration
+        config = new ListSwapMoveSelectorConfig();
+        config.withValueSelectorConfig(new ValueSelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getValueSelectorConfig().getSelectionOrder());
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig());
+        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getSecondaryValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+    }
+
+    @Test
+    void assertEnableNearbyForKoptMoveSelectorConfig() {
+        // Default configuration
+        KOptListMoveSelectorConfig config = new KOptListMoveSelectorConfig();
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        KOptListMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertNotNull(nearbyConfig.getOriginSelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        // Custom configuration
+        config = new KOptListMoveSelectorConfig();
+        config.withValueSelectorConfig(new ValueSelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertEquals(SelectionOrder.PROBABILISTIC, nearbyConfig.getValueSelectorConfig().getSelectionOrder());
+        assertNotNull(nearbyConfig.getOriginSelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+    }
+
+    @Test
+    void assertEnableNearbyForUnionMoveSelectorConfig() {
+        // Default configuration
+        UnionMoveSelectorConfig config =
+                new UnionMoveSelectorConfig(List.of(new ChangeMoveSelectorConfig(), new SwapMoveSelectorConfig()));
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        UnionMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertEquals(4, nearbyConfig.getMoveSelectorList().size());
+
+        ChangeMoveSelectorConfig nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(0);
+        assertFalse(nearbyChangeConfig.hasNearbySelectionConfig());
+
+        SwapMoveSelectorConfig nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
+        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
+
+        nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(2);
+        assertNotNull(nearbyChangeConfig.getEntitySelectorConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(3);
+        assertNotNull(nearbySwapConfig.getEntitySelectorConfig());
+        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig());
+        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
+        assertNotNull(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        // Custom configuration
+        config =
+                new UnionMoveSelectorConfig(List.of(
+                        new ChangeMoveSelectorConfig().withEntitySelectorConfig(
+                                new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC)),
+                        new SwapMoveSelectorConfig()));
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertEquals(4, nearbyConfig.getMoveSelectorList().size());
+
+        nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(0);
+        assertFalse(nearbyChangeConfig.hasNearbySelectionConfig());
+
+        nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
+        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
+
+        nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(2);
+        assertNotNull(nearbyChangeConfig.getEntitySelectorConfig());
+        assertEquals(SelectionOrder.PROBABILISTIC, nearbyChangeConfig.getEntitySelectorConfig().getSelectionOrder());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(3);
+        assertNotNull(nearbySwapConfig.getEntitySelectorConfig());
+        assertNull(nearbySwapConfig.getSelectionOrder());
+        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig());
+        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
+        assertNotNull(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+    }
+
+    @Test
+    void assertDisabledNearbyAutoConfiguration() {
+        List<MoveSelectorConfig<?>> moveSelectorConfigList = List.of(
+                new CartesianProductMoveSelectorConfig(),
+                new MoveIteratorFactoryConfig(),
+                new MoveListFactoryConfig(),
+                new KOptMoveSelectorConfig(),
+                new SubChainChangeMoveSelectorConfig(),
+                new SubChainSwapMoveSelectorConfig(),
+                new SubListChangeMoveSelectorConfig(),
+                new SubListSwapMoveSelectorConfig(),
+                new PillarChangeMoveSelectorConfig(),
+                new PillarSwapMoveSelectorConfig());
+
+        for (MoveSelectorConfig<?> config : moveSelectorConfigList) {
+            assertFalse(config.acceptNearbySelectionAutoConfiguration());
+            assertFalse(config.hasNearbySelectionConfig());
+        }
+    }
+}

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
@@ -40,7 +40,7 @@ class MoveSelectorConfigTest {
         // Default configuration
         ChangeMoveSelectorConfig config = new ChangeMoveSelectorConfig();
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         ChangeMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -54,7 +54,7 @@ class MoveSelectorConfigTest {
         config = new ChangeMoveSelectorConfig();
         config.withEntitySelectorConfig(new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -71,7 +71,7 @@ class MoveSelectorConfigTest {
         // Default configuration
         SwapMoveSelectorConfig config = new SwapMoveSelectorConfig();
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         SwapMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -86,7 +86,7 @@ class MoveSelectorConfigTest {
         config = new SwapMoveSelectorConfig();
         config.withEntitySelectorConfig(new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -104,7 +104,7 @@ class MoveSelectorConfigTest {
         // Default configuration
         TailChainSwapMoveSelectorConfig config = new TailChainSwapMoveSelectorConfig();
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         TailChainSwapMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -117,7 +117,7 @@ class MoveSelectorConfigTest {
         config = new TailChainSwapMoveSelectorConfig();
         config.withEntitySelectorConfig(new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -133,7 +133,7 @@ class MoveSelectorConfigTest {
         // Default configuration
         ListChangeMoveSelectorConfig config = new ListChangeMoveSelectorConfig();
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         ListChangeMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -147,7 +147,7 @@ class MoveSelectorConfigTest {
         config = new ListChangeMoveSelectorConfig();
         config.withValueSelectorConfig(new ValueSelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -164,7 +164,7 @@ class MoveSelectorConfigTest {
         // Default configuration
         ListSwapMoveSelectorConfig config = new ListSwapMoveSelectorConfig();
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         ListSwapMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -177,7 +177,7 @@ class MoveSelectorConfigTest {
         config = new ListSwapMoveSelectorConfig();
         config.withValueSelectorConfig(new ValueSelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -193,7 +193,7 @@ class MoveSelectorConfigTest {
         // Default configuration
         KOptListMoveSelectorConfig config = new KOptListMoveSelectorConfig();
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         KOptListMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -206,7 +206,7 @@ class MoveSelectorConfigTest {
         config = new KOptListMoveSelectorConfig();
         config.withValueSelectorConfig(new ValueSelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC));
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -223,7 +223,7 @@ class MoveSelectorConfigTest {
         UnionMoveSelectorConfig config =
                 new UnionMoveSelectorConfig(List.of(new ChangeMoveSelectorConfig(), new SwapMoveSelectorConfig()));
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         UnionMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -258,7 +258,7 @@ class MoveSelectorConfigTest {
                                 new EntitySelectorConfig().withSelectionOrder(SelectionOrder.PROBABILISTIC)),
                         new SwapMoveSelectorConfig()));
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
 
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
@@ -301,7 +301,7 @@ class MoveSelectorConfigTest {
         UnionMoveSelectorConfig config =
                 new UnionMoveSelectorConfig(List.of(unionChangeSelectorConfig, unionSwapSelectorConfig));
         assertFalse(config.hasNearbySelectionConfig());
-        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        assertTrue(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
         UnionMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
         assertTrue(nearbyConfig.hasNearbySelectionConfig());
         assertNotNull(nearbyConfig);
@@ -348,7 +348,7 @@ class MoveSelectorConfigTest {
                 new PillarSwapMoveSelectorConfig());
 
         for (MoveSelectorConfig<?> config : moveSelectorConfigList) {
-            assertFalse(config.acceptNearbySelectionAutoConfiguration());
+            assertFalse(NearbyAutoConfigurationMoveSelectorConfig.class.isAssignableFrom(config.getClass()));
             assertFalse(config.hasNearbySelectionConfig());
         }
     }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
@@ -232,15 +232,15 @@ class MoveSelectorConfigTest {
         ChangeMoveSelectorConfig nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(0);
         assertFalse(nearbyChangeConfig.hasNearbySelectionConfig());
 
-        SwapMoveSelectorConfig nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
-        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
-
-        nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(2);
+        nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
         assertNotNull(nearbyChangeConfig.getEntitySelectorConfig());
         assertNotNull(nearbyChangeConfig.getValueSelectorConfig());
         assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig());
         assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
         assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        SwapMoveSelectorConfig nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(2);
+        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
 
         nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(3);
         assertNotNull(nearbySwapConfig.getEntitySelectorConfig());
@@ -268,10 +268,8 @@ class MoveSelectorConfigTest {
         nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(0);
         assertFalse(nearbyChangeConfig.hasNearbySelectionConfig());
 
-        nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
-        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
 
-        nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(2);
+        nearbyChangeConfig = (ChangeMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
         assertNotNull(nearbyChangeConfig.getEntitySelectorConfig());
         assertEquals(SelectionOrder.PROBABILISTIC, nearbyChangeConfig.getEntitySelectorConfig().getSelectionOrder());
         assertNotNull(nearbyChangeConfig.getValueSelectorConfig());
@@ -279,9 +277,54 @@ class MoveSelectorConfigTest {
         assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
         assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
 
+        nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(2);
+        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
+
         nearbySwapConfig = (SwapMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(3);
         assertNotNull(nearbySwapConfig.getEntitySelectorConfig());
         assertNull(nearbySwapConfig.getSelectionOrder());
+        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig());
+        assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
+        assertNotNull(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(
+                nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+    }
+
+    @Test
+    void assertEnableNearbyForMultipleUnionMoveSelectorConfig() {
+        // Default configuration
+        UnionMoveSelectorConfig unionChangeSelectorConfig =
+                new UnionMoveSelectorConfig(List.of(new ChangeMoveSelectorConfig()));
+        UnionMoveSelectorConfig unionSwapSelectorConfig =
+                new UnionMoveSelectorConfig(List.of(new SwapMoveSelectorConfig()));
+        UnionMoveSelectorConfig config =
+                new UnionMoveSelectorConfig(List.of(unionChangeSelectorConfig, unionSwapSelectorConfig));
+        assertFalse(config.hasNearbySelectionConfig());
+        assertTrue(config.acceptNearbySelectionAutoConfiguration());
+        UnionMoveSelectorConfig nearbyConfig = config.enableNearbySelection(TestDistanceMeter.class, new Random());
+        assertTrue(nearbyConfig.hasNearbySelectionConfig());
+        assertNotNull(nearbyConfig);
+        assertEquals(2, nearbyConfig.getMoveSelectorList().size());
+
+        UnionMoveSelectorConfig changeConfig = (UnionMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(0);
+        ChangeMoveSelectorConfig nearbyChangeConfig = (ChangeMoveSelectorConfig) changeConfig.getMoveSelectorList().get(0);
+        assertFalse(nearbyChangeConfig.hasNearbySelectionConfig());
+
+        nearbyChangeConfig = (ChangeMoveSelectorConfig) changeConfig.getMoveSelectorList().get(1);
+        assertNotNull(nearbyChangeConfig.getEntitySelectorConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getOriginEntitySelectorConfig());
+        assertNotNull(nearbyChangeConfig.getValueSelectorConfig().getNearbySelectionConfig().getNearbyDistanceMeterClass());
+
+        UnionMoveSelectorConfig swapConfig = (UnionMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
+
+        SwapMoveSelectorConfig nearbySwapConfig = (SwapMoveSelectorConfig) swapConfig.getMoveSelectorList().get(0);
+        assertFalse(nearbySwapConfig.hasNearbySelectionConfig());
+
+        nearbySwapConfig = (SwapMoveSelectorConfig) swapConfig.getMoveSelectorList().get(1);
+        assertNotNull(nearbySwapConfig.getEntitySelectorConfig());
         assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig());
         assertNotNull(nearbySwapConfig.getSecondaryEntitySelectorConfig().getNearbySelectionConfig());
         assertNotNull(

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
@@ -310,7 +310,7 @@ class MoveSelectorConfigTest {
         UnionMoveSelectorConfig unionChangeSelectorConfig =
                 new UnionMoveSelectorConfig(List.of(new ChangeMoveSelectorConfig()));
         UnionMoveSelectorConfig unionSwapSelectorConfig =
-                new UnionMoveSelectorConfig(List.of(new SwapMoveSelectorConfig()));
+                new UnionMoveSelectorConfig(List.of(new SwapMoveSelectorConfig(), new PillarSwapMoveSelectorConfig()));
         UnionMoveSelectorConfig config =
                 new UnionMoveSelectorConfig(List.of(unionChangeSelectorConfig, unionSwapSelectorConfig));
         assertThat(config.hasNearbySelectionConfig()).isFalse();
@@ -334,7 +334,7 @@ class MoveSelectorConfigTest {
                 .isNotNull();
 
         UnionMoveSelectorConfig swapConfig = (UnionMoveSelectorConfig) nearbyConfig.getMoveSelectorList().get(1);
-
+        assertThat(swapConfig.getMoveSelectorList()).hasSize(3);
         SwapMoveSelectorConfig nearbySwapConfig = (SwapMoveSelectorConfig) swapConfig.getMoveSelectorList().get(0);
         assertThat(nearbySwapConfig.hasNearbySelectionConfig()).isFalse();
 

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/MoveSelectorFactoryTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/MoveSelectorFactoryTest.java
@@ -262,6 +262,11 @@ class MoveSelectorFactoryTest {
         public void visitReferencedClasses(Consumer<Class<?>> classVisitor) {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public boolean hasNearbySelectionConfig() {
+            return false;
+        }
     }
 
     static class DummyMoveSelectorFactory extends AbstractMoveSelectorFactory<TestdataSolution, DummyMoveSelectorConfig> {


### PR DESCRIPTION
This pull request makes the Nearby Selection feature easy to configure and updates the local search phase settings to provide the default Nearby configuration when the user specifies move selectors.

1. Only a subset of the move selectors accepts Nearby autoconfiguration.
2. We fail fast if there is any pre-defined Nearby configuration.
3. We fail fast if Nearby is enabled and the Cartesian product move selector is defined.
