### PR TITLE
fix: Change the default moves for multi-variable domain models

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
@@ -219,7 +219,7 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
                     .withMoveSelectors(new ListChangeMoveSelectorConfig(), new ListSwapMoveSelectorConfig(),
                             new KOptListMoveSelectorConfig());
         } else if (listVariableDescriptor == null) { // We only have basic variables.
-            if (hasChainedVariable) {
+            if (hasChainedVariable && basicVariableDescriptorList.size() == 1) {
                 return new UnionMoveSelectorConfig()
                         .withMoveSelectors(new ChangeMoveSelectorConfig(), new SwapMoveSelectorConfig(),
                                 new TailChainSwapMoveSelectorConfig());

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
@@ -14,6 +14,8 @@ import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
+import ai.timefold.solver.core.impl.testdata.domain.chained.TestdataChainedEntity;
+import ai.timefold.solver.core.impl.testdata.domain.chained.TestdataChainedSolution;
 import ai.timefold.solver.core.impl.testdata.domain.list.TestdataListEntity;
 import ai.timefold.solver.core.impl.testdata.domain.list.TestdataListSolution;
 import ai.timefold.solver.core.impl.testdata.domain.list.TestdataListValue;
@@ -239,6 +241,16 @@ class DefaultLocalSearchPhaseTest {
                 TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class);
 
         var solution = TestdataListSolution.generateUninitializedSolution(6, 2);
+
+        solution = PlannerTestUtils.solve(solverConfig, solution);
+        assertThat(solution).isNotNull();
+    }
+
+    @Test
+    void solveMultiVarChainedVariable() {
+        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataChainedSolution.class, TestdataChainedEntity.class);
+
+        var solution = TestdataChainedSolution.generateUninitializedSolution(6, 2);
 
         solution = PlannerTestUtils.solve(solverConfig, solution);
         assertThat(solution).isNotNull();

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/chained/TestdataChainedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/chained/TestdataChainedSolution.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.testdata.domain.chained;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
 import ai.timefold.solver.core.api.domain.solution.PlanningScore;
@@ -73,5 +74,26 @@ public class TestdataChainedSolution extends TestdataObject {
     // ************************************************************************
     // Complex methods
     // ************************************************************************
+
+    public static TestdataChainedSolution generateUninitializedSolution(int valueCount, int entityCount) {
+        return generateSolution(valueCount, entityCount);
+    }
+
+    private static TestdataChainedSolution generateSolution(int valueCount, int entityCount) {
+        List<TestdataChainedEntity> entityList = IntStream.range(0, entityCount)
+                .mapToObj(i -> new TestdataChainedEntity("Generated Entity " + i))
+                .toList();
+        List<TestdataChainedAnchor> anchorList = IntStream.range(0, entityCount)
+                .mapToObj(i -> new TestdataChainedAnchor("Generated Anchor " + i))
+                .toList();
+        List<TestdataValue> valueList = IntStream.range(0, valueCount)
+                .mapToObj(i -> new TestdataValue("Generated Value " + i))
+                .toList();
+        TestdataChainedSolution solution = new TestdataChainedSolution();
+        solution.setChainedEntityList(entityList);
+        solution.setChainedAnchorList(anchorList);
+        solution.setUnchainedValueList(valueList);
+        return solution;
+    }
 
 }


### PR DESCRIPTION
This pull request updates the list of default moves for multi-variable domain models.