### PR TITLE
chore: deprecate constraint package

### DIFF
--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalbestscore/ConstraintMatchTotalBestScoreStatisticPoint.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalbestscore/ConstraintMatchTotalBestScoreStatisticPoint.java
@@ -23,12 +23,8 @@ public class ConstraintMatchTotalBestScoreStatisticPoint extends StatisticPoint 
         return timeMillisSpent;
     }
 
-    public String getConstraintPackage() {
-        return constraintRef.packageName();
-    }
-
-    public String getConstraintName() {
-        return constraintRef.constraintName();
+    public ConstraintRef getConstraintRef() {
+        return constraintRef;
     }
 
     public int getConstraintMatchCount() {
@@ -39,13 +35,9 @@ public class ConstraintMatchTotalBestScoreStatisticPoint extends StatisticPoint 
         return scoreTotal;
     }
 
-    public String getConstraintId() {
-        return constraintRef.constraintId();
-    }
-
     @Override
     public String toCsvLine() {
-        return buildCsvLineWithStrings(timeMillisSpent, getConstraintPackage(), getConstraintName(),
+        return buildCsvLineWithStrings(timeMillisSpent, constraintRef.packageName(), constraintRef.constraintName(),
                 Integer.toString(constraintMatchCount), scoreTotal.toString());
     }
 

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalbestscore/ConstraintMatchTotalBestScoreSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalbestscore/ConstraintMatchTotalBestScoreSubSingleStatistic.java
@@ -63,7 +63,7 @@ public class ConstraintMatchTotalBestScoreSubSingleStatistic<Solution_>
                     builderList.add(new LineChart.Builder<>());
                 }
                 LineChart.Builder<Long, Double> builder = builderList.get(i);
-                String seriesLabel = point.getConstraintName() + " weight";
+                String seriesLabel = point.getConstraintRef().constraintName() + " weight";
                 // Only add changes
                 double lastValue = (builder.count(seriesLabel) == 0) ? 0.0 : builder.getLastValue(seriesLabel);
                 if (levelValues[i] != lastValue) {

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalstepscore/ConstraintMatchTotalStepScoreStatisticPoint.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalstepscore/ConstraintMatchTotalStepScoreStatisticPoint.java
@@ -23,12 +23,8 @@ public class ConstraintMatchTotalStepScoreStatisticPoint extends StatisticPoint 
         return timeMillisSpent;
     }
 
-    public String getConstraintPackage() {
-        return constraintRef.packageName();
-    }
-
-    public String getConstraintName() {
-        return constraintRef.constraintName();
+    public ConstraintRef getConstraintRef() {
+        return constraintRef;
     }
 
     public int getConstraintMatchCount() {
@@ -39,13 +35,9 @@ public class ConstraintMatchTotalStepScoreStatisticPoint extends StatisticPoint 
         return scoreTotal;
     }
 
-    public String getConstraintId() {
-        return constraintRef.constraintId();
-    }
-
     @Override
     public String toCsvLine() {
-        return buildCsvLineWithStrings(timeMillisSpent, getConstraintPackage(), getConstraintName(),
+        return buildCsvLineWithStrings(timeMillisSpent, constraintRef.packageName(), constraintRef.constraintName(),
                 Integer.toString(constraintMatchCount), scoreTotal.toString());
     }
 

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalstepscore/ConstraintMatchTotalStepScoreSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalstepscore/ConstraintMatchTotalStepScoreSubSingleStatistic.java
@@ -62,7 +62,7 @@ public class ConstraintMatchTotalStepScoreSubSingleStatistic<Solution_>
                     builderList.add(new LineChart.Builder<>());
                 }
                 LineChart.Builder<Long, Double> builder = builderList.get(i);
-                String seriesLabel = point.getConstraintName() + " weight";
+                String seriesLabel = point.getConstraintRef().constraintName() + " weight";
                 // Only add changes
                 double lastValue = (builder.count(seriesLabel) == 0) ? 0.0 : builder.getLastValue(seriesLabel);
                 if (levelValues[i] != lastValue) {

--- a/benchmark/src/test/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalbestscore/ConstraintMatchTotalBestScoreSubSingleStatisticTest.java
+++ b/benchmark/src/test/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalbestscore/ConstraintMatchTotalBestScoreSubSingleStatisticTest.java
@@ -36,7 +36,7 @@ public final class ConstraintMatchTotalBestScoreSubSingleStatisticTest
         assertions.assertThat(outputPoints)
                 .hasSize(1)
                 .first()
-                .matches(s -> Objects.equals(s.getConstraintId(), "CN/CP"), "Constraint IDs do not match.")
+                .matches(s -> Objects.equals(s.getConstraintRef().constraintId(), "CN/CP"), "Constraint IDs do not match.")
                 .matches(s -> s.getConstraintMatchCount() == Integer.MAX_VALUE, "Constraint match counts do not match.")
                 .matches(s -> s.getScoreTotal().equals(SimpleScore.of(Integer.MAX_VALUE)), "Scores do not match.")
                 .matches(s -> s.getTimeMillisSpent() == Long.MAX_VALUE, "Millis do not match.");

--- a/benchmark/src/test/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalstepscore/ConstraintMatchTotalStepScoreSubSingleStatisticTest.java
+++ b/benchmark/src/test/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/constraintmatchtotalstepscore/ConstraintMatchTotalStepScoreSubSingleStatisticTest.java
@@ -36,7 +36,7 @@ public final class ConstraintMatchTotalStepScoreSubSingleStatisticTest
         assertions.assertThat(outputPoints)
                 .hasSize(1)
                 .first()
-                .matches(s -> Objects.equals(s.getConstraintId(), "CN/CP"), "Constraint IDs do not match.")
+                .matches(s -> Objects.equals(s.getConstraintRef().constraintId(), "CN/CP"), "Constraint IDs do not match.")
                 .matches(s -> s.getConstraintMatchCount() == Integer.MAX_VALUE, "Constraint match counts do not match.")
                 .matches(s -> s.getScoreTotal().equals(SimpleScore.of(Integer.MAX_VALUE)), "Scores do not match.")
                 .matches(s -> s.getTimeMillisSpent() == Long.MAX_VALUE, "Millis do not match.");

--- a/core/src/main/java/ai/timefold/solver/core/api/domain/constraintweight/ConstraintConfiguration.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/constraintweight/ConstraintConfiguration.java
@@ -26,7 +26,9 @@ public @interface ConstraintConfiguration {
      * This is the default for every {@link ConstraintWeight#constraintPackage()} in the annotated class.
      *
      * @return defaults to the annotated class's package.
+     * @deprecated Leave empty and let the solver provide the default. Do not rely on constraint package in user code.
      */
+    @Deprecated(forRemoval = true, since = "1.13.0")
     String constraintPackage() default "";
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/domain/constraintweight/ConstraintWeight.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/constraintweight/ConstraintWeight.java
@@ -28,7 +28,9 @@ public @interface ConstraintWeight {
      * concatenated with "/" and {@link #value() the constraint name}.
      *
      * @return defaults to {@link ConstraintConfiguration#constraintPackage()}
+     * @deprecated Leave empty and let the solver provide the default. Do not rely on constraint package in user code.
      */
+    @Deprecated(forRemoval = true, since = "1.13.0")
     String constraintPackage() default "";
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ConstraintAnalysis.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ConstraintAnalysis.java
@@ -160,7 +160,9 @@ public record ConstraintAnalysis<Score_ extends Score<Score_>>(ConstraintRef con
      * Return package name of the constraint that this analysis is for.
      *
      * @return equal to {@code constraintRef.packageName()}
+     * @deprecated Do not rely on constraint package in user code.
      */
+    @Deprecated(forRemoval = true, since = "1.13.0")
     public String constraintPackage() {
         return constraintRef.packageName();
     }

--- a/core/src/main/java/ai/timefold/solver/core/api/score/constraint/ConstraintRef.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/constraint/ConstraintRef.java
@@ -14,6 +14,9 @@ import ai.timefold.solver.core.api.domain.constraintweight.ConstraintWeight;
  * @param packageName The constraint package is the namespace of the constraint.
  *        When using a {@link ConstraintConfiguration},
  *        it is equal to the {@link ConstraintWeight#constraintPackage()}.
+ *        It is not recommended for the user to set this, or to read its value;
+ *        instead, the user should use whatever the solver provided as default and not rely on this information at all.
+ *        The entire concept of constraint package is likely to be removed in a future version of the solver.
  * @param constraintName The constraint name.
  *        It might not be unique, but {@link #constraintId()} is unique.
  *        When using a {@link ConstraintConfiguration},

--- a/core/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintBuilder.java
@@ -21,7 +21,9 @@ public interface ConstraintBuilder {
      * @param constraintName never null, shows up in {@link ConstraintMatchTotal} during score justification
      * @param constraintPackage never null
      * @return never null
+     * @deprecated Constraint package should no longer be used, use {@link #asConstraint(String)} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.13.0")
     Constraint asConstraint(String constraintPackage, String constraintName);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintFactory.java
@@ -27,7 +27,9 @@ public interface ConstraintFactory {
      * otherwise the package of the {@link PlanningSolution} class.
      *
      * @return never null
+     * @deprecated Do not rely on any constraint package in user code.
      */
+    @Deprecated(forRemoval = true, since = "1.13.0")
     String getDefaultConstraintPackage();
 
     // ************************************************************************

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintFactory.java
@@ -20,6 +20,18 @@ import ai.timefold.solver.core.impl.score.stream.common.RetrievalSemantics;
 public final class BavetConstraintFactory<Solution_>
         extends InnerConstraintFactory<Solution_, BavetConstraint<Solution_>> {
 
+    /**
+     * Used for code in no package, also called the "unnamed package".
+     * Classes here can only be instantiated via reflection,
+     * they cannot be imported and used directly.
+     * But still, in corner cases such as Kotlin notebooks,
+     * all code is in the unnamed package.
+     * Assume a constraint provider under these conditions,
+     * where asConstraint(...) only specifies constraint name, not constraint package.
+     * In this situation, the default constraint package is used.
+     */
+    private static final String DEFAULT_CONSTRAINT_PACKAGE = "unnamed.package";
+
     private final SolutionDescriptor<Solution_> solutionDescriptor;
     private final EnvironmentMode environmentMode;
     private final String defaultConstraintPackage;
@@ -33,11 +45,19 @@ public final class BavetConstraintFactory<Solution_>
         ConstraintConfigurationDescriptor<Solution_> configurationDescriptor = solutionDescriptor
                 .getConstraintConfigurationDescriptor();
         if (configurationDescriptor == null) {
-            Package pack = solutionDescriptor.getSolutionClass().getPackage();
-            defaultConstraintPackage = (pack == null) ? "" : pack.getName();
+            defaultConstraintPackage = determineDefaultConstraintPackage(solutionDescriptor.getSolutionClass().getPackage());
         } else {
-            defaultConstraintPackage = configurationDescriptor.getConstraintPackage();
+            defaultConstraintPackage = determineDefaultConstraintPackage(configurationDescriptor.getConstraintPackage());
         }
+    }
+
+    private static String determineDefaultConstraintPackage(Package pkg) {
+        var asString = pkg == null ? "" : pkg.getName();
+        return determineDefaultConstraintPackage(asString);
+    }
+
+    private static String determineDefaultConstraintPackage(String constraintPackage) {
+        return constraintPackage == null || constraintPackage.isEmpty() ? DEFAULT_CONSTRAINT_PACKAGE : constraintPackage;
     }
 
     public <Stream_ extends BavetAbstractConstraintStream<Solution_>> Stream_ share(Stream_ stream) {

--- a/core/src/test/java/TestdataInUnnamedPackageSolution.java
+++ b/core/src/test/java/TestdataInUnnamedPackageSolution.java
@@ -1,0 +1,88 @@
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataObject;
+import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution
+public class TestdataInUnnamedPackageSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataInUnnamedPackageSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataInUnnamedPackageSolution.class, TestdataEntity.class);
+    }
+
+    public static TestdataInUnnamedPackageSolution generateSolution() {
+        return generateSolution(5, 7);
+    }
+
+    public static TestdataInUnnamedPackageSolution generateSolution(int valueListSize, int entityListSize) {
+        TestdataInUnnamedPackageSolution solution = new TestdataInUnnamedPackageSolution("Generated Solution 0");
+        List<TestdataValue> valueList = new ArrayList<>(valueListSize);
+        for (int i = 0; i < valueListSize; i++) {
+            TestdataValue value = new TestdataValue("Generated Value " + i);
+            valueList.add(value);
+        }
+        solution.setValueList(valueList);
+        List<TestdataEntity> entityList = new ArrayList<>(entityListSize);
+        for (int i = 0; i < entityListSize; i++) {
+            TestdataValue value = valueList.get(i % valueListSize);
+            TestdataEntity entity = new TestdataEntity("Generated Entity " + i, value);
+            entityList.add(entity);
+        }
+        solution.setEntityList(entityList);
+        return solution;
+    }
+
+    private List<TestdataValue> valueList;
+    private List<TestdataEntity> entityList;
+
+    private SimpleScore score;
+
+    public TestdataInUnnamedPackageSolution() {
+    }
+
+    public TestdataInUnnamedPackageSolution(String code) {
+        super(code);
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/api/score/analysis/ScoreAnalysisTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/analysis/ScoreAnalysisTest.java
@@ -81,7 +81,7 @@ class ScoreAnalysisTest {
 
         // Complete score analysis
         var summary = scoreAnalysis.summarize();
-        assertThat(scoreAnalysis.getConstraintAnalysis(constraintPackage, constraintName1).matchCount()).isEqualTo(5);
+        assertThat(scoreAnalysis.getConstraintAnalysis(constraintName1).matchCount()).isEqualTo(5);
         assertThat(summary)
                 .isEqualTo("""
                         Explanation of score (67):
@@ -126,7 +126,7 @@ class ScoreAnalysisTest {
 
         // Complete score analysis
         var summary = scoreAnalysis.summarize();
-        assertThat(scoreAnalysis.getConstraintAnalysis(constraintPackage, constraintName1).matchCount()).isZero();
+        assertThat(scoreAnalysis.getConstraintAnalysis(constraintName1).matchCount()).isZero();
         assertThat(summary)
                 .isEqualTo("""
                         Explanation of score (3init/0):
@@ -206,19 +206,19 @@ class ScoreAnalysisTest {
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 not present.
-        var constraintAnalysis1 = comparison.getConstraintAnalysis(constraintPackage, constraintName1);
+        var constraintAnalysis1 = comparison.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis1.score()).isEqualTo(SimpleScore.of(20));
             softly.assertThat(constraintAnalysis1.matches()).isNull();
         });
         // Matches for constraint2 still not present.
-        var constraintAnalysis2 = comparison.getConstraintAnalysis(constraintPackage, constraintName2);
+        var constraintAnalysis2 = comparison.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis2.score()).isEqualTo(SimpleScore.of(18));
             softly.assertThat(constraintAnalysis2.matches()).isNull();
         });
         // Matches for constraint3 not present.
-        var constraintAnalysis3 = comparison.getConstraintAnalysis(constraintPackage, constraintName3);
+        var constraintAnalysis3 = comparison.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis3.score()).isEqualTo(SimpleScore.of(-30));
             softly.assertThat(constraintAnalysis3.matches()).isNull();
@@ -232,19 +232,19 @@ class ScoreAnalysisTest {
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 not present.
-        var reverseConstraintAnalysis1 = reverseComparison.getConstraintAnalysis(constraintPackage, constraintName1);
+        var reverseConstraintAnalysis1 = reverseComparison.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis1.score()).isEqualTo(SimpleScore.of(-20));
             softly.assertThat(reverseConstraintAnalysis1.matches()).isNull();
         });
         // Matches for constraint2 still not present.
-        var reverseConstraintAnalysis2 = reverseComparison.getConstraintAnalysis(constraintPackage, constraintName2);
+        var reverseConstraintAnalysis2 = reverseComparison.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis2.score()).isEqualTo(SimpleScore.of(-18));
             softly.assertThat(reverseConstraintAnalysis2.matches()).isNull();
         });
         // Matches for constraint3 not present in reverse.
-        var reverseConstraintAnalysis3 = reverseComparison.getConstraintAnalysis(constraintPackage, constraintName3);
+        var reverseConstraintAnalysis3 = reverseComparison.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis3.score()).isEqualTo(SimpleScore.of(30));
             softly.assertThat(reverseConstraintAnalysis3.matches()).isNull();
@@ -302,7 +302,7 @@ class ScoreAnalysisTest {
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 present.
-        var constraintAnalysis1 = comparison.getConstraintAnalysis(constraintPackage, constraintName1);
+        var constraintAnalysis1 = comparison.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis1.score()).isEqualTo(SimpleScore.of(20));
             var matchAnalyses = constraintAnalysis1.matches();
@@ -314,7 +314,7 @@ class ScoreAnalysisTest {
                             matchAnalysisOf(constraintAnalysis1.constraintRef(), 8));
         });
         // Matches for constraint2 present in both.
-        var constraintAnalysis2 = comparison.getConstraintAnalysis(constraintPackage, constraintName2);
+        var constraintAnalysis2 = comparison.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis2.score()).isEqualTo(SimpleScore.of(18));
             var matchAnalyses = constraintAnalysis2.matches();
@@ -328,7 +328,7 @@ class ScoreAnalysisTest {
                             matchAnalysisOf(constraintAnalysis2.constraintRef(), -6, "A", "B"));
         });
         // Matches for constraint3 not present.
-        var constraintAnalysis3 = comparison.getConstraintAnalysis(constraintPackage, constraintName3);
+        var constraintAnalysis3 = comparison.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis3.score()).isEqualTo(SimpleScore.of(-30));
             var matchAnalyses = constraintAnalysis3.matches();
@@ -348,7 +348,7 @@ class ScoreAnalysisTest {
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 not present.
-        var reverseConstraintAnalysis1 = reverseComparison.getConstraintAnalysis(constraintPackage, constraintName1);
+        var reverseConstraintAnalysis1 = reverseComparison.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis1.score()).isEqualTo(SimpleScore.of(-20));
             var matchAnalyses = reverseConstraintAnalysis1.matches();
@@ -360,7 +360,7 @@ class ScoreAnalysisTest {
                             matchAnalysisOf(reverseConstraintAnalysis1.constraintRef(), -8));
         });
         // Matches for constraint2 present in both.
-        var reverseConstraintAnalysis2 = reverseComparison.getConstraintAnalysis(constraintPackage, constraintName2);
+        var reverseConstraintAnalysis2 = reverseComparison.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis2.score()).isEqualTo(SimpleScore.of(-18));
             var matchAnalyses = reverseConstraintAnalysis2.matches();
@@ -374,7 +374,7 @@ class ScoreAnalysisTest {
                             matchAnalysisOf(reverseConstraintAnalysis2.constraintRef(), 6, "A", "B"));
         });
         // Matches for constraint3 present in reverse.
-        var reverseConstraintAnalysis3 = reverseComparison.getConstraintAnalysis(constraintPackage, constraintName3);
+        var reverseConstraintAnalysis3 = reverseComparison.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis3.score()).isEqualTo(SimpleScore.of(30));
             var matchAnalyses = reverseConstraintAnalysis3.matches();

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/bi/AbstractBiConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/bi/AbstractBiConstraintStreamTest.java
@@ -942,8 +942,8 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
         // From scratch
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, solution.getFirstEntity().toString(), 6),
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, solution.getEntityList().get(1).toString(), 5));
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, solution.getFirstEntity().toString(), 6),
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, solution.getEntityList().get(1).toString(), 5));
 
         // Incremental; we have a new first entity, and less entities in total.
         TestdataLavishEntity entity = solution.getFirstEntity();
@@ -951,7 +951,7 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
         solution.getEntityList().remove(entity);
         scoreDirector.afterEntityRemoved(entity);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, solution.getFirstEntity().toString(), 5));
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, solution.getFirstEntity().toString(), 5));
     }
 
     @Override
@@ -973,8 +973,8 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
         // From scratch
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity1.toString(), 2, singleton(entity1)),
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity1.toString(), 2, singleton(entity1)),
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
 
         // Incremental
         TestdataLavishEntity entity = solution.getFirstEntity();
@@ -982,7 +982,7 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
         solution.getEntityList().remove(entity);
         scoreDirector.afterEntityRemoved(entity);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
     }
 
     @Override
@@ -1007,9 +1007,9 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
         // From scratch
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity1.toString(), Long.MAX_VALUE, Long.MAX_VALUE,
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity1.toString(), Long.MAX_VALUE, Long.MAX_VALUE,
                         singleton(entity1)),
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
                         singleton(entity2)));
 
         // Incremental
@@ -1018,7 +1018,7 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
         solution.getEntityList().remove(entity);
         scoreDirector.afterEntityRemoved(entity);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
                         singleton(entity2)));
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/quad/AbstractQuadConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/quad/AbstractQuadConstraintStreamTest.java
@@ -739,8 +739,8 @@ public abstract class AbstractQuadConstraintStreamTest
         // From scratch
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity1.toString(), 2, singleton(entity1)),
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity1.toString(), 2, singleton(entity1)),
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
 
         // Incremental
         TestdataLavishEntity entity = solution.getFirstEntity();
@@ -748,7 +748,7 @@ public abstract class AbstractQuadConstraintStreamTest
         solution.getEntityList().remove(entity);
         scoreDirector.afterEntityRemoved(entity);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
     }
 
     @Override
@@ -777,9 +777,9 @@ public abstract class AbstractQuadConstraintStreamTest
         // From scratch
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity1.toString(), Long.MAX_VALUE, Long.MAX_VALUE,
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity1.toString(), Long.MAX_VALUE, Long.MAX_VALUE,
                         singleton(entity1)),
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
                         singleton(entity2)));
 
         // Incremental
@@ -788,7 +788,7 @@ public abstract class AbstractQuadConstraintStreamTest
         solution.getEntityList().remove(entity);
         scoreDirector.afterEntityRemoved(entity);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
                         singleton(entity2)));
     }
 
@@ -1251,7 +1251,7 @@ public abstract class AbstractQuadConstraintStreamTest
         // From scratch
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector,
-                assertMatch(TEST_CONSTRAINT_NAME, solution.getFirstEntity().getCode(),
+                assertMatch(null, TEST_CONSTRAINT_NAME, solution.getFirstEntity().getCode(),
                         solution.getEntityList().get(1).getCode(), solution.getFirstEntityGroup().getCode(),
                         solution.getEntityGroupList().get(1).getCode()));
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/tri/AbstractTriConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/tri/AbstractTriConstraintStreamTest.java
@@ -1054,8 +1054,8 @@ public abstract class AbstractTriConstraintStreamTest
         // From scratch
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity1.toString(), 2, singleton(entity1)),
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity1.toString(), 2, singleton(entity1)),
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
 
         // Incremental
         TestdataLavishEntity entity = solution.getFirstEntity();
@@ -1063,7 +1063,7 @@ public abstract class AbstractTriConstraintStreamTest
         solution.getEntityList().remove(entity);
         scoreDirector.afterEntityRemoved(entity);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), 1, singleton(entity2)));
     }
 
     @Override
@@ -1091,9 +1091,9 @@ public abstract class AbstractTriConstraintStreamTest
         // From scratch
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity1.toString(), Long.MAX_VALUE, Long.MAX_VALUE,
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity1.toString(), Long.MAX_VALUE, Long.MAX_VALUE,
                         singleton(entity1)),
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
                         singleton(entity2)));
 
         // Incremental
@@ -1102,7 +1102,7 @@ public abstract class AbstractTriConstraintStreamTest
         solution.getEntityList().remove(entity);
         scoreDirector.afterEntityRemoved(entity);
         assertScore(scoreDirector,
-                assertMatchWithScore(-1, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
+                assertMatchWithScore(-1, null, TEST_CONSTRAINT_NAME, entity2.toString(), Long.MIN_VALUE, Long.MIN_VALUE,
                         singleton(entity2)));
     }
 

--- a/docs/src/modules/ROOT/pages/constraints-and-score/constraint-configuration.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/constraint-configuration.adoc
@@ -69,7 +69,7 @@ In the constraint configuration class, add a `@ConstraintWeight` field or proper
 
 [source,java,options="nowrap"]
 ----
-@ConstraintConfiguration(constraintPackage = "...conferencescheduling.score")
+@ConstraintConfiguration
 public class ConferenceConstraintConfiguration {
 
     @ConstraintWeight("Speaker conflict")
@@ -95,9 +95,16 @@ Notice how it defaults the _"Content conflict"_ constraint as ten times more imp
 Normally, a constraint weight only uses one score level,
 but it's possible to use multiple score levels (at a small performance cost).
 
-Each constraint has a constraint package and a constraint name, together they form the constraint id.
+Each constraint has a constraint name, and optionally a constraint package; together they form the constraint id.
 These connect the constraint weight with the constraint implementation.
-*For each constraint weight, there must be a constraint implementation with the same package and the same name.*
+*For each constraint weight, there must be a constraint implementation with the same constraint id.*
+
+[NOTE]
+====
+Constraint packages are optional and have been deprecated.
+We recommend that you don't use them, and instead keep constraint names unique.
+If constraint package is not provided, the solver will transparently provide a default value.
+====
 
 * The `@ConstraintConfiguration` annotation has a `constraintPackage` property that defaults to the package of the constraint configuration class.
 Cases with xref:constraints-and-score/score-calculation.adoc[Constraint Streams API] normally don't need to specify it.

--- a/docs/src/modules/ROOT/pages/constraints-and-score/score-calculation.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/score-calculation.adoc
@@ -259,13 +259,11 @@ To do this, every constraint stream must contain a call to either a `penalize()`
 building block.
 The `penalize()` building block makes the score worse and the `reward()` building block improves the score.
 
-Each constraint stream is then terminated by calling `asConstraint()` method, which finally builds the constraint. Constraints have several components:
+Each constraint stream is then terminated by calling `asConstraint()` method, which finally builds the constraint.
+Constraints have several components:
 
-- Constraint package is the Java package that contains the constraint.
-The default value is the package that contains the `ConstraintProvider` implementation or the value from
-xref:constraints-and-score/constraint-configuration.adoc#constraintConfiguration[constraint configuration], if implemented.
-- Constraint name is the human-readable descriptive name for the constraint, which
-(together with the constraint package) must be unique within the entire `ConstraintProvider` implementation.
+- Constraint name is the human-readable descriptive name for the constraint,
+which must be unique within the entire `ConstraintProvider` implementation.
 - Constraint weight is a constant score value indicating how much every breach of the constraint affects the score.
 Valid examples include `SimpleScore.ONE`, `HardSoftScore.ONE_HARD` and `HardMediumSoftScore.of(1, 2, 3)`.
 - Constraint match weigher is an optional function indicating how many times the constraint weight should be applied in
@@ -276,6 +274,13 @@ The default value is `1`.
 [NOTE]
 ====
 Constraints with zero constraint weight are automatically disabled and do not impose any performance penalty.
+====
+
+[NOTE]
+====
+The constraint has another component: a constraint package.
+It has no practical impact on the solver and it has been deprecated.
+We recommend you don't use constraint packages; the solver will choose a suitable default value.
 ====
 
 The Constraint Streams API supports many different types of penalties.

--- a/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
@@ -45,7 +45,7 @@ In the string above, there are some previously unexplained concepts.
 * A _Constraint match_ is created every time a constraint causes a change to the score.
 * _Justifications_ are user-defined objects that implement the `ai.timefold.solver.core.api.score.stream.ConstraintJustification` interface,
 which carry meaningful information about a constraint match,
-such as its package, name and any metadata that the user chooses to expose.
+such as its name and any metadata that the user chooses to expose.
 Justifications are most easily available via <<scoreAnalysis,score analysis>>.
 * _Indicted objects_ are objects which were directly involved in causing a constraint to match.
 For example, if your constraints penalize each vehicle,

--- a/docs/src/modules/ROOT/pages/upgrade-and-migration/upgrade-to-latest-version.adoc
+++ b/docs/src/modules/ROOT/pages/upgrade-and-migration/upgrade-to-latest-version.adoc
@@ -57,6 +57,38 @@ Every upgrade note indicates how likely your code will be affected by that chang
 The upgrade recipe often lists the changes as they apply to Java code.
 We kindly ask Kotlin and Python users to translate the changes accordingly.
 
+=== Upgrade from 1.12.0 to 1.13.0 (Work in progress)
+
+.icon:info-circle[role=yellow] Constraint packages have been deprecated
+[%collapsible%open]
+====
+In the solver, constraints are uniquely identified by their package and name.
+We have now deprecated the package name and we recommend to keep constraint names unique instead.
+
+Before in `*ConstraintProvider.java`:
+
+[source,java]
+----
+...
+    .penalize(ONE_SOFT)
+    .asConstraint("employees.paris", "maxHoursWorked");
+...
+----
+
+After in `*ConstraintProvider.java`:
+
+[source,java]
+----
+...
+    .penalize(ONE_SOFT)
+    .asConstraint("employees.paris.maxHoursWorked");
+...
+----
+
+While constraint packages are still supported, they will be removed in a future major version.
+====
+
+
 === Upgrade from 1.9.0 to 1.10.0
 
 .icon:info-circle[role=yellow] Pinning unassigned entities now fails fast, unless allowed

--- a/docs/src/modules/ROOT/pages/using-timefold-solver/running-the-solver.adoc
+++ b/docs/src/modules/ROOT/pages/using-timefold-solver/running-the-solver.adoc
@@ -468,14 +468,14 @@ This does not measure the amount of memory used by a solver; two solvers on the 
 - `CONSTRAINT_MATCH_TOTAL_BEST_SCORE` (Micrometer meter id: "timefold.solver.constraint.match.best.score.*"):
 Measures the score impact of each constraint on the best solution Timefold Solver found so far.
 There are separate meters for each level of the score, with tags for each constraint.
-For instance, for a `HardSoftScore` for a constraint "Minimize Cost" in package "com.example",
-there are `timefold.solver.constraint.match.best.score.hard.score` and `timefold.solver.constraint.match.best.score.soft.score` meters with tags "constraint.package=com.example" and "constraint.name=Minimize Cost".
+For instance, for a `HardSoftScore` for a constraint "Minimize Cost",
+there are `timefold.solver.constraint.match.best.score.hard.score` and `timefold.solver.constraint.match.best.score.soft.score` meters with a tag "constraint.name=Minimize Cost".
 
 - `CONSTRAINT_MATCH_TOTAL_STEP_SCORE` (Micrometer meter id: "timefold.solver.constraint.match.step.score.*"):
 Measures the score impact of each constraint on the current step.
 There are separate meters for each level of the score, with tags for each constraint.
-For instance, for a `HardSoftScore` for a constraint "Minimize Cost" in package "com.example",
-there are `timefold.solver.constraint.match.step.score.hard.score` and `timefold.solver.constraint.match.step.score.soft.score` meters with tags "constraint.package=com.example" and "constraint.name=Minimize Cost".
+For instance, for a `HardSoftScore` for a constraint "Minimize Cost",
+there are `timefold.solver.constraint.match.step.score.hard.score` and `timefold.solver.constraint.match.step.score.soft.score` meters with a tag "constraint.name=Minimize Cost".
 
 - `PICKED_MOVE_TYPE_BEST_SCORE_DIFF` (Micrometer meter id: "timefold.solver.move.type.best.score.diff.*"):
 Measures how much a particular move type improves the best solution.

--- a/migration/src/main/java/ai/timefold/solver/migration/v8/AsConstraintRecipe.java
+++ b/migration/src/main/java/ai/timefold/solver/migration/v8/AsConstraintRecipe.java
@@ -261,8 +261,9 @@ public final class AsConstraintRecipe extends Recipe {
                         if (!matcherMeta.constraintPackageIncluded) {
                             templateCode += ".asConstraint(#{any(String)})";
                         } else {
-                            templateCode += ".asConstraint(#{any(String)}, #{any(String)})";
+                            templateCode += ".asConstraint(\"#{}\")";
                         }
+                        System.out.println(templateCode);
                         JavaTemplate template = JavaTemplate.builder(templateCode)
                                 .javaParser(buildJavaParser())
                                 .build();
@@ -293,26 +294,31 @@ public final class AsConstraintRecipe extends Recipe {
                                 if (!matcherMeta.matchWeigherIncluded) {
                                     return template.apply(getCursor(),
                                             e.getCoordinates().replace(), select,
-                                            arguments.get(2), arguments.get(0), arguments.get(1));
+                                            arguments.get(2), mergeExpressions(arguments.get(0), arguments.get(1)));
                                 } else {
                                     return template.apply(getCursor(),
                                             e.getCoordinates().replace(), select,
-                                            arguments.get(2), arguments.get(3), arguments.get(0), arguments.get(1));
+                                            arguments.get(2), arguments.get(3),
+                                            mergeExpressions(arguments.get(0), arguments.get(1)));
                                 }
                             } else {
                                 if (!matcherMeta.matchWeigherIncluded) {
                                     return template.apply(getCursor(),
                                             e.getCoordinates().replace(), select,
-                                            arguments.get(0), arguments.get(1));
+                                            mergeExpressions(arguments.get(0), arguments.get(1)));
                                 } else {
                                     return template.apply(getCursor(),
                                             e.getCoordinates().replace(), select,
-                                            arguments.get(2), arguments.get(0), arguments.get(1));
+                                            arguments.get(2), mergeExpressions(arguments.get(0), arguments.get(1)));
                                 }
                             }
                         }
                     }
                 });
+    }
+
+    private String mergeExpressions(Expression constraintPackage, Expression constraintName) {
+        return constraintPackage.toString() + "." + constraintName.toString();
     }
 
     public static JavaParser.Builder buildJavaParser() {

--- a/migration/src/main/java/ai/timefold/solver/migration/v8/RemoveConstraintPackageRecipe.java
+++ b/migration/src/main/java/ai/timefold/solver/migration/v8/RemoveConstraintPackageRecipe.java
@@ -1,0 +1,62 @@
+package ai.timefold.solver.migration.v8;
+
+import java.util.List;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+public final class RemoveConstraintPackageRecipe extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Constraint Streams: don't use package name in the asConstraint() method";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove the use of constraint package from `asConstraint(package, name)`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                Preconditions.or(new UsesMethod<>(new MethodMatcher(
+                        "ai.timefold.solver.core.api.score.stream.ConstraintBuilder asConstraint(String, String)"))),
+                new JavaIsoVisitor<>() {
+
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        Expression select = method.getSelect();
+                        List<Expression> arguments = method.getArguments();
+
+                        String templateCode = "#{any(ai.timefold.solver.core.api.score.stream.ConstraintBuilder)}\n" +
+                                ".asConstraint(\"#{}\")";
+                        JavaTemplate template = JavaTemplate.builder(templateCode)
+                                .javaParser(buildJavaParser())
+                                .build();
+                        return template.apply(getCursor(),
+                                method.getCoordinates().replace(), select,
+                                mergeExpressions(arguments.get(0), arguments.get(1)));
+                    }
+                });
+    }
+
+    private String mergeExpressions(Expression constraintPackage, Expression constraintName) {
+        return constraintPackage.toString() + "." + constraintName.toString();
+    }
+
+    public static JavaParser.Builder buildJavaParser() {
+        return JavaParser.fromJavaVersion()
+                .classpath(JavaParser.runtimeClasspath());
+    }
+
+}

--- a/migration/src/test/java/ai/timefold/solver/migration/v8/AsConstraintRecipeTest.java
+++ b/migration/src/test/java/ai/timefold/solver/migration/v8/AsConstraintRecipeTest.java
@@ -35,7 +35,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .penalize(\"My package\", \"My constraint\", HardSoftScore.ONE_HARD);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .penalize(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -55,7 +55,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .penalizeConfigurable(\"My package\", \"My constraint\");"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .penalizeConfigurable()\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -75,7 +75,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .penalize(\"My package\", \"My constraint\", HardSoftScore.ONE_HARD, (a) -> 7);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .penalize(HardSoftScore.ONE_HARD, (a) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -95,7 +95,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .penalizeConfigurable(\"My package\", \"My constraint\", (a) -> 7);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .penalizeConfigurable((a) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -115,7 +115,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .penalizeLong(\"My package\", \"My constraint\", HardSoftLongScore.ONE_HARD, (a) -> 7L);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .penalizeLong(HardSoftLongScore.ONE_HARD, (a) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -135,7 +135,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .penalizeConfigurableLong(\"My package\", \"My constraint\", (a) -> 7L);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .penalizeConfigurableLong((a) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -155,7 +155,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .penalizeBigDecimal(\"My package\", \"My constraint\", HardSoftBigDecimalScore.ONE_HARD, (a) -> BigDecimal.TEN);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .penalizeBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -175,7 +175,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .penalizeConfigurableBigDecimal(\"My package\", \"My constraint\", (a) -> BigDecimal.TEN);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .penalizeConfigurableBigDecimal((a) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -195,7 +195,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .reward(\"My package\", \"My constraint\", HardSoftScore.ONE_HARD);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .reward(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -215,7 +215,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .rewardConfigurable(\"My package\", \"My constraint\");"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .rewardConfigurable()\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -235,7 +235,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .reward(\"My package\", \"My constraint\", HardSoftScore.ONE_HARD, (a) -> 7);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .reward(HardSoftScore.ONE_HARD, (a) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -255,7 +255,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .rewardConfigurable(\"My package\", \"My constraint\", (a) -> 7);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .rewardConfigurable((a) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -275,7 +275,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .rewardLong(\"My package\", \"My constraint\", HardSoftLongScore.ONE_HARD, (a) -> 7L);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .rewardLong(HardSoftLongScore.ONE_HARD, (a) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -295,7 +295,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .rewardConfigurableLong(\"My package\", \"My constraint\", (a) -> 7L);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .rewardConfigurableLong((a) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -315,7 +315,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .rewardBigDecimal(\"My package\", \"My constraint\", HardSoftBigDecimalScore.ONE_HARD, (a) -> BigDecimal.TEN);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .rewardBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -335,7 +335,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .rewardConfigurableBigDecimal(\"My package\", \"My constraint\", (a) -> BigDecimal.TEN);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .rewardConfigurableBigDecimal((a) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -355,7 +355,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .impact(\"My package\", \"My constraint\", HardSoftScore.ONE_HARD);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .impact(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -375,7 +375,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .impact(\"My package\", \"My constraint\", HardSoftScore.ONE_HARD, (a) -> 7);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .impact(HardSoftScore.ONE_HARD, (a) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -395,7 +395,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .impactLong(\"My package\", \"My constraint\", HardSoftLongScore.ONE_HARD, (a) -> 7L);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .impactLong(HardSoftLongScore.ONE_HARD, (a) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -415,7 +415,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .impactBigDecimal(\"My package\", \"My constraint\", HardSoftBigDecimalScore.ONE_HARD, (a) -> BigDecimal.TEN);"),
                 wrap("        return f.forEach(String.class)\n" +
                         "                .impactBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     // ************************************************************************
@@ -443,7 +443,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalize(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -467,7 +467,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurable()\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -491,7 +491,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalize(HardSoftScore.ONE_HARD, (a, b) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -515,7 +515,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurable((a, b) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -539,7 +539,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeLong(HardSoftLongScore.ONE_HARD, (a, b) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -563,7 +563,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurableLong((a, b) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -587,7 +587,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a, b) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -611,7 +611,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurableBigDecimal((a, b) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -635,7 +635,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .reward(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -659,7 +659,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurable()\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -683,7 +683,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .reward(HardSoftScore.ONE_HARD, (a, b) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -707,7 +707,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurable((a, b) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -731,7 +731,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardLong(HardSoftLongScore.ONE_HARD, (a, b) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -755,7 +755,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurableLong((a, b) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -779,7 +779,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a, b) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -803,7 +803,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurableBigDecimal((a, b) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -827,7 +827,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impact(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -851,7 +851,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impact(HardSoftScore.ONE_HARD, (a, b) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -875,7 +875,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impactLong(HardSoftLongScore.ONE_HARD, (a, b) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -899,7 +899,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                 wrap("        return f.forEach(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impactBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a, b) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     // ************************************************************************
@@ -931,7 +931,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalize(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -959,7 +959,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurable()\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -987,7 +987,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalize(HardSoftScore.ONE_HARD, (a, b, c) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1015,7 +1015,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurable((a, b, c) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1043,7 +1043,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeLong(HardSoftLongScore.ONE_HARD, (a, b, c) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1071,7 +1071,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurableLong((a, b, c) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1099,7 +1099,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a, b, c) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1127,7 +1127,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurableBigDecimal((a, b, c) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1155,7 +1155,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .reward(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1183,7 +1183,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurable()\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1211,7 +1211,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .reward(HardSoftScore.ONE_HARD, (a, b, c) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1239,7 +1239,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurable((a, b, c) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1267,7 +1267,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardLong(HardSoftLongScore.ONE_HARD, (a, b, c) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1295,7 +1295,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurableLong((a, b, c) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1323,7 +1323,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a, b, c) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1351,7 +1351,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurableBigDecimal((a, b, c) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1379,7 +1379,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impact(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1407,7 +1407,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impact(HardSoftScore.ONE_HARD, (a, b, c) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1435,7 +1435,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impactLong(HardSoftLongScore.ONE_HARD, (a, b, c) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1463,7 +1463,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impactBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a, b, c) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     // ************************************************************************
@@ -1499,7 +1499,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalize(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1531,7 +1531,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurable()\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1563,7 +1563,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalize(HardSoftScore.ONE_HARD, (a, b, c, d) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1595,7 +1595,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurable((a, b, c, d) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1627,7 +1627,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeLong(HardSoftLongScore.ONE_HARD, (a, b, c, d) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1659,7 +1659,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurableLong((a, b, c, d) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1693,7 +1693,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .penalizeBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a, b, c, d) -> BigDecimal.TEN)\n"
                         +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1725,7 +1725,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .penalizeConfigurableBigDecimal((a, b, c, d) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1757,7 +1757,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .reward(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1789,7 +1789,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurable()\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1821,7 +1821,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .reward(HardSoftScore.ONE_HARD, (a, b, c, d) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1853,7 +1853,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurable((a, b, c, d) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1885,7 +1885,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardLong(HardSoftLongScore.ONE_HARD, (a, b, c, d) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1917,7 +1917,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurableLong((a, b, c, d) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1951,7 +1951,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .rewardBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a, b, c, d) -> BigDecimal.TEN)\n"
                         +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -1983,7 +1983,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .rewardConfigurableBigDecimal((a, b, c, d) -> BigDecimal.TEN)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -2015,7 +2015,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impact(HardSoftScore.ONE_HARD)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -2047,7 +2047,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impact(HardSoftScore.ONE_HARD, (a, b, c, d) -> 7)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -2079,7 +2079,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .join(String.class)\n" +
                         "                .impactLong(HardSoftLongScore.ONE_HARD, (a, b, c, d) -> 7L)\n" +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     @Test
@@ -2113,7 +2113,7 @@ class AsConstraintRecipeTest implements RewriteTest {
                         "                .join(String.class)\n" +
                         "                .impactBigDecimal(HardSoftBigDecimalScore.ONE_HARD, (a, b, c, d) -> BigDecimal.TEN)\n"
                         +
-                        "                .asConstraint(\"My package\", \"My constraint\");")));
+                        "                .asConstraint(\"My package.My constraint\");")));
     }
 
     // ************************************************************************

--- a/migration/src/test/java/ai/timefold/solver/migration/v8/RemoveConstraintPackageRecipeTest.java
+++ b/migration/src/test/java/ai/timefold/solver/migration/v8/RemoveConstraintPackageRecipeTest.java
@@ -1,0 +1,93 @@
+package ai.timefold.solver.migration.v8;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+class RemoveConstraintPackageRecipeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveConstraintPackageRecipe())
+                .parser(RemoveConstraintPackageRecipe.buildJavaParser());
+    }
+
+    @Test
+    void uni() {
+        rewriteRun(
+                java(
+                        wrap("        return f.forEach(String.class)\n" +
+                                "                .penalize(HardSoftScore.ONE_HARD)\n" +
+                                "                .asConstraint(\"My package\", \"My constraint\");"),
+                        wrap("        return f.forEach(String.class)\n" +
+                                "                .penalize(HardSoftScore.ONE_HARD)\n" +
+                                "                .asConstraint(\"My package.My constraint\");")));
+    }
+
+    @Test
+    void bi() {
+        rewriteRun(
+                java(
+                        wrap("        return f.forEach(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .penalize(HardSoftScore.ONE_HARD)\n" +
+                                "                .asConstraint(\"My package\", \"My constraint\");"),
+                        wrap("        return f.forEach(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .penalize(HardSoftScore.ONE_HARD)\n" +
+                                "                .asConstraint(\"My package.My constraint\");")));
+    }
+
+    @Test
+    void tri() {
+        rewriteRun(
+                java(
+                        wrap("        return f.forEach(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .penalize(HardSoftScore.ONE_HARD)\n" +
+                                "                .asConstraint(\"My package\", \"My constraint\");"),
+                        wrap("        return f.forEach(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .penalize(HardSoftScore.ONE_HARD)\n" +
+                                "                .asConstraint(\"My package.My constraint\");")));
+    }
+
+    @Test
+    void quad() {
+        rewriteRun(
+                java(
+                        wrap("        return f.forEach(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .penalize(HardSoftScore.ONE_HARD)\n" +
+                                "                .asConstraint(\"My package\", \"My constraint\");"),
+                        wrap("        return f.forEach(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .join(String.class)\n" +
+                                "                .penalize(HardSoftScore.ONE_HARD)\n" +
+                                "                .asConstraint(\"My package.My constraint\");")));
+    }
+
+    // ************************************************************************
+    // Helper methods
+    // ************************************************************************
+
+    private static String wrap(String content) {
+        return "import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;\n" +
+                "import ai.timefold.solver.core.api.score.stream.ConstraintFactory;\n" +
+                "import ai.timefold.solver.core.api.score.stream.Constraint;\n" +
+                "\n" +
+                "class Test {\n" +
+                "    Constraint myConstraint(ConstraintFactory f) {\n" +
+                content + "\n" +
+                "    }" +
+                "}\n";
+    }
+
+}


### PR DESCRIPTION
Constraint packages are still used internally, as there is no way to remove them without breaking backwards compatibility. 
All user-facing references to them have been deprecated though.