### PR TITLE
chore: improve score corruption error message

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
@@ -41,7 +41,7 @@ public class DefaultConstructionHeuristicPhase<Solution_> extends AbstractPhase<
 
     @Override
     public void solve(SolverScope<Solution_> solverScope) {
-        var phaseScope = new ConstructionHeuristicPhaseScope<>(solverScope);
+        var phaseScope = new ConstructionHeuristicPhaseScope<>(solverScope, phaseIndex);
         phaseStarted(phaseScope);
 
         var solutionDescriptor = solverScope.getSolutionDescriptor();

--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/decider/ConstructionHeuristicDecider.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/decider/ConstructionHeuristicDecider.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.core.impl.constructionheuristic.scope.ConstructionHeur
 import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.heuristic.move.NoChangeMove;
 import ai.timefold.solver.core.impl.heuristic.selector.move.generic.ChangeMove;
+import ai.timefold.solver.core.impl.phase.scope.SolverLifecyclePoint;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.Termination;
@@ -135,11 +136,11 @@ public class ConstructionHeuristicDecider<Solution_> {
         });
         if (assertExpectedUndoMoveScore) {
             scoreDirector.assertExpectedUndoMoveScore(moveScope.getMove(),
-                    (Score_) moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore());
+                    (Score_) moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore(),
+                    SolverLifecyclePoint.of(moveScope));
         }
         logger.trace("{}        Move index ({}), score ({}), move ({}).",
-                logIndentation,
-                moveScope.getMoveIndex(), moveScope.getScore(), moveScope.getMove());
+                logIndentation, moveScope.getMoveIndex(), moveScope.getScore(), moveScope.getMove());
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/scope/ConstructionHeuristicMoveScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/scope/ConstructionHeuristicMoveScope.java
@@ -7,23 +7,16 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractMoveScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class ConstructionHeuristicMoveScope<Solution_> extends AbstractMoveScope<Solution_> {
-
-    private final ConstructionHeuristicStepScope<Solution_> stepScope;
+public final class ConstructionHeuristicMoveScope<Solution_> extends AbstractMoveScope<Solution_> {
 
     public ConstructionHeuristicMoveScope(ConstructionHeuristicStepScope<Solution_> stepScope,
             int moveIndex, Move<Solution_> move) {
-        super(moveIndex, move);
-        this.stepScope = stepScope;
+        super(stepScope, moveIndex, move);
     }
 
     @Override
     public ConstructionHeuristicStepScope<Solution_> getStepScope() {
-        return stepScope;
+        return (ConstructionHeuristicStepScope<Solution_>) super.getStepScope();
     }
-
-    // ************************************************************************
-    // Calculated methods
-    // ************************************************************************
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/scope/ConstructionHeuristicPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/scope/ConstructionHeuristicPhaseScope.java
@@ -7,12 +7,12 @@ import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class ConstructionHeuristicPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
+public final class ConstructionHeuristicPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
 
     private ConstructionHeuristicStepScope<Solution_> lastCompletedStepScope;
 
-    public ConstructionHeuristicPhaseScope(SolverScope<Solution_> solverScope) {
-        super(solverScope, false);
+    public ConstructionHeuristicPhaseScope(SolverScope<Solution_> solverScope, int phaseIndex) {
+        super(solverScope, phaseIndex, false);
         lastCompletedStepScope = new ConstructionHeuristicStepScope<>(this, -1);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/scope/ConstructionHeuristicStepScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/scope/ConstructionHeuristicStepScope.java
@@ -7,7 +7,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class ConstructionHeuristicStepScope<Solution_> extends AbstractStepScope<Solution_> {
+public final class ConstructionHeuristicStepScope<Solution_> extends AbstractStepScope<Solution_> {
 
     private final ConstructionHeuristicPhaseScope<Solution_> phaseScope;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhase.java
@@ -59,7 +59,7 @@ public class DefaultExhaustiveSearchPhase<Solution_> extends AbstractPhase<Solut
     @Override
     public void solve(SolverScope<Solution_> solverScope) {
         SortedSet<ExhaustiveSearchNode> expandableNodeQueue = new TreeSet<>(nodeComparator);
-        ExhaustiveSearchPhaseScope<Solution_> phaseScope = new ExhaustiveSearchPhaseScope<>(solverScope);
+        ExhaustiveSearchPhaseScope<Solution_> phaseScope = new ExhaustiveSearchPhaseScope<>(solverScope, phaseIndex);
         phaseScope.setExpandableNodeQueue(expandableNodeQueue);
         phaseStarted(phaseScope);
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/decider/ExhaustiveSearchDecider.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/decider/ExhaustiveSearchDecider.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.core.impl.exhaustivesearch.scope.ExhaustiveSearchStepS
 import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.heuristic.selector.entity.mimic.ManualEntityMimicRecorder;
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector;
+import ai.timefold.solver.core.impl.phase.scope.SolverLifecyclePoint;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.recaller.BestSolutionRecaller;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
@@ -132,15 +133,15 @@ public final class ExhaustiveSearchDecider<Solution_> implements ExhaustiveSearc
         moveNode.setUndoMove(undoMove);
         processMove(stepScope, moveNode);
         undoMove.doMoveOnly(scoreDirector);
+        var executionPoint = SolverLifecyclePoint.of(stepScope, moveNode.getTreeId());
         if (assertExpectedUndoMoveScore) {
             // In BRUTE_FORCE a stepScore can be null because it was not calculated
             if (stepScope.getStartingStepScore() != null) {
-                scoreDirector.assertExpectedUndoMoveScore(move, (Score_) stepScope.getStartingStepScore());
+                scoreDirector.assertExpectedUndoMoveScore(move, (Score_) stepScope.getStartingStepScore(), executionPoint);
             }
         }
         LOGGER.trace("{}        Move treeId ({}), score ({}), expandable ({}), move ({}).",
-                logIndentation,
-                moveNode.getTreeId(), moveNode.getScore(), moveNode.isExpandable(), moveNode.getMove());
+                logIndentation, executionPoint.treeId(), moveNode.getScore(), moveNode.isExpandable(), moveNode.getMove());
     }
 
     private <Score_ extends Score<Score_>> void processMove(ExhaustiveSearchStepScope<Solution_> stepScope,

--- a/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScope.java
@@ -13,7 +13,7 @@ import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class ExhaustiveSearchPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
+public final class ExhaustiveSearchPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
 
     private List<ExhaustiveSearchLayer> layerList;
     private SortedSet<ExhaustiveSearchNode> expandableNodeQueue;
@@ -21,8 +21,8 @@ public class ExhaustiveSearchPhaseScope<Solution_> extends AbstractPhaseScope<So
 
     private ExhaustiveSearchStepScope<Solution_> lastCompletedStepScope;
 
-    public ExhaustiveSearchPhaseScope(SolverScope<Solution_> solverScope) {
-        super(solverScope, false);
+    public ExhaustiveSearchPhaseScope(SolverScope<Solution_> solverScope, int phaseIndex) {
+        super(solverScope, phaseIndex, false);
         lastCompletedStepScope = new ExhaustiveSearchStepScope<>(this, -1);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/scope/ExhaustiveSearchStepScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/scope/ExhaustiveSearchStepScope.java
@@ -8,7 +8,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class ExhaustiveSearchStepScope<Solution_> extends AbstractStepScope<Solution_> {
+public final class ExhaustiveSearchStepScope<Solution_> extends AbstractStepScope<Solution_> {
 
     private final ExhaustiveSearchPhaseScope<Solution_> phaseScope;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -55,7 +55,7 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
 
     @Override
     public void solve(SolverScope<Solution_> solverScope) {
-        LocalSearchPhaseScope<Solution_> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchPhaseScope<Solution_> phaseScope = new LocalSearchPhaseScope<>(solverScope, phaseIndex);
         phaseStarted(phaseScope);
 
         if (solverScope.isMetricEnabled(SolverMetric.MOVE_COUNT_PER_STEP)) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/LocalSearchDecider.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/LocalSearchDecider.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.core.impl.localsearch.decider.forager.LocalSearchForag
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
+import ai.timefold.solver.core.impl.phase.scope.SolverLifecyclePoint;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.Termination;
@@ -121,12 +122,11 @@ public class LocalSearchDecider<Solution_> {
         });
         if (assertExpectedUndoMoveScore) {
             scoreDirector.assertExpectedUndoMoveScore(moveScope.getMove(),
-                    (Score_) moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore());
+                    (Score_) moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore(),
+                    SolverLifecyclePoint.of(moveScope));
         }
         logger.trace("{}        Move index ({}), score ({}), accepted ({}), move ({}).",
-                logIndentation,
-                moveScope.getMoveIndex(), moveScope.getScore(), moveScope.getAccepted(),
-                moveScope.getMove());
+                logIndentation, moveScope.getMoveIndex(), moveScope.getScore(), moveScope.getAccepted(), moveScope.getMove());
     }
 
     protected void pickMove(LocalSearchStepScope<Solution_> stepScope) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/scope/LocalSearchMoveScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/scope/LocalSearchMoveScope.java
@@ -7,20 +7,17 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractMoveScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class LocalSearchMoveScope<Solution_> extends AbstractMoveScope<Solution_> {
-
-    private final LocalSearchStepScope<Solution_> stepScope;
+public final class LocalSearchMoveScope<Solution_> extends AbstractMoveScope<Solution_> {
 
     private Boolean accepted = null;
 
     public LocalSearchMoveScope(LocalSearchStepScope<Solution_> stepScope, int moveIndex, Move<Solution_> move) {
-        super(moveIndex, move);
-        this.stepScope = stepScope;
+        super(stepScope, moveIndex, move);
     }
 
     @Override
     public LocalSearchStepScope<Solution_> getStepScope() {
-        return stepScope;
+        return (LocalSearchStepScope<Solution_>) super.getStepScope();
     }
 
     public Boolean getAccepted() {
@@ -30,9 +27,5 @@ public class LocalSearchMoveScope<Solution_> extends AbstractMoveScope<Solution_
     public void setAccepted(Boolean accepted) {
         this.accepted = accepted;
     }
-
-    // ************************************************************************
-    // Calculated methods
-    // ************************************************************************
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/scope/LocalSearchPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/scope/LocalSearchPhaseScope.java
@@ -7,12 +7,12 @@ import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class LocalSearchPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
+public final class LocalSearchPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
 
     private LocalSearchStepScope<Solution_> lastCompletedStepScope;
 
-    public LocalSearchPhaseScope(SolverScope<Solution_> solverScope) {
-        super(solverScope);
+    public LocalSearchPhaseScope(SolverScope<Solution_> solverScope, int phaseIndex) {
+        super(solverScope, phaseIndex);
         lastCompletedStepScope = new LocalSearchStepScope<>(this, -1);
         lastCompletedStepScope.setTimeGradient(0.0);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/scope/LocalSearchStepScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/scope/LocalSearchStepScope.java
@@ -7,7 +7,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class LocalSearchStepScope<Solution_> extends AbstractStepScope<Solution_> {
+public final class LocalSearchStepScope<Solution_> extends AbstractStepScope<Solution_> {
 
     private final LocalSearchPhaseScope<Solution_> phaseScope;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
@@ -35,7 +35,7 @@ final class DefaultCustomPhase<Solution_> extends AbstractPhase<Solution_> imple
 
     @Override
     public void solve(SolverScope<Solution_> solverScope) {
-        CustomPhaseScope<Solution_> phaseScope = new CustomPhaseScope<>(solverScope);
+        CustomPhaseScope<Solution_> phaseScope = new CustomPhaseScope<>(solverScope, phaseIndex);
         phaseStarted(phaseScope);
         for (CustomPhaseCommand<Solution_> customPhaseCommand : customPhaseCommandList) {
             solverScope.checkYielding();

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/scope/CustomPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/scope/CustomPhaseScope.java
@@ -7,16 +7,16 @@ import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class CustomPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
+public final class CustomPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
 
     private CustomStepScope<Solution_> lastCompletedStepScope;
 
-    public CustomPhaseScope(SolverScope<Solution_> solverScope) {
-        this(solverScope, false);
+    public CustomPhaseScope(SolverScope<Solution_> solverScope, int phaseIndex) {
+        this(solverScope, phaseIndex, false);
     }
 
-    public CustomPhaseScope(SolverScope<Solution_> solverScope, boolean phaseSendsBestSolutionEvents) {
-        super(solverScope, phaseSendsBestSolutionEvents);
+    public CustomPhaseScope(SolverScope<Solution_> solverScope, int phaseIndex, boolean phaseSendsBestSolutionEvents) {
+        super(solverScope, phaseIndex, phaseSendsBestSolutionEvents);
         lastCompletedStepScope = new CustomStepScope<>(this, -1);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/scope/CustomStepScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/scope/CustomStepScope.java
@@ -6,7 +6,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class CustomStepScope<Solution_> extends AbstractStepScope<Solution_> {
+public final class CustomStepScope<Solution_> extends AbstractStepScope<Solution_> {
 
     private final CustomPhaseScope<Solution_> phaseScope;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractMoveScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractMoveScope.java
@@ -12,17 +12,21 @@ import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
  */
 public abstract class AbstractMoveScope<Solution_> {
 
+    protected final AbstractStepScope<Solution_> stepScope;
     protected final int moveIndex;
     protected final Move<Solution_> move;
 
     protected Score<?> score = null;
 
-    public AbstractMoveScope(int moveIndex, Move<Solution_> move) {
+    protected AbstractMoveScope(AbstractStepScope<Solution_> stepScope, int moveIndex, Move<Solution_> move) {
+        this.stepScope = stepScope;
         this.moveIndex = moveIndex;
         this.move = move;
     }
 
-    public abstract AbstractStepScope<Solution_> getStepScope();
+    public AbstractStepScope<Solution_> getStepScope() {
+        return stepScope;
+    }
 
     public int getMoveIndex() {
         return moveIndex;

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
@@ -19,6 +19,7 @@ public abstract class AbstractPhaseScope<Solution_> {
     protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     protected final SolverScope<Solution_> solverScope;
+    protected final int phaseIndex;
     protected final boolean phaseSendingBestSolutionEvents;
 
     protected Long startingSystemTimeMillis;
@@ -31,28 +32,34 @@ public abstract class AbstractPhaseScope<Solution_> {
     protected int bestSolutionStepIndex;
 
     /**
-     * As defined by #AbstractPhaseScope(SolverScope, boolean),
+     * As defined by #AbstractPhaseScope(SolverScope, int, boolean)
      * with the phaseSendingBestSolutionEvents parameter set to true.
      */
-    protected AbstractPhaseScope(SolverScope<Solution_> solverScope) {
-        this(solverScope, true);
+    protected AbstractPhaseScope(SolverScope<Solution_> solverScope, int phaseIndex) {
+        this(solverScope, phaseIndex, true);
     }
 
     /**
      *
      * @param solverScope never null
+     * @param phaseIndex the index of the phase, >= 0
      * @param phaseSendingBestSolutionEvents set to false if the phase only sends one best solution event at the end,
      *        or none at all;
      *        this is typical for construction heuristics,
      *        whose result only matters when it reached its natural end.
      */
-    protected AbstractPhaseScope(SolverScope<Solution_> solverScope, boolean phaseSendingBestSolutionEvents) {
+    protected AbstractPhaseScope(SolverScope<Solution_> solverScope, int phaseIndex, boolean phaseSendingBestSolutionEvents) {
         this.solverScope = solverScope;
+        this.phaseIndex = phaseIndex;
         this.phaseSendingBestSolutionEvents = phaseSendingBestSolutionEvents;
     }
 
     public SolverScope<Solution_> getSolverScope() {
         return solverScope;
+    }
+
+    public int getPhaseIndex() {
+        return phaseIndex;
     }
 
     public boolean isPhaseSendingBestSolutionEvents() {
@@ -206,7 +213,7 @@ public abstract class AbstractPhaseScope<Solution_> {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName(); // TODO add + "(" + phaseIndex + ")"
+        return getClass().getSimpleName() + "(" + phaseIndex + ")";
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/SolverLifecyclePoint.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/SolverLifecyclePoint.java
@@ -1,0 +1,49 @@
+package ai.timefold.solver.core.impl.phase.scope;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+/**
+ * Identifies which move thread, which phase, step and move/move tree the solver is currently executing.
+ *
+ * @param moveThreadIndex the index of the move thread, or -1 if moveThreadCount = NONE.
+ * @param phaseIndex the index of the phase.
+ * @param stepIndex the index of the step.
+ * @param moveIndex the index of the move, or -1 if exhaustive search.
+ * @param treeId the id of the move tree if exhaustive search, null otherwise.
+ */
+public record SolverLifecyclePoint(int moveThreadIndex, int phaseIndex, int stepIndex, int moveIndex, String treeId) {
+
+    public static SolverLifecyclePoint of(AbstractMoveScope<?> moveScope) { // General purpose.
+        var stepScope = moveScope.getStepScope();
+        return new SolverLifecyclePoint(-1, stepScope.getPhaseScope().getPhaseIndex(), stepScope.getStepIndex(),
+                moveScope.moveIndex, null);
+    }
+
+    public static SolverLifecyclePoint of(AbstractStepScope<?> stepScope, String treeId) { // Used in exhaustive search.
+        return new SolverLifecyclePoint(-1, stepScope.getPhaseScope().getPhaseIndex(), stepScope.getStepIndex(), -1,
+                Objects.requireNonNull(treeId));
+    }
+
+    public static SolverLifecyclePoint of(int moveThreadIndex, int phaseIndex, int stepIndex, int moveIndex) {
+        // Used in multi-threaded solving.
+        return new SolverLifecyclePoint(moveThreadIndex, phaseIndex, stepIndex, moveIndex, null);
+    }
+
+    @Override
+    public String toString() {
+        var stringList = new ArrayList<String>();
+        stringList.add("Phase index (%d)".formatted(phaseIndex));
+        if (moveThreadIndex >= 0) {
+            stringList.add("move thread index (%d)".formatted(moveThreadIndex));
+        }
+        stringList.add("step index (%d)".formatted(stepIndex));
+        if (moveIndex == -1) {
+            stringList.add("move tree id (%s)".formatted(treeId));
+        } else {
+            stringList.add("move index (%d)".formatted(moveIndex));
+        }
+        return String.join(", ", stringList) + ".";
+    }
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -28,6 +28,7 @@ import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.supply.SupplyManager;
 import ai.timefold.solver.core.impl.heuristic.move.Move;
+import ai.timefold.solver.core.impl.phase.scope.SolverLifecyclePoint;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 import ai.timefold.solver.core.impl.util.CollectionUtils;
@@ -313,7 +314,7 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
      * @param move never null
      * @param beforeMoveScore never null
      */
-    void assertExpectedUndoMoveScore(Move<Solution_> move, Score_ beforeMoveScore);
+    void assertExpectedUndoMoveScore(Move<Solution_> move, Score_ beforeMoveScore, SolverLifecyclePoint executionPoint);
 
     /**
      * Needs to be called after use because some implementations need to clean up their resources.

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/FitProcessor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/FitProcessor.java
@@ -47,7 +47,7 @@ public final class FitProcessor<Solution_, In_, Out_, Score_ extends Score<Score
         var solverScope = new SolverScope<Solution_>();
         solverScope.setWorkingRandom(new Random(0)); // We will evaluate every option; random does not matter.
         solverScope.setScoreDirector(scoreDirector);
-        var phaseScope = new ConstructionHeuristicPhaseScope<>(solverScope);
+        var phaseScope = new ConstructionHeuristicPhaseScope<>(solverScope, -1);
         var stepScope = new ConstructionHeuristicStepScope<>(phaseScope);
         entityPlacer.solvingStarted(solverScope);
         entityPlacer.phaseStarted(phaseScope);

--- a/core/src/test/java/ai/timefold/solver/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScopeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScopeTest.java
@@ -16,7 +16,7 @@ class ExhaustiveSearchPhaseScopeTest extends AbstractNodeComparatorTest {
 
     @Test
     void testNodePruning() {
-        ExhaustiveSearchPhaseScope<TestdataSolution> phase = new ExhaustiveSearchPhaseScope<>(new SolverScope<>());
+        ExhaustiveSearchPhaseScope<TestdataSolution> phase = new ExhaustiveSearchPhaseScope<>(new SolverScope<>(), 0);
         phase.setExpandableNodeQueue(new TreeSet<>(new ScoreFirstNodeComparator(true)));
         phase.addExpandableNode(buildNode(0, "0", 0, 0));
         phase.addExpandableNode(buildNode(0, "1", 0, 0));

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
@@ -181,7 +181,7 @@ class ElementDestinationSelectorTest {
                 solutionDescriptor.findEntityDescriptorOrFail(TestdataPinnedUnassignedValuesListEntity.class),
                 SelectionCacheType.PHASE, true);
         entitySelector.solvingStarted(solverScope);
-        entitySelector.phaseStarted(new LocalSearchPhaseScope<>(solverScope));
+        entitySelector.phaseStarted(new LocalSearchPhaseScope<>(solverScope, 0));
 
         var valueSelector = mockEntityIndependentValueSelector(
                 getPinnedAllowsUnassignedvaluesListVariableDescriptor(scoreDirector),

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptorTest.java
@@ -11,7 +11,6 @@ import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
-import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,22 +18,22 @@ class GreatDelugeAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void waterLevelIncrementScore_SimpleScore() {
-        GreatDelugeAcceptor acceptor = new GreatDelugeAcceptor();
+        var acceptor = new GreatDelugeAcceptor<>();
         acceptor.setWaterLevelIncrementScore(SimpleScore.of(100));
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-1000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(SimpleScore.of(-1000));
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // lastCompletedStepScore = -1000
         // water level -1000
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         acceptor.stepStarted(stepScope0);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
+        var moveScope0 = buildMoveScope(stepScope0, -500);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -900))).isTrue();
         assertThat(acceptor.isAccepted(moveScope0)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -800))).isTrue();
@@ -51,9 +50,9 @@ class GreatDelugeAcceptorTest extends AbstractAcceptorTest {
 
         // lastCompletedStepScore = -500
         // water level -900
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         acceptor.stepStarted(stepScope1);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -600);
+        var moveScope1 = buildMoveScope(stepScope1, -600);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -2000))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -700))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -1000))).isFalse();
@@ -69,9 +68,9 @@ class GreatDelugeAcceptorTest extends AbstractAcceptorTest {
 
         // lastCompletedStepScore = -600
         // water level -800
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
         acceptor.stepStarted(stepScope2);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -350);
+        var moveScope2 = buildMoveScope(stepScope1, -350);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -900))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -2000))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -700))).isTrue();
@@ -89,36 +88,36 @@ class GreatDelugeAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void waterLevelIncrementScore_HardMediumSoftScore() {
-        GreatDelugeAcceptor acceptor = new GreatDelugeAcceptor();
+        var acceptor = new GreatDelugeAcceptor<>();
         acceptor.setInitialWaterLevel(HardMediumSoftScore.of(0, -100, -400));
         acceptor.setWaterLevelIncrementScore(HardMediumSoftScore.of(0, 100, 100));
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(HardMediumSoftScore.of(0, -200, -1000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(HardMediumSoftScore.of(0, -200, -1000));
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // lastCompletedStepScore = 0/-200/-1000
         // water level 0/-100/-400
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         acceptor.stepStarted(stepScope0);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
+        var moveScope0 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
         moveScope0.setScore(HardMediumSoftScore.of(0, -100, -300));
         assertThat(acceptor.isAccepted(moveScope0)).isTrue();
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
+        var moveScope1 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
         moveScope1.setScore(HardMediumSoftScore.of(0, -100, -500));
         // Aspiration
         assertThat(acceptor.isAccepted(moveScope1)).isTrue();
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
+        var moveScope2 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
         moveScope2.setScore(HardMediumSoftScore.of(0, -50, -800));
         assertThat(acceptor.isAccepted(moveScope2)).isTrue();
-        LocalSearchMoveScope<TestdataSolution> moveScope3 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
+        var moveScope3 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
         moveScope3.setScore(HardMediumSoftScore.of(-5, -50, -100));
         assertThat(acceptor.isAccepted(moveScope3)).isFalse();
-        LocalSearchMoveScope<TestdataSolution> moveScope4 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
+        var moveScope4 = new LocalSearchMoveScope<>(stepScope0, 0, mock(Move.class));
         moveScope4.setScore(HardMediumSoftScore.of(0, -22, -200));
         assertThat(acceptor.isAccepted(moveScope4)).isTrue();
 
@@ -133,22 +132,22 @@ class GreatDelugeAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void waterLevelIncrementRatio() {
-        GreatDelugeAcceptor acceptor = new GreatDelugeAcceptor();
+        var acceptor = new GreatDelugeAcceptor<>();
         acceptor.setWaterLevelIncrementRatio(0.1);
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-8));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(SimpleScore.of(-8));
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // lastCompletedStepScore = -8
         // water level -8
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         acceptor.stepStarted(stepScope0);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -5);
+        var moveScope0 = buildMoveScope(stepScope0, -5);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -8))).isTrue();
         assertThat(acceptor.isAccepted(moveScope0)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -7))).isTrue();
@@ -162,9 +161,9 @@ class GreatDelugeAcceptorTest extends AbstractAcceptorTest {
 
         // lastCompletedStepScore = -5
         // water level -8 (rounded down from -7.2)
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         acceptor.stepStarted(stepScope1);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -6);
+        var moveScope1 = buildMoveScope(stepScope1, -6);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -10))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -7))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -9))).isFalse();
@@ -179,9 +178,9 @@ class GreatDelugeAcceptorTest extends AbstractAcceptorTest {
 
         // lastCompletedStepScore = -6
         // water level -7 (rounded down from -6.4)
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
         acceptor.stepStarted(stepScope2);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -4);
+        var moveScope2 = buildMoveScope(stepScope1, -4);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -9))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -8))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -7))).isTrue();

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptorTest.java
@@ -4,11 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.AbstractAcceptorTest;
-import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
-import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,19 +14,19 @@ class HillClimbingAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void hillClimbingEnabled() {
-        HillClimbingAcceptor acceptor = new HillClimbingAcceptor();
+        var acceptor = new HillClimbingAcceptor<>();
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-1000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(SimpleScore.of(-1000));
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // lastCompletedStepScore = -1000
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope0 = buildMoveScope(stepScope0, -500);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -900))).isTrue();
         assertThat(acceptor.isAccepted(moveScope0)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -800))).isTrue();
@@ -43,8 +41,8 @@ class HillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // lastCompletedStepScore = -500
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, 600);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1 = buildMoveScope(stepScope1, 600);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -900))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -2000))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -700))).isFalse();

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptorTest.java
@@ -5,11 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.AbstractAcceptorTest;
-import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
-import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,21 +15,21 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void lateAcceptanceSize() {
-        LateAcceptanceAcceptor acceptor = new LateAcceptanceAcceptor();
+        var acceptor = new LateAcceptanceAcceptor<>();
         acceptor.setLateAcceptanceSize(3);
         acceptor.setHillClimbingEnabled(false);
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-1000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(SimpleScore.of(Integer.MIN_VALUE));
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // lateScore = -1000
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope0 = buildMoveScope(stepScope0, -500);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -900))).isTrue();
         assertThat(acceptor.isAccepted(moveScope0)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -800))).isTrue();
@@ -46,8 +44,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // lateScore = -1000
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1 = buildMoveScope(stepScope1, -700);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -900))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -2000))).isFalse();
         assertThat(acceptor.isAccepted(moveScope1)).isTrue();
@@ -62,8 +60,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // lateScore = -1000
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope2 = buildMoveScope(stepScope1, -400);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -900))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -2000))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -1001))).isFalse();
@@ -78,8 +76,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // lateScore = -500
-        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -200);
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope3 = buildMoveScope(stepScope1, -200);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -900))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -500))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -501))).isFalse();
@@ -94,8 +92,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // lateScore = -700 (not the best score of -500!)
-        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope4 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -700))).isTrue();
         assertThat(acceptor.isAccepted(moveScope4)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -500))).isTrue();
@@ -110,8 +108,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // lateScore = -400
-        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
+        var stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope5 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -401))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -400))).isTrue();
         assertThat(acceptor.isAccepted(moveScope5)).isTrue();
@@ -130,21 +128,21 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void hillClimbingEnabled() {
-        LateAcceptanceAcceptor acceptor = new LateAcceptanceAcceptor();
+        var acceptor = new LateAcceptanceAcceptor<>();
         acceptor.setLateAcceptanceSize(2);
         acceptor.setHillClimbingEnabled(true);
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-1000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // lateScore = -1000, lastCompletedStepScore = Integer.MIN_VALUE
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope0 = buildMoveScope(stepScope0, -500);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -900))).isTrue();
         assertThat(acceptor.isAccepted(moveScope0)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -800))).isTrue();
@@ -159,8 +157,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // lateScore = -1000, lastCompletedStepScore = -500
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1 = buildMoveScope(stepScope1, -700);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -900))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -2000))).isFalse();
         assertThat(acceptor.isAccepted(moveScope1)).isTrue();
@@ -175,8 +173,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // lateScore = -500, lastCompletedStepScore = -700
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope2 = buildMoveScope(stepScope1, -400);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -700))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -2000))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -701))).isFalse();
@@ -191,8 +189,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // lateScore = -700, lastCompletedStepScore = -400
-        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -200);
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope3 = buildMoveScope(stepScope1, -200);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -900))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -700))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -701))).isFalse();
@@ -207,8 +205,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // lateScore = -400 (not the best score of -200!), lastCompletedStepScore = -200
-        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope4 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -400))).isTrue();
         assertThat(acceptor.isAccepted(moveScope4)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -500))).isFalse();
@@ -223,8 +221,8 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // lateScore = -200, lastCompletedStepScore = -300
-        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
+        var stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope5 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -301))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -400))).isFalse();
         assertThat(acceptor.isAccepted(moveScope5)).isTrue();
@@ -243,14 +241,14 @@ class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void zeroLateAcceptanceSize() {
-        LateAcceptanceAcceptor acceptor = new LateAcceptanceAcceptor();
+        var acceptor = new LateAcceptanceAcceptor<>();
         acceptor.setLateAcceptanceSize(0);
         assertThatIllegalArgumentException().isThrownBy(() -> acceptor.phaseStarted(null));
     }
 
     @Test
     void negativeLateAcceptanceSize() {
-        LateAcceptanceAcceptor acceptor = new LateAcceptanceAcceptor();
+        var acceptor = new LateAcceptanceAcceptor<>();
         acceptor.setLateAcceptanceSize(-1);
         assertThatIllegalArgumentException().isThrownBy(() -> acceptor.phaseStarted(null));
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptorTest.java
@@ -6,11 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import ai.timefold.solver.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.AbstractAcceptorTest;
-import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
-import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testutil.TestRandom;
 
 import org.junit.jupiter.api.Test;
@@ -19,21 +17,21 @@ class SimulatedAnnealingAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void lateAcceptanceSize() {
-        SimulatedAnnealingAcceptor acceptor = new SimulatedAnnealingAcceptor();
+        var acceptor = new SimulatedAnnealingAcceptor<>();
         acceptor.setStartingTemperature(SimpleScore.of(200));
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-1000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(SimpleScore.of(-1000));
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         stepScope0.setTimeGradient(0.0);
         acceptor.stepStarted(stepScope0);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
+        var moveScope0 = buildMoveScope(stepScope0, -500);
         solverScope.setWorkingRandom(new TestRandom(0.3));
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -1300))).isFalse();
         solverScope.setWorkingRandom(new TestRandom(0.3));
@@ -47,10 +45,10 @@ class SimulatedAnnealingAcceptorTest extends AbstractAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         stepScope1.setTimeGradient(0.5);
         acceptor.stepStarted(stepScope1);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -800);
+        var moveScope1 = buildMoveScope(stepScope1, -800);
         solverScope.setWorkingRandom(new TestRandom(0.13));
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -700))).isTrue();
         solverScope.setWorkingRandom(new TestRandom(0.14));
@@ -64,10 +62,10 @@ class SimulatedAnnealingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         solverScope.setWorkingRandom(new TestRandom(0.01, 0.01));
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
         stepScope2.setTimeGradient(1.0);
         acceptor.stepStarted(stepScope2);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
+        var moveScope2 = buildMoveScope(stepScope1, -400);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -800))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -801))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -1200))).isFalse();
@@ -84,7 +82,7 @@ class SimulatedAnnealingAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void negativeSimulatedAnnealingSize() {
-        SimulatedAnnealingAcceptor acceptor = new SimulatedAnnealingAcceptor();
+        var acceptor = new SimulatedAnnealingAcceptor<>();
         acceptor.setStartingTemperature(HardMediumSoftScore.of(1, -1, 2));
         assertThatIllegalArgumentException().isThrownBy(() -> acceptor.phaseStarted(null));
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptorTest.java
@@ -6,11 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.config.localsearch.decider.acceptor.stepcountinghillclimbing.StepCountingHillClimbingType;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.AbstractAcceptorTest;
-import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
-import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,20 +16,19 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void typeStep() {
-        StepCountingHillClimbingAcceptor acceptor = new StepCountingHillClimbingAcceptor(2,
-                StepCountingHillClimbingType.STEP);
+        var acceptor = new StepCountingHillClimbingAcceptor<>(2, StepCountingHillClimbingType.STEP);
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-1000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // thresholdScore = -1000, lastCompletedStepScore = Integer.MIN_VALUE
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope0 = buildMoveScope(stepScope0, -500);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -900))).isTrue();
         assertThat(acceptor.isAccepted(moveScope0)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -800))).isTrue();
@@ -46,8 +43,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // thresholdScore = -1000, lastCompletedStepScore = -500
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1 = buildMoveScope(stepScope1, -700);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -900))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -2000))).isFalse();
         assertThat(acceptor.isAccepted(moveScope1)).isTrue();
@@ -62,8 +59,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // thresholdScore = -700, lastCompletedStepScore = -700
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope2 = buildMoveScope(stepScope1, -400);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -700))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -2000))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -701))).isFalse();
@@ -78,8 +75,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // thresholdScore = -700, lastCompletedStepScore = -400
-        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -400);
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope3 = buildMoveScope(stepScope1, -400);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -900))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -700))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -701))).isFalse();
@@ -94,8 +91,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // thresholdScore = -400 (not the best score of -200!), lastCompletedStepScore = -400
-        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope4 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -400))).isTrue();
         assertThat(acceptor.isAccepted(moveScope4)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -500))).isFalse();
@@ -110,8 +107,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // thresholdScore = -400, lastCompletedStepScore = -300
-        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
+        var stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope5 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -301))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -400))).isTrue();
         assertThat(acceptor.isAccepted(moveScope5)).isTrue();
@@ -130,20 +127,19 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void typeEqualOrImprovingStep() {
-        StepCountingHillClimbingAcceptor acceptor = new StepCountingHillClimbingAcceptor(2,
-                StepCountingHillClimbingType.EQUAL_OR_IMPROVING_STEP);
+        var acceptor = new StepCountingHillClimbingAcceptor<>(2, StepCountingHillClimbingType.EQUAL_OR_IMPROVING_STEP);
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-1000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // thresholdScore = -1000, lastCompletedStepScore = Integer.MIN_VALUE
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope0 = buildMoveScope(stepScope0, -500);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -900))).isTrue();
         assertThat(acceptor.isAccepted(moveScope0)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -800))).isTrue();
@@ -158,8 +154,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // thresholdScore = -1000, lastCompletedStepScore = -500
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1 = buildMoveScope(stepScope1, -700);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -900))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -2000))).isFalse();
         assertThat(acceptor.isAccepted(moveScope1)).isTrue();
@@ -174,8 +170,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // thresholdScore = -1000, lastCompletedStepScore = -700
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope2 = buildMoveScope(stepScope1, -400);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -700))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -2000))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, 1000))).isTrue();
@@ -191,8 +187,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // thresholdScore = -400, lastCompletedStepScore = -400
-        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -400);
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope3 = buildMoveScope(stepScope1, -400);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -900))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -401))).isFalse();
         assertThat(acceptor.isAccepted(moveScope3)).isTrue();
@@ -206,8 +202,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // thresholdScore = -400, lastCompletedStepScore = -400
-        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope4 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -400))).isTrue();
         assertThat(acceptor.isAccepted(moveScope4)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -500))).isFalse();
@@ -222,8 +218,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // thresholdScore = -300, lastCompletedStepScore = -300
-        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
+        var stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope5 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -301))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -400))).isFalse();
         assertThat(acceptor.isAccepted(moveScope5)).isTrue();
@@ -242,20 +238,19 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
 
     @Test
     void typeImprovingStep() {
-        StepCountingHillClimbingAcceptor acceptor = new StepCountingHillClimbingAcceptor(2,
-                StepCountingHillClimbingType.IMPROVING_STEP);
+        var acceptor = new StepCountingHillClimbingAcceptor<>(2, StepCountingHillClimbingType.IMPROVING_STEP);
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-1000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // thresholdScore = -1000, lastCompletedStepScore = Integer.MIN_VALUE
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope0 = buildMoveScope(stepScope0, -500);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -900))).isTrue();
         assertThat(acceptor.isAccepted(moveScope0)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, -800))).isTrue();
@@ -270,8 +265,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // thresholdScore = -1000, lastCompletedStepScore = -500
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1 = buildMoveScope(stepScope1, -700);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -900))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -2000))).isFalse();
         assertThat(acceptor.isAccepted(moveScope1)).isTrue();
@@ -286,8 +281,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // thresholdScore = -1000, lastCompletedStepScore = -700
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope2 = buildMoveScope(stepScope1, -400);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -700))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, -2000))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, 1000))).isTrue();
@@ -303,8 +298,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // thresholdScore = -400, lastCompletedStepScore = -400
-        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -400);
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope3 = buildMoveScope(stepScope1, -400);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -900))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, -401))).isFalse();
         assertThat(acceptor.isAccepted(moveScope3)).isTrue();
@@ -318,8 +313,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // thresholdScore = -400, lastCompletedStepScore = -400
-        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope4 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -400))).isTrue();
         assertThat(acceptor.isAccepted(moveScope4)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, -500))).isFalse();
@@ -334,8 +329,8 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // thresholdScore = -400, lastCompletedStepScore = -300
-        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
+        var stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope5 = buildMoveScope(stepScope1, -300);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -301))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -400))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, -401))).isFalse();
@@ -356,13 +351,13 @@ class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
     @Test
     void zeroStepCountingHillClimbingSize() {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new StepCountingHillClimbingAcceptor(0, StepCountingHillClimbingType.STEP));
+                .isThrownBy(() -> new StepCountingHillClimbingAcceptor<>(0, StepCountingHillClimbingType.STEP));
     }
 
     @Test
     void negativeStepCountingHillClimbingSize() {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new StepCountingHillClimbingAcceptor(-1, StepCountingHillClimbingType.STEP));
+                .isThrownBy(() -> new StepCountingHillClimbingAcceptor<>(-1, StepCountingHillClimbingType.STEP));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
@@ -14,7 +14,6 @@ import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
-import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,23 +21,23 @@ class EntityTabuAcceptorTest {
 
     @Test
     void tabuSize() {
-        EntityTabuAcceptor acceptor = new EntityTabuAcceptor("");
-        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy(2));
+        var acceptor = new EntityTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
         acceptor.setAspirationEnabled(true);
 
-        TestdataEntity e0 = new TestdataEntity("e0");
-        TestdataEntity e1 = new TestdataEntity("e1");
-        TestdataEntity e2 = new TestdataEntity("e2");
-        TestdataEntity e3 = new TestdataEntity("e3");
-        TestdataEntity e4 = new TestdataEntity("e4");
+        var e0 = new TestdataEntity("e0");
+        var e1 = new TestdataEntity("e1");
+        var e2 = new TestdataEntity("e2");
+        var e3 = new TestdataEntity("e3");
+        var e4 = new TestdataEntity("e4");
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(0));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope0, e1);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1 = buildMoveScope(stepScope0, e1);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, e0))).isTrue();
         assertThat(acceptor.isAccepted(moveScope1)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, e2))).isTrue();
@@ -50,8 +49,8 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, e2);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope2 = buildMoveScope(stepScope1, e2);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, e0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, e1))).isFalse();
         assertThat(acceptor.isAccepted(moveScope2)).isTrue();
@@ -63,8 +62,8 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope2, e4);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope4 = buildMoveScope(stepScope2, e4);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, e0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, e1))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, e2))).isFalse();
@@ -76,8 +75,8 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope3, e3);
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope3 = buildMoveScope(stepScope3, e3);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e1))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e2))).isFalse();
@@ -89,8 +88,8 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope3);
         phaseScope.setLastCompletedStepScope(stepScope3);
 
-        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1Again = buildMoveScope(stepScope4, e1);
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1Again = buildMoveScope(stepScope4, e1);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, e0))).isTrue();
         assertThat(acceptor.isAccepted(moveScope1Again)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, e2))).isTrue();
@@ -107,22 +106,22 @@ class EntityTabuAcceptorTest {
 
     @Test
     void tabuSizeMultipleEntitiesPerStep() {
-        EntityTabuAcceptor acceptor = new EntityTabuAcceptor("");
-        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy(2));
+        var acceptor = new EntityTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
         acceptor.setAspirationEnabled(true);
 
-        TestdataEntity e0 = new TestdataEntity("e0");
-        TestdataEntity e1 = new TestdataEntity("e1");
-        TestdataEntity e2 = new TestdataEntity("e2");
-        TestdataEntity e3 = new TestdataEntity("e3");
-        TestdataEntity e4 = new TestdataEntity("e4");
+        var e0 = new TestdataEntity("e0");
+        var e1 = new TestdataEntity("e1");
+        var e2 = new TestdataEntity("e2");
+        var e3 = new TestdataEntity("e3");
+        var e4 = new TestdataEntity("e4");
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(0));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, e0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, e1))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, e2))).isTrue();
@@ -142,7 +141,7 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, e0))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, e1))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, e2))).isFalse();
@@ -162,7 +161,7 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, e0))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, e1))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, e2))).isFalse();
@@ -182,7 +181,7 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e1))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e2))).isTrue();
@@ -207,24 +206,24 @@ class EntityTabuAcceptorTest {
 
     @Test
     void aspiration() {
-        EntityTabuAcceptor acceptor = new EntityTabuAcceptor("");
-        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy(2));
+        var acceptor = new EntityTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
         acceptor.setAspirationEnabled(true);
 
-        TestdataEntity e0 = new TestdataEntity("e0");
-        TestdataEntity e1 = new TestdataEntity("e1");
+        var e0 = new TestdataEntity("e0");
+        var e1 = new TestdataEntity("e1");
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-100));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         stepScope0.setStep(buildMoveScope(stepScope0, e1).getMove());
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -120, e0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -20, e0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -120, e1))).isFalse();
@@ -238,16 +237,16 @@ class EntityTabuAcceptorTest {
         acceptor.phaseEnded(phaseScope);
     }
 
-    private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
-            LocalSearchStepScope<Solution_> stepScope, TestdataEntity... entities) {
+    private static <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(LocalSearchStepScope<Solution_> stepScope,
+            TestdataEntity... entities) {
         return buildMoveScope(stepScope, 0, entities);
     }
 
-    private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+    private static <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
             LocalSearchStepScope<Solution_> stepScope, int score, TestdataEntity... entities) {
-        Move move = mock(Move.class);
+        var move = mock(Move.class);
         when(move.getPlanningEntities()).thenReturn(Arrays.asList(entities));
-        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
+        var moveScope = new LocalSearchMoveScope<Solution_>(stepScope, 0, move);
         moveScope.setScore(SimpleScore.of(score));
         return moveScope;
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
@@ -13,7 +13,6 @@ import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
-import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 
 import org.junit.jupiter.api.Test;
@@ -22,23 +21,23 @@ class ValueTabuAcceptorTest {
 
     @Test
     void tabuSize() {
-        ValueTabuAcceptor acceptor = new ValueTabuAcceptor("");
-        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy(2));
+        var acceptor = new ValueTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
         acceptor.setAspirationEnabled(true);
 
-        TestdataValue v0 = new TestdataValue("v0");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        TestdataValue v3 = new TestdataValue("v3");
-        TestdataValue v4 = new TestdataValue("v4");
+        var v0 = new TestdataValue("v0");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
+        var v4 = new TestdataValue("v4");
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(0));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope0, v1);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1 = buildMoveScope(stepScope0, v1);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, v0))).isTrue();
         assertThat(acceptor.isAccepted(moveScope1)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, v2))).isTrue();
@@ -50,8 +49,8 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, v2);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope2 = buildMoveScope(stepScope1, v2);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, v0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, v1))).isFalse();
         assertThat(acceptor.isAccepted(moveScope2)).isTrue();
@@ -63,8 +62,8 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope2, v4);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope4 = buildMoveScope(stepScope2, v4);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, v0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, v1))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, v2))).isFalse();
@@ -76,8 +75,8 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope3, v3);
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope3 = buildMoveScope(stepScope3, v3);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v1))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v2))).isFalse();
@@ -89,8 +88,8 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope3);
         phaseScope.setLastCompletedStepScope(stepScope3);
 
-        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        LocalSearchMoveScope<TestdataSolution> moveScope1Again = buildMoveScope(stepScope4, v1);
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        var moveScope1Again = buildMoveScope(stepScope4, v1);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, v0))).isTrue();
         assertThat(acceptor.isAccepted(moveScope1Again)).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, v2))).isTrue();
@@ -107,22 +106,22 @@ class ValueTabuAcceptorTest {
 
     @Test
     void tabuSizeMultipleEntitiesPerStep() {
-        ValueTabuAcceptor acceptor = new ValueTabuAcceptor("");
-        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy(2));
+        var acceptor = new ValueTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
         acceptor.setAspirationEnabled(true);
 
-        TestdataValue v0 = new TestdataValue("v0");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        TestdataValue v3 = new TestdataValue("v3");
-        TestdataValue v4 = new TestdataValue("v4");
+        var v0 = new TestdataValue("v0");
+        var v1 = new TestdataValue("v1");
+        var v2 = new TestdataValue("v2");
+        var v3 = new TestdataValue("v3");
+        var v4 = new TestdataValue("v4");
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(0));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, v0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, v1))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, v2))).isTrue();
@@ -142,7 +141,7 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, v0))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, v1))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, v2))).isFalse();
@@ -162,7 +161,7 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, v0))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, v1))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, v2))).isFalse();
@@ -182,7 +181,7 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v1))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v2))).isTrue();
@@ -207,24 +206,24 @@ class ValueTabuAcceptorTest {
 
     @Test
     void aspiration() {
-        ValueTabuAcceptor acceptor = new ValueTabuAcceptor("");
-        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy(2));
+        var acceptor = new ValueTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
         acceptor.setAspirationEnabled(true);
 
-        TestdataValue v0 = new TestdataValue("v0");
-        TestdataValue v1 = new TestdataValue("v1");
+        var v0 = new TestdataValue("v0");
+        var v1 = new TestdataValue("v1");
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(SimpleScore.of(-100));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         stepScope0.setStep(buildMoveScope(stepScope0, v1).getMove());
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -120, v0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -20, v0))).isTrue();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -120, v1))).isFalse();
@@ -238,16 +237,16 @@ class ValueTabuAcceptorTest {
         acceptor.phaseEnded(phaseScope);
     }
 
-    private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+    private static <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
             LocalSearchStepScope<Solution_> stepScope, TestdataValue... values) {
         return buildMoveScope(stepScope, 0, values);
     }
 
-    private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+    private static <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
             LocalSearchStepScope<Solution_> stepScope, int score, TestdataValue... values) {
-        Move move = mock(Move.class);
+        var move = mock(Move.class);
         when(move.getPlanningValues()).thenReturn(Arrays.asList(values));
-        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
+        var moveScope = new LocalSearchMoveScope<Solution_>(stepScope, 0, move);
         moveScope.setScore(SimpleScore.of(score));
         return moveScope;
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/size/EntityRatioTabuSizeStrategyTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/size/EntityRatioTabuSizeStrategyTest.java
@@ -13,18 +13,18 @@ import org.junit.jupiter.api.Test;
 class EntityRatioTabuSizeStrategyTest {
 
     @Test
-    void tabuSize() {
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(mock(SolverScope.class));
+    <Solution_> void tabuSize() {
+        var phaseScope = new LocalSearchPhaseScope<Solution_>(mock(SolverScope.class), 0);
         when(phaseScope.getWorkingEntityCount()).thenReturn(100);
-        LocalSearchStepScope stepScope = new LocalSearchStepScope(phaseScope);
-        assertThat(new EntityRatioTabuSizeStrategy(0.1).determineTabuSize(stepScope)).isEqualTo(10);
-        assertThat(new EntityRatioTabuSizeStrategy(0.5).determineTabuSize(stepScope)).isEqualTo(50);
+        var stepScope = new LocalSearchStepScope<>(phaseScope);
+        assertThat(new EntityRatioTabuSizeStrategy<Solution_>(0.1).determineTabuSize(stepScope)).isEqualTo(10);
+        assertThat(new EntityRatioTabuSizeStrategy<Solution_>(0.5).determineTabuSize(stepScope)).isEqualTo(50);
         // Rounding
-        assertThat(new EntityRatioTabuSizeStrategy(0.1051).determineTabuSize(stepScope)).isEqualTo(11);
-        assertThat(new EntityRatioTabuSizeStrategy(0.1049).determineTabuSize(stepScope)).isEqualTo(10);
+        assertThat(new EntityRatioTabuSizeStrategy<Solution_>(0.1051).determineTabuSize(stepScope)).isEqualTo(11);
+        assertThat(new EntityRatioTabuSizeStrategy<Solution_>(0.1049).determineTabuSize(stepScope)).isEqualTo(10);
         // Corner cases
-        assertThat(new EntityRatioTabuSizeStrategy(0.0000001).determineTabuSize(stepScope)).isEqualTo(1);
-        assertThat(new EntityRatioTabuSizeStrategy(0.9999999).determineTabuSize(stepScope)).isEqualTo(99);
+        assertThat(new EntityRatioTabuSizeStrategy<Solution_>(0.0000001).determineTabuSize(stepScope)).isEqualTo(1);
+        assertThat(new EntityRatioTabuSizeStrategy<Solution_>(0.9999999).determineTabuSize(stepScope)).isEqualTo(99);
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/forager/AcceptedLocalSearchForagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/forager/AcceptedLocalSearchForagerTest.java
@@ -209,9 +209,9 @@ class AcceptedLocalSearchForagerTest {
         forager.phaseEnded(phaseScope);
     }
 
-    private LocalSearchPhaseScope<TestdataSolution> createPhaseScope() {
+    private static LocalSearchPhaseScope<TestdataSolution> createPhaseScope() {
         SolverScope<TestdataSolution> solverScope = new SolverScope<>();
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         InnerScoreDirector<TestdataSolution, SimpleScore> scoreDirector = mock(InnerScoreDirector.class);
         when(scoreDirector.getSolutionDescriptor()).thenReturn(TestdataSolution.buildSolutionDescriptor());
         when(scoreDirector.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
@@ -225,7 +225,7 @@ class AcceptedLocalSearchForagerTest {
         return phaseScope;
     }
 
-    public LocalSearchMoveScope<TestdataSolution> createMoveScope(LocalSearchStepScope<TestdataSolution> stepScope,
+    public static LocalSearchMoveScope<TestdataSolution> createMoveScope(LocalSearchStepScope<TestdataSolution> stepScope,
             SimpleScore score, boolean accepted) {
         LocalSearchMoveScope<TestdataSolution> moveScope = new LocalSearchMoveScope<>(stepScope, 0, new DummyMove());
         moveScope.setScore(score);

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
@@ -11,7 +11,6 @@ import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
-import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,19 +18,19 @@ class StrategicOscillationByLevelFinalistPodiumTest {
 
     @Test
     void referenceLastStepScore() {
-        StrategicOscillationByLevelFinalistPodium finalistPodium = new StrategicOscillationByLevelFinalistPodium(false);
+        var finalistPodium = new StrategicOscillationByLevelFinalistPodium<>(false);
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(HardSoftScore.of(-200, -5000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         finalistPodium.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope0);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -100, -7000);
+        var moveScope0 = buildMoveScope(stepScope0, -100, -7000);
         finalistPodium.addMove(buildMoveScope(stepScope0, -150, -2000));
         finalistPodium.addMove(moveScope0);
         finalistPodium.addMove(buildMoveScope(stepScope0, -100, -7100));
@@ -41,9 +40,9 @@ class StrategicOscillationByLevelFinalistPodiumTest {
         finalistPodium.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope1);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -120, -4000);
+        var moveScope1 = buildMoveScope(stepScope1, -120, -4000);
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -8000));
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -7000));
         finalistPodium.addMove(buildMoveScope(stepScope1, -150, -3000));
@@ -55,9 +54,9 @@ class StrategicOscillationByLevelFinalistPodiumTest {
         finalistPodium.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope2);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope2, -150, -1000);
+        var moveScope2 = buildMoveScope(stepScope2, -150, -1000);
         finalistPodium.addMove(buildMoveScope(stepScope2, -120, -4000));
         finalistPodium.addMove(buildMoveScope(stepScope2, -120, -5000));
         finalistPodium.addMove(buildMoveScope(stepScope2, -150, -3000));
@@ -72,19 +71,19 @@ class StrategicOscillationByLevelFinalistPodiumTest {
 
     @Test
     void referenceBestScore() {
-        StrategicOscillationByLevelFinalistPodium finalistPodium = new StrategicOscillationByLevelFinalistPodium(true);
+        var finalistPodium = new StrategicOscillationByLevelFinalistPodium<>(true);
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(HardSoftScore.of(-200, -5000));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         finalistPodium.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope0);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -100, -7000);
+        var moveScope0 = buildMoveScope(stepScope0, -100, -7000);
         finalistPodium.addMove(buildMoveScope(stepScope0, -150, -2000));
         finalistPodium.addMove(moveScope0);
         finalistPodium.addMove(buildMoveScope(stepScope0, -100, -7100));
@@ -95,9 +94,9 @@ class StrategicOscillationByLevelFinalistPodiumTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
         solverScope.setBestScore(stepScope0.getScore());
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope1);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -120, -4000);
+        var moveScope1 = buildMoveScope(stepScope1, -120, -4000);
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -8000));
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -7000));
         finalistPodium.addMove(buildMoveScope(stepScope1, -150, -3000));
@@ -110,9 +109,9 @@ class StrategicOscillationByLevelFinalistPodiumTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
         // do not change bestScore
 
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope2);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope2, -110, -6000);
+        var moveScope2 = buildMoveScope(stepScope2, -110, -6000);
         finalistPodium.addMove(buildMoveScope(stepScope2, -110, -8000));
         finalistPodium.addMove(buildMoveScope(stepScope2, -150, -3000));
         finalistPodium.addMove(buildMoveScope(stepScope2, -150, -1000));
@@ -126,10 +125,10 @@ class StrategicOscillationByLevelFinalistPodiumTest {
         // do not change bestScore
     }
 
-    protected <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
-            LocalSearchStepScope<Solution_> stepScope, int hardScore, int softScore) {
+    protected static <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(LocalSearchStepScope<Solution_> stepScope,
+            int hardScore, int softScore) {
         Move<Solution_> move = mock(Move.class);
-        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
+        var moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
         moveScope.setScore(HardSoftScore.of(hardScore, softScore));
         moveScope.setAccepted(true);
         return moveScope;
@@ -137,19 +136,19 @@ class StrategicOscillationByLevelFinalistPodiumTest {
 
     @Test
     void referenceLastStepScore3Levels() {
-        StrategicOscillationByLevelFinalistPodium finalistPodium = new StrategicOscillationByLevelFinalistPodium(false);
+        var finalistPodium = new StrategicOscillationByLevelFinalistPodium<>(false);
 
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(HardMediumSoftScore.of(-200, -5000, -10));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         finalistPodium.phaseStarted(phaseScope);
 
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope0);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -100, -7000, -20);
+        var moveScope0 = buildMoveScope(stepScope0, -100, -7000, -20);
         finalistPodium.addMove(buildMoveScope(stepScope0, -150, -2000, -10));
         finalistPodium.addMove(moveScope0);
         finalistPodium.addMove(buildMoveScope(stepScope0, -100, -7100, -5));
@@ -159,9 +158,9 @@ class StrategicOscillationByLevelFinalistPodiumTest {
         finalistPodium.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope1);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -120, -4000, -40);
+        var moveScope1 = buildMoveScope(stepScope1, -120, -4000, -40);
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -8000, -10));
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -7000, -30));
         finalistPodium.addMove(buildMoveScope(stepScope1, -150, -3000, -10));
@@ -173,9 +172,9 @@ class StrategicOscillationByLevelFinalistPodiumTest {
         finalistPodium.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope2);
-        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope2, -150, -1000, -20);
+        var moveScope2 = buildMoveScope(stepScope2, -150, -1000, -20);
         finalistPodium.addMove(buildMoveScope(stepScope2, -120, -4000, -50));
         finalistPodium.addMove(buildMoveScope(stepScope2, -120, -5000, -10));
         finalistPodium.addMove(buildMoveScope(stepScope2, -150, -3000, -10));
@@ -190,33 +189,33 @@ class StrategicOscillationByLevelFinalistPodiumTest {
 
     @Test
     void alwaysPickImprovingMove() {
-        StrategicOscillationByLevelFinalistPodium finalistPodium = new StrategicOscillationByLevelFinalistPodium(false);
+        var finalistPodium = new StrategicOscillationByLevelFinalistPodium<>(false);
 
         // Reference score is [0, -2, -3]
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
+        var solverScope = new SolverScope<>();
         solverScope.setBestScore(HardMediumSoftScore.of(-0, -2, -3));
-        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
-        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         finalistPodium.phaseStarted(phaseScope);
 
         // Have two moves, scores [-1, -1, 3] and [0, -2, -1]
-        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope0);
-        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -1, -1, -3);
+        var moveScope0 = buildMoveScope(stepScope0, -1, -1, -3);
         finalistPodium.addMove(moveScope0);
-        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope0, 0, -2, -1);
+        var moveScope1 = buildMoveScope(stepScope0, 0, -2, -1);
         finalistPodium.addMove(moveScope1);
 
         // The better is picked
         assertThat(finalistPodium.getFinalistList()).containsOnly(moveScope1);
     }
 
-    protected <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
-            LocalSearchStepScope<Solution_> stepScope, int hardScore, int mediumScore, int softScore) {
+    protected static <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(LocalSearchStepScope<Solution_> stepScope,
+            int hardScore, int mediumScore, int softScore) {
         Move<Solution_> move = mock(Move.class);
-        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
+        var moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
         moveScope.setScore(HardMediumSoftScore.of(hardScore, mediumScore, softScore));
         moveScope.setAccepted(true);
         return moveScope;

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
@@ -35,7 +35,7 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
     @Test
     void scoreImproves_terminationIsPostponed() {
         var solverScope = spy(new SolverScope<TestdataSolution>());
-        var phaseScope = spy(new LocalSearchPhaseScope<>(solverScope));
+        var phaseScope = spy(new LocalSearchPhaseScope<>(solverScope, 0));
         var stepScope = spy(new LocalSearchStepScope<>(phaseScope));
         var clock = mock(Clock.class);
 
@@ -83,7 +83,7 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
     @Test
     void scoreImprovesTooLate_terminates() {
         var solverScope = spy(new SolverScope<TestdataSolution>());
-        var phaseScope = spy(new LocalSearchPhaseScope<>(solverScope));
+        var phaseScope = spy(new LocalSearchPhaseScope<>(solverScope, 0));
         var stepScope = spy(new LocalSearchStepScope<>(phaseScope));
         var clock = mock(Clock.class);
 
@@ -135,7 +135,7 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
     @Test
     void withConstructionHeuristic() { // CH ignores unimproved time spent termination.
         var solverScope = spy(new SolverScope<TestdataSolution>());
-        var phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope));
+        var phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope, 0));
         var stepScope = spy(new ConstructionHeuristicStepScope<>(phaseScope));
         var clock = mock(Clock.class);
 
@@ -173,7 +173,7 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
     @Test
     void withConstructionHeuristicAndLocalSearch() { // CH ignores unimproved time spent termination.
         var solverScope = spy(new SolverScope<TestdataSolution>());
-        var phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope));
+        var phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope, 0));
         var stepScope = spy(new ConstructionHeuristicStepScope<>(phaseScope));
         var clock = mock(Clock.class);
 
@@ -211,7 +211,7 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         assertThat(termination.isSolverTerminated(solverScope)).isFalse();
         assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.0, withPrecision(0.0));
 
-        var lsPhaseScope = spy(new LocalSearchPhaseScope<>(solverScope));
+        var lsPhaseScope = spy(new LocalSearchPhaseScope<>(solverScope, 0));
         var lsStepScope = spy(new LocalSearchStepScope<>(lsPhaseScope));
 
         // second step - score has improved, but not beyond the threshold

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
@@ -29,7 +29,7 @@ class UnimprovedTimeMillisSpentTerminationTest {
     @Test
     void solverTermination() {
         SolverScope<TestdataSolution> solverScope = spy(new SolverScope<>());
-        AbstractPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        AbstractPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         Clock clock = mock(Clock.class);
 
         Termination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
@@ -50,7 +50,7 @@ class UnimprovedTimeMillisSpentTerminationTest {
     @Test
     void phaseTermination() {
         SolverScope<TestdataSolution> solverScope = new SolverScope<>();
-        AbstractPhaseScope<TestdataSolution> phaseScope = spy(new LocalSearchPhaseScope<>(solverScope));
+        AbstractPhaseScope<TestdataSolution> phaseScope = spy(new LocalSearchPhaseScope<>(solverScope, 0));
         Clock clock = mock(Clock.class);
 
         Termination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
@@ -76,7 +76,7 @@ class UnimprovedTimeMillisSpentTerminationTest {
         Termination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
         termination.solvingStarted(solverScope);
 
-        AbstractPhaseScope<TestdataSolution> chPhaseScope = new ConstructionHeuristicPhaseScope<>(solverScope);
+        AbstractPhaseScope<TestdataSolution> chPhaseScope = new ConstructionHeuristicPhaseScope<>(solverScope, 0);
         termination.phaseStarted(chPhaseScope);
 
         // During the construction heuristic, the unimproved termination should not trigger.
@@ -92,7 +92,7 @@ class UnimprovedTimeMillisSpentTerminationTest {
 
         termination.phaseEnded(chPhaseScope);
 
-        AbstractPhaseScope<TestdataSolution> lsPhaseScope = new LocalSearchPhaseScope<>(solverScope);
+        AbstractPhaseScope<TestdataSolution> lsPhaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         termination.phaseStarted(lsPhaseScope);
 
         // When local search starts, the unimproved termination should start triggering,
@@ -114,7 +114,7 @@ class UnimprovedTimeMillisSpentTerminationTest {
     @Test
     void phaseTerminationWithConstructionHeuristic() { // CH ignores unimproved time spent termination.
         SolverScope<TestdataSolution> solverScope = new SolverScope<>();
-        AbstractPhaseScope<TestdataSolution> phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope));
+        AbstractPhaseScope<TestdataSolution> phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope, 0));
         Clock clock = mock(Clock.class);
 
         Termination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/util/PlannerTestUtils.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/util/PlannerTestUtils.java
@@ -45,7 +45,7 @@ import org.mockito.AdditionalAnswers;
 /**
  * @see PlannerAssert
  */
-public class PlannerTestUtils {
+public final class PlannerTestUtils {
 
     public static final int TERMINATION_STEP_COUNT_LIMIT = 10;
 
@@ -186,7 +186,7 @@ public class PlannerTestUtils {
      * @return never null
      */
     public static <Solution_> AbstractPhaseScope<Solution_> delegatingPhaseScope(SolverScope<Solution_> solverScope) {
-        return new AbstractPhaseScope<>(solverScope) {
+        return new AbstractPhaseScope<>(solverScope, 0) {
             @Override
             public AbstractStepScope<Solution_> getLastCompletedStepScope() {
                 return null;


### PR DESCRIPTION
Since I was already touching the tests for scopes, I refactored them to remove literally hundreds of raw type warnings.

Other parts of the ensemble:
https://github.com/TimefoldAI/timefold-solver-enterprise/pull/133
https://github.com/TimefoldAI/timefold-solver-benchmarks/pull/14

While doing this, I realized we have two ways of doing score corruption diagnosis/analysis, each apparently doing something a little bit different. This is an interesting piece of code we may want to unify - @Christopher-Chianelli, would you mind taking a look at that?
