### PR TITLE
chore: Add internal interface for planning cloning atypical types

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
@@ -108,8 +108,14 @@ public final class FieldAccessingSolutionCloner<Solution_> implements SolutionCl
         if (existingClone != null) {
             return existingClone;
         }
+
         Class<C> declaringClass = (Class<C>) original.getClass();
-        C clone = constructClone(declaringClass);
+        C clone;
+        if (original instanceof PlanningCloneable<?> planningCloneable) {
+            clone = (C) planningCloneable.createNewInstance();
+        } else {
+            clone = constructClone(declaringClass);
+        }
         originalToCloneMap.put(original, clone);
         copyFields(declaringClass, original, clone, unprocessedQueue, declaringClassMetadata);
         return clone;
@@ -192,11 +198,11 @@ public final class FieldAccessingSolutionCloner<Solution_> implements SolutionCl
     @SuppressWarnings("unchecked")
     private static <E> Collection<E> constructCloneCollection(Collection<E> originalCollection) {
         // TODO Don't hardcode all standard collections
+        if (originalCollection instanceof PlanningCloneable<?> planningCloneable) {
+            return (Collection<E>) planningCloneable.createNewInstance();
+        }
         if (originalCollection instanceof LinkedList) {
             return new LinkedList<>();
-        }
-        if (originalCollection instanceof PlanningCloneable<?> planningClonable) {
-            return (Collection<E>) planningClonable.createEmptyInstance();
         }
         var size = originalCollection.size();
         if (originalCollection instanceof Set) {
@@ -235,12 +241,12 @@ public final class FieldAccessingSolutionCloner<Solution_> implements SolutionCl
     @SuppressWarnings("unchecked")
     private static <K, V> Map<K, V> constructCloneMap(Map<K, V> originalMap) {
         // Normally, a Map will never be selected for cloning, but extending implementations might anyway.
+        if (originalMap instanceof PlanningCloneable<?> planningCloneable) {
+            return (Map<K, V>) planningCloneable.createNewInstance();
+        }
         if (originalMap instanceof SortedMap<K, V> map) {
             var setComparator = map.comparator();
             return new TreeMap<>(setComparator);
-        }
-        if (originalMap instanceof PlanningCloneable<?> planningClonable) {
-            return (Map<K, V>) planningClonable.createEmptyInstance();
         }
         var originalMapSize = originalMap.size();
         if (!(originalMap instanceof LinkedHashMap)) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
@@ -189,10 +189,14 @@ public final class FieldAccessingSolutionCloner<Solution_> implements SolutionCl
         return cloneCollection;
     }
 
+    @SuppressWarnings("unchecked")
     private static <E> Collection<E> constructCloneCollection(Collection<E> originalCollection) {
         // TODO Don't hardcode all standard collections
         if (originalCollection instanceof LinkedList) {
             return new LinkedList<>();
+        }
+        if (originalCollection instanceof PlanningCloneable<?> planningClonable) {
+            return (Collection<E>) planningClonable.createEmptyInstance();
         }
         var size = originalCollection.size();
         if (originalCollection instanceof Set) {
@@ -228,11 +232,15 @@ public final class FieldAccessingSolutionCloner<Solution_> implements SolutionCl
         return cloneMap;
     }
 
+    @SuppressWarnings("unchecked")
     private static <K, V> Map<K, V> constructCloneMap(Map<K, V> originalMap) {
         // Normally, a Map will never be selected for cloning, but extending implementations might anyway.
         if (originalMap instanceof SortedMap<K, V> map) {
             var setComparator = map.comparator();
             return new TreeMap<>(setComparator);
+        }
+        if (originalMap instanceof PlanningCloneable<?> planningClonable) {
+            return (Map<K, V>) planningClonable.createEmptyInstance();
         }
         var originalMapSize = originalMap.size();
         if (!(originalMap instanceof LinkedHashMap)) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/PlanningCloneable.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/PlanningCloneable.java
@@ -1,5 +1,22 @@
 package ai.timefold.solver.core.impl.domain.solution.cloner;
 
+/**
+ * An internal interface used to construct new instances of an object
+ * when there is no suitable constructor.
+ * Used during planning cloning to create an "empty"/"blank" instance
+ * whose fields/items will be set to the planning clone of the original's
+ * fields/items.
+ *
+ * @param <T> The type of object being cloned.
+ */
 public interface PlanningCloneable<T> {
-    T createEmptyInstance();
+    /**
+     * Creates a new "empty"/"blank" instance.
+     * If the {@link PlanningCloneable} is a {@link java.util.Collection}
+     * or {@link java.util.Map}, the returned instance should be
+     * empty and modifiable.
+     *
+     * @return never null, a new instance with the same type as the object being cloned.
+     */
+    T createNewInstance();
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/PlanningCloneable.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/PlanningCloneable.java
@@ -1,0 +1,5 @@
+package ai.timefold.solver.core.impl.domain.solution.cloner;
+
+public interface PlanningCloneable<T> {
+    T createEmptyInstance();
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtils.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import ai.timefold.solver.core.impl.domain.solution.cloner.DeepCloningUtils;
+import ai.timefold.solver.core.impl.domain.solution.cloner.PlanningCloneable;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 
 public final class GizmoCloningUtils {
@@ -27,7 +28,8 @@ public final class GizmoCloningUtils {
             deepClonedClassSet.add(clazz);
             for (Field field : getAllFields(clazz)) {
                 deepClonedClassSet.addAll(getDeepClonedTypeArguments(solutionDescriptor, field.getGenericType()));
-                if (DeepCloningUtils.isFieldDeepCloned(solutionDescriptor, field, clazz)) {
+                if (DeepCloningUtils.isFieldDeepCloned(solutionDescriptor, field, clazz)
+                        && !PlanningCloneable.class.isAssignableFrom(field.getType())) {
                     deepClonedClassSet.add(field.getType());
                 }
             }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -40,6 +40,7 @@ import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.TestdataDe
 import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.TestdataVariousTypes;
 import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.field.TestdataFieldAnnotatedDeepCloningEntity;
 import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.field.TestdataFieldAnnotatedDeepCloningSolution;
+import ai.timefold.solver.core.impl.testdata.domain.clone.planning_cloneable.PlanningCloneableEntity;
 import ai.timefold.solver.core.impl.testdata.domain.clone.planning_cloneable.PlanningCloneableSolution;
 import ai.timefold.solver.core.impl.testdata.domain.collection.TestdataArrayBasedEntity;
 import ai.timefold.solver.core.impl.testdata.domain.collection.TestdataArrayBasedSolution;
@@ -1121,13 +1122,13 @@ public abstract class AbstractSolutionClonerTest {
     }
 
     @Test
-    void clonePlanningCloneableLists() {
+    void clonePlanningCloneableItems() {
         var solutionDescriptor = PlanningCloneableSolution.buildSolutionDescriptor();
         var cloner = createSolutionCloner(solutionDescriptor);
 
-        var entityA = new TestdataEntity("A");
-        var entityB = new TestdataEntity("B");
-        var entityC = new TestdataEntity("C");
+        var entityA = new PlanningCloneableEntity("A");
+        var entityB = new PlanningCloneableEntity("B");
+        var entityC = new PlanningCloneableEntity("C");
 
         var original = new PlanningCloneableSolution(List.of(entityA, entityB, entityC));
         var clone = cloner.cloneSolution(original);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -40,6 +40,7 @@ import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.TestdataDe
 import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.TestdataVariousTypes;
 import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.field.TestdataFieldAnnotatedDeepCloningEntity;
 import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.field.TestdataFieldAnnotatedDeepCloningSolution;
+import ai.timefold.solver.core.impl.testdata.domain.clone.planning_cloneable.PlanningCloneableSolution;
 import ai.timefold.solver.core.impl.testdata.domain.collection.TestdataArrayBasedEntity;
 import ai.timefold.solver.core.impl.testdata.domain.collection.TestdataArrayBasedSolution;
 import ai.timefold.solver.core.impl.testdata.domain.collection.TestdataEntityCollectionPropertyEntity;
@@ -1117,6 +1118,50 @@ public abstract class AbstractSolutionClonerTest {
 
         assertThat(clone.shadowEntityList.get(0))
                 .isNotSameAs(original.shadowEntityList.get(0));
+    }
+
+    @Test
+    void clonePlanningCloneableLists() {
+        var solutionDescriptor = PlanningCloneableSolution.buildSolutionDescriptor();
+        var cloner = createSolutionCloner(solutionDescriptor);
+
+        var entityA = new TestdataEntity("A");
+        var entityB = new TestdataEntity("B");
+        var entityC = new TestdataEntity("C");
+
+        var original = new PlanningCloneableSolution(List.of(entityA, entityB, entityC));
+        var clone = cloner.cloneSolution(original);
+
+        assertThat(clone.entityList)
+                .hasSize(3)
+                .isNotSameAs(original.entityList)
+                .first()
+                .isNotNull();
+
+        assertThat(clone.entityList.get(0))
+                .isNotSameAs(original.entityList.get(0))
+                .hasFieldOrPropertyWithValue("code", "A");
+
+        assertThat(clone.entityList.get(1))
+                .isNotSameAs(original.entityList.get(1))
+                .hasFieldOrPropertyWithValue("code", "B");
+
+        assertThat(clone.entityList.get(2))
+                .isNotSameAs(original.entityList.get(2))
+                .hasFieldOrPropertyWithValue("code", "C");
+
+        assertThat(clone.codeToEntity)
+                .hasSize(3)
+                .isNotSameAs(original.codeToEntity);
+
+        assertThat(clone.codeToEntity.get("A"))
+                .isSameAs(clone.entityList.get(0));
+
+        assertThat(clone.codeToEntity.get("B"))
+                .isSameAs(clone.entityList.get(1));
+
+        assertThat(clone.codeToEntity.get("C"))
+                .isSameAs(clone.entityList.get(2));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableEntity.java
@@ -1,0 +1,26 @@
+package ai.timefold.solver.core.impl.testdata.domain.clone.planning_cloneable;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.solution.cloner.PlanningCloneable;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
+
+@PlanningEntity
+public class PlanningCloneableEntity implements PlanningCloneable<PlanningCloneableEntity> {
+    public String code;
+    @PlanningVariable
+    public TestdataValue value;
+
+    public PlanningCloneableEntity(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public PlanningCloneableEntity createNewInstance() {
+        return new PlanningCloneableEntity(code);
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableList.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableList.java
@@ -1,0 +1,45 @@
+package ai.timefold.solver.core.impl.testdata.domain.clone.planning_cloneable;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.impl.domain.solution.cloner.PlanningCloneable;
+
+public class PlanningCloneableList<T> extends AbstractList<T> implements PlanningCloneable<PlanningCloneableList<T>> {
+    private final List<T> backingList;
+
+    public PlanningCloneableList() {
+        this.backingList = new ArrayList<>();
+    }
+
+    @Override
+    public PlanningCloneableList<T> createEmptyInstance() {
+        return new PlanningCloneableList<>();
+    }
+
+    @Override
+    public T get(int i) {
+        return backingList.get(i);
+    }
+
+    @Override
+    public T set(int i, T item) {
+        return backingList.set(i, item);
+    }
+
+    @Override
+    public void add(int i, T item) {
+        backingList.add(i, item);
+    }
+
+    @Override
+    public T remove(int i) {
+        return backingList.remove(i);
+    }
+
+    @Override
+    public int size() {
+        return backingList.size();
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableList.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableList.java
@@ -14,7 +14,7 @@ public class PlanningCloneableList<T> extends AbstractList<T> implements Plannin
     }
 
     @Override
-    public PlanningCloneableList<T> createEmptyInstance() {
+    public PlanningCloneableList<T> createNewInstance() {
         return new PlanningCloneableList<>();
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableMap.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableMap.java
@@ -15,7 +15,7 @@ public class PlanningCloneableMap<K, V> extends AbstractMap<K, V> implements Pla
     }
 
     @Override
-    public PlanningCloneableMap<K, V> createEmptyInstance() {
+    public PlanningCloneableMap<K, V> createNewInstance() {
         return new PlanningCloneableMap<>();
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableMap.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableMap.java
@@ -1,0 +1,31 @@
+package ai.timefold.solver.core.impl.testdata.domain.clone.planning_cloneable;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import ai.timefold.solver.core.impl.domain.solution.cloner.PlanningCloneable;
+
+public class PlanningCloneableMap<K, V> extends AbstractMap<K, V> implements PlanningCloneable<PlanningCloneableMap<K, V>> {
+    private final Map<K, V> backingMap;
+
+    public PlanningCloneableMap() {
+        this.backingMap = new HashMap<>();
+    }
+
+    @Override
+    public PlanningCloneableMap<K, V> createEmptyInstance() {
+        return new PlanningCloneableMap<>();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return backingMap.entrySet();
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return backingMap.put(key, value);
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableSolution.java
@@ -1,0 +1,42 @@
+package ai.timefold.solver.core.impl.testdata.domain.clone.planning_cloneable;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution
+public class PlanningCloneableSolution {
+    public static SolutionDescriptor<PlanningCloneableSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(PlanningCloneableSolution.class, TestdataEntity.class);
+    }
+
+    @PlanningEntityCollectionProperty
+    public PlanningCloneableList<TestdataEntity> entityList;
+    @ValueRangeProvider(id = "valueRange")
+    public PlanningCloneableList<TestdataValue> valueList;
+    public PlanningCloneableMap<String, TestdataEntity> codeToEntity;
+
+    @PlanningScore
+    public HardSoftScore score;
+
+    public PlanningCloneableSolution() {
+    }
+
+    public PlanningCloneableSolution(List<TestdataEntity> entityList) {
+        this.entityList = new PlanningCloneableList<>();
+        this.valueList = new PlanningCloneableList<>();
+        this.codeToEntity = new PlanningCloneableMap<>();
+        this.score = null;
+        for (TestdataEntity entity : entityList) {
+            this.entityList.add(entity);
+            this.codeToEntity.put(entity.getCode(), entity);
+        }
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/planning_cloneable/PlanningCloneableSolution.java
@@ -7,36 +7,38 @@ import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+import ai.timefold.solver.core.impl.domain.solution.cloner.PlanningCloneable;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 
 @PlanningSolution
-public class PlanningCloneableSolution {
+public class PlanningCloneableSolution implements PlanningCloneable<PlanningCloneableSolution> {
     public static SolutionDescriptor<PlanningCloneableSolution> buildSolutionDescriptor() {
-        return SolutionDescriptor.buildSolutionDescriptor(PlanningCloneableSolution.class, TestdataEntity.class);
+        return SolutionDescriptor.buildSolutionDescriptor(PlanningCloneableSolution.class, PlanningCloneableEntity.class);
     }
 
     @PlanningEntityCollectionProperty
-    public PlanningCloneableList<TestdataEntity> entityList;
-    @ValueRangeProvider(id = "valueRange")
+    public PlanningCloneableList<PlanningCloneableEntity> entityList;
+    @ValueRangeProvider
     public PlanningCloneableList<TestdataValue> valueList;
-    public PlanningCloneableMap<String, TestdataEntity> codeToEntity;
+    public PlanningCloneableMap<String, PlanningCloneableEntity> codeToEntity;
 
     @PlanningScore
     public HardSoftScore score;
 
-    public PlanningCloneableSolution() {
-    }
-
-    public PlanningCloneableSolution(List<TestdataEntity> entityList) {
+    public PlanningCloneableSolution(List<PlanningCloneableEntity> entityList) {
         this.entityList = new PlanningCloneableList<>();
         this.valueList = new PlanningCloneableList<>();
         this.codeToEntity = new PlanningCloneableMap<>();
         this.score = null;
-        for (TestdataEntity entity : entityList) {
+        for (PlanningCloneableEntity entity : entityList) {
             this.entityList.add(entity);
             this.codeToEntity.put(entity.getCode(), entity);
         }
+    }
+
+    @Override
+    public PlanningCloneableSolution createNewInstance() {
+        return new PlanningCloneableSolution(List.of());
     }
 }


### PR DESCRIPTION
Sometimes, the domain model has atypical types for fields (for instance, UserList instead of List or ArrayList). The default planning cloner originally failed fast when the field cannot be assigned a typical value. Now, it checks if the collection implements the internal interface. If it does, it uses it to create an empty collection/map. This allows the default planning cloner to be used when the user has control over UserList.