### PR TITLE
fix: add rebase support to NoChangeMove and ListUnassignMove

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/move/Move.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/move/Move.java
@@ -112,8 +112,9 @@ public interface Move<Solution_> {
      * @return never null, a new move that does the same change as this move on another solution instance
      */
     default Move<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
-        throw new UnsupportedOperationException("The custom move class (" + getClass()
-                + ") doesn't implement the rebase() method, so multithreaded solving is impossible.");
+        throw new UnsupportedOperationException(
+                "Move class (%s) doesn't implement the rebase() method, so multithreaded solving is impossible."
+                        .formatted(getClass()));
     }
 
     // ************************************************************************
@@ -145,8 +146,9 @@ public interface Move<Solution_> {
      * @return never null
      */
     default Collection<? extends Object> getPlanningEntities() {
-        throw new UnsupportedOperationException("The custom move class (" + getClass()
-                + ") doesn't implement the getPlanningEntities() method, so Entity Tabu Search is impossible.");
+        throw new UnsupportedOperationException(
+                "Move class (%s) doesn't implement the getPlanningEntities() method, so Entity Tabu Search is impossible."
+                        .formatted(getClass()));
     }
 
     /**
@@ -162,8 +164,9 @@ public interface Move<Solution_> {
      * @return never null
      */
     default Collection<? extends Object> getPlanningValues() {
-        throw new UnsupportedOperationException("The custom move class (" + getClass()
-                + ") doesn't implement the getPlanningEntities() method, so Value Tabu Search is impossible.");
+        throw new UnsupportedOperationException(
+                "Move class (%s) doesn't implement the getPlanningEntities() method, so Value Tabu Search is impossible."
+                        .formatted(getClass()));
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/move/NoChangeMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/move/NoChangeMove.java
@@ -31,6 +31,11 @@ public final class NoChangeMove<Solution_> extends AbstractSimplifiedMove<Soluti
     }
 
     @Override
+    public Move<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
+        return (Move<Solution_>) INSTANCE;
+    }
+
+    @Override
     public String getSimpleMoveTypeDescription() {
         return "No change";
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListUnassignMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListUnassignMove.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.move.AbstractSimplifiedMove;
+import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.score.director.VariableDescriptorAwareScoreDirector;
 
 public class ListUnassignMove<Solution_> extends AbstractSimplifiedMove<Solution_> {
@@ -55,6 +56,12 @@ public class ListUnassignMove<Solution_> extends AbstractSimplifiedMove<Solution
         movedValue = listVariable.remove(sourceIndex);
         innerScoreDirector.afterListVariableChanged(variableDescriptor, sourceEntity, sourceIndex, sourceIndex);
         innerScoreDirector.afterListVariableElementUnassigned(variableDescriptor, element);
+    }
+
+    @Override
+    public Move<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
+        return new ListUnassignMove<>(variableDescriptor, destinationScoreDirector.lookUpWorkingObject(sourceEntity),
+                sourceIndex);
     }
 
     // ************************************************************************

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/move/NoChangeMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/move/NoChangeMoveTest.java
@@ -2,9 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.move;
 
 import static ai.timefold.solver.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
 import org.junit.jupiter.api.Test;
@@ -18,11 +16,10 @@ class NoChangeMoveTest {
 
     @Test
     void rebase() {
-        ScoreDirector<TestdataSolution> destinationScoreDirector = mockRebasingScoreDirector(
-                TestdataSolution.buildSolutionDescriptor(), new Object[][] {});
-        NoChangeMove<TestdataSolution> move = NoChangeMove.getInstance();
-        assertThatThrownBy(() -> move.rebase(destinationScoreDirector))
-                .isInstanceOf(UnsupportedOperationException.class);
+        var destinationScoreDirector = mockRebasingScoreDirector(TestdataSolution.buildSolutionDescriptor(), new Object[][] {});
+        var move = NoChangeMove.<TestdataSolution> getInstance();
+        var rebasedMove = move.rebase(destinationScoreDirector);
+        assertThat(rebasedMove).isSameAs(move);
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListUnassignMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListUnassignMoveTest.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.heuristic.selector.move.generic.list;
 
+import static ai.timefold.solver.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -8,6 +9,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirector;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.list.TestdataListEntity;
 import ai.timefold.solver.core.impl.testdata.domain.list.TestdataListSolution;
 import ai.timefold.solver.core.impl.testdata.domain.list.TestdataListValue;
@@ -66,6 +68,16 @@ class ListUnassignMoveTest {
         assertThat(e1.getValueList()).hasSize(3);
         verify(scoreDirector).beforeListVariableElementAssigned(variableDescriptor, v3);
         verify(scoreDirector).afterListVariableElementAssigned(variableDescriptor, v3);
+    }
+
+    @Test
+    void rebase() {
+        var solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
+        var variableDescriptor = solutionDescriptor.getListVariableDescriptor();
+        var destinationScoreDirector = mockRebasingScoreDirector(solutionDescriptor, new Object[][] {});
+        var move = new ListUnassignMove<TestdataSolution>(null, null, 0);
+        var rebasedMove = move.rebase(destinationScoreDirector);
+        assertThat(rebasedMove).isNotSameAs(move);
     }
 
     @Test


### PR DESCRIPTION
Otherwise construction heuristics is going
to fail with multi-threaded solving,
when list variable with unassigned values is used.