### PR TITLE
fix: forbid pinning uninitialized entities when unassigned not allowed

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/api/domain/variable/PlanningListVariable.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/variable/PlanningListVariable.java
@@ -38,9 +38,6 @@ import ai.timefold.solver.core.api.domain.entity.PlanningPinToIndex;
  * the <em>order</em> in which customers are visited and tasks are being worked on matters. Also, each customer
  * must be visited <em>once</em> and each task must be completed by <em>exactly one</em> employee.
  *
- * <p>
- * <strong>Overconstrained planning is currently not supported for list variables.</strong>
- *
  * @see PlanningPin
  * @see PlanningPinToIndex
  */

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
@@ -101,7 +101,6 @@ public final class ListVariableDescriptor<Solution_> extends GenuineVariableDesc
 
     public int countUnassigned(Solution_ solution) {
         var valueCount = new MutableLong(getValueRangeSize(solution, null));
-        var entityDescriptor = getEntityDescriptor();
         var solutionDescriptor = entityDescriptor.getSolutionDescriptor();
         solutionDescriptor.visitEntitiesByEntityClass(solution,
                 entityDescriptor.getEntityClass(), entity -> {
@@ -113,11 +112,12 @@ public final class ListVariableDescriptor<Solution_> extends GenuineVariableDesc
     }
 
     public InverseRelationShadowVariableDescriptor<Solution_> getInverseRelationShadowVariableDescriptor() {
-        var entityDescriptor = getEntityDescriptor().getSolutionDescriptor().findEntityDescriptor(getElementType());
-        if (entityDescriptor == null) {
+        var inverseRelationEntityDescriptor =
+                getEntityDescriptor().getSolutionDescriptor().findEntityDescriptor(getElementType());
+        if (inverseRelationEntityDescriptor == null) {
             return null;
         }
-        var applicableShadowDescriptors = entityDescriptor.getShadowVariableDescriptors()
+        var applicableShadowDescriptors = inverseRelationEntityDescriptor.getShadowVariableDescriptors()
                 .stream()
                 .filter(f -> f instanceof InverseRelationShadowVariableDescriptor<Solution_> inverseRelationShadowVariableDescriptor
                         && Objects.equals(inverseRelationShadowVariableDescriptor.getSourceVariableDescriptorList().get(0),
@@ -131,7 +131,7 @@ public final class ListVariableDescriptor<Solution_> extends GenuineVariableDesc
                     """
                             Instances of entityClass (%s) may be used in list variable (%s), but the class has more than one @%s-annotated field (%s).
                             Remove the annotations from all but one field."""
-                            .formatted(entityDescriptor.getEntityClass().getCanonicalName(),
+                            .formatted(inverseRelationEntityDescriptor.getEntityClass().getCanonicalName(),
                                     getSimpleEntityAndVariableName(),
                                     InverseRelationShadowVariable.class.getSimpleName(),
                                     applicableShadowDescriptors.stream()
@@ -150,7 +150,8 @@ public final class ListVariableDescriptor<Solution_> extends GenuineVariableDesc
     public List<Object> getValue(Object entity) {
         Object value = super.getValue(entity);
         if (value == null) {
-            throw new IllegalStateException("The planning list variable (" + this + ") of entity (" + entity + ") is null.");
+            throw new IllegalStateException("The planning list variable (%s) of entity (%s) is null."
+                    .formatted(this, entity));
         }
         return (List<Object>) value;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -223,6 +223,8 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             solutionDescriptor.visitAllProblemFacts(workingSolution, visitor);
         }
         // This visits all the entities, applying the visitor if non-null.
+        Consumer<Object> entityValidator = entity -> scoreDirectorFactory.validateEntity(this, entity);
+        visitor = visitor == null ? entityValidator : visitor.andThen(entityValidator);
         var initializationStatistics = solutionDescriptor.computeInitializationStatistics(workingSolution, visitor);
         setWorkingEntityListDirty();
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseTest.java
@@ -2,20 +2,30 @@ package ai.timefold.solver.core.impl.constructionheuristic;
 
 import static ai.timefold.solver.core.impl.testdata.util.PlannerAssert.assertCode;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
-import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.constructionheuristic.ConstructionHeuristicType;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 import ai.timefold.solver.core.impl.testdata.domain.allows_unassigned.TestdataAllowsUnassignedEasyScoreCalculator;
 import ai.timefold.solver.core.impl.testdata.domain.allows_unassigned.TestdataAllowsUnassignedEntity;
 import ai.timefold.solver.core.impl.testdata.domain.allows_unassigned.TestdataAllowsUnassignedSolution;
+import ai.timefold.solver.core.impl.testdata.domain.list.allows_unassigned.TestdataAllowsUnassignedValuesListEasyScoreCalculator;
+import ai.timefold.solver.core.impl.testdata.domain.list.allows_unassigned.TestdataAllowsUnassignedValuesListEntity;
+import ai.timefold.solver.core.impl.testdata.domain.list.allows_unassigned.TestdataAllowsUnassignedValuesListSolution;
+import ai.timefold.solver.core.impl.testdata.domain.list.allows_unassigned.TestdataAllowsUnassignedValuesListValue;
 import ai.timefold.solver.core.impl.testdata.domain.pinned.TestdataPinnedEntity;
 import ai.timefold.solver.core.impl.testdata.domain.pinned.TestdataPinnedSolution;
+import ai.timefold.solver.core.impl.testdata.domain.pinned.allows_unassigned.TestdataPinnedAllowsUnassignedEntity;
+import ai.timefold.solver.core.impl.testdata.domain.pinned.allows_unassigned.TestdataPinnedAllowsUnassignedSolution;
 import ai.timefold.solver.core.impl.testdata.util.PlannerTestUtils;
 
 import org.junit.jupiter.api.Test;
@@ -24,13 +34,13 @@ class DefaultConstructionHeuristicPhaseTest {
 
     @Test
     void solveWithInitializedEntities() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
                 .withPhases(new ConstructionHeuristicPhaseConfig());
 
-        TestdataSolution solution = new TestdataSolution("s1");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        TestdataValue v3 = new TestdataValue("v3");
+        var solution = new TestdataSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
         solution.setValueList(Arrays.asList(v1, v2, v3));
         solution.setEntityList(Arrays.asList(
                 new TestdataEntity("e1", null),
@@ -39,13 +49,13 @@ class DefaultConstructionHeuristicPhaseTest {
 
         solution = PlannerTestUtils.solve(solverConfig, solution);
         assertThat(solution).isNotNull();
-        TestdataEntity solvedE1 = solution.getEntityList().get(0);
+        var solvedE1 = solution.getEntityList().get(0);
         assertCode("e1", solvedE1);
         assertThat(solvedE1.getValue()).isNotNull();
-        TestdataEntity solvedE2 = solution.getEntityList().get(1);
+        var solvedE2 = solution.getEntityList().get(1);
         assertCode("e2", solvedE2);
         assertThat(solvedE2.getValue()).isEqualTo(v2);
-        TestdataEntity solvedE3 = solution.getEntityList().get(2);
+        var solvedE3 = solution.getEntityList().get(2);
         assertCode("e3", solvedE3);
         assertThat(solvedE3.getValue()).isEqualTo(v1);
         assertThat(solution.getScore().initScore()).isEqualTo(0);
@@ -53,100 +63,193 @@ class DefaultConstructionHeuristicPhaseTest {
 
     @Test
     void solveWithInitializedSolution() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
                 .withPhases(new ConstructionHeuristicPhaseConfig());
 
-        TestdataSolution inputProblem = new TestdataSolution("s1");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        TestdataValue v3 = new TestdataValue("v3");
+        var inputProblem = new TestdataSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
         inputProblem.setValueList(Arrays.asList(v1, v2, v3));
         inputProblem.setEntityList(Arrays.asList(
                 new TestdataEntity("e1", v1),
                 new TestdataEntity("e2", v2),
                 new TestdataEntity("e3", v3)));
 
-        TestdataSolution solution = PlannerTestUtils.solve(solverConfig, inputProblem, false);
+        var solution = PlannerTestUtils.solve(solverConfig, inputProblem, false);
         assertThat(inputProblem).isSameAs(solution);
     }
 
     @Test
     void solveWithPinnedEntities() {
-        SolverConfig solverConfig =
+        var solverConfig =
                 PlannerTestUtils.buildSolverConfig(TestdataPinnedSolution.class, TestdataPinnedEntity.class)
                         .withPhases(new ConstructionHeuristicPhaseConfig());
 
-        TestdataPinnedSolution solution = new TestdataPinnedSolution("s1");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        TestdataValue v3 = new TestdataValue("v3");
+        var solution = new TestdataPinnedSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
+        solution.setValueList(Arrays.asList(v1, v2, v3));
+        solution.setEntityList(Arrays.asList(
+                new TestdataPinnedEntity("e1", null, false, false),
+                new TestdataPinnedEntity("e2", v2, true, false),
+                new TestdataPinnedEntity("e3", v3, false, true)));
+
+        solution = PlannerTestUtils.solve(solverConfig, solution);
+        assertThat(solution).isNotNull();
+        var solvedE1 = solution.getEntityList().get(0);
+        assertCode("e1", solvedE1);
+        assertThat(solvedE1.getValue()).isNotNull();
+        var solvedE2 = solution.getEntityList().get(1);
+        assertCode("e2", solvedE2);
+        assertThat(solvedE2.getValue()).isEqualTo(v2);
+        var solvedE3 = solution.getEntityList().get(2);
+        assertCode("e3", solvedE3);
+        assertThat(solvedE3.getValue()).isEqualTo(v3);
+        assertThat(solution.getScore()).isEqualTo(SimpleScore.ZERO);
+    }
+
+    @Test
+    void solveWithPinnedEntitiesWhenUnassignedAllowedAndPinnedToNull() {
+        var solverConfig =
+                PlannerTestUtils.buildSolverConfig(TestdataPinnedAllowsUnassignedSolution.class,
+                        TestdataPinnedAllowsUnassignedEntity.class)
+                        .withPhases(new ConstructionHeuristicPhaseConfig());
+
+        var solution = new TestdataPinnedAllowsUnassignedSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
+        solution.setValueList(Arrays.asList(v1, v2, v3));
+        solution.setEntityList(Arrays.asList(
+                new TestdataPinnedAllowsUnassignedEntity("e1", null, false, false),
+                new TestdataPinnedAllowsUnassignedEntity("e2", v2, true, false),
+                new TestdataPinnedAllowsUnassignedEntity("e3", null, false, true)));
+
+        solution = PlannerTestUtils.solve(solverConfig, solution, false); // No change will be made.
+        assertThat(solution).isNotNull();
+        assertThat(solution.getScore()).isEqualTo(SimpleScore.ZERO);
+    }
+
+    @Test
+    void solveWithPinnedEntitiesWhenUnassignedNotAllowedAndPinnedToNull() {
+        var solverConfig =
+                PlannerTestUtils.buildSolverConfig(TestdataPinnedSolution.class, TestdataPinnedEntity.class)
+                        .withPhases(new ConstructionHeuristicPhaseConfig());
+
+        var solution = new TestdataPinnedSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
         solution.setValueList(Arrays.asList(v1, v2, v3));
         solution.setEntityList(Arrays.asList(
                 new TestdataPinnedEntity("e1", null, false, false),
                 new TestdataPinnedEntity("e2", v2, true, false),
                 new TestdataPinnedEntity("e3", null, false, true)));
 
-        solution = PlannerTestUtils.solve(solverConfig, solution);
-        assertThat(solution).isNotNull();
-        TestdataPinnedEntity solvedE1 = solution.getEntityList().get(0);
-        assertCode("e1", solvedE1);
-        assertThat(solvedE1.getValue()).isNotNull();
-        TestdataPinnedEntity solvedE2 = solution.getEntityList().get(1);
-        assertCode("e2", solvedE2);
-        assertThat(solvedE2.getValue()).isEqualTo(v2);
-        TestdataPinnedEntity solvedE3 = solution.getEntityList().get(2);
-        assertCode("e3", solvedE3);
-        assertThat(solvedE3.getValue()).isEqualTo(null);
-        assertThat(solution.getScore().initScore()).isEqualTo(-1);
-    }
-
-    @Test
-    void solveWithEntitiesAllowedUnassigned() {
-        SolverConfig solverConfig = new SolverConfig()
-                .withSolutionClass(TestdataAllowsUnassignedSolution.class)
-                .withEntityClasses(TestdataAllowsUnassignedEntity.class)
-                .withEasyScoreCalculatorClass(TestdataAllowsUnassignedEasyScoreCalculator.class)
-                .withPhases(new ConstructionHeuristicPhaseConfig());
-
-        TestdataAllowsUnassignedSolution solution = new TestdataAllowsUnassignedSolution("s1");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        solution.setValueList(Arrays.asList(v1, v2));
-        solution.setEntityList(Arrays.asList(
-                new TestdataAllowsUnassignedEntity("e1", null),
-                new TestdataAllowsUnassignedEntity("e2", null),
-                new TestdataAllowsUnassignedEntity("e3", null)));
-
-        solution = PlannerTestUtils.solve(solverConfig, solution);
-        assertThat(solution).isNotNull();
-        TestdataAllowsUnassignedEntity solvedE1 = solution.getEntityList().get(0);
-        assertCode("e1", solvedE1);
-        assertThat(solvedE1.getValue()).isEqualTo(v1);
-        TestdataAllowsUnassignedEntity solvedE2 = solution.getEntityList().get(1);
-        assertCode("e2", solvedE2);
-        assertThat(solvedE2.getValue()).isEqualTo(v2);
-        TestdataAllowsUnassignedEntity solvedE3 = solution.getEntityList().get(2);
-        assertCode("e3", solvedE3);
-        assertThat(solvedE3.getValue()).isEqualTo(null);
-        assertThat(solution.getScore().initScore()).isEqualTo(0);
-        assertThat(solution.getScore().score()).isEqualTo(-1);
+        assertThatThrownBy(() -> PlannerTestUtils.solve(solverConfig, solution))
+                .hasMessageContaining("entity (e3)")
+                .hasMessageContaining("variable (value");
     }
 
     @Test
     void solveWithEmptyEntityList() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
                 .withPhases(new ConstructionHeuristicPhaseConfig());
 
-        TestdataSolution solution = new TestdataSolution("s1");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        TestdataValue v3 = new TestdataValue("v3");
+        var solution = new TestdataSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
         solution.setValueList(Arrays.asList(v1, v2, v3));
         solution.setEntityList(Collections.emptyList());
 
         solution = PlannerTestUtils.solve(solverConfig, solution, false);
         assertThat(solution).isNotNull();
         assertThat(solution.getEntityList()).isEmpty();
+    }
+
+    @Test
+    void solveWithAllowsUnassignedBasicVariable() {
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataAllowsUnassignedSolution.class,
+                TestdataAllowsUnassignedEntity.class)
+                .withEasyScoreCalculatorClass(TestdataAllowsUnassignedEasyScoreCalculator.class)
+                .withPhases(new ConstructionHeuristicPhaseConfig());
+
+        var value1 = new TestdataValue("v1");
+        var value2 = new TestdataValue("v2");
+        var entity = new TestdataAllowsUnassignedEntity("e1");
+        entity.setValue(value1);
+        var entity2 = new TestdataAllowsUnassignedEntity("e2");
+        var entity3 = new TestdataAllowsUnassignedEntity("e3");
+
+        var solution = new TestdataAllowsUnassignedSolution();
+        solution.setEntityList(List.of(entity, entity2, entity3));
+        solution.setValueList(Arrays.asList(value1, value2));
+
+        var bestSolution = PlannerTestUtils.solve(solverConfig, solution);
+        assertSoftly(softly -> {
+            softly.assertThat(bestSolution.getScore())
+                    .isEqualTo(SimpleScore.of(-1)); // No value assigned twice, null once.
+            var firstEntity = bestSolution.getEntityList().get(0);
+            var firstValue = bestSolution.getValueList().get(0);
+            softly.assertThat(firstEntity.getValue())
+                    .isEqualTo(firstValue);
+            var secondEntity = bestSolution.getEntityList().get(1);
+            var secondValue = bestSolution.getValueList().get(1);
+            softly.assertThat(secondEntity.getValue())
+                    .isEqualTo(secondValue);
+            var thirdEntity = bestSolution.getEntityList().get(2);
+            softly.assertThat(thirdEntity.getValue())
+                    .isNull();
+        });
+
+    }
+
+    @Test
+    void solveWithAllowsUnassignedValuesListVariable() {
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataAllowsUnassignedValuesListSolution.class,
+                TestdataAllowsUnassignedValuesListEntity.class, TestdataAllowsUnassignedValuesListValue.class)
+                .withEasyScoreCalculatorClass(TestdataAllowsUnassignedValuesListEasyScoreCalculator.class)
+                .withPhases(new ConstructionHeuristicPhaseConfig());
+
+        var value1 = new TestdataAllowsUnassignedValuesListValue("v1");
+        var value2 = new TestdataAllowsUnassignedValuesListValue("v2");
+        var value3 = new TestdataAllowsUnassignedValuesListValue("v3");
+        var value4 = new TestdataAllowsUnassignedValuesListValue("v4");
+        var entity = TestdataAllowsUnassignedValuesListEntity.createWithValues("e1", value1, value2);
+
+        var solution = new TestdataAllowsUnassignedValuesListSolution();
+        solution.setEntityList(List.of(entity));
+        solution.setValueList(Arrays.asList(value1, value2, value3, value4));
+
+        var bestSolution = PlannerTestUtils.solve(solverConfig, solution, false);
+        assertSoftly(softly -> {
+            softly.assertThat(bestSolution.getScore())
+                    .isEqualTo(SimpleScore.of(-2)); // Length of the entity's value list.
+            var firstEntity = bestSolution.getEntityList().get(0);
+            var firstValue = bestSolution.getValueList().get(0);
+            var secondValue = bestSolution.getValueList().get(1);
+            softly.assertThat(firstEntity.getValueList())
+                    .containsExactly(firstValue, secondValue);
+        });
+
+    }
+
+    @Test
+    void constructionHeuristicAllocateToValueFromQueue() {
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
+                .withPhases(new ConstructionHeuristicPhaseConfig()
+                        .withConstructionHeuristicType(ConstructionHeuristicType.ALLOCATE_TO_VALUE_FROM_QUEUE));
+
+        var solution = new TestdataSolution("s1");
+        solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
+        solution.setEntityList(Arrays.asList(new TestdataEntity("e1")));
+
+        solution = PlannerTestUtils.solve(solverConfig, solution);
+        assertThat(solution).isNotNull();
+        assertThat(solution.getScore().isSolutionInitialized()).isTrue();
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.exhaustivesearch;
 
 import static ai.timefold.solver.core.impl.testdata.util.PlannerAssert.assertCode;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -14,8 +15,6 @@ import java.util.Collections;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.config.exhaustivesearch.ExhaustiveSearchPhaseConfig;
-import ai.timefold.solver.core.config.solver.SolverConfig;
-import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.exhaustivesearch.decider.ExhaustiveSearchDecider;
 import ai.timefold.solver.core.impl.exhaustivesearch.node.ExhaustiveSearchLayer;
 import ai.timefold.solver.core.impl.exhaustivesearch.node.ExhaustiveSearchNode;
@@ -29,6 +28,8 @@ import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 import ai.timefold.solver.core.impl.testdata.domain.pinned.TestdataPinnedEntity;
 import ai.timefold.solver.core.impl.testdata.domain.pinned.TestdataPinnedSolution;
+import ai.timefold.solver.core.impl.testdata.domain.pinned.allows_unassigned.TestdataPinnedAllowsUnassignedEntity;
+import ai.timefold.solver.core.impl.testdata.domain.pinned.allows_unassigned.TestdataPinnedAllowsUnassignedSolution;
 import ai.timefold.solver.core.impl.testdata.util.PlannerTestUtils;
 
 import org.junit.jupiter.api.Test;
@@ -42,38 +43,38 @@ class DefaultExhaustiveSearchPhaseTest {
         when(phaseScope.getLastCompletedStepScope()).thenReturn(lastCompletedStepScope);
         ExhaustiveSearchStepScope<TestdataSolution> stepScope = mock(ExhaustiveSearchStepScope.class);
         when(stepScope.getPhaseScope()).thenReturn(phaseScope);
-        TestdataSolution workingSolution = new TestdataSolution();
+        var workingSolution = new TestdataSolution();
         when(phaseScope.getWorkingSolution()).thenReturn(workingSolution);
         InnerScoreDirector<TestdataSolution, SimpleScore> scoreDirector = mock(InnerScoreDirector.class);
         when(phaseScope.getScoreDirector()).thenReturn((InnerScoreDirector) scoreDirector);
 
-        SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
+        var solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
         when(phaseScope.getSolutionDescriptor()).thenReturn(solutionDescriptor);
 
-        ExhaustiveSearchLayer layer0 = new ExhaustiveSearchLayer(0, mock(Object.class));
-        ExhaustiveSearchLayer layer1 = new ExhaustiveSearchLayer(1, mock(Object.class));
-        ExhaustiveSearchLayer layer2 = new ExhaustiveSearchLayer(2, mock(Object.class));
-        ExhaustiveSearchLayer layer3 = new ExhaustiveSearchLayer(3, mock(Object.class));
-        ExhaustiveSearchLayer layer4 = new ExhaustiveSearchLayer(4, mock(Object.class));
-        ExhaustiveSearchNode node0 = new ExhaustiveSearchNode(layer0, null);
+        var layer0 = new ExhaustiveSearchLayer(0, mock(Object.class));
+        var layer1 = new ExhaustiveSearchLayer(1, mock(Object.class));
+        var layer2 = new ExhaustiveSearchLayer(2, mock(Object.class));
+        var layer3 = new ExhaustiveSearchLayer(3, mock(Object.class));
+        var layer4 = new ExhaustiveSearchLayer(4, mock(Object.class));
+        var node0 = new ExhaustiveSearchNode(layer0, null);
         node0.setMove(mock(Move.class));
         node0.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node1 = new ExhaustiveSearchNode(layer1, node0);
+        var node1 = new ExhaustiveSearchNode(layer1, node0);
         node1.setMove(mock(Move.class));
         node1.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node2A = new ExhaustiveSearchNode(layer2, node1);
+        var node2A = new ExhaustiveSearchNode(layer2, node1);
         node2A.setMove(mock(Move.class));
         node2A.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node3A = new ExhaustiveSearchNode(layer3, node2A); // oldNode
+        var node3A = new ExhaustiveSearchNode(layer3, node2A); // oldNode
         node3A.setMove(mock(Move.class));
         node3A.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node2B = new ExhaustiveSearchNode(layer2, node1);
+        var node2B = new ExhaustiveSearchNode(layer2, node1);
         node2B.setMove(mock(Move.class));
         node2B.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node3B = new ExhaustiveSearchNode(layer3, node2B);
+        var node3B = new ExhaustiveSearchNode(layer3, node2B);
         node3B.setMove(mock(Move.class));
         node3B.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node4B = new ExhaustiveSearchNode(layer4, node3B); // newNode
+        var node4B = new ExhaustiveSearchNode(layer4, node3B); // newNode
         node4B.setMove(mock(Move.class));
         node4B.setUndoMove(mock(Move.class));
         node4B.setScore(SimpleScore.ofUninitialized(-96, 7));
@@ -104,14 +105,14 @@ class DefaultExhaustiveSearchPhaseTest {
 
     @Test
     void solveWithInitializedEntities() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class,
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class,
                 TestdataEntity.class);
         solverConfig.setPhaseConfigList(Collections.singletonList(new ExhaustiveSearchPhaseConfig()));
 
-        TestdataSolution solution = new TestdataSolution("s1");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        TestdataValue v3 = new TestdataValue("v3");
+        var solution = new TestdataSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
         solution.setValueList(Arrays.asList(v1, v2, v3));
         solution.setEntityList(Arrays.asList(
                 new TestdataEntity("e1", null),
@@ -120,13 +121,13 @@ class DefaultExhaustiveSearchPhaseTest {
 
         solution = PlannerTestUtils.solve(solverConfig, solution);
         assertThat(solution).isNotNull();
-        TestdataEntity solvedE1 = solution.getEntityList().get(0);
+        var solvedE1 = solution.getEntityList().get(0);
         assertCode("e1", solvedE1);
         assertThat(solvedE1.getValue()).isNotNull();
-        TestdataEntity solvedE2 = solution.getEntityList().get(1);
+        var solvedE2 = solution.getEntityList().get(1);
         assertCode("e2", solvedE2);
         assertThat(solvedE2.getValue()).isEqualTo(v2);
-        TestdataEntity solvedE3 = solution.getEntityList().get(2);
+        var solvedE3 = solution.getEntityList().get(2);
         assertCode("e3", solvedE3);
         assertThat(solvedE3.getValue()).isEqualTo(v1);
         assertThat(solution.getScore().initScore()).isEqualTo(0);
@@ -134,44 +135,84 @@ class DefaultExhaustiveSearchPhaseTest {
 
     @Test
     void solveWithPinnedEntities() {
-        SolverConfig solverConfig =
-                PlannerTestUtils.buildSolverConfig(TestdataPinnedSolution.class, TestdataPinnedEntity.class);
-        solverConfig.setPhaseConfigList(Collections.singletonList(new ExhaustiveSearchPhaseConfig()));
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataPinnedSolution.class, TestdataPinnedEntity.class)
+                .withPhases(new ExhaustiveSearchPhaseConfig());
 
-        TestdataPinnedSolution solution = new TestdataPinnedSolution("s1");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        TestdataValue v3 = new TestdataValue("v3");
+        var solution = new TestdataPinnedSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
+        solution.setValueList(Arrays.asList(v1, v2, v3));
+        solution.setEntityList(Arrays.asList(
+                new TestdataPinnedEntity("e1", null, false, false),
+                new TestdataPinnedEntity("e2", v2, true, false),
+                new TestdataPinnedEntity("e3", v3, false, true)));
+
+        solution = PlannerTestUtils.solve(solverConfig, solution);
+        assertThat(solution).isNotNull();
+        var solvedE1 = solution.getEntityList().get(0);
+        assertCode("e1", solvedE1);
+        assertThat(solvedE1.getValue()).isNotNull();
+        var solvedE2 = solution.getEntityList().get(1);
+        assertCode("e2", solvedE2);
+        assertThat(solvedE2.getValue()).isEqualTo(v2);
+        var solvedE3 = solution.getEntityList().get(2);
+        assertCode("e3", solvedE3);
+        assertThat(solvedE3.getValue()).isEqualTo(v3);
+        assertThat(solution.getScore()).isEqualTo(SimpleScore.ZERO);
+    }
+
+    @Test
+    void solveWithPinnedEntitiesWhenUnassignedAllowedAndPinnedToNull() {
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataPinnedAllowsUnassignedSolution.class,
+                TestdataPinnedAllowsUnassignedEntity.class)
+                .withPhases(new ExhaustiveSearchPhaseConfig());
+
+        var solution = new TestdataPinnedAllowsUnassignedSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
+        solution.setValueList(Arrays.asList(v1, v2, v3));
+        solution.setEntityList(Arrays.asList(
+                new TestdataPinnedAllowsUnassignedEntity("e1", null, false, false),
+                new TestdataPinnedAllowsUnassignedEntity("e2", v2, true, false),
+                new TestdataPinnedAllowsUnassignedEntity("e3", null, false, true)));
+
+        solution = PlannerTestUtils.solve(solverConfig, solution, false); // No change will be made.
+        assertThat(solution).isNotNull();
+        assertThat(solution.getScore()).isEqualTo(SimpleScore.ZERO);
+    }
+
+    @Test
+    void solveWithPinnedEntitiesWhenUnassignedNotAllowedAndPinnedToNull() {
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataPinnedSolution.class, TestdataPinnedEntity.class)
+                .withPhases(new ExhaustiveSearchPhaseConfig());
+
+        var solution = new TestdataPinnedSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
         solution.setValueList(Arrays.asList(v1, v2, v3));
         solution.setEntityList(Arrays.asList(
                 new TestdataPinnedEntity("e1", null, false, false),
                 new TestdataPinnedEntity("e2", v2, true, false),
                 new TestdataPinnedEntity("e3", null, false, true)));
 
-        solution = PlannerTestUtils.solve(solverConfig, solution);
-        assertThat(solution).isNotNull();
-        TestdataPinnedEntity solvedE1 = solution.getEntityList().get(0);
-        assertCode("e1", solvedE1);
-        assertThat(solvedE1.getValue()).isNotNull();
-        TestdataPinnedEntity solvedE2 = solution.getEntityList().get(1);
-        assertCode("e2", solvedE2);
-        assertThat(solvedE2.getValue()).isEqualTo(v2);
-        TestdataPinnedEntity solvedE3 = solution.getEntityList().get(2);
-        assertCode("e3", solvedE3);
-        assertThat(solvedE3.getValue()).isEqualTo(null);
-        assertThat(solution.getScore().initScore()).isEqualTo(-1);
+        assertThatThrownBy(() -> PlannerTestUtils.solve(solverConfig, solution))
+                .hasMessageContaining("entity (e3)")
+                .hasMessageContaining("variable (value");
     }
 
     @Test
     void solveWithEmptyEntityList() {
-        SolverConfig solverConfig =
+        var solverConfig =
                 PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         solverConfig.setPhaseConfigList(Collections.singletonList(new ExhaustiveSearchPhaseConfig()));
 
-        TestdataSolution solution = new TestdataSolution("s1");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        TestdataValue v3 = new TestdataValue("v3");
+        var solution = new TestdataSolution("s1");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
         solution.setValueList(Arrays.asList(v1, v2, v3));
         solution.setEntityList(Collections.emptyList());
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/pinned/allows_unassigned/TestdataAllowsUnassignedPinningFilter.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/pinned/allows_unassigned/TestdataAllowsUnassignedPinningFilter.java
@@ -1,0 +1,13 @@
+package ai.timefold.solver.core.impl.testdata.domain.pinned.allows_unassigned;
+
+import ai.timefold.solver.core.api.domain.entity.PinningFilter;
+
+public class TestdataAllowsUnassignedPinningFilter
+        implements PinningFilter<TestdataPinnedAllowsUnassignedSolution, TestdataPinnedAllowsUnassignedEntity> {
+
+    @Override
+    public boolean accept(TestdataPinnedAllowsUnassignedSolution solution, TestdataPinnedAllowsUnassignedEntity entity) {
+        return entity.isLocked();
+    }
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/pinned/allows_unassigned/TestdataPinnedAllowsUnassignedEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/pinned/allows_unassigned/TestdataPinnedAllowsUnassignedEntity.java
@@ -1,0 +1,76 @@
+package ai.timefold.solver.core.impl.testdata.domain.pinned.allows_unassigned;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataObject;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
+
+@PlanningEntity(pinningFilter = TestdataAllowsUnassignedPinningFilter.class)
+public class TestdataPinnedAllowsUnassignedEntity extends TestdataObject {
+
+    public static EntityDescriptor<TestdataPinnedAllowsUnassignedSolution> buildEntityDescriptor() {
+        return TestdataPinnedAllowsUnassignedSolution.buildSolutionDescriptor()
+                .findEntityDescriptorOrFail(TestdataPinnedAllowsUnassignedEntity.class);
+    }
+
+    private TestdataValue value;
+    private boolean locked;
+    private boolean pinned;
+
+    public TestdataPinnedAllowsUnassignedEntity() {
+    }
+
+    public TestdataPinnedAllowsUnassignedEntity(String code) {
+        super(code);
+    }
+
+    public TestdataPinnedAllowsUnassignedEntity(String code, boolean locked, boolean pinned) {
+        this(code);
+        this.locked = locked;
+        this.pinned = pinned;
+    }
+
+    public TestdataPinnedAllowsUnassignedEntity(String code, TestdataValue value) {
+        this(code);
+        this.value = value;
+    }
+
+    public TestdataPinnedAllowsUnassignedEntity(String code, TestdataValue value, boolean locked, boolean pinned) {
+        this(code, value);
+        this.locked = locked;
+        this.pinned = pinned;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange", allowsUnassigned = true)
+    public TestdataValue getValue() {
+        return value;
+    }
+
+    public void setValue(TestdataValue value) {
+        this.value = value;
+    }
+
+    public boolean isLocked() {
+        return locked;
+    }
+
+    public void setLocked(boolean locked) {
+        this.locked = locked;
+    }
+
+    @PlanningPin
+    public boolean isPinned() {
+        return pinned;
+    }
+
+    public void setPinned(boolean pinned) {
+        this.pinned = pinned;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/pinned/allows_unassigned/TestdataPinnedAllowsUnassignedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/pinned/allows_unassigned/TestdataPinnedAllowsUnassignedSolution.java
@@ -1,0 +1,67 @@
+package ai.timefold.solver.core.impl.testdata.domain.pinned.allows_unassigned;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataObject;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution
+public class TestdataPinnedAllowsUnassignedSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataPinnedAllowsUnassignedSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataPinnedAllowsUnassignedSolution.class,
+                TestdataPinnedAllowsUnassignedEntity.class);
+    }
+
+    private List<TestdataValue> valueList;
+    private List<TestdataPinnedAllowsUnassignedEntity> entityList;
+
+    private SimpleScore score;
+
+    public TestdataPinnedAllowsUnassignedSolution() {
+    }
+
+    public TestdataPinnedAllowsUnassignedSolution(String code) {
+        super(code);
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataPinnedAllowsUnassignedEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataPinnedAllowsUnassignedEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/util/PlannerTestUtils.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/util/PlannerTestUtils.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.testdata.util;
 
 import static java.util.Arrays.stream;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -80,7 +80,11 @@ public final class PlannerTestUtils {
         AtomicReference<Solution_> eventBestSolutionRef = new AtomicReference<>();
         solver.addEventListener(event -> eventBestSolutionRef.set(event.getNewBestSolution()));
         Solution_ finalBestSolution = solver.solve(problem);
-        assertEquals(bestSolutionEventExists ? finalBestSolution : null, eventBestSolutionRef.get());
+        if (bestSolutionEventExists) {
+            assertThat(eventBestSolutionRef).doesNotHaveNullValue();
+        } else {
+            assertThat(eventBestSolutionRef).hasNullValue();
+        }
         return finalBestSolution;
     }
 

--- a/docs/src/modules/ROOT/pages/upgrade-and-migration/upgrade-to-latest-version.adoc
+++ b/docs/src/modules/ROOT/pages/upgrade-and-migration/upgrade-to-latest-version.adoc
@@ -42,8 +42,7 @@ Having done that, you can check the local changes and commit them.
 Note that none of the upgrade steps could be automatically applied,
 and it may still be worth your while to read the rest the upgrade recipe below.
 
-For the time being,
-Kotlin users need to follow the upgrade recipe and apply the steps manually.
+For the time being, Kotlin users need to follow the upgrade recipe and apply the steps manually.
 
 [#manualUpgrade]
 == Manual upgrade recipe
@@ -59,6 +58,26 @@ The upgrade recipe often lists the changes as they apply to Java code.
 We kindly ask Kotlin and Python users to translate the changes accordingly.
 
 === Upgrade from 1.9.0 to 1.10.0
+
+.icon:info-circle[role=yellow] Pinning unassigned entities now fails fast, unless allowed
+[%collapsible%open]
+====
+The solver behavior has changed in the following situation:
+
+1. There is a planning entity with a `@PlanningVariable` that does not allow unassigned values.
+2. And that planning entity is pinned.
+3. And that variable is set to `null`, therefore unassigned.
+
+This situation is both unlikely and erroneous.
+The solver is asked to require all variables to be assigned, but at the same time one variable is forced unassigned.
+
+Before Timefold Solver 1.10.0, this would result in Construction Heuristics finishing with a negative `init` score.
+Starting with Timefold Solver 1.10.0, this situation will result in a runtime exception.
+
+Read more about xref:using-timefold-solver/modeling-planning-problems.adoc#planningVariableAllowingUnassigned[explicitly allowing unassigned values].
+====
+
+'''
 
 .icon:eye[] Enterprise Edition Maven Repository will soon require authentication
 [%collapsible%open]
@@ -82,15 +101,15 @@ see xref:enterprise-edition/enterprise-edition.adoc#switchToEnterpriseEdition[th
 ====
 `LookupStrategyType` is used in xref:enterprise-edition/enterprise-edition.adoc#multithreadedSolving[multi-threaded solving]
 to specify how the solver should match entities and facts between parent and child score directors.
-The default value is `PLANNING_ID_OR_NONE`, which means that
-the solver will look up entities by their xref:using-timefold-solver/modeling-planning-problems.adoc#planningId[planning ID].
+The default value is `PLANNING_ID_OR_NONE`, which means
+that the solver will look up entities by their xref:using-timefold-solver/modeling-planning-problems.adoc#planningId[planning ID].
 If the solver doesn't find anything with that ID, it will throw an exception.
 
 In a future version of _Timefold Solver_, we will remove the option of configuring the lookup strategy.
 The behavior will be fixed to the behavior explained above.
 To prepare for this change,
-remove the use of `@PlanningSolution.lookupStrategyType` and ensure that your planning entities and problem facts
-have a `@PlanningId`-annotated field.
+remove the use of `@PlanningSolution.lookupStrategyType`
+and ensure that your planning entities and problem facts have a `@PlanningId`-annotated field.
 
 Before in `Timetable.java`:
 
@@ -148,7 +167,7 @@ public class Lesson {
 We have finished the process of removing the Swing-based examples.
 The legacy examples from the solver codebase have been removed entirely.
 
-You can find better, more modern implementations of many of these use cases in our quickstarts, including:
+You can find better, more modern implementations of these use cases in our quickstarts, including:
 
 - `bed-allocation`,
 - `conference-scheduling`,
@@ -197,8 +216,8 @@ In the first wave, we have removed the following examples from the `examples` mo
 - `tsp`,
 - and `vehiclerouting`.
 
-You can find better, more modern implementations of many of these use cases in our quickstarts.
-The other examples on the list were removed without replacement as we didn't see sufficient traction.
+You can find better, more modern implementations of these use cases in our quickstarts.
+The other examples on the list were removed without a replacement as we didn't see sufficient traction.
 
 Going forward, our intention is to convert every other current example into a quickstart
 and remove the original Swing-based examples from the solver codebase entirely.
@@ -226,8 +245,7 @@ Finally, with the folding of these modules into `timefold-solver-core`,
 the solver no longer relies on `ServiceLoader`s to find implementations of Constraint Streams,
 or to find the Enterprise Edition.
 
-None of these changes are likely to affect you,
-unless you have chosen to depend on internal classes and modules.
+None of these changes are likely to affect you, unless you have chosen to depend on internal classes and modules.
 ====
 
 '''
@@ -237,18 +255,11 @@ unless you have chosen to depend on internal classes and modules.
 .icon:exclamation-triangle[role=red] Constraint Verifier: Check your tests if you use the planning list variable
 [%collapsible%open]
 ====
-In some cases,
-especially if you've reused our https://github.com/TimefoldAI/timefold-quickstarts/tree/stable/use-cases/food-packaging[Food Packaging quickstart],
-you may see your tests failing after the upgrade.
-This is due to a bug fix in xref:constraints-and-score/score-calculation.adoc#constraintStreams[Constraint Streams],
-which now currently handles values not present in any list variable.
+In some cases, especially if you've reused our https://github.com/TimefoldAI/timefold-quickstarts/tree/stable/use-cases/food-packaging[Food Packaging quickstart], you may see your tests failing after the upgrade.
+This is due to a bug fix in xref:constraints-and-score/score-calculation.adoc#constraintStreams[Constraint Streams], which now currently handles values not present in any list variable.
 
-If your code has a shadow entity
-whose xref:using-timefold-solver/modeling-planning-problems.adoc#listVariableShadowVariablesInverseRelation[inverse relation shadow variable] is a planning list variable
-and your test leaves that reference `null`,
-the constraints will no longer take that shadow entity into account.
-This will result in `ConstraintVerifier` failing the test,
-as the expected number of penalties/rewards will no longer match the actual number.
+If your code has a shadow entity whose xref:using-timefold-solver/modeling-planning-problems.adoc#listVariableShadowVariablesInverseRelation[inverse relation shadow variable] is a planning list variable and your test leaves that reference `null`, the constraints will no longer take that shadow entity into account.
+This will result in `ConstraintVerifier` failing the test, as the expected number of penalties/rewards will no longer match the actual number.
 
 You can solve this problem by manually assigning a value to the inverse relation shadow variable.
 
@@ -276,8 +287,7 @@ constraintVerifier.verifyThat(FoodPackagingConstraintProvider::dueDateTime)
     .penalizesBy(...);
 ----
 
-The aforementioned quickstart unfortunately did not follow our own guidance on the use of shadow variables,
-which is why it exposed this bug.
+The aforementioned quickstart unfortunately did not follow our own guidance on the use of shadow variables, which is why it exposed this bug.
 ====
 
 '''
@@ -286,8 +296,7 @@ which is why it exposed this bug.
 [%collapsible%open]
 ====
 To better align with the newly introduced support for
-xref:using-timefold-solver/modeling-planning-problems.adoc#planningListVariableAllowingUnassigned[unassigned values in list variables],
-several methods in xref:constraints-and-score/score-calculation.adoc#constraintStreams[Constraint Streams]
+xref:using-timefold-solver/modeling-planning-problems.adoc#planningListVariableAllowingUnassigned[unassigned values in list variables], several methods in xref:constraints-and-score/score-calculation.adoc#constraintStreams[Constraint Streams]
 which dealt with `null` variable values have been renamed.
 
 Before in `*ConstraintProvider.java`:
@@ -329,8 +338,7 @@ On `BiConstraintStream` and its `Tri` and `Quad` counterparts, the following met
 [%collapsible%open]
 ====
 To better align with the newly introduced support for
-xref:using-timefold-solver/modeling-planning-problems.adoc#planningListVariableAllowingUnassigned[unassigned values in list variables],
-the `nullable` attribute of `@PlanningVariable` has been renamed to `allowsUnassigned`.
+xref:using-timefold-solver/modeling-planning-problems.adoc#planningListVariableAllowingUnassigned[unassigned values in list variables], the `nullable` attribute of `@PlanningVariable` has been renamed to `allowsUnassigned`.
 
 Before in `*.java`:
 
@@ -354,8 +362,7 @@ private Bed bed;
 .icon:magic[] Constraint Verifier: assertion methods `message` argument comes first now
 [%collapsible%open]
 ====
-To better align with the newly introduced support for testing justifications and indictments,
-the assertion methods which accepted a `message` argument now have it as the first argument.
+To better align with the newly introduced support for testing justifications and indictments, the assertion methods which accepted a `message` argument now have it as the first argument.
 
 Before in `*ConstraintProviderTest.java`:
 

--- a/docs/src/modules/ROOT/pages/upgrade-and-migration/upgrade-to-latest-version.adoc
+++ b/docs/src/modules/ROOT/pages/upgrade-and-migration/upgrade-to-latest-version.adoc
@@ -82,11 +82,12 @@ Read more about xref:using-timefold-solver/modeling-planning-problems.adoc#plann
 .icon:eye[] Enterprise Edition Maven Repository will soon require authentication
 [%collapsible%open]
 ====
-Timefold customers newly need to authenticate to access the Enterprise Edition Maven Repository.
-If you are a Timefold customer, you should have received your credentials from Timefold by now.
-If you haven't, we kindly ask that you https://timefold.ai/contact[contact us].
+Users of Enterprise Edition will soon need to authenticate to access Timefold's Maven Repository.
 
-If you are not a Timefold customer and you wish to retain your access to the Enterprise Edition Maven Repository,
+If you are a Timefold customer, a Timefold representative will reach out to you
+to give you the necessary credentials, as well as sufficient time to make the necessary changes.
+
+If you are not a Timefold customer and you wish to retain your access to the Enterprise Edition artifacts,
 you can https://timefold.ai/contact[contact us] to start your evaluation.
 There are https://timefold.ai/pricing[many benefits] to being a Timefold customer.
 


### PR DESCRIPTION
Interestingly, plenty of tests were actually intentionally testing the situation where allowsUnassigned=false and yet value pinned to null, making sure the solver didn't fail in that case.

That was probably an oversight; if I had thought about it more at the time, I would've convinced myself that failing in this situation is the correct behavior. But it raises questions of backwards compatibility.

In my opinion, changing this is not a problem, because before this fix it would result in negative init score, and that would've made local search fail anyway.