### PR TITLE
ci: external contributions require a label before CI can run

### DIFF
--- a/.github/workflows/downstream_benchmarks.yml
+++ b/.github/workflows/downstream_benchmarks.yml
@@ -1,14 +1,15 @@
 name: Downstream - Integration Tests
 
 on:
-  # Enables the workflow to run on PRs from forks;
-  # token sharing is safe here, because enterprise is a private repo and therefore fully under our control.
+  # Enables the workflow to run on PRs from forks.
+  # CI will only run once the PR is labeled as "Safe for CI", in order to prevent stealing of secrets.
   pull_request_target:
     branches: [main] # Benchmarks aren't branched, so they will only ever work against current main.
     types:
       - opened
       - reopened
       - synchronize
+      - labeled
     paths-ignore:
       - 'LICENSE*'
       - '.gitignore'
@@ -17,7 +18,17 @@ on:
       - '*.txt'
 
 jobs:
+  safe_for_ci:
+    name: "Ensure that PR is safe for CI"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if not safe
+        if: ${{ !contains( github.event.pull_request.labels.*.name, 'Safe for CI') }}
+        shell: bash
+        run:
+          exit 1
   build:
+    needs: safe_for_ci
     runs-on: ubuntu-latest
     concurrency:
       group: pr-${{ github.event_name }}-${{ github.head_ref }}

--- a/.github/workflows/downstream_enterprise.yml
+++ b/.github/workflows/downstream_enterprise.yml
@@ -1,14 +1,15 @@
 name: Downstream - Timefold Solver Enterprise Edition
 
 on:
-  # Enables the workflow to run on PRs from forks;
-  # token sharing is safe here, because enterprise is a private repo and therefore fully under our control.
+  # Enables the workflow to run on PRs from forks.
+  # CI will only run once the PR is labeled as "Safe for CI", in order to prevent stealing of secrets.
   pull_request_target:
     branches: [main, '*.x']
     types:
       - opened
       - reopened
       - synchronize
+      - labeled
     paths-ignore:
       - 'LICENSE*'
       - '.gitignore'
@@ -17,7 +18,17 @@ on:
       - '*.txt'
 
 jobs:
+  safe_for_ci:
+    name: "Ensure that PR is safe for CI"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if not safe
+        if: ${{ !contains( github.event.pull_request.labels.*.name, 'Safe for CI') }}
+        shell: bash
+        run:
+          exit 1
   build:
+    needs: safe_for_ci
     runs-on: ubuntu-latest
     concurrency:
       group: downstream-enterprise-${{ github.event_name }}-${{ github.head_ref }}

--- a/.github/workflows/downstream_python_enterprise.yml
+++ b/.github/workflows/downstream_python_enterprise.yml
@@ -2,14 +2,15 @@
 name: Downstream - Timefold Solver Enterprise for Python
 
 on:
-  # Enables the workflow to run on PRs from forks;
-  # token sharing is safe here, because enterprise is a private repo and therefore fully under our control.
+  # Enables the workflow to run on PRs from forks.
+  # CI will only run once the PR is labeled as "Safe for CI", in order to prevent stealing of secrets.
   pull_request_target:
     branches: [ main, '*.x' ]
     types:
       - opened
       - reopened
       - synchronize
+      - labeled
     paths-ignore:
       - 'LICENSE*'
       - '.gitignore'
@@ -22,13 +23,22 @@ defaults:
     shell: bash
 
 jobs:
+  safe_for_ci:
+    name: "Ensure that PR is safe for CI"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if not safe
+        if: ${{ !contains( github.event.pull_request.labels.*.name, 'Safe for CI') }}
+        shell: bash
+        run:
+          exit 1
   build:
+    needs: safe_for_ci
     concurrency:
       group: downstream-enterprise-python-${{ github.event_name }}-${{ github.head_ref }}
       cancel-in-progress: true
     timeout-minutes: 120
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/downstream_python_quickstarts.yml
+++ b/.github/workflows/downstream_python_quickstarts.yml
@@ -3,7 +3,10 @@ name: Downstream - Timefold Solver for Python Quickstarts
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types:
+      - opened
+      - reopened
+      - synchronize
     branches:
       - main
     paths-ignore:
@@ -19,7 +22,7 @@ defaults:
     shell: bash
 
 jobs:
-  test-build:
+  build:
     concurrency:
       group: pull_request_python_quickstarts-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}-${{ matrix.python-version }}
       cancel-in-progress: true

--- a/.github/workflows/downstream_quickstarts.yml
+++ b/.github/workflows/downstream_quickstarts.yml
@@ -3,6 +3,10 @@ name: Downstream - Timefold Quickstarts
 on:
   pull_request:
     branches: [main, '*.x']
+    types:
+      - opened
+      - reopened
+      - synchronize
     paths-ignore:
       - 'LICENSE*'
       - '.gitignore'

--- a/.github/workflows/safe_for_ci.yml
+++ b/.github/workflows/safe_for_ci.yml
@@ -1,0 +1,34 @@
+name: Check if PR safe for CI
+
+on:
+  # Workflow always runs from the blessed repo; cannot be forged.
+  pull_request_target:
+    types: [ opened ]
+
+jobs:
+  add_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+
+      - id: auth_check
+        uses: morfien101/actions-authorized-user@v3
+        with:
+          username: ${{ github.actor }}
+          org: "TimefoldAI"
+          whitelist: "timefold-release,dependabot[bot]" # We trust dependabot to not steal secrets.
+          github_token: ${{ secrets.JRELEASER_GITHUB_TOKEN }} # Release account is a Solver Gatekeeper.
+      - name: Add labels
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.auth_check.outputs.authorized }}
+        with:
+          labels: |
+            Safe for CI
+      - name: Add labels
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ !steps.auth_check.outputs.authorized }}
+        with:
+          labels: |
+            External Contribution

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,8 +8,19 @@ on:
       - opened
       - reopened
       - synchronize
+      - labeled
 jobs:
+  safe_for_ci:
+    name: "Ensure that PR is safe for CI"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if not safe
+        if: ${{ !contains( github.event.pull_request.labels.*.name, 'Safe for CI') }}
+        shell: bash
+        run:
+          exit 1
   build:
+    needs: safe_for_ci
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR makes it so that pull requests that could steal secrets now require a specific label.
It also makes it so that a workflow runs automatically to grant that label to PRs by trusted users.