### PR TITLE
feat: make `nearbyDistanceMeterClass` available for GIZMO

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
@@ -704,6 +704,9 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
         if (scoreDirectorFactoryConfig != null) {
             scoreDirectorFactoryConfig.visitReferencedClasses(classVisitor);
         }
+        if (nearbyDistanceMeterClass != null) {
+            classVisitor.accept(nearbyDistanceMeterClass);
+        }
         if (terminationConfig != null) {
             terminationConfig.visitReferencedClasses(classVisitor);
         }

--- a/core/src/test/java/ai/timefold/solver/core/config/solver/SolverConfigTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/config/solver/SolverConfigTest.java
@@ -35,6 +35,7 @@ import ai.timefold.solver.core.config.constructionheuristic.ConstructionHeuristi
 import ai.timefold.solver.core.config.localsearch.LocalSearchPhaseConfig;
 import ai.timefold.solver.core.impl.heuristic.move.DummyMove;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
+import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 import ai.timefold.solver.core.impl.heuristic.selector.move.factory.MoveIteratorFactory;
 import ai.timefold.solver.core.impl.heuristic.selector.move.factory.MoveListFactory;
 import ai.timefold.solver.core.impl.heuristic.selector.move.generic.ChangeMove;
@@ -182,6 +183,7 @@ class SolverConfigTest {
         verify(classVisitor, atLeastOnce()).accept(DummyEasyScoreCalculator.class);
         verify(classVisitor, atLeastOnce()).accept(DummyConstraintProvider.class);
         verify(classVisitor, atLeastOnce()).accept(DummyIncrementalScoreCalculator.class);
+        verify(classVisitor, atLeastOnce()).accept(DummyNearbyDistanceClass.class);
         verify(classVisitor, atLeastOnce()).accept(DummyEntityFilter.class);
         verify(classVisitor, atLeastOnce()).accept(DummyValueFilter.class);
         verify(classVisitor, atLeastOnce()).accept(DummyChangeMoveFilter.class);
@@ -372,6 +374,14 @@ class SolverConfigTest {
     }
 
     public abstract static class DummyMoveListFactory implements MoveListFactory<TestdataSolution> {
+    }
+
+    public class DummyNearbyDistanceClass implements NearbyDistanceMeter<String, String> {
+
+        @Override
+        public double getNearbyDistance(String origin, String destination) {
+            return 0;
+        }
     }
 
 }

--- a/core/src/test/resources/ai/timefold/solver/core/config/solver/testSolverConfigWithoutNamespace.xml
+++ b/core/src/test/resources/ai/timefold/solver/core/config/solver/testSolverConfigWithoutNamespace.xml
@@ -11,6 +11,7 @@
     <incrementalScoreCalculatorClass>ai.timefold.solver.core.config.solver.SolverConfigTest$DummyIncrementalScoreCalculator</incrementalScoreCalculatorClass>
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
   </scoreDirectorFactory>
+  <nearbyDistanceMeterClass>ai.timefold.solver.core.config.solver.SolverConfigTest$DummyNearbyDistanceClass</nearbyDistanceMeterClass>
   <constructionHeuristic>
     <constructionHeuristicType>FIRST_FIT_DECREASING</constructionHeuristicType>
     <queuedEntityPlacer>


### PR DESCRIPTION
This pull request updates `ai.timefold.solver.core.config.solver.SolverConfig#visitReferencedClasses` to ensure that `nearbyDistanceMeterClass` is visitable, making it available in GIZMO and used by the Quarkus integration.

It was found that the Quarkus Native compilation does not include the Nearby class, resulting in errors like the following:

```
Caused by: java.lang.IllegalArgumentException: Impossible state: could not find the NearbySelectionConfig's nearbyDistanceMeterClass (org.acme.vehiclerouting.domain.LocationDistanceMeter) generated Gizmo supplier.
        at ai.timefold.solver.core.config.util.ConfigUtils.newInstance(ConfigUtils.java:23)
        at ai.timefold.solver.core.config.util.ConfigUtils.newInstance(ConfigUtils.java:62)
        at ai.timefold.solver.core.impl.solver.ClassInstanceCache.lambda$newInstance$0(ClassInstanceCache.java:41)
        at java.base@17.0.10/java.util.Map.computeIfAbsent(Map.java:1054)
        at ai.timefold.solver.core.impl.solver.ClassInstanceCache.newInstance(ClassInstanceCache.java:41)
        at ai.timefold.solver.enterprise.core.DefaultTimefoldSolverEnterpriseService.applyNearbySelection(DefaultTimefoldSolverEnterpriseService.java:354)
        at ai.timefold.solver.core.impl.heuristic.selector.list.DestinationSelectorFactory.applyNearbySelection(DestinationSelectorFactory.java:82)
        at ai.timefold.solver.core.impl.heuristic.selector.list.DestinationSelectorFactory.buildDestinationSelector(DestinationSelectorFactory.java:39)
        at ai.timefold.solver.core.impl.heuristic.selector.move.generic.list.ListChangeMoveSelectorFactory.buildBaseMoveSelector(ListChangeMoveSelectorFactory.java:66)
        at ai.timefold.solver.core.impl.heuristic.selector.move.AbstractMoveSelectorFactory.buildMoveSelector(AbstractMoveSelectorFactory.java:70)
        at ai.timefold.solver.core.impl.heuristic.selector.move.AbstractMoveSelectorFactory.buildMoveSelector(AbstractMoveSelectorFactory.java:56)
        at ai.timefold.solver.core.impl.heuristic.selector.move.composite.AbstractCompositeMoveSelectorFactory.lambda$buildInnerMoveSelectors$0(AbstractCompositeMoveSelectorFactory.java:28)
        at java.base@17.0.10/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base@17.0.10/java.util.LinkedList$LLSpliterator.forEachRemaining(LinkedList.java:1242)
        at java.base@17.0.10/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@17.0.10/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@17.0.10/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
        at java.base@17.0.10/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base@17.0.10/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
        at ai.timefold.solver.core.impl.heuristic.selector.move.composite.AbstractCompositeMoveSelectorFactory.buildInnerMoveSelectors(AbstractCompositeMoveSelectorFactory.java:29)
        at ai.timefold.solver.core.impl.heuristic.selector.move.composite.UnionMoveSelectorFactory.buildBaseMoveSelector(UnionMoveSelectorFactory.java:46)
        at ai.timefold.solver.core.impl.heuristic.selector.move.AbstractMoveSelectorFactory.buildMoveSelector(AbstractMoveSelectorFactory.java:70)
        at ai.timefold.solver.core.impl.localsearch.DefaultLocalSearchPhaseFactory.buildMoveSelector(DefaultLocalSearchPhaseFactory.java:184)
        at ai.timefold.solver.core.impl.localsearch.DefaultLocalSearchPhaseFactory.buildDecider(DefaultLocalSearchPhaseFactory.java:67)
        at ai.timefold.solver.core.impl.localsearch.DefaultLocalSearchPhaseFactory.buildPhase(DefaultLocalSearchPhaseFactory.java:53)
        at ai.timefold.solver.core.impl.localsearch.DefaultLocalSearchPhaseFactory.buildPhase(DefaultLocalSearchPhaseFactory.java:40)
        at ai.timefold.solver.core.impl.phase.PhaseFactory.buildPhases(PhaseFactory.java:59)
        at ai.timefold.solver.core.impl.solver.DefaultSolverFactory.buildPhaseList(DefaultSolverFactory.java:249)
        at ai.timefold.solver.core.impl.solver.DefaultSolverFactory.buildSolver(DefaultSolverFactory.java:125)
        at ai.timefold.solver.core.api.solver.SolverFactory.buildSolver(SolverFactory.java:119)
        at ai.timefold.solver.core.impl.solver.DefaultSolverManager.validateSolverFactory(DefaultSolverManager.java:65)
        at ai.timefold.solver.core.impl.solver.DefaultSolverManager.<init>(DefaultSolverManager.java:49)
        at ai.timefold.solver.core.api.solver.SolverManager.create(SolverManager.java:98)
        at ai.timefold.solver.quarkus.bean.DefaultTimefoldBeanProvider.solverManager(DefaultTimefoldBeanProvider.java:62)
        at ai.timefold.solver.quarkus.bean.DefaultTimefoldBeanProvider_ProducerMethod_solverManager_T5OWUir0G727pboehAmaToghWS8_Bean.doCreate(Unknown Source)
        at ai.timefold.solver.quarkus.bean.DefaultTimefoldBeanProvider_ProducerMethod_solverManager_T5OWUir0G727pboehAmaToghWS8_Bean.create(Unknown Source)
        at ai.timefold.solver.quarkus.bean.DefaultTimefoldBeanProvider_ProducerMethod_solverManager_T5OWUir0G727pboehAmaToghWS8_Bean.get(Unknown Source)
        at ai.timefold.solver.quarkus.bean.DefaultTimefoldBeanProvider_ProducerMethod_solverManager_T5OWUir0G727pboehAmaToghWS8_Bean.get(Unknown Source)
        at org.acme.vehiclerouting.rest.VehicleRoutePlanResource_Bean.doCreate(Unknown Source)
        at org.acme.vehiclerouting.rest.VehicleRoutePlanResource_Bean.create(Unknown Source)
        at org.acme.vehiclerouting.rest.VehicleRoutePlanResource_Bean.create(Unknown Source)
        at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:119)
        at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:38)
        at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:35)
        at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:32)
        at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
        at io.quarkus.arc.impl.ComputingCacheContextInstances.computeIfAbsent(ComputingCacheContextInstances.java:19)
        at io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:35)
        at org.acme.vehiclerouting.rest.VehicleRoutePlanResource_Bean.get(Unknown Source)
        at org.acme.vehiclerouting.rest.VehicleRoutePlanResource_Bean.get(Unknown Source)
        at io.quarkus.arc.impl.ArcContainerImpl.beanInstanceHandle(ArcContainerImpl.java:559)
        at io.quarkus.arc.impl.ArcContainerImpl.beanInstanceHandle(ArcContainerImpl.java:539)
        at io.quarkus.arc.impl.ArcContainerImpl.beanInstanceHandle(ArcContainerImpl.java:572)
        at io.quarkus.arc.impl.ArcContainerImpl$3.get(ArcContainerImpl.java:331)
        at io.quarkus.arc.impl.ArcContainerImpl$3.get(ArcContainerImpl.java:328)
        at io.quarkus.resteasy.common.runtime.QuarkusConstructorInjector.construct(QuarkusConstructorInjector.java:52)
        at org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory.createResource(POJOResourceFactory.java:64)
        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:349)
        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:70)
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:429)
        ... 18 more

```