### PR TITLE
fix: Benchmark duplicated metrics

### DIFF
--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/config/ProblemBenchmarksConfig.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/config/ProblemBenchmarksConfig.java
@@ -182,9 +182,9 @@ public class ProblemBenchmarksConfig extends AbstractConfig<ProblemBenchmarksCon
                 inheritedConfig.getInputSolutionFileList());
         problemStatisticEnabled = ConfigUtils.inheritOverwritableProperty(problemStatisticEnabled,
                 inheritedConfig.getProblemStatisticEnabled());
-        problemStatisticTypeList = ConfigUtils.inheritMergeableListProperty(problemStatisticTypeList,
+        problemStatisticTypeList = ConfigUtils.inheritUniqueMergeableListProperty(problemStatisticTypeList,
                 inheritedConfig.getProblemStatisticTypeList());
-        singleStatisticTypeList = ConfigUtils.inheritMergeableListProperty(singleStatisticTypeList,
+        singleStatisticTypeList = ConfigUtils.inheritUniqueMergeableListProperty(singleStatisticTypeList,
                 inheritedConfig.getSingleStatisticTypeList());
         return this;
     }

--- a/benchmark/src/test/java/ai/timefold/solver/benchmark/config/ProblemBenchmarksConfigTest.java
+++ b/benchmark/src/test/java/ai/timefold/solver/benchmark/config/ProblemBenchmarksConfigTest.java
@@ -46,4 +46,17 @@ class ProblemBenchmarksConfigTest {
         assertThat(problemBenchmarksConfig.determineSingleStatisticTypeList())
                 .containsExactly(SingleStatisticType.CONSTRAINT_MATCH_TOTAL_STEP_SCORE);
     }
+
+    @Test
+    void testDuplicatedDefaultMetrics() {
+        ProblemBenchmarksConfig benchmarksConfig = new ProblemBenchmarksConfig();
+        benchmarksConfig.withProblemStatisticTypeList(List.of(ProblemStatisticType.BEST_SCORE));
+        SolverBenchmarkConfig defaultConfig = new SolverBenchmarkConfig();
+        defaultConfig.withProblemBenchmarksConfig(benchmarksConfig);
+
+        SolverBenchmarkConfig inheritedConfig = new SolverBenchmarkConfig();
+        inheritedConfig.withProblemBenchmarksConfig(benchmarksConfig);
+        inheritedConfig.inherit(defaultConfig);
+        assertThat(inheritedConfig.getProblemBenchmarksConfig().getProblemStatisticTypeList()).hasSize(1);
+    }
 }

--- a/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
@@ -18,10 +18,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -211,10 +213,10 @@ public class ConfigUtils {
             // Shallow clone due to modifications after calling inherit
             return new ArrayList<>(inheritedList);
         } else {
-            // The inheritedList should be before the originalList
-            List<T> mergedList = new ArrayList<>(inheritedList);
-            mergedList.addAll(originalList.stream().filter(v -> !mergedList.contains(v)).toList());
-            return mergedList;
+            // The inheritedMap should be before the originalMap
+            Set<T> mergedSet = new LinkedHashSet<>(inheritedList);
+            mergedSet.addAll(originalList);
+            return new ArrayList<>(mergedSet);
         }
     }
 
@@ -224,7 +226,6 @@ public class ConfigUtils {
         } else if (originalMap == null) {
             return inheritedMap;
         } else {
-            // The inheritedMap should be before the originalMap
             Map<K, T> mergedMap = new LinkedHashMap<>(inheritedMap);
             mergedMap.putAll(originalMap);
             return mergedMap;

--- a/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
@@ -204,6 +204,20 @@ public class ConfigUtils {
         }
     }
 
+    public static <T> List<T> inheritUniqueMergeableListProperty(List<T> originalList, List<T> inheritedList) {
+        if (inheritedList == null) {
+            return originalList;
+        } else if (originalList == null) {
+            // Shallow clone due to modifications after calling inherit
+            return new ArrayList<>(inheritedList);
+        } else {
+            // The inheritedList should be before the originalList
+            List<T> mergedList = new ArrayList<>(inheritedList);
+            mergedList.addAll(originalList.stream().filter(v -> !mergedList.contains(v)).toList());
+            return mergedList;
+        }
+    }
+
     public static <K, T> Map<K, T> inheritMergeableMapProperty(Map<K, T> originalMap, Map<K, T> inheritedMap) {
         if (inheritedMap == null) {
             return originalMap;


### PR DESCRIPTION
This pull request resolves a bug in the benchmark module where metrics are duplicated when running it multiple times, leading to inconsistent results.

The problem is caused by a combination of an existing benchmark config that is created after the first run and the property `inheritedSolverBenchmark`. Therefore,  the method `ai.timefold.solver.benchmark.impl.DefaultPlannerBenchmarkFactory#buildEffectiveSolverBenchmarkConfigList` will duplicate the values when inheriting the configuration at the line `#163`.

The proposed solution fixes the problem by avoiding the duplicates in the config class `ProblemBenchmarksConfig`.