### PR TITLE
ci: don't run on MacOS

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
         java-version: [ 17, 21, 22 ] #Latest two LTS + latest non-LTS.
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
It's too slow, and OpenRewrite is too flaky.