### PR TITLE
ci: Change pip install command in Sonarcloud to one line

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -35,7 +35,6 @@ jobs:
             **/setup.py
       - name: Install tox
         run:
-          python -m pip install --upgrade pip
           pip install tox coverage pytest pytest-cov
       - name: Cache SonarCloud packages
         uses: actions/cache@v4


### PR DESCRIPTION
For some reason, the entire block is being executed as one command instead of two. The first command is unnecessary, so it was removed.