### PR TITLE
fix: Do not recalculate problem size statistics in benchmarker

### DIFF
--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/SubSingleBenchmarkRunner.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/SubSingleBenchmarkRunner.java
@@ -121,9 +121,7 @@ public class SubSingleBenchmarkRunner<Solution_> implements Callable<SubSingleBe
         if (!warmUp) {
             var solverScope = solver.getSolverScope();
             var solutionDescriptor = solverScope.getSolutionDescriptor();
-            problemBenchmarkResult
-                    .registerProblemSizeStatistics(
-                            solutionDescriptor.getProblemSizeStatistics(solverScope.getScoreDirector(), solution));
+            problemBenchmarkResult.registerProblemSizeStatistics(solverScope.getProblemSizeStatistics());
             subSingleBenchmarkResult.setScore(solutionDescriptor.getScore(solution));
             subSingleBenchmarkResult.setTimeMillisSpent(timeMillisSpent);
             subSingleBenchmarkResult.setScoreCalculationCount(solverScope.getScoreCalculationCount());


### PR DESCRIPTION
Fixes a NPE in benchmarker caused by working solution being set to null after solving finishes.