### PR TITLE
ci: Install enterprise package in Python enterprise CI

### DIFF
--- a/.github/workflows/downstream_python_enterprise.yml
+++ b/.github/workflows/downstream_python_enterprise.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Quickly Build timefold-solver-enterprise
         working-directory: ./timefold-solver-enterprise
         shell: bash
-        run: mvn -B -Dquickly clean verify
+        run: mvn -B -Dquickly clean install
       - name: Build with Maven to install parent poms for python build
         working-directory: ./timefold-solver-python
         run: mvn -B --fail-at-end clean install


### PR DESCRIPTION
Before, it only verified the package, making it unable to the Python Enterprise Package. It now installs it to the local repository, so the Python Enterprise Package is allowed to use it.