### PR TITLE
fix: Do not throw an exception when the solution or entity classes are interfaces

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
@@ -310,7 +310,7 @@ public class ConfigUtils {
 
     public static List<Class<?>> getAllAnnotatedLineageClasses(Class<?> bottomClass,
             Class<? extends Annotation> annotation) {
-        if (!bottomClass.isAnnotationPresent(annotation)) {
+        if (bottomClass == null || !bottomClass.isAnnotationPresent(annotation)) {
             return Collections.emptyList();
         }
         List<Class<?>> lineageClassList = new ArrayList<>();

--- a/core/src/test/java/ai/timefold/solver/core/config/solver/SolverConfigTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/config/solver/SolverConfigTest.java
@@ -48,6 +48,9 @@ import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 import ai.timefold.solver.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedEntity;
 import ai.timefold.solver.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedSolution;
+import ai.timefold.solver.core.impl.testdata.domain.interface_domain.TestdataInterfaceConstraintProvider;
+import ai.timefold.solver.core.impl.testdata.domain.interface_domain.TestdataInterfaceEntity;
+import ai.timefold.solver.core.impl.testdata.domain.interface_domain.TestdataInterfaceSolution;
 import ai.timefold.solver.core.impl.testdata.domain.record.TestdataRecordEntity;
 import ai.timefold.solver.core.impl.testdata.domain.record.TestdataRecordSolution;
 
@@ -223,6 +226,20 @@ class SolverConfigTest {
                 .buildSolver();
 
         var solution = TestdataRecordSolution.generateSolution();
+        Assertions.assertThatNoException().isThrownBy(() -> solver.solve(solution));
+    }
+
+    @Test
+    void domainClassesAreInterfaces() {
+        var solverConfig = new SolverConfig()
+                .withSolutionClass(TestdataInterfaceSolution.class)
+                .withEntityClasses(TestdataInterfaceEntity.class)
+                .withConstraintProviderClass(TestdataInterfaceConstraintProvider.class)
+                .withPhases(new ConstructionHeuristicPhaseConfig()); // Run CH and finish.
+        var solver = SolverFactory.create(solverConfig)
+                .buildSolver();
+
+        var solution = TestdataInterfaceSolution.generateSolution();
         Assertions.assertThatNoException().isThrownBy(() -> solver.solve(solution));
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceConstraintProvider.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceConstraintProvider.java
@@ -1,0 +1,20 @@
+package ai.timefold.solver.core.impl.testdata.domain.interface_domain;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+
+public class TestdataInterfaceConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
+        return new Constraint[] { alwaysPenalizingConstraint(constraintFactory) };
+    }
+
+    private Constraint alwaysPenalizingConstraint(ConstraintFactory constraintFactory) {
+        return constraintFactory.forEach(TestdataInterfaceEntity.class)
+                .penalize(SimpleScore.ONE)
+                .asConstraint("Always penalize");
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceEntity.java
@@ -1,0 +1,12 @@
+package ai.timefold.solver.core.impl.testdata.domain.interface_domain;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public interface TestdataInterfaceEntity {
+    @PlanningVariable
+    TestdataInterfaceValue getValue();
+
+    void setValue(TestdataInterfaceValue value);
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceSolution.java
@@ -1,0 +1,91 @@
+package ai.timefold.solver.core.impl.testdata.domain.interface_domain;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+@PlanningSolution
+public interface TestdataInterfaceSolution {
+    static SolutionDescriptor<TestdataInterfaceSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataInterfaceSolution.class, TestdataInterfaceEntity.class);
+    }
+
+    static TestdataInterfaceSolution generateSolution() {
+        var out = new TestdataInterfaceSolution() {
+            private List<TestdataInterfaceEntity> entityList;
+            private List<TestdataInterfaceValue> valueList;
+            private SimpleScore score;
+
+            @Override
+            public List<TestdataInterfaceEntity> getEntityList() {
+                return entityList;
+            }
+
+            @Override
+            public void setEntityList(List<TestdataInterfaceEntity> entityList) {
+                this.entityList = entityList;
+            }
+
+            @Override
+            public List<TestdataInterfaceValue> getValueList() {
+                return valueList;
+            }
+
+            @Override
+            public void setValueList(List<TestdataInterfaceValue> valueList) {
+                this.valueList = valueList;
+            }
+
+            @Override
+            public SimpleScore getScore() {
+                return score;
+            }
+
+            @Override
+            public void setScore(SimpleScore score) {
+                this.score = score;
+            }
+        };
+
+        out.setEntityList(List.of(
+                new TestdataInterfaceEntity() {
+                    private TestdataInterfaceValue value;
+
+                    @Override
+                    public TestdataInterfaceValue getValue() {
+                        return value;
+                    }
+
+                    @Override
+                    public void setValue(TestdataInterfaceValue value) {
+                        this.value = value;
+                    }
+                }));
+
+        out.setValueList(List.of(
+                new TestdataInterfaceValue() {
+                }));
+
+        return out;
+    }
+
+    @PlanningEntityCollectionProperty
+    List<TestdataInterfaceEntity> getEntityList();
+
+    void setEntityList(List<TestdataInterfaceEntity> entityList);
+
+    @ValueRangeProvider
+    List<TestdataInterfaceValue> getValueList();
+
+    void setValueList(List<TestdataInterfaceValue> valueList);
+
+    @PlanningScore
+    SimpleScore getScore();
+
+    void setScore(SimpleScore score);
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceValue.java
@@ -1,0 +1,4 @@
+package ai.timefold.solver.core.impl.testdata.domain.interface_domain;
+
+public interface TestdataInterfaceValue {
+}


### PR DESCRIPTION
The superclass of an interface is `null`. This caused this line of code to throw an exception for solution classes that are interface:

```java
var superclass = bottomClass.getSuperclass();
lineageClassList.addAll(getAllAnnotatedLineageClasses(superclass, annotation));
```

Since `getAllAnnotatedLineageClasses` expected superclass to not be `null`. `getAllAnnotatedLineageClasses` now returns an empty list for `null` arguments.