### PR TITLE
fix: Remove too eager fail-fast in concat node's retract

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractConcatNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractConcatNode.java
@@ -86,6 +86,12 @@ public abstract class AbstractConcatNode<LeftTuple_ extends AbstractTuple, Right
             return;
         }
         TupleState state = outTuple.state;
+        if (!state.isActive()) {
+            // No fail fast for inactive tuples, since the same tuple can be
+            // passed twice if they are from the same source;
+            // @see BavetRegressionTest#concatSameTupleDeadAndAlive for an example.
+            return;
+        }
         propagationQueue.retract(outTuple, state == TupleState.CREATING ? TupleState.ABORTING : TupleState.DYING);
     }
 
@@ -123,6 +129,12 @@ public abstract class AbstractConcatNode<LeftTuple_ extends AbstractTuple, Right
             return;
         }
         TupleState state = outTuple.state;
+        if (!state.isActive()) {
+            // No fail fast for inactive tuples, since the same tuple can be
+            // passed twice if they are from the same source;
+            // @see BavetRegressionTest#concatSameTupleDeadAndAlive for an example.
+            return;
+        }
         propagationQueue.retract(outTuple, state == TupleState.CREATING ? TupleState.ABORTING : TupleState.DYING);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractConcatNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractConcatNode.java
@@ -86,10 +86,6 @@ public abstract class AbstractConcatNode<LeftTuple_ extends AbstractTuple, Right
             return;
         }
         TupleState state = outTuple.state;
-        if (!state.isActive()) {
-            throw new IllegalStateException("Impossible state: The tuple (" + outTuple.state + ") in node (" + this
-                    + ") is in an unexpected state (" + outTuple.state + ").");
-        }
         propagationQueue.retract(outTuple, state == TupleState.CREATING ? TupleState.ABORTING : TupleState.DYING);
     }
 
@@ -127,10 +123,6 @@ public abstract class AbstractConcatNode<LeftTuple_ extends AbstractTuple, Right
             return;
         }
         TupleState state = outTuple.state;
-        if (!state.isActive()) {
-            throw new IllegalStateException("Impossible state: The tuple (" + outTuple.state + ") in node (" + this
-                    + ") is in an unexpected state (" + outTuple.state + ").");
-        }
         propagationQueue.retract(outTuple, state == TupleState.CREATING ? TupleState.ABORTING : TupleState.DYING);
     }
 


### PR DESCRIPTION
- A dead tuple might be retracted in concat if a "complex No-op" `calculateScore` occurs. A "complex No-op" refers to the following situlation:

  - Move A
  - Calculate Score
  - Undo Move A
  - Move A again (but potentially expressed a different way)
  - Calculate Score (here is where a dead tuple will be retracted)

- The fail-fast seems to be too eager, and the dead tuple being retracted does not seem to cause issues downstream.

Fixes #828 