### PR TITLE
feat: Improve constraint verifier error messages

### DIFF
--- a/docs/src/modules/ROOT/pages/constraints-and-score/score-calculation.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/score-calculation.adoc
@@ -1281,7 +1281,7 @@ Alternatively, you can use a `givenSolution(...)` method here and provide a plan
 
 [NOTE]
 ====
-You can also use methods `justifiesWith(...)` and `indictsWith(...)`
+You can also use methods `justifiesWith(...)`, `justifiesWithExactly(...)`, `indictsWith(...)` and `indictsWithExactly(...)`
 to validate the expected constraint justifications and indictments mapped by the constraint definition.
 ====
 
@@ -1300,7 +1300,7 @@ It will neither set nor update shadow variables.
 If the tested constraints depend on shadow variables,
 it is your responsibility to assign the correct values beforehand.
 
-When executing `justifiesWith(...)` and `indictsWith(...)`,
+When executing `justifiesWith(...)`, `justifiesWithExactly(...)`, `indictsWith(...)` and `indictsWithExactly(...)`,
 comparisons are made using the standard method `equals` on the fact problem instances.
 ====
 

--- a/test/src/main/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertion.java
+++ b/test/src/main/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertion.java
@@ -19,10 +19,8 @@ public interface SingleConstraintAssertion {
     SingleConstraintAssertion justifiesWith(String message, ConstraintJustification... justifications);
 
     /**
-     * Asserts that the {@link Constraint} being tested, given a set of facts, results in a specific
+     * Asserts that the {@link Constraint} being tested, given a set of facts, results in a given
      * {@link ConstraintJustification}.
-     * <p>
-     * The justification class types must match; otherwise it fails with no match.
      *
      * @param justifications the expected justifications.
      * @return never null
@@ -33,7 +31,29 @@ public interface SingleConstraintAssertion {
     }
 
     /**
-     * Asserts that the {@link Constraint} being tested, given a set of facts, results in a specific indictments.
+     * As defined by {@link #justifiesWithExactly(ConstraintJustification...)}.
+     *
+     * @param justifications the expected justification.
+     * @param message sometimes null, description of the scenario being asserted
+     * @return never null
+     * @throws AssertionError when the expected penalty is not observed
+     */
+    SingleConstraintAssertion justifiesWithExactly(String message, ConstraintJustification... justifications);
+
+    /**
+     * Asserts that the {@link Constraint} being tested, given a set of facts, results in a given
+     * {@link ConstraintJustification} and nothing else.
+     *
+     * @param justifications the expected justifications.
+     * @return never null
+     * @throws AssertionError when the expected penalty is not observed
+     */
+    default SingleConstraintAssertion justifiesWithExactly(ConstraintJustification... justifications) {
+        return justifiesWithExactly(null, justifications);
+    }
+
+    /**
+     * Asserts that the {@link Constraint} being tested, given a set of facts, results in the given indictments.
      *
      * @param indictments the expected indictments.
      * @return never null
@@ -52,6 +72,28 @@ public interface SingleConstraintAssertion {
      * @throws AssertionError when the expected penalty is not observed
      */
     SingleConstraintAssertion indictsWith(String message, Object... indictments);
+
+    /**
+     * Asserts that the {@link Constraint} being tested, given a set of facts, results in the given indictments and
+     * nothing else.
+     *
+     * @param indictments the expected indictments.
+     * @return never null
+     * @throws AssertionError when the expected penalty is not observed
+     */
+    default SingleConstraintAssertion indictsWithExactly(Object... indictments) {
+        return indictsWithExactly(null, indictments);
+    }
+
+    /**
+     * As defined by {@link #indictsWithExactly(Object...)}.
+     *
+     * @param message sometimes null, description of the scenario being asserted
+     * @param indictments the expected indictments.
+     * @return never null
+     * @throws AssertionError when the expected penalty is not observed
+     */
+    SingleConstraintAssertion indictsWithExactly(String message, Object... indictments);
 
     /**
      * Asserts that the {@link Constraint} being tested, given a set of facts, results in a specific penalty.

--- a/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintAssertion.java
+++ b/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintAssertion.java
@@ -64,6 +64,18 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
     }
 
     @Override
+    public SingleConstraintAssertion justifiesWithExactly(String message, ConstraintJustification... justifications) {
+        assertJustification(message, true, justifications);
+        return this;
+    }
+
+    @Override
+    public SingleConstraintAssertion indictsWithExactly(String message, Object... indictments) {
+        assertIndictments(message, true, indictments);
+        return this;
+    }
+
+    @Override
     public void penalizesBy(String message, int matchWeightTotal) {
         validateMatchWeighTotal(matchWeightTotal);
         assertImpact(ScoreImpactType.PENALTY, matchWeightTotal, message);
@@ -187,7 +199,7 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
         List<ConstraintJustification> unexpectedFound = emptyList();
         if (completeValidation) {
             unexpectedFound = justificationCollection.stream()
-                    .filter(justification -> Stream.of(justification).noneMatch(justification::equals))
+                    .filter(justification -> Stream.of(justifications).noneMatch(justification::equals))
                     .toList();
         }
         if (expectedNotFound.isEmpty() && unexpectedFound.isEmpty()) {

--- a/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintAssertion.java
+++ b/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintAssertion.java
@@ -7,7 +7,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -189,7 +188,7 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
             throw new AssertionError(assertionMessage);
         }
 
-        List<Object> expectedNotFound = new LinkedList<>();
+        List<Object> expectedNotFound = new ArrayList<>(justificationCollection.size());
         for (Object justification : justifications) {
             // Test invalid match
             if (justificationCollection.stream().noneMatch(justification::equals)) {
@@ -232,7 +231,7 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
             throw new AssertionError(assertionMessage);
         }
 
-        List<Object> expectedNotFound = new LinkedList<>();
+        List<Object> expectedNotFound = new ArrayList<>(indictmentObjectList.size());
         for (Object indictment : indictments) {
             // Test invalid match
             if (indictmentObjectList.stream().noneMatch(indictment::equals)) {
@@ -404,7 +403,7 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
         String expectation = message != null ? message : "Broken expectation.";
         StringBuilder preformattedMessage = new StringBuilder("%s%n")
                 .append("%18s: %s%n");
-        List<Object> params = new LinkedList<>();
+        List<Object> params = new ArrayList<>();
         params.add(expectation);
         params.add(type);
         params.add(constraintId);

--- a/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintAssertion.java
+++ b/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintAssertion.java
@@ -165,14 +165,14 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
         // No justifications
         if (emptyJustifications && !justificationCollection.isEmpty()) {
             String assertionMessage = buildAssertionErrorMessage("Justification", constraint.getConstraintRef().constraintId(),
-                    emptyList(), emptyList(), justificationCollection, message);
+                    emptyList(), emptyList(), Arrays.asList(justifications), justificationCollection, message);
             throw new AssertionError(assertionMessage);
         }
 
         // Empty justifications
         if (justificationCollection.isEmpty()) {
             String assertionMessage = buildAssertionErrorMessage("Justification", constraint.getConstraintRef().constraintId(),
-                    emptyList(), Arrays.asList(justifications), emptyList(), message);
+                    emptyList(), Arrays.asList(justifications), Arrays.asList(justifications), emptyList(), message);
             throw new AssertionError(assertionMessage);
         }
 
@@ -193,7 +193,7 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
             return;
         }
         String assertionMessage = buildAssertionErrorMessage("Justification", constraint.getConstraintRef().constraintId(),
-                noneMatchedList, invalidMatchList, justificationCollection, message);
+                noneMatchedList, invalidMatchList, Arrays.asList(justifications), justificationCollection, message);
         throw new AssertionError(assertionMessage);
     }
 
@@ -208,14 +208,14 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
         Collection<Object> indictmentObjectList = indictmentCollection.stream().map(Indictment::getIndictedObject).toList();
         if (emptyIndictments && !indictmentObjectList.isEmpty()) {
             String assertionMessage = buildAssertionErrorMessage("Indictment", constraint.getConstraintRef().constraintId(),
-                    emptyList(), emptyList(), indictmentObjectList, message);
+                    emptyList(), emptyList(), Arrays.asList(indictments), indictmentObjectList, message);
             throw new AssertionError(assertionMessage);
         }
 
         // Empty indictments
         if (indictmentObjectList.isEmpty()) {
             String assertionMessage = buildAssertionErrorMessage("Indictment", constraint.getConstraintRef().constraintId(),
-                    emptyList(), Arrays.asList(indictments), emptyList(), message);
+                    emptyList(), Arrays.asList(indictments), Arrays.asList(indictments), emptyList(), message);
             throw new AssertionError(assertionMessage);
         }
 
@@ -236,7 +236,7 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
             return;
         }
         String assertionMessage = buildAssertionErrorMessage("Indictment", constraint.getConstraintRef().constraintId(),
-                noneMatchedList, invalidMatchList, indictmentObjectList, message);
+                noneMatchedList, invalidMatchList, Arrays.asList(indictments), indictmentObjectList, message);
         throw new AssertionError(assertionMessage);
     }
 
@@ -386,7 +386,7 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
     }
 
     private static String buildAssertionErrorMessage(String type, String constraintId, Collection<?> noneMatchedCollection,
-            Collection<?> invalidMatchedCollection, Collection<?> actualCollection,
+            Collection<?> invalidMatchedCollection, Collection<?> expectedCollection, Collection<?> actualCollection,
             String message) {
         String expectation = message != null ? message : "Broken expectation.";
         StringBuilder preformattedMessage = new StringBuilder("%s%n")
@@ -395,53 +395,49 @@ public final class DefaultSingleConstraintAssertion<Solution_, Score_ extends Sc
         params.add(expectation);
         params.add(type);
         params.add(constraintId);
-        if (!noneMatchedCollection.isEmpty()) {
-            preformattedMessage.append("%22s%n");
-            preformattedMessage.append("%24s%n");
-            params.add("No match:");
-            params.add("Expected:");
-            noneMatchedCollection.forEach(indictment -> {
+        preformattedMessage.append("%24s%n");
+        params.add("Expected:");
+        if (expectedCollection.isEmpty()) {
+            preformattedMessage.append("%26s%s%n");
+            params.add("");
+            params.add("No " + type);
+        } else {
+            expectedCollection.forEach(actual -> {
                 preformattedMessage.append("%26s%s%n");
                 params.add("");
-                params.add(indictment);
+                params.add(actual);
             });
-            preformattedMessage.append("%24s%n");
-            params.add("Actual:");
+        }
+        preformattedMessage.append("%24s%n");
+        params.add("Actual:");
+        if (actualCollection.isEmpty()) {
+            preformattedMessage.append("%26s%s%n");
+            params.add("");
+            params.add("No " + type);
+        } else {
             actualCollection.forEach(actual -> {
                 preformattedMessage.append("%26s%s%n");
                 params.add("");
                 params.add(actual);
             });
         }
-        if (!invalidMatchedCollection.isEmpty() || (noneMatchedCollection.isEmpty() && !actualCollection.isEmpty())) {
-            preformattedMessage.append("%22s%n");
+        if (!noneMatchedCollection.isEmpty()) {
+            preformattedMessage.append("%24s%n");
+            params.add("No match:");
+            noneMatchedCollection.forEach(indictment -> {
+                preformattedMessage.append("%26s%s%n");
+                params.add("");
+                params.add(indictment);
+            });
+        }
+        if (!invalidMatchedCollection.isEmpty()) {
             preformattedMessage.append("%24s%n");
             params.add("Invalid match:");
-            params.add("Expected:");
-            if (invalidMatchedCollection.isEmpty()) {
+            invalidMatchedCollection.forEach(indictment -> {
                 preformattedMessage.append("%26s%s%n");
                 params.add("");
-                params.add("No " + type);
-            } else {
-                invalidMatchedCollection.forEach(indictment -> {
-                    preformattedMessage.append("%26s%s%n");
-                    params.add("");
-                    params.add(indictment);
-                });
-            }
-            preformattedMessage.append("%24s%n");
-            params.add("Actual:");
-            if (actualCollection.isEmpty()) {
-                preformattedMessage.append("%26s%s%n");
-                params.add("");
-                params.add("No " + type);
-            } else {
-                actualCollection.forEach(actual -> {
-                    preformattedMessage.append("%26s%s%n");
-                    params.add("");
-                    params.add(actual);
-                });
-            }
+                params.add(indictment);
+            });
         }
         return String.format(preformattedMessage.toString(), params.toArray());
     }

--- a/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
+++ b/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
@@ -399,7 +399,7 @@ class SingleConstraintAssertionTest {
     }
 
     @Test
-    void justifiesPartialValidation() {
+    void justifies() {
         TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
 
         // No error
@@ -495,7 +495,7 @@ class SingleConstraintAssertionTest {
     }
 
     @Test
-    void justifiesPartialValidationWithCustomMessage() {
+    void justifiesWithCustomMessage() {
         TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
 
         assertThatCode(
@@ -532,7 +532,7 @@ class SingleConstraintAssertionTest {
     }
 
     @Test
-    void justifiesPartialValidationEmptyMatches() {
+    void justifiesEmptyMatches() {
         TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
 
         assertThatCode(
@@ -553,13 +553,133 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]");
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Unexpected but found:");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
                         .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithNoJustifications)
                         .given(solution.getEntityList().toArray())
                         .justifiesWith(new TestFirstJustification("1")))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestFirstJustification[id=1]")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("No Justification")
+                .hasMessageContaining("Expected but not found:");
+    }
+
+    @Test
+    void justifiesExactly() {
+        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
+
+        // No error
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .justifiesWithExactly(new TestFirstJustification("Generated Entity 0"),
+                                new TestFirstJustification("Generated Entity 1"),
+                                new TestFirstJustification("Generated Entity 2")))
+                .doesNotThrowAnyException();
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .givenSolution(solution)
+                        .justifiesWithExactly(new TestFirstJustification("Generated Entity 0"),
+                                new TestFirstJustification("Generated Entity 1"),
+                                new TestFirstJustification("Generated Entity 2")))
+                .doesNotThrowAnyException();
+
+        // Different justification
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .justifiesWithExactly(new TestFirstJustification("2")))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining(
+                        "Justification: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestFirstJustification[id=2]")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Expected but not found:")
+                .hasMessageContaining("Unexpected but found:");
+    }
+
+    @Test
+    void justifiesExactlyWithCustomMessage() {
+        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .justifiesWithExactly("Custom Message", new TestFirstJustification("2")))
+                .hasMessageContaining("Custom Message")
+                .hasMessageContaining(
+                        "Justification: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestFirstJustification[id=2]")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Expected but not found:")
+                .hasMessageContaining("Unexpected but found:");
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .givenSolution(solution)
+                        .justifiesWithExactly("Custom Message", new TestFirstJustification("2")))
+                .hasMessageContaining("Custom Message")
+                .hasMessageContaining(
+                        "Justification: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestFirstJustification[id=2]")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Expected but not found:")
+                .hasMessageContaining("Unexpected but found:");
+    }
+
+    @Test
+    void justifiesExactlyEmptyMatches() {
+        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithNoJustifications)
+                        .given(solution.getEntityList().toArray())
+                        .justifiesWithExactly())
+                .doesNotThrowAnyException();
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .justifiesWithExactly())
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("No Justification")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Unexpected but found:");
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithNoJustifications)
+                        .given(solution.getEntityList().toArray())
+                        .justifiesWithExactly(new TestFirstJustification("1")))
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("TestFirstJustification[id=1]")
@@ -723,13 +843,149 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')")
                 .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 1')")
-                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 2')");
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 2')")
+                .hasMessageContaining("Unexpected but found:");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
                         .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithNoJustifications)
                         .given(solution.getEntityList().toArray())
                         .indictsWith(new TestFirstJustification("1")))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestFirstJustification[id=1]")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("No Indictment")
+                .hasMessageContaining("Expected but not found:");
+    }
+
+    @Test
+    void indictsWithExactly() {
+        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
+
+        // No error
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .indictsWithExactly(solution.getEntityList().toArray()))
+                .doesNotThrowAnyException();
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .givenSolution(solution)
+                        .indictsWithExactly(solution.getEntityList().toArray()))
+                .doesNotThrowAnyException();
+
+        // Invalid indictment
+        TestdataConstraintVerifierFirstEntity badEntity =
+                new TestdataConstraintVerifierFirstEntity("bad code", new TestdataValue("bad code"));
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .indictsWithExactly(badEntity))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining(
+                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining(badEntity.toString())
+                .hasMessageContaining("Actual")
+                .hasMessageContaining(solution.getEntityList().get(0).toString())
+                .hasMessageContaining(solution.getEntityList().get(1).toString())
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("Expected but not found:");
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .givenSolution(solution)
+                        .indictsWithExactly(badEntity))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining(
+                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining(badEntity.toString())
+                .hasMessageContaining("Actual")
+                .hasMessageContaining(solution.getEntityList().get(0).toString())
+                .hasMessageContaining(solution.getEntityList().get(1).toString())
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("Expected but not found:")
+                .hasMessageContaining("Unexpected but found:");
+    }
+
+    @Test
+    void indictsWithExactlyWithCustomMessage() {
+        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
+
+        TestdataConstraintVerifierFirstEntity badEntity =
+                new TestdataConstraintVerifierFirstEntity("bad code", new TestdataValue("bad code"));
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .indictsWithExactly("Custom Message", badEntity))
+                .hasMessageContaining("Custom Message")
+                .hasMessageContaining(
+                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining(badEntity.toString())
+                .hasMessageContaining("Actual")
+                .hasMessageContaining(solution.getEntityList().get(0).toString())
+                .hasMessageContaining(solution.getEntityList().get(1).toString())
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("Expected but not found:")
+                .hasMessageContaining("Unexpected but found:");
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .givenSolution(solution)
+                        .indictsWithExactly("Custom Message", badEntity))
+                .hasMessageContaining("Custom Message")
+                .hasMessageContaining(
+                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining(badEntity.toString())
+                .hasMessageContaining("Actual")
+                .hasMessageContaining(solution.getEntityList().get(0).toString())
+                .hasMessageContaining(solution.getEntityList().get(1).toString())
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("Expected but not found:")
+                .hasMessageContaining("Unexpected but found:");
+    }
+
+    @Test
+    void indictsWithExactlyEmptyMatches() {
+        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithNoJustifications)
+                        .given(solution.getEntityList().toArray())
+                        .indictsWithExactly())
+                .doesNotThrowAnyException();
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .indictsWithExactly())
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("No Indictment")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 1')")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 2')")
+                .hasMessageContaining("Unexpected but found:");
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithNoJustifications)
+                        .given(solution.getEntityList().toArray())
+                        .indictsWithExactly(new TestFirstJustification("1")))
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("TestFirstJustification[id=1]")

--- a/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
+++ b/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
@@ -399,7 +399,7 @@ class SingleConstraintAssertionTest {
     }
 
     @Test
-    void justifies() {
+    void justifiesPartialValidation() {
         TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
 
         // No error
@@ -434,7 +434,7 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
-                .hasMessageContaining("Invalid match");
+                .hasMessageContaining("Expected but not found:");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -450,7 +450,7 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
-                .hasMessageContaining("Invalid match");
+                .hasMessageContaining("Expected but not found:");
 
         // Multiple justifications
         assertThatCode(
@@ -469,11 +469,33 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
-                .hasMessageContaining("Invalid match");
+                .hasMessageContaining("Expected but not found:");
+
+        // Invalid matches and classes
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .justifiesWith(new TestFirstJustification("Generated Entity 0"), new TestFirstJustification("2"),
+                                new TestSecondJustification("1")))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining(
+                        "Justification: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestFirstJustification[id=2]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("TestSecondJustification[id=1]")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Expected but not found:")
+                .hasMessageContaining("TestSecondJustification[id=1]")
+                .hasMessageContaining("TestSecondJustification[id=1]");
     }
 
     @Test
-    void justifiesWithCustomMessage() {
+    void justifiesPartialValidationWithCustomMessage() {
         TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
 
         assertThatCode(
@@ -490,7 +512,7 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
-                .hasMessageContaining("Invalid match");
+                .hasMessageContaining("Expected but not found:");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -506,46 +528,11 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
-                .hasMessageContaining("Invalid match");
+                .hasMessageContaining("Expected but not found:");
     }
 
     @Test
-    void justifiesWithNoMatch() {
-        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
-
-        assertThatCode(
-                () -> constraintVerifierForJustification
-                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
-                        .given(solution.getEntityList().toArray())
-                        .justifiesWith(new TestSecondJustification("1")))
-                .hasMessageContaining("Broken expectation")
-                .hasMessageContaining("No match")
-                .hasMessageContaining("Expected")
-                .hasMessageContaining("TestSecondJustification[id=1]")
-                .hasMessageContaining("Actual")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
-                .hasMessageContaining("No match");
-
-        assertThatCode(
-                () -> constraintVerifierForJustification
-                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
-                        .givenSolution(solution)
-                        .justifiesWith(new TestSecondJustification("1")))
-                .hasMessageContaining("Broken expectation")
-                .hasMessageContaining("No match")
-                .hasMessageContaining("Expected")
-                .hasMessageContaining("TestSecondJustification[id=1]")
-                .hasMessageContaining("Actual")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
-                .hasMessageContaining("No match");
-    }
-
-    @Test
-    void justifiesEmptyMatches() {
+    void justifiesPartialValidationEmptyMatches() {
         TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
 
         assertThatCode(
@@ -578,34 +565,7 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("TestFirstJustification[id=1]")
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("No Justification")
-                .hasMessageContaining("Invalid match");
-    }
-
-    @Test
-    void justifyWithInvalidAndNoMatches() {
-        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
-
-        assertThatCode(
-                () -> constraintVerifierForJustification
-                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
-                        .given(solution.getEntityList().toArray())
-                        .justifiesWith(new TestFirstJustification("Generated Entity 0"), new TestFirstJustification("2"),
-                                new TestSecondJustification("1")))
-                .hasMessageContaining("Broken expectation")
-                .hasMessageContaining(
-                        "Justification: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("Expected")
-                .hasMessageContaining("TestFirstJustification[id=2]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
-                .hasMessageContaining("TestSecondJustification[id=1]")
-                .hasMessageContaining("Actual")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
-                .hasMessageContaining("Invalid match")
-                .hasMessageContaining("TestSecondJustification[id=1]")
-                .hasMessageContaining("No match")
-                .hasMessageContaining("TestSecondJustification[id=1]");
+                .hasMessageContaining("Expected but not found:");
     }
 
     @Test
@@ -644,7 +604,7 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
                 .hasMessageContaining(solution.getEntityList().get(2).toString())
-                .hasMessageContaining("Invalid match");
+                .hasMessageContaining("Expected but not found:");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -660,7 +620,7 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
                 .hasMessageContaining(solution.getEntityList().get(2).toString())
-                .hasMessageContaining("Invalid match");
+                .hasMessageContaining("Expected but not found:");
 
         // Multiple indictments
         assertThatCode(
@@ -678,7 +638,28 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
                 .hasMessageContaining(solution.getEntityList().get(2).toString())
-                .hasMessageContaining("Invalid match");
+                .hasMessageContaining("Expected but not found:");
+
+        // Invalid matches and classes
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .indictsWith(solution.getEntityList().get(0), badEntity, "bad indictment"))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining(
+                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='bad code')")
+                .hasMessageContaining("bad indictment")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 1')")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 2')")
+                .hasMessageContaining("Expected but not found:")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='bad code')")
+                .hasMessageContaining("bad indictment");
     }
 
     @Test
@@ -701,7 +682,7 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
                 .hasMessageContaining(solution.getEntityList().get(2).toString())
-                .hasMessageContaining("Invalid match");
+                .hasMessageContaining("Expected but not found:");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -717,44 +698,7 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
                 .hasMessageContaining(solution.getEntityList().get(2).toString())
-                .hasMessageContaining("Invalid match");
-    }
-
-    @Test
-    void indictsWithNoMatch() {
-        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
-
-        assertThatCode(
-                () -> constraintVerifierForJustification
-                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
-                        .given(solution.getEntityList().toArray())
-                        .indictsWith(solution.getEntityList().get(0), "bad indictment"))
-                .hasMessageContaining("Broken expectation")
-                .hasMessageContaining(
-                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("Expected")
-                .hasMessageContaining("bad indictment")
-                .hasMessageContaining("Actual")
-                .hasMessageContaining(solution.getEntityList().get(0).toString())
-                .hasMessageContaining(solution.getEntityList().get(1).toString())
-                .hasMessageContaining(solution.getEntityList().get(2).toString())
-                .hasMessageContaining("No match");
-
-        assertThatCode(
-                () -> constraintVerifierForJustification
-                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
-                        .givenSolution(solution)
-                        .indictsWith(solution.getEntityList().get(0), "bad indictment"))
-                .hasMessageContaining("Broken expectation")
-                .hasMessageContaining(
-                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("Expected")
-                .hasMessageContaining("bad indictment")
-                .hasMessageContaining("Actual")
-                .hasMessageContaining(solution.getEntityList().get(0).toString())
-                .hasMessageContaining(solution.getEntityList().get(1).toString())
-                .hasMessageContaining(solution.getEntityList().get(2).toString())
-                .hasMessageContaining("No match");
+                .hasMessageContaining("Expected but not found:");
     }
 
     @Test
@@ -791,34 +735,6 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("TestFirstJustification[id=1]")
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("No Indictment")
-                .hasMessageContaining("Invalid match");
-    }
-
-    @Test
-    void indictWithInvalidAndNoMatches() {
-        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
-        TestdataConstraintVerifierFirstEntity badEntity =
-                new TestdataConstraintVerifierFirstEntity("bad code", new TestdataValue("bad code"));
-
-        assertThatCode(
-                () -> constraintVerifierForJustification
-                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
-                        .given(solution.getEntityList().toArray())
-                        .indictsWith(solution.getEntityList().get(0), badEntity, "bad indictment"))
-                .hasMessageContaining("Broken expectation")
-                .hasMessageContaining(
-                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("Expected")
-                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')")
-                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='bad code')")
-                .hasMessageContaining("bad indictment")
-                .hasMessageContaining("Actual")
-                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')")
-                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 1')")
-                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 2')")
-                .hasMessageContaining("Invalid match")
-                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='bad code')")
-                .hasMessageContaining("No match")
-                .hasMessageContaining("bad indictment");
+                .hasMessageContaining("Expected but not found:");
     }
 }

--- a/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
+++ b/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
@@ -433,7 +433,8 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]");
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Invalid match");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -448,7 +449,27 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]");
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Invalid match");
+
+        // Multiple justifications
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .justifiesWith(new TestFirstJustification("Generated Entity 0"),
+                                new TestFirstJustification("2")))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining(
+                        "Justification: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestFirstJustification[id=2]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Invalid match");
     }
 
     @Test
@@ -468,7 +489,8 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]");
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Invalid match");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -483,7 +505,8 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]");
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Invalid match");
     }
 
     @Test
@@ -502,7 +525,8 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]");
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("No match");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -516,7 +540,8 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Actual")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
                 .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
-                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]");
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("No match");
     }
 
     @Test
@@ -536,7 +561,6 @@ class SingleConstraintAssertionTest {
                         .given(solution.getEntityList().toArray())
                         .justifiesWith())
                 .hasMessageContaining("Broken expectation")
-                .hasMessageContaining("Invalid match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("No Justification")
                 .hasMessageContaining("Actual")
@@ -550,11 +574,38 @@ class SingleConstraintAssertionTest {
                         .given(solution.getEntityList().toArray())
                         .justifiesWith(new TestFirstJustification("1")))
                 .hasMessageContaining("Broken expectation")
-                .hasMessageContaining("Invalid match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("TestFirstJustification[id=1]")
                 .hasMessageContaining("Actual")
-                .hasMessageContaining("No Justification");
+                .hasMessageContaining("No Justification")
+                .hasMessageContaining("Invalid match");
+    }
+
+    @Test
+    void justifyWithInvalidAndNoMatches() {
+        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .justifiesWith(new TestFirstJustification("Generated Entity 0"), new TestFirstJustification("2"),
+                                new TestSecondJustification("1")))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining(
+                        "Justification: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestFirstJustification[id=2]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("TestSecondJustification[id=1]")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 0]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 1]")
+                .hasMessageContaining("TestFirstJustification[id=Generated Entity 2]")
+                .hasMessageContaining("Invalid match")
+                .hasMessageContaining("TestSecondJustification[id=1]")
+                .hasMessageContaining("No match")
+                .hasMessageContaining("TestSecondJustification[id=1]");
     }
 
     @Test
@@ -587,13 +638,13 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining(
                         "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("Invalid match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining(badEntity.toString())
                 .hasMessageContaining("Actual")
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
-                .hasMessageContaining(solution.getEntityList().get(2).toString());
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("Invalid match");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -603,13 +654,31 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining(
                         "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("Invalid match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining(badEntity.toString())
                 .hasMessageContaining("Actual")
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
-                .hasMessageContaining(solution.getEntityList().get(2).toString());
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("Invalid match");
+
+        // Multiple indictments
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .givenSolution(solution)
+                        .indictsWith(solution.getEntityList().get(0), badEntity))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining(
+                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining(solution.getEntityList().get(0).toString())
+                .hasMessageContaining(badEntity.toString())
+                .hasMessageContaining("Actual")
+                .hasMessageContaining(solution.getEntityList().get(0).toString())
+                .hasMessageContaining(solution.getEntityList().get(1).toString())
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("Invalid match");
     }
 
     @Test
@@ -626,13 +695,13 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Custom Message")
                 .hasMessageContaining(
                         "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("Invalid match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining(badEntity.toString())
                 .hasMessageContaining("Actual")
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
-                .hasMessageContaining(solution.getEntityList().get(2).toString());
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("Invalid match");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -642,13 +711,13 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Custom Message")
                 .hasMessageContaining(
                         "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("Invalid match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining(badEntity.toString())
                 .hasMessageContaining("Actual")
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
-                .hasMessageContaining(solution.getEntityList().get(2).toString());
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("Invalid match");
     }
 
     @Test
@@ -663,13 +732,13 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining(
                         "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("No match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("bad indictment")
                 .hasMessageContaining("Actual")
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
-                .hasMessageContaining(solution.getEntityList().get(2).toString());
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("No match");
 
         assertThatCode(
                 () -> constraintVerifierForJustification
@@ -679,13 +748,13 @@ class SingleConstraintAssertionTest {
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining(
                         "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
-                .hasMessageContaining("No match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("bad indictment")
                 .hasMessageContaining("Actual")
                 .hasMessageContaining(solution.getEntityList().get(0).toString())
                 .hasMessageContaining(solution.getEntityList().get(1).toString())
-                .hasMessageContaining(solution.getEntityList().get(2).toString());
+                .hasMessageContaining(solution.getEntityList().get(2).toString())
+                .hasMessageContaining("No match");
     }
 
     @Test
@@ -705,7 +774,6 @@ class SingleConstraintAssertionTest {
                         .given(solution.getEntityList().toArray())
                         .indictsWith())
                 .hasMessageContaining("Broken expectation")
-                .hasMessageContaining("Invalid match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("No Indictment")
                 .hasMessageContaining("Actual")
@@ -719,10 +787,38 @@ class SingleConstraintAssertionTest {
                         .given(solution.getEntityList().toArray())
                         .indictsWith(new TestFirstJustification("1")))
                 .hasMessageContaining("Broken expectation")
-                .hasMessageContaining("Invalid match")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("TestFirstJustification[id=1]")
                 .hasMessageContaining("Actual")
-                .hasMessageContaining("No Indictment");
+                .hasMessageContaining("No Indictment")
+                .hasMessageContaining("Invalid match");
+    }
+
+    @Test
+    void indictWithInvalidAndNoMatches() {
+        TestdataConstraintVerifierSolution solution = TestdataConstraintVerifierSolution.generateSolution(2, 3);
+        TestdataConstraintVerifierFirstEntity badEntity =
+                new TestdataConstraintVerifierFirstEntity("bad code", new TestdataValue("bad code"));
+
+        assertThatCode(
+                () -> constraintVerifierForJustification
+                        .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
+                        .given(solution.getEntityList().toArray())
+                        .indictsWith(solution.getEntityList().get(0), badEntity, "bad indictment"))
+                .hasMessageContaining("Broken expectation")
+                .hasMessageContaining(
+                        "Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification")
+                .hasMessageContaining("Expected")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='bad code')")
+                .hasMessageContaining("bad indictment")
+                .hasMessageContaining("Actual")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 1')")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='Generated Entity 2')")
+                .hasMessageContaining("Invalid match")
+                .hasMessageContaining("TestdataConstraintVerifierFirstEntity(code='bad code')")
+                .hasMessageContaining("No match")
+                .hasMessageContaining("bad indictment");
     }
 }


### PR DESCRIPTION
This PR improves the error messages of the constraint verifier and adds two new methods: `justifiesWithExactly()` and `indictsWithExactly()`. The new messages will be formatted as follows:

## Justifications

```
Broken expectation.
     Justification: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification
               Expected:
                          TestFirstJustification[id=2]
                 Actual:
                          TestFirstJustification[id=Generated Entity 0]
                          TestFirstJustification[id=Generated Entity 1]
                          TestFirstJustification[id=Generated Entity 2]
 Expected but not found:
                          TestFirstJustification[id=2]
   Unexpected but found:
                          TestFirstJustification[id=Generated Entity 0]
                          TestFirstJustification[id=Generated Entity 1]
                          TestFirstJustification[id=Generated Entity 2]
```

## Indictments

```
Broken expectation.
        Indictment: ai.timefold.solver.test.api.score.stream.testdata/Justify with first justification
               Expected:
                          TestdataConstraintVerifierFirstEntity(code='bad code')
                 Actual:
                          TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')
                          TestdataConstraintVerifierFirstEntity(code='Generated Entity 1')
                          TestdataConstraintVerifierFirstEntity(code='Generated Entity 2')
 Expected but not found:
                          TestdataConstraintVerifierFirstEntity(code='bad code')
   Unexpected but found:
                          TestdataConstraintVerifierFirstEntity(code='Generated Entity 0')
                          TestdataConstraintVerifierFirstEntity(code='Generated Entity 1')
                          TestdataConstraintVerifierFirstEntity(code='Generated Entity 2')
```