### PR TITLE
chore: standarize the `minStart` and `maxEnd` variables

### DIFF
--- a/docs/src/modules/ROOT/pages/upgrade-and-migration/upgrade-to-latest-version.adoc
+++ b/docs/src/modules/ROOT/pages/upgrade-and-migration/upgrade-to-latest-version.adoc
@@ -270,7 +270,7 @@ Before in `*ConstraintProviderTest.java`:
 ----
 Job job = new Job("job1", ...);
 
-constraintVerifier.verifyThat(FoodPackagingConstraintProvider::dueDateTime)
+constraintVerifier.verifyThat(FoodPackagingConstraintProvider::maxEndDateTime)
     .given(job)
     .penalizesBy(...);
 ----
@@ -283,7 +283,7 @@ Job job = new Job("job1",  ...);
 Line line = new Line("line1", ...);
 job.setLine(line);
 
-constraintVerifier.verifyThat(FoodPackagingConstraintProvider::dueDateTime)
+constraintVerifier.verifyThat(FoodPackagingConstraintProvider::maxEndDateTime)
     .given(job)
     .penalizesBy(...);
 ----


### PR DESCRIPTION
This pull request standardizes the use of the `minStart` and `maxEnd` variables in the documentation.

Relates to TimefoldAI/timefold-quickstarts#495