### PR TITLE
fix: unimproved terminations skip construction heuristic

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/scope/ConstructionHeuristicPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/scope/ConstructionHeuristicPhaseScope.java
@@ -12,7 +12,7 @@ public class ConstructionHeuristicPhaseScope<Solution_> extends AbstractPhaseSco
     private ConstructionHeuristicStepScope<Solution_> lastCompletedStepScope;
 
     public ConstructionHeuristicPhaseScope(SolverScope<Solution_> solverScope) {
-        super(solverScope);
+        super(solverScope, false);
         lastCompletedStepScope = new ConstructionHeuristicStepScope<>(this, -1);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScope.java
@@ -22,7 +22,7 @@ public class ExhaustiveSearchPhaseScope<Solution_> extends AbstractPhaseScope<So
     private ExhaustiveSearchStepScope<Solution_> lastCompletedStepScope;
 
     public ExhaustiveSearchPhaseScope(SolverScope<Solution_> solverScope) {
-        super(solverScope);
+        super(solverScope, false);
         lastCompletedStepScope = new ExhaustiveSearchStepScope<>(this, -1);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/scope/CustomPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/scope/CustomPhaseScope.java
@@ -12,7 +12,11 @@ public class CustomPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
     private CustomStepScope<Solution_> lastCompletedStepScope;
 
     public CustomPhaseScope(SolverScope<Solution_> solverScope) {
-        super(solverScope);
+        this(solverScope, false);
+    }
+
+    public CustomPhaseScope(SolverScope<Solution_> solverScope, boolean phaseSendsBestSolutionEvents) {
+        super(solverScope, phaseSendsBestSolutionEvents);
         lastCompletedStepScope = new CustomStepScope<>(this, -1);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
@@ -19,6 +19,7 @@ public abstract class AbstractPhaseScope<Solution_> {
     protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     protected final SolverScope<Solution_> solverScope;
+    protected final boolean phaseSendsBestSolutionEvents;
 
     protected Long startingSystemTimeMillis;
     protected Long startingScoreCalculationCount;
@@ -29,12 +30,33 @@ public abstract class AbstractPhaseScope<Solution_> {
 
     protected int bestSolutionStepIndex;
 
-    public AbstractPhaseScope(SolverScope<Solution_> solverScope) {
+    /**
+     * As defined by #AbstractPhaseScope(SolverScope, boolean),
+     * with the phaseSendsBestSolutionEvents parameter set to true.
+     */
+    protected AbstractPhaseScope(SolverScope<Solution_> solverScope) {
+        this(solverScope, true);
+    }
+
+    /**
+     *
+     * @param solverScope never null
+     * @param phaseSendsBestSolutionEvents set to false if the phase only sends one best solution event at the end,
+     *        or none at all;
+     *        this is typical for construction heuristics,
+     *        whose result only matters when it reached its natural end.
+     */
+    protected AbstractPhaseScope(SolverScope<Solution_> solverScope, boolean phaseSendsBestSolutionEvents) {
         this.solverScope = solverScope;
+        this.phaseSendsBestSolutionEvents = phaseSendsBestSolutionEvents;
     }
 
     public SolverScope<Solution_> getSolverScope() {
         return solverScope;
+    }
+
+    public boolean phaseSendsBestSolutionEvents() {
+        return phaseSendsBestSolutionEvents;
     }
 
     public Long getStartingSystemTimeMillis() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
@@ -19,7 +19,7 @@ public abstract class AbstractPhaseScope<Solution_> {
     protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     protected final SolverScope<Solution_> solverScope;
-    protected final boolean phaseSendsBestSolutionEvents;
+    protected final boolean phaseSendingBestSolutionEvents;
 
     protected Long startingSystemTimeMillis;
     protected Long startingScoreCalculationCount;
@@ -32,7 +32,7 @@ public abstract class AbstractPhaseScope<Solution_> {
 
     /**
      * As defined by #AbstractPhaseScope(SolverScope, boolean),
-     * with the phaseSendsBestSolutionEvents parameter set to true.
+     * with the phaseSendingBestSolutionEvents parameter set to true.
      */
     protected AbstractPhaseScope(SolverScope<Solution_> solverScope) {
         this(solverScope, true);
@@ -41,22 +41,22 @@ public abstract class AbstractPhaseScope<Solution_> {
     /**
      *
      * @param solverScope never null
-     * @param phaseSendsBestSolutionEvents set to false if the phase only sends one best solution event at the end,
+     * @param phaseSendingBestSolutionEvents set to false if the phase only sends one best solution event at the end,
      *        or none at all;
      *        this is typical for construction heuristics,
      *        whose result only matters when it reached its natural end.
      */
-    protected AbstractPhaseScope(SolverScope<Solution_> solverScope, boolean phaseSendsBestSolutionEvents) {
+    protected AbstractPhaseScope(SolverScope<Solution_> solverScope, boolean phaseSendingBestSolutionEvents) {
         this.solverScope = solverScope;
-        this.phaseSendsBestSolutionEvents = phaseSendsBestSolutionEvents;
+        this.phaseSendingBestSolutionEvents = phaseSendingBestSolutionEvents;
     }
 
     public SolverScope<Solution_> getSolverScope() {
         return solverScope;
     }
 
-    public boolean phaseSendsBestSolutionEvents() {
-        return phaseSendsBestSolutionEvents;
+    public boolean isPhaseSendingBestSolutionEvents() {
+        return phaseSendingBestSolutionEvents;
     }
 
     public Long getStartingSystemTimeMillis() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractCompositeTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractCompositeTermination.java
@@ -15,7 +15,9 @@ import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
  * @see AndCompositeTermination
  * @see OrCompositeTermination
  */
-public abstract class AbstractCompositeTermination<Solution_> extends AbstractTermination<Solution_> {
+public abstract sealed class AbstractCompositeTermination<Solution_>
+        extends AbstractTermination<Solution_>
+        permits AndCompositeTermination, OrCompositeTermination {
 
     protected final List<Termination<Solution_>> terminationList;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractTermination.java
@@ -7,7 +7,7 @@ import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public sealed abstract class AbstractTermination<Solution_>
+public abstract sealed class AbstractTermination<Solution_>
         extends PhaseLifecycleListenerAdapter<Solution_>
         implements Termination<Solution_>
         permits AbstractCompositeTermination, BasicPlumbingTermination, BestScoreFeasibleTermination, BestScoreTermination,

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractTermination.java
@@ -7,23 +7,22 @@ import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Abstract superclass for {@link Termination}.
- */
-public abstract class AbstractTermination<Solution_> extends PhaseLifecycleListenerAdapter<Solution_>
-        implements Termination<Solution_> {
+public sealed abstract class AbstractTermination<Solution_>
+        extends PhaseLifecycleListenerAdapter<Solution_>
+        implements Termination<Solution_>
+        permits AbstractCompositeTermination, BasicPlumbingTermination, BestScoreFeasibleTermination, BestScoreTermination,
+        ChildThreadPlumbingTermination, PhaseToSolverTerminationBridge, ScoreCalculationCountTermination, StepCountTermination,
+        TimeMillisSpentTermination, UnimprovedStepCountTermination,
+        UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination, UnimprovedTimeMillisSpentTermination {
 
     protected final transient Logger logger = LoggerFactory.getLogger(getClass());
-
-    // ************************************************************************
-    // Other methods
-    // ************************************************************************
 
     @Override
     public Termination<Solution_> createChildThreadTermination(SolverScope<Solution_> solverScope,
             ChildThreadType childThreadType) {
-        throw new UnsupportedOperationException("This terminationClass (" + getClass()
-                + ") does not yet support being used in child threads of type (" + childThreadType + ").");
+        throw new UnsupportedOperationException(
+                "This terminationClass (%s) does not yet support being used in child threads of type (%s)."
+                        .formatted(getClass().getSimpleName(), childThreadType));
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AndCompositeTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AndCompositeTermination.java
@@ -6,7 +6,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class AndCompositeTermination<Solution_> extends AbstractCompositeTermination<Solution_> {
+public final class AndCompositeTermination<Solution_> extends AbstractCompositeTermination<Solution_> {
 
     public AndCompositeTermination(List<Termination<Solution_>> terminationList) {
         super(terminationList);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BasicPlumbingTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BasicPlumbingTermination.java
@@ -14,7 +14,7 @@ import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
  * Concurrency notes:
  * Condition predicate on ({@link #problemFactChangeQueue} is not empty or {@link #terminatedEarly} is true).
  */
-public class BasicPlumbingTermination<Solution_> extends AbstractTermination<Solution_> {
+public final class BasicPlumbingTermination<Solution_> extends AbstractTermination<Solution_> {
 
     protected final boolean daemon;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BasicPlumbingTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BasicPlumbingTermination.java
@@ -16,13 +16,11 @@ import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
  */
 public final class BasicPlumbingTermination<Solution_> extends AbstractTermination<Solution_> {
 
-    protected final boolean daemon;
+    private final boolean daemon;
+    private final BlockingQueue<ProblemChangeAdapter<Solution_>> problemFactChangeQueue = new LinkedBlockingQueue<>();
 
-    protected boolean terminatedEarly = false;
-
-    protected BlockingQueue<ProblemChangeAdapter<Solution_>> problemFactChangeQueue = new LinkedBlockingQueue<>();
-
-    protected boolean problemFactChangesBeingProcessed = false;
+    private boolean terminatedEarly = false;
+    private boolean problemFactChangesBeingProcessed = false;
 
     public BasicPlumbingTermination(boolean daemon) {
         this.daemon = daemon;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
@@ -18,7 +18,7 @@ public final class BestScoreFeasibleTermination<Solution_> extends AbstractTermi
         this.timeGradientWeightFeasibleNumbers = timeGradientWeightFeasibleNumbers;
         if (timeGradientWeightFeasibleNumbers.length != this.feasibleLevelsSize - 1) {
             throw new IllegalStateException(
-                    "The timeGradientWeightNumbers (%s)'s length (%d) is not 1 less than the feasibleLevelsSize (%s)."
+                    "The timeGradientWeightNumbers (%s)'s length (%d) is not 1 less than the feasibleLevelsSize (%d)."
                             .formatted(Arrays.toString(timeGradientWeightFeasibleNumbers),
                                     timeGradientWeightFeasibleNumbers.length, scoreDefinition.getFeasibleLevelsSize()));
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
@@ -8,7 +8,7 @@ import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class BestScoreFeasibleTermination<Solution_> extends AbstractTermination<Solution_> {
+public final class BestScoreFeasibleTermination<Solution_> extends AbstractTermination<Solution_> {
 
     private final int feasibleLevelsSize;
     private final double[] timeGradientWeightFeasibleNumbers;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
@@ -14,14 +14,13 @@ public final class BestScoreFeasibleTermination<Solution_> extends AbstractTermi
     private final double[] timeGradientWeightFeasibleNumbers;
 
     public BestScoreFeasibleTermination(ScoreDefinition scoreDefinition, double[] timeGradientWeightFeasibleNumbers) {
-        feasibleLevelsSize = scoreDefinition.getFeasibleLevelsSize();
+        this.feasibleLevelsSize = scoreDefinition.getFeasibleLevelsSize();
         this.timeGradientWeightFeasibleNumbers = timeGradientWeightFeasibleNumbers;
-        if (timeGradientWeightFeasibleNumbers.length != feasibleLevelsSize - 1) {
+        if (timeGradientWeightFeasibleNumbers.length != this.feasibleLevelsSize - 1) {
             throw new IllegalStateException(
-                    "The timeGradientWeightNumbers (" + Arrays.toString(timeGradientWeightFeasibleNumbers)
-                            + ")'s length (" + timeGradientWeightFeasibleNumbers.length
-                            + ") is not 1 less than the feasibleLevelsSize (" + scoreDefinition.getFeasibleLevelsSize()
-                            + ").");
+                    "The timeGradientWeightNumbers (%s)'s length (%d) is not 1 less than the feasibleLevelsSize (%s)."
+                            .formatted(Arrays.toString(timeGradientWeightFeasibleNumbers),
+                                    timeGradientWeightFeasibleNumbers.length, scoreDefinition.getFeasibleLevelsSize()));
         }
     }
 
@@ -35,7 +34,7 @@ public final class BestScoreFeasibleTermination<Solution_> extends AbstractTermi
         return isTerminated((Score) phaseScope.getBestScore());
     }
 
-    protected boolean isTerminated(Score bestScore) {
+    private static boolean isTerminated(Score bestScore) {
         return bestScore.isFeasible();
     }
 
@@ -49,7 +48,7 @@ public final class BestScoreFeasibleTermination<Solution_> extends AbstractTermi
         return calculateFeasibilityTimeGradient((Score) phaseScope.getStartingScore(), (Score) phaseScope.getBestScore());
     }
 
-    protected <Score_ extends Score<Score_>> double calculateFeasibilityTimeGradient(Score_ startScore, Score_ score) {
+    <Score_ extends Score<Score_>> double calculateFeasibilityTimeGradient(Score_ startScore, Score_ score) {
         if (startScore == null || !startScore.isSolutionInitialized()) {
             return 0.0;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
@@ -13,7 +13,7 @@ public final class BestScoreFeasibleTermination<Solution_> extends AbstractTermi
     private final int feasibleLevelsSize;
     private final double[] timeGradientWeightFeasibleNumbers;
 
-    public BestScoreFeasibleTermination(ScoreDefinition scoreDefinition, double[] timeGradientWeightFeasibleNumbers) {
+    public BestScoreFeasibleTermination(ScoreDefinition<?> scoreDefinition, double[] timeGradientWeightFeasibleNumbers) {
         this.feasibleLevelsSize = scoreDefinition.getFeasibleLevelsSize();
         this.timeGradientWeightFeasibleNumbers = timeGradientWeightFeasibleNumbers;
         if (timeGradientWeightFeasibleNumbers.length != this.feasibleLevelsSize - 1) {
@@ -31,10 +31,10 @@ public final class BestScoreFeasibleTermination<Solution_> extends AbstractTermi
 
     @Override
     public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
-        return isTerminated((Score) phaseScope.getBestScore());
+        return isTerminated(phaseScope.getBestScore());
     }
 
-    private static boolean isTerminated(Score bestScore) {
+    private static boolean isTerminated(Score<?> bestScore) {
         return bestScore.isFeasible();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreTermination.java
@@ -8,7 +8,7 @@ import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class BestScoreTermination<Solution_> extends AbstractTermination<Solution_> {
+public final class BestScoreTermination<Solution_> extends AbstractTermination<Solution_> {
 
     private final int levelsSize;
     private final Score bestScoreLimit;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreTermination.java
@@ -14,19 +14,19 @@ public final class BestScoreTermination<Solution_> extends AbstractTermination<S
     private final Score bestScoreLimit;
     private final double[] timeGradientWeightNumbers;
 
-    public BestScoreTermination(ScoreDefinition scoreDefinition, Score bestScoreLimit, double[] timeGradientWeightNumbers) {
+    public BestScoreTermination(ScoreDefinition<?> scoreDefinition, Score<?> bestScoreLimit,
+            double[] timeGradientWeightNumbers) {
         levelsSize = scoreDefinition.getLevelsSize();
         this.bestScoreLimit = bestScoreLimit;
         if (bestScoreLimit == null) {
-            throw new IllegalArgumentException("The bestScoreLimit (" + bestScoreLimit
-                    + ") cannot be null.");
+            throw new IllegalArgumentException("The bestScoreLimit cannot be null.");
         }
         this.timeGradientWeightNumbers = timeGradientWeightNumbers;
         if (timeGradientWeightNumbers.length != levelsSize - 1) {
             throw new IllegalStateException(
-                    "The timeGradientWeightNumbers (" + Arrays.toString(timeGradientWeightNumbers)
-                            + ")'s length (" + timeGradientWeightNumbers.length
-                            + ") is not 1 less than the levelsSize (" + scoreDefinition.getLevelsSize() + ").");
+                    "The timeGradientWeightNumbers (%s)'s length (%d) is not 1 less than the levelsSize (%d)."
+                            .formatted(Arrays.toString(timeGradientWeightNumbers), timeGradientWeightNumbers.length,
+                                    scoreDefinition.getLevelsSize()));
         }
     }
 
@@ -44,7 +44,7 @@ public final class BestScoreTermination<Solution_> extends AbstractTermination<S
         return isTerminated(phaseScope.isBestSolutionInitialized(), (Score) phaseScope.getBestScore());
     }
 
-    protected boolean isTerminated(boolean bestSolutionInitialized, Score bestScore) {
+    private boolean isTerminated(boolean bestSolutionInitialized, Score bestScore) {
         return bestSolutionInitialized && bestScore.compareTo(bestScoreLimit) >= 0;
     }
 
@@ -54,8 +54,8 @@ public final class BestScoreTermination<Solution_> extends AbstractTermination<S
 
     @Override
     public double calculateSolverTimeGradient(SolverScope<Solution_> solverScope) {
-        Score startingInitializedScore = solverScope.getStartingInitializedScore();
-        Score bestScore = solverScope.getBestScore();
+        var startingInitializedScore = solverScope.getStartingInitializedScore();
+        var bestScore = solverScope.getBestScore();
         return calculateTimeGradient(startingInitializedScore, bestScoreLimit, bestScore);
     }
 
@@ -66,12 +66,11 @@ public final class BestScoreTermination<Solution_> extends AbstractTermination<S
         return calculateTimeGradient(startingInitializedScore, bestScoreLimit, bestScore);
     }
 
-    protected <Score_ extends Score<Score_>> double calculateTimeGradient(Score_ startScore, Score_ endScore,
-            Score_ score) {
-        Score_ totalDiff = endScore.subtract(startScore);
-        Number[] totalDiffNumbers = totalDiff.toLevelNumbers();
-        Score_ scoreDiff = score.subtract(startScore);
-        Number[] scoreDiffNumbers = scoreDiff.toLevelNumbers();
+    <Score_ extends Score<Score_>> double calculateTimeGradient(Score_ startScore, Score_ endScore, Score_ score) {
+        var totalDiff = endScore.subtract(startScore);
+        var totalDiffNumbers = totalDiff.toLevelNumbers();
+        var scoreDiff = score.subtract(startScore);
+        var scoreDiffNumbers = scoreDiff.toLevelNumbers();
         if (scoreDiffNumbers.length != totalDiffNumbers.length) {
             throw new IllegalStateException("The startScore (" + startScore + "), endScore (" + endScore
                     + ") and score (" + score + ") don't have the same levelsSize.");
@@ -90,9 +89,9 @@ public final class BestScoreTermination<Solution_> extends AbstractTermination<S
      */
     static double calculateTimeGradient(Number[] totalDiffNumbers, Number[] scoreDiffNumbers,
             double[] timeGradientWeightNumbers, int levelDepth) {
-        double timeGradient = 0.0;
-        double remainingTimeGradient = 1.0;
-        for (int i = 0; i < levelDepth; i++) {
+        var timeGradient = 0.0;
+        var remainingTimeGradient = 1.0;
+        for (var i = 0; i < levelDepth; i++) {
             double levelTimeGradientWeight;
             if (i != (levelDepth - 1)) {
                 levelTimeGradientWeight = remainingTimeGradient * timeGradientWeightNumbers[i];
@@ -101,8 +100,8 @@ public final class BestScoreTermination<Solution_> extends AbstractTermination<S
                 levelTimeGradientWeight = remainingTimeGradient;
                 remainingTimeGradient = 0.0;
             }
-            double totalDiffLevel = totalDiffNumbers[i].doubleValue();
-            double scoreDiffLevel = scoreDiffNumbers[i].doubleValue();
+            var totalDiffLevel = totalDiffNumbers[i].doubleValue();
+            var scoreDiffLevel = scoreDiffNumbers[i].doubleValue();
             if (scoreDiffLevel == totalDiffLevel) {
                 // Max out this level
                 timeGradient += levelTimeGradientWeight;
@@ -118,7 +117,7 @@ public final class BestScoreTermination<Solution_> extends AbstractTermination<S
                 // timeGradient += 0.0
                 break;
             } else {
-                double levelTimeGradient = scoreDiffLevel / totalDiffLevel;
+                var levelTimeGradient = scoreDiffLevel / totalDiffLevel;
                 timeGradient += levelTimeGradient * levelTimeGradientWeight;
             }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ChildThreadPlumbingTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ChildThreadPlumbingTermination.java
@@ -4,7 +4,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class ChildThreadPlumbingTermination<Solution_> extends AbstractTermination<Solution_> {
+public final class ChildThreadPlumbingTermination<Solution_> extends AbstractTermination<Solution_> {
 
     protected boolean terminateChildren = false;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ChildThreadPlumbingTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ChildThreadPlumbingTermination.java
@@ -6,7 +6,7 @@ import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
 public final class ChildThreadPlumbingTermination<Solution_> extends AbstractTermination<Solution_> {
 
-    protected boolean terminateChildren = false;
+    private boolean terminateChildren = false;
 
     // ************************************************************************
     // Plumbing worker methods
@@ -18,7 +18,7 @@ public final class ChildThreadPlumbingTermination<Solution_> extends AbstractTer
      * @return true if termination hasn't been requested previously
      */
     public synchronized boolean terminateChildren() {
-        boolean terminationEarlySuccessful = !terminateChildren;
+        var terminationEarlySuccessful = !terminateChildren;
         terminateChildren = true;
         return terminationEarlySuccessful;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/OrCompositeTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/OrCompositeTermination.java
@@ -6,7 +6,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class OrCompositeTermination<Solution_> extends AbstractCompositeTermination<Solution_> {
+public final class OrCompositeTermination<Solution_> extends AbstractCompositeTermination<Solution_> {
 
     public OrCompositeTermination(List<Termination<Solution_>> terminationList) {
         super(terminationList);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/PhaseToSolverTerminationBridge.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/PhaseToSolverTerminationBridge.java
@@ -4,7 +4,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class PhaseToSolverTerminationBridge<Solution_> extends AbstractTermination<Solution_> {
+public final class PhaseToSolverTerminationBridge<Solution_> extends AbstractTermination<Solution_> {
 
     private final Termination<Solution_> solverTermination;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ScoreCalculationCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ScoreCalculationCountTermination.java
@@ -12,8 +12,9 @@ public final class ScoreCalculationCountTermination<Solution_> extends AbstractT
     public ScoreCalculationCountTermination(long scoreCalculationCountLimit) {
         this.scoreCalculationCountLimit = scoreCalculationCountLimit;
         if (scoreCalculationCountLimit < 0L) {
-            throw new IllegalArgumentException("The scoreCalculationCountLimit (" + scoreCalculationCountLimit
-                    + ") cannot be negative.");
+            throw new IllegalArgumentException(
+                    "The scoreCalculationCountLimit (%d) cannot be negative."
+                            .formatted(scoreCalculationCountLimit));
         }
     }
 
@@ -31,8 +32,8 @@ public final class ScoreCalculationCountTermination<Solution_> extends AbstractT
         return isTerminated(phaseScope.getScoreDirector());
     }
 
-    protected boolean isTerminated(InnerScoreDirector<Solution_, ?> scoreDirector) {
-        long scoreCalculationCount = scoreDirector.getCalculationCount();
+    private boolean isTerminated(InnerScoreDirector<Solution_, ?> scoreDirector) {
+        var scoreCalculationCount = scoreDirector.getCalculationCount();
         return scoreCalculationCount >= scoreCalculationCountLimit;
     }
 
@@ -50,9 +51,9 @@ public final class ScoreCalculationCountTermination<Solution_> extends AbstractT
         return calculateTimeGradient(phaseScope.getScoreDirector());
     }
 
-    protected double calculateTimeGradient(InnerScoreDirector<Solution_, ?> scoreDirector) {
-        long scoreCalculationCount = scoreDirector.getCalculationCount();
-        double timeGradient = scoreCalculationCount / ((double) scoreCalculationCountLimit);
+    private double calculateTimeGradient(InnerScoreDirector<Solution_, ?> scoreDirector) {
+        var scoreCalculationCount = scoreDirector.getCalculationCount();
+        var timeGradient = scoreCalculationCount / ((double) scoreCalculationCountLimit);
         return Math.min(timeGradient, 1.0);
     }
 
@@ -67,7 +68,8 @@ public final class ScoreCalculationCountTermination<Solution_> extends AbstractT
             // The ScoreDirector.calculationCount of partitions is maxed, not summed.
             return new ScoreCalculationCountTermination<>(scoreCalculationCountLimit);
         } else {
-            throw new IllegalStateException("The childThreadType (" + childThreadType + ") is not implemented.");
+            throw new IllegalStateException("The childThreadType (%s) is not implemented."
+                    .formatted(childThreadType));
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ScoreCalculationCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ScoreCalculationCountTermination.java
@@ -5,7 +5,7 @@ import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class ScoreCalculationCountTermination<Solution_> extends AbstractTermination<Solution_> {
+public final class ScoreCalculationCountTermination<Solution_> extends AbstractTermination<Solution_> {
 
     private final long scoreCalculationCountLimit;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/StepCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/StepCountTermination.java
@@ -4,7 +4,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class StepCountTermination<Solution_> extends AbstractTermination<Solution_> {
+public final class StepCountTermination<Solution_> extends AbstractTermination<Solution_> {
 
     private final int stepCountLimit;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTermination.java
@@ -4,7 +4,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class TimeMillisSpentTermination<Solution_> extends AbstractTermination<Solution_> {
+public final class TimeMillisSpentTermination<Solution_> extends AbstractTermination<Solution_> {
 
     private final long timeMillisSpentLimit;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTermination.java
@@ -11,8 +11,8 @@ public final class TimeMillisSpentTermination<Solution_> extends AbstractTermina
     public TimeMillisSpentTermination(long timeMillisSpentLimit) {
         this.timeMillisSpentLimit = timeMillisSpentLimit;
         if (timeMillisSpentLimit < 0L) {
-            throw new IllegalArgumentException("The timeMillisSpentLimit (" + timeMillisSpentLimit
-                    + ") cannot be negative.");
+            throw new IllegalArgumentException("The timeMillisSpentLimit (%d) cannot be negative."
+                    .formatted(timeMillisSpentLimit));
         }
     }
 
@@ -36,7 +36,7 @@ public final class TimeMillisSpentTermination<Solution_> extends AbstractTermina
         return isTerminated(phaseTimeMillisSpent);
     }
 
-    protected boolean isTerminated(long timeMillisSpent) {
+    private boolean isTerminated(long timeMillisSpent) {
         return timeMillisSpent >= timeMillisSpentLimit;
     }
 
@@ -56,7 +56,7 @@ public final class TimeMillisSpentTermination<Solution_> extends AbstractTermina
         return calculateTimeGradient(phaseTimeMillisSpent);
     }
 
-    protected double calculateTimeGradient(long timeMillisSpent) {
+    private double calculateTimeGradient(long timeMillisSpent) {
         double timeGradient = timeMillisSpent / ((double) timeMillisSpentLimit);
         return Math.min(timeGradient, 1.0);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTermination.java
@@ -26,13 +26,13 @@ public final class TimeMillisSpentTermination<Solution_> extends AbstractTermina
 
     @Override
     public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
-        long solverTimeMillisSpent = solverScope.calculateTimeMillisSpentUpToNow();
+        var solverTimeMillisSpent = solverScope.calculateTimeMillisSpentUpToNow();
         return isTerminated(solverTimeMillisSpent);
     }
 
     @Override
     public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
-        long phaseTimeMillisSpent = phaseScope.calculatePhaseTimeMillisSpentUpToNow();
+        var phaseTimeMillisSpent = phaseScope.calculatePhaseTimeMillisSpentUpToNow();
         return isTerminated(phaseTimeMillisSpent);
     }
 
@@ -46,18 +46,18 @@ public final class TimeMillisSpentTermination<Solution_> extends AbstractTermina
 
     @Override
     public double calculateSolverTimeGradient(SolverScope<Solution_> solverScope) {
-        long solverTimeMillisSpent = solverScope.calculateTimeMillisSpentUpToNow();
+        var solverTimeMillisSpent = solverScope.calculateTimeMillisSpentUpToNow();
         return calculateTimeGradient(solverTimeMillisSpent);
     }
 
     @Override
     public double calculatePhaseTimeGradient(AbstractPhaseScope<Solution_> phaseScope) {
-        long phaseTimeMillisSpent = phaseScope.calculatePhaseTimeMillisSpentUpToNow();
+        var phaseTimeMillisSpent = phaseScope.calculatePhaseTimeMillisSpentUpToNow();
         return calculateTimeGradient(phaseTimeMillisSpent);
     }
 
     private double calculateTimeGradient(long timeMillisSpent) {
-        double timeGradient = timeMillisSpent / ((double) timeMillisSpentLimit);
+        var timeGradient = timeMillisSpent / ((double) timeMillisSpentLimit);
         return Math.min(timeGradient, 1.0);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedStepCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedStepCountTermination.java
@@ -11,13 +11,9 @@ public final class UnimprovedStepCountTermination<Solution_> extends AbstractTer
     public UnimprovedStepCountTermination(int unimprovedStepCountLimit) {
         this.unimprovedStepCountLimit = unimprovedStepCountLimit;
         if (unimprovedStepCountLimit < 0) {
-            throw new IllegalArgumentException("The unimprovedStepCountLimit (" + unimprovedStepCountLimit
-                    + ") cannot be negative.");
+            throw new IllegalArgumentException("The unimprovedStepCountLimit (%d) cannot be negative."
+                    .formatted(unimprovedStepCountLimit));
         }
-    }
-
-    public int getUnimprovedStepCountLimit() {
-        return unimprovedStepCountLimit;
     }
 
     // ************************************************************************
@@ -36,7 +32,7 @@ public final class UnimprovedStepCountTermination<Solution_> extends AbstractTer
         return unimprovedStepCount >= unimprovedStepCountLimit;
     }
 
-    protected int calculateUnimprovedStepCount(AbstractPhaseScope<Solution_> phaseScope) {
+    private static int calculateUnimprovedStepCount(AbstractPhaseScope<?> phaseScope) {
         int bestStepIndex = phaseScope.getBestSolutionStepIndex();
         int lastStepIndex = phaseScope.getLastCompletedStepScope().getStepIndex();
         return lastStepIndex - bestStepIndex;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedStepCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedStepCountTermination.java
@@ -4,7 +4,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class UnimprovedStepCountTermination<Solution_> extends AbstractTermination<Solution_> {
+public final class UnimprovedStepCountTermination<Solution_> extends AbstractTermination<Solution_> {
 
     private final int unimprovedStepCountLimit;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedStepCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedStepCountTermination.java
@@ -28,13 +28,13 @@ public final class UnimprovedStepCountTermination<Solution_> extends AbstractTer
 
     @Override
     public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
-        int unimprovedStepCount = calculateUnimprovedStepCount(phaseScope);
+        var unimprovedStepCount = calculateUnimprovedStepCount(phaseScope);
         return unimprovedStepCount >= unimprovedStepCountLimit;
     }
 
     private static int calculateUnimprovedStepCount(AbstractPhaseScope<?> phaseScope) {
-        int bestStepIndex = phaseScope.getBestSolutionStepIndex();
-        int lastStepIndex = phaseScope.getLastCompletedStepScope().getStepIndex();
+        var bestStepIndex = phaseScope.getBestSolutionStepIndex();
+        var lastStepIndex = phaseScope.getLastCompletedStepScope().getStepIndex();
         return lastStepIndex - bestStepIndex;
     }
 
@@ -50,8 +50,8 @@ public final class UnimprovedStepCountTermination<Solution_> extends AbstractTer
 
     @Override
     public double calculatePhaseTimeGradient(AbstractPhaseScope<Solution_> phaseScope) {
-        int unimprovedStepCount = calculateUnimprovedStepCount(phaseScope);
-        double timeGradient = unimprovedStepCount / ((double) unimprovedStepCountLimit);
+        var unimprovedStepCount = calculateUnimprovedStepCount(phaseScope);
+        var timeGradient = unimprovedStepCount / ((double) unimprovedStepCountLimit);
         return Math.min(timeGradient, 1.0);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
@@ -88,9 +88,6 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
 
     @Override
     public void stepEnded(AbstractStepScope<Solution_> stepScope) {
-        if (!currentPhaseSendsBestSolutionEvents) {
-            return;
-        }
         if (stepScope.getBestScoreImproved()) {
             SolverScope<Solution_> solverScope = stepScope.getPhaseScope().getSolverScope();
             long bestSolutionTimeMillis = solverScope.getBestSolutionTimeMillis();
@@ -99,7 +96,7 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
                 Pair<Long, Score> bestScoreImprovement = it.next();
                 Score scoreDifference = bestScore.subtract(bestScoreImprovement.value());
                 boolean timeLimitNotYetReached = bestScoreImprovement.key()
-                        + unimprovedTimeMillisSpentLimit >= getUnimprovedTimeMillisSpent(bestSolutionTimeMillis);
+                        + unimprovedTimeMillisSpentLimit >= bestSolutionTimeMillis;
                 boolean scoreImprovedOverThreshold = scoreDifference.compareTo(unimprovedScoreDifferenceThreshold) >= 0;
                 if (scoreImprovedOverThreshold && timeLimitNotYetReached) {
                     it.remove();

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
@@ -12,7 +12,7 @@ import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 import ai.timefold.solver.core.impl.util.Pair;
 
-public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<Solution_>
+public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<Solution_>
         extends AbstractTermination<Solution_> {
 
     private final long unimprovedTimeMillisSpentLimit;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
@@ -119,7 +119,7 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
     }
 
     private boolean isTerminated(long safeTimeMillis) {
-        if (!currentPhaseSendsBestSolutionEvents) {
+        if (!currentPhaseSendsBestSolutionEvents) { // This phase never terminates early.
             return false;
         }
         // It's possible that there is already an improving move in the forager

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
@@ -56,7 +56,11 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
     @Override
     public void solvingStarted(SolverScope<Solution_> solverScope) {
         bestScoreImprovementHistoryQueue = new ArrayDeque<>();
-        solverSafeTimeMillis = solverScope.getBestSolutionTimeMillis() + unimprovedTimeMillisSpentLimit;
+        resetSolverSafeTimeMillis(solverScope);
+    }
+
+    void resetSolverSafeTimeMillis(SolverScope<Solution_> solverScope) {
+        solverSafeTimeMillis = clock.millis() + unimprovedTimeMillisSpentLimit;
     }
 
     @Override
@@ -84,6 +88,9 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
     @Override
     public void phaseEnded(AbstractPhaseScope<Solution_> phaseScope) {
         phaseSafeTimeMillis = -1L;
+        if (!currentPhaseSendsBestSolutionEvents) { // The next phase starts all over.
+            resetSolverSafeTimeMillis(phaseScope.getSolverScope());
+        }
     }
 
     @Override
@@ -109,11 +116,6 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
             }
             bestScoreImprovementHistoryQueue.add(new Pair<>(bestSolutionTimeMillis, bestScore));
         }
-    }
-
-    private long getUnimprovedTimeMillisSpent(long bestSolutionTimeMillis) {
-        long now = clock.millis();
-        return now - Math.max(bestSolutionTimeMillis, phaseStartedTimeMillis);
     }
 
     // ************************************************************************

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
@@ -25,12 +25,12 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
     private boolean currentPhaseSendsBestSolutionEvents = false;
 
     public UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(long unimprovedTimeMillisSpentLimit,
-            Score unimprovedScoreDifferenceThreshold) {
+            Score<?> unimprovedScoreDifferenceThreshold) {
         this(unimprovedTimeMillisSpentLimit, unimprovedScoreDifferenceThreshold, Clock.systemUTC());
     }
 
     UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(long unimprovedTimeMillisSpentLimit,
-            Score unimprovedScoreDifferenceThreshold, Clock clock) {
+            Score<?> unimprovedScoreDifferenceThreshold, Clock clock) {
         this.unimprovedTimeMillisSpentLimit = unimprovedTimeMillisSpentLimit;
         if (unimprovedTimeMillisSpentLimit < 0L) {
             throw new IllegalArgumentException("The unimprovedTimeMillisSpentLimit (%d) cannot be negative."

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
@@ -68,7 +68,7 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
          * We avoid that by never terminating during these phases,
          * and resetting the counter to zero when the next phase starts.
          */
-        currentPhaseSendsBestSolutionEvents = phaseScope.phaseSendsBestSolutionEvents();
+        currentPhaseSendsBestSolutionEvents = phaseScope.isPhaseSendingBestSolutionEvents();
     }
 
     @Override
@@ -110,21 +110,18 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
 
     @Override
     public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
-        if (!currentPhaseSendsBestSolutionEvents) {
-            return false;
-        }
         return isTerminated(solverSafeTimeMillis);
     }
 
     @Override
     public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
-        if (!currentPhaseSendsBestSolutionEvents) {
-            return false;
-        }
         return isTerminated(phaseSafeTimeMillis);
     }
 
     private boolean isTerminated(long safeTimeMillis) {
+        if (!currentPhaseSendsBestSolutionEvents) {
+            return false;
+        }
         // It's possible that there is already an improving move in the forager
         // that will end up pushing the safeTimeMillis further
         // but that doesn't change the fact that the best score didn't improve enough in the specified time interval.
@@ -139,21 +136,18 @@ public final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<
 
     @Override
     public double calculateSolverTimeGradient(SolverScope<Solution_> solverScope) {
-        if (!currentPhaseSendsBestSolutionEvents) {
-            return 0.0;
-        }
         return calculateTimeGradient(solverSafeTimeMillis);
     }
 
     @Override
     public double calculatePhaseTimeGradient(AbstractPhaseScope<Solution_> phaseScope) {
-        if (!currentPhaseSendsBestSolutionEvents) {
-            return 0.0;
-        }
         return calculateTimeGradient(phaseSafeTimeMillis);
     }
 
     private double calculateTimeGradient(long safeTimeMillis) {
+        if (!currentPhaseSendsBestSolutionEvents) {
+            return 0.0;
+        }
         var now = clock.millis();
         var unimprovedTimeMillisSpent = now - (safeTimeMillis - unimprovedTimeMillisSpentLimit);
         var timeGradient = unimprovedTimeMillisSpent / ((double) unimprovedTimeMillisSpentLimit);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -42,7 +42,7 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
          * We avoid that by never terminating during these phases,
          * and resetting the counter to zero when the next phase starts.
          */
-        currentPhaseSendsBestSolutionEvents = phaseScope.phaseSendsBestSolutionEvents();
+        currentPhaseSendsBestSolutionEvents = phaseScope.isPhaseSendingBestSolutionEvents();
         phaseStartedTimeMillis = clock.millis();
     }
 
@@ -52,23 +52,20 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
 
     @Override
     public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
-        if (!currentPhaseSendsBestSolutionEvents) {
-            return false;
-        }
         long bestSolutionTimeMillis = solverScope.getBestSolutionTimeMillis();
         return isTerminated(bestSolutionTimeMillis);
     }
 
     @Override
     public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
-        if (!currentPhaseSendsBestSolutionEvents) {
-            return false;
-        }
         var bestSolutionTimeMillis = phaseScope.getPhaseBestSolutionTimeMillis();
         return isTerminated(bestSolutionTimeMillis);
     }
 
     private boolean isTerminated(long bestSolutionTimeMillis) {
+        if (!currentPhaseSendsBestSolutionEvents) {
+            return false;
+        }
         return getUnimprovedTimeMillisSpent(bestSolutionTimeMillis) >= unimprovedTimeMillisSpentLimit;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -18,11 +18,11 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
         this(unimprovedTimeMillisSpentLimit, Clock.systemUTC());
     }
 
-    protected UnimprovedTimeMillisSpentTermination(long unimprovedTimeMillisSpentLimit, Clock clock) {
+    UnimprovedTimeMillisSpentTermination(long unimprovedTimeMillisSpentLimit, Clock clock) {
         this.unimprovedTimeMillisSpentLimit = unimprovedTimeMillisSpentLimit;
         if (unimprovedTimeMillisSpentLimit < 0L) {
-            throw new IllegalArgumentException("The unimprovedTimeMillisSpentLimit (" + unimprovedTimeMillisSpentLimit
-                    + ") cannot be negative.");
+            throw new IllegalArgumentException("The unimprovedTimeMillisSpentLimit (%d) cannot be negative."
+                    .formatted(unimprovedTimeMillisSpentLimit));
         }
         this.clock = clock;
     }
@@ -68,7 +68,7 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
         return isTerminated(bestSolutionTimeMillis);
     }
 
-    protected boolean isTerminated(long bestSolutionTimeMillis) {
+    private boolean isTerminated(long bestSolutionTimeMillis) {
         return getUnimprovedTimeMillisSpent(bestSolutionTimeMillis) >= unimprovedTimeMillisSpentLimit;
     }
 
@@ -93,7 +93,7 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
         return calculateTimeGradient(bestSolutionTimeMillis);
     }
 
-    protected double calculateTimeGradient(long bestSolutionTimeMillis) {
+    private double calculateTimeGradient(long bestSolutionTimeMillis) {
         if (!currentPhaseSendsBestSolutionEvents) {
             return 0.0;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -9,8 +9,8 @@ import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 public final class UnimprovedTimeMillisSpentTermination<Solution_> extends AbstractTermination<Solution_> {
 
     private final long unimprovedTimeMillisSpentLimit;
-
     private final Clock clock;
+
     private boolean currentPhaseSendsBestSolutionEvents = false;
     private long phaseStartedTimeMillis = -1L;
 
@@ -64,7 +64,7 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
         if (!currentPhaseSendsBestSolutionEvents) {
             return false;
         }
-        long bestSolutionTimeMillis = phaseScope.getPhaseBestSolutionTimeMillis();
+        var bestSolutionTimeMillis = phaseScope.getPhaseBestSolutionTimeMillis();
         return isTerminated(bestSolutionTimeMillis);
     }
 
@@ -73,7 +73,7 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
     }
 
     private long getUnimprovedTimeMillisSpent(long bestSolutionTimeMillis) {
-        long now = clock.millis();
+        var now = clock.millis();
         return now - Math.max(bestSolutionTimeMillis, phaseStartedTimeMillis);
     }
 
@@ -89,7 +89,7 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
 
     @Override
     public double calculatePhaseTimeGradient(AbstractPhaseScope<Solution_> phaseScope) {
-        long bestSolutionTimeMillis = phaseScope.getPhaseBestSolutionTimeMillis();
+        var bestSolutionTimeMillis = phaseScope.getPhaseBestSolutionTimeMillis();
         return calculateTimeGradient(bestSolutionTimeMillis);
     }
 
@@ -97,7 +97,7 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
         if (!currentPhaseSendsBestSolutionEvents) {
             return 0.0;
         }
-        double timeGradient = getUnimprovedTimeMillisSpent(bestSolutionTimeMillis) / ((double) unimprovedTimeMillisSpentLimit);
+        var timeGradient = getUnimprovedTimeMillisSpent(bestSolutionTimeMillis) / ((double) unimprovedTimeMillisSpentLimit);
         return Math.min(timeGradient, 1.0);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -6,7 +6,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
-public class UnimprovedTimeMillisSpentTermination<Solution_> extends AbstractTermination<Solution_> {
+public final class UnimprovedTimeMillisSpentTermination<Solution_> extends AbstractTermination<Solution_> {
 
     private final long unimprovedTimeMillisSpentLimit;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -63,7 +63,7 @@ public final class UnimprovedTimeMillisSpentTermination<Solution_> extends Abstr
     }
 
     private boolean isTerminated(long bestSolutionTimeMillis) {
-        if (!currentPhaseSendsBestSolutionEvents) {
+        if (!currentPhaseSendsBestSolutionEvents) { // This phase never terminates early.
             return false;
         }
         return getUnimprovedTimeMillisSpent(bestSolutionTimeMillis) >= unimprovedTimeMillisSpentLimit;

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
@@ -157,6 +157,15 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         assertThat(termination.isSolverTerminated(solverScope)).isFalse();
         assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.0, withPrecision(0.0));
 
+        termination.stepEnded(stepScope);
+
+        // time has run out
+        doReturn(START_TIME_MILLIS + 1001).when(clock).millis();
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.0, withPrecision(0.0));
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.0, withPrecision(0.0));
+
         termination.phaseEnded(phaseScope);
         termination.solvingEnded(solverScope);
     }
@@ -179,9 +188,18 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         termination.phaseStarted(phaseScope);
         termination.stepEnded(stepScope);
 
-        // time has not yet run out
+        // CH time has not yet run out
         doReturn(START_TIME_MILLIS + 500).when(clock).millis();
         doReturn(START_TIME_MILLIS + 500).when(phaseScope).getStartingSystemTimeMillis();
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.0, withPrecision(0.0));
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.0, withPrecision(0.0));
+
+        termination.stepEnded(stepScope);
+
+        // CH time has not yet run out
+        doReturn(START_TIME_MILLIS + 1001).when(clock).millis();
         assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
         assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.0, withPrecision(0.0));
         assertThat(termination.isSolverTerminated(solverScope)).isFalse();
@@ -197,9 +215,9 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         var lsStepScope = spy(new LocalSearchStepScope<>(lsPhaseScope));
 
         // second step - score has improved, but not beyond the threshold
-        doReturn(START_TIME_MILLIS + 1000).when(clock).millis();
-        doReturn(START_TIME_MILLIS + 1000).when(lsPhaseScope).getStartingSystemTimeMillis();
-        doReturn(START_TIME_MILLIS + 1000).when(solverScope).getBestSolutionTimeMillis();
+        doReturn(START_TIME_MILLIS + 1501).when(clock).millis();
+        doReturn(START_TIME_MILLIS + 1501).when(lsPhaseScope).getStartingSystemTimeMillis();
+        doReturn(START_TIME_MILLIS + 1501).when(solverScope).getBestSolutionTimeMillis();
         doReturn(true).when(lsStepScope).getBestScoreImproved();
         doReturn(SimpleScore.of(5)).when(solverScope).getBestScore();
         termination.phaseStarted(lsPhaseScope);
@@ -211,8 +229,8 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.5, withPrecision(0.0));
 
         // third step - score has improved beyond the threshold
-        doReturn(START_TIME_MILLIS + 1001).when(clock).millis();
-        doReturn(START_TIME_MILLIS + 1001).when(solverScope).getBestSolutionTimeMillis();
+        doReturn(START_TIME_MILLIS + 1502).when(clock).millis();
+        doReturn(START_TIME_MILLIS + 1502).when(solverScope).getBestSolutionTimeMillis();
         doReturn(SimpleScore.of(10)).when(solverScope).getBestScore();
         termination.stepEnded(lsStepScope);
 
@@ -221,7 +239,7 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         assertThat(termination.isSolverTerminated(solverScope)).isFalse();
         assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.501, withPrecision(0.0));
 
-        doReturn(START_TIME_MILLIS + 1500).when(clock).millis();
+        doReturn(START_TIME_MILLIS + 2001).when(clock).millis();
         termination.stepEnded(lsStepScope);
         assertThat(termination.isPhaseTerminated(lsPhaseScope)).isFalse();
         assertThat(termination.calculatePhaseTimeGradient(lsPhaseScope)).isEqualTo(0.5, withPrecision(0.0));
@@ -229,7 +247,7 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(1.0, withPrecision(0.0));
 
         // fourth step - no more improvements
-        doReturn(START_TIME_MILLIS + 2001).when(clock).millis();
+        doReturn(START_TIME_MILLIS + 2502).when(clock).millis();
         termination.stepEnded(lsStepScope);
 
         assertThat(termination.isPhaseTerminated(lsPhaseScope)).isTrue();

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.withPrecision;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
@@ -34,17 +35,13 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
 
     @Test
     void scoreImproves_terminationIsPostponed() {
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
-        AbstractPhaseScope<TestdataSolution> phaseScope = mock(LocalSearchPhaseScope.class);
-        AbstractStepScope<TestdataSolution> stepScope = mock(LocalSearchStepScope.class);
-        Clock clock = mock(Clock.class);
+        var solverScope = new SolverScope<TestdataSolution>();
+        var phaseScope = spy(new LocalSearchPhaseScope<>(solverScope));
+        var stepScope = spy(new LocalSearchStepScope<>(phaseScope));
+        var clock = mock(Clock.class);
 
-        Termination<TestdataSolution> termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<>(
-                1000L,
-                SimpleScore.of(7),
-                clock);
-        doReturn(solverScope).when(phaseScope).getSolverScope();
-        doReturn(phaseScope).when(stepScope).getPhaseScope();
+        var termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<TestdataSolution>(1000L,
+                SimpleScore.of(7), clock);
 
         // first step
         when(clock.millis()).thenReturn(START_TIME_MILLIS);

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
@@ -3,11 +3,14 @@ package ai.timefold.solver.core.impl.solver.termination;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.withPrecision;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
 
 import java.time.Clock;
 
+import ai.timefold.solver.core.impl.constructionheuristic.scope.ConstructionHeuristicPhaseScope;
+import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
@@ -25,37 +28,107 @@ class UnimprovedTimeMillisSpentTerminationTest {
 
     @Test
     void solverTermination() {
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = spy(new SolverScope<>());
+        AbstractPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
         Clock clock = mock(Clock.class);
 
         Termination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
+        termination.solvingStarted(solverScope);
+        termination.phaseStarted(phaseScope);
 
-        when(clock.millis()).thenReturn(1000L);
-        when(solverScope.getBestSolutionTimeMillis()).thenReturn(500L);
+        doReturn(1000L).when(clock).millis();
+        doReturn(500L).when(solverScope).getBestSolutionTimeMillis();
         assertThat(termination.isSolverTerminated(solverScope)).isFalse();
         assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.5, withPrecision(0.0));
 
-        when(clock.millis()).thenReturn(2000L);
-        when(solverScope.getBestSolutionTimeMillis()).thenReturn(1000L);
+        doReturn(2000L).when(clock).millis();
+        doReturn(1000L).when(solverScope).getBestSolutionTimeMillis();
         assertThat(termination.isSolverTerminated(solverScope)).isTrue();
         assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(1.0, withPrecision(0.0));
     }
 
     @Test
     void phaseTermination() {
-        AbstractPhaseScope<TestdataSolution> phaseScope = mock(AbstractPhaseScope.class);
+        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        AbstractPhaseScope<TestdataSolution> phaseScope = spy(new LocalSearchPhaseScope<>(solverScope));
         Clock clock = mock(Clock.class);
 
         Termination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
+        termination.solvingStarted(solverScope);
+        termination.phaseStarted(phaseScope);
 
-        when(clock.millis()).thenReturn(1000L);
-        when(phaseScope.getPhaseBestSolutionTimeMillis()).thenReturn(500L);
+        doReturn(1000L).when(clock).millis();
+        doReturn(500L).when(phaseScope).getPhaseBestSolutionTimeMillis();
         assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
         assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.5, withPrecision(0.0));
 
-        when(clock.millis()).thenReturn(2000L);
-        when(phaseScope.getPhaseBestSolutionTimeMillis()).thenReturn(1000L);
+        doReturn(2000L).when(clock).millis();
+        doReturn(1000L).when(phaseScope).getPhaseBestSolutionTimeMillis();
         assertThat(termination.isPhaseTerminated(phaseScope)).isTrue();
         assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(1.0, withPrecision(0.0));
+    }
+
+    @Test
+    void solverTerminationWithConstructionHeuristic() { // CH ignores unimproved time spent termination.
+        SolverScope<TestdataSolution> solverScope = spy(new SolverScope<>());
+        Clock clock = mock(Clock.class);
+
+        Termination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
+        termination.solvingStarted(solverScope);
+
+        AbstractPhaseScope<TestdataSolution> chPhaseScope = new ConstructionHeuristicPhaseScope<>(solverScope);
+        termination.phaseStarted(chPhaseScope);
+
+        // During the construction heuristic, the unimproved termination should not trigger.
+        doReturn(1000L).when(clock).millis();
+        doReturn(0L).when(solverScope).getBestSolutionTimeMillis();
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.0, withPrecision(0.0));
+
+        doReturn(2000L).when(clock).millis();
+        doReturn(0L).when(solverScope).getBestSolutionTimeMillis();
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.0, withPrecision(0.0));
+
+        termination.phaseEnded(chPhaseScope);
+
+        AbstractPhaseScope<TestdataSolution> lsPhaseScope = new LocalSearchPhaseScope<>(solverScope);
+        termination.phaseStarted(lsPhaseScope);
+
+        // When local search starts, the unimproved termination should start triggering,
+        // but the start time should act as if reset to zero.
+        doReturn(3000L).when(clock).millis();
+        doReturn(2500L).when(solverScope).getBestSolutionTimeMillis();
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.5, withPrecision(0.0));
+
+        doReturn(4000L).when(clock).millis();
+        doReturn(3000L).when(solverScope).getBestSolutionTimeMillis();
+        assertThat(termination.isSolverTerminated(solverScope)).isTrue();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(1.0, withPrecision(0.0));
+
+        termination.phaseEnded(lsPhaseScope);
+        termination.solvingEnded(solverScope);
+    }
+
+    @Test
+    void phaseTerminationWithConstructionHeuristic() { // CH ignores unimproved time spent termination.
+        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        AbstractPhaseScope<TestdataSolution> phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope));
+        Clock clock = mock(Clock.class);
+
+        Termination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
+        termination.solvingStarted(solverScope);
+        termination.phaseStarted(phaseScope);
+
+        doReturn(1000L).when(clock).millis();
+        doReturn(500L).when(phaseScope).getPhaseBestSolutionTimeMillis();
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.0, withPrecision(0.0));
+
+        doReturn(2000L).when(clock).millis();
+        doReturn(1000L).when(phaseScope).getPhaseBestSolutionTimeMillis();
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.0, withPrecision(0.0));
     }
 }

--- a/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
+++ b/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
@@ -459,6 +459,13 @@ Just like <<timeMillisSpentTermination,time spent termination>>, combinations ar
 
 It is preffered to configure this termination on a specific `Phase` (such as ``<localSearch>``) instead of on the `Solver` itself.
 
+Several phases, such as construction heuristics, do not count towards this termination because
+they only trigger new best solution events when they are done.
+If such a phase is encountered, the termination is disabled and when the next phase is encountered,
+the termination is enabled again and the timer resets back to zero.
+In the most typical case, where a local search phase follows a construction heuristic phase,
+the termination will only trigger if the local search phase does not improve the best solution for the specified time.
+
 [NOTE]
 ====
 This `Termination` will most likely sacrifice perfect reproducibility (even with `environmentMode` ``REPRODUCIBLE``)
@@ -589,7 +596,8 @@ This is useful for hardware performance independent runs.
 ----
 
 If the score has not improved recently, it is unlikely to improve in a reasonable timeframe.
-It has been observed that once a new best solution is found (even after a long time without improvement on the best solution), the next few steps tend to improve the best solution.
+It has been observed that once a new best solution is found (even after a long time without improvement on the best solution),
+the next few steps tend to improve the best solution.
 
 This `Termination` can only be used for a `Phase` (such as ``<localSearch>``), not for the `Solver` itself.
 

--- a/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
+++ b/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
@@ -461,7 +461,7 @@ It is preffered to configure this termination on a specific `Phase` (such as ``<
 
 Several phases, such as construction heuristics, do not count towards this termination because
 they only trigger new best solution events when they are done.
-If such a phase is encountered, the termination is disabled and when the next phase is encountered,
+If such a phase is encountered, the termination is disabled and when the next phase is started,
 the termination is enabled again and the timer resets back to zero.
 In the most typical case, where a local search phase follows a construction heuristic phase,
 the termination will only trigger if the local search phase does not improve the best solution for the specified time.


### PR DESCRIPTION
Closes #731 

The `Unimproved*` classes have the important changes.
The rest is just assorted cleanup while I was already in this ancient part of the codebase.