### PR TITLE
chore: do not require team during auth

### DIFF
--- a/.github/workflows/downstream_benchmarks.yml
+++ b/.github/workflows/downstream_benchmarks.yml
@@ -24,13 +24,12 @@ jobs:
       is_member_of_org: ${{ steps.auth_check.outputs.authorized }}
     steps:
       - id: auth_check
-        uses: morfien101/actions-authorized-user@v3
-        with:
-          username: ${{ github.actor }}
-          org: "TimefoldAI"
-          team: "trusted-committers"
-          whitelist: "timefold-release,dependabot[bot]" # We trust dependabot to not steal secrets.
-          github_token: ${{ secrets.JRELEASER_GITHUB_TOKEN }} # Release account is a Solver Gatekeeper.
+        env:
+          GH_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}  # Release account is a Solver Gatekeeper.
+        shell: bash
+        run: |
+          ORG_MEMBERSHIP=`curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/orgs/TimefoldAI/memberships/${{ github.actor }}" | jq -r '.state == "active"'`
+          echo "authorized=$ORG_MEMBERSHIP" >> "$GITHUB_OUTPUT"
       - id: validation
         shell: bash
         run: |

--- a/.github/workflows/downstream_enterprise.yml
+++ b/.github/workflows/downstream_enterprise.yml
@@ -24,13 +24,12 @@ jobs:
       is_member_of_org: ${{ steps.auth_check.outputs.authorized }}
     steps:
       - id: auth_check
-        uses: morfien101/actions-authorized-user@v3
-        with:
-          username: ${{ github.actor }}
-          org: "TimefoldAI"
-          team: "trusted-committers"
-          whitelist: "timefold-release,dependabot[bot]" # We trust dependabot to not steal secrets.
-          github_token: ${{ secrets.JRELEASER_GITHUB_TOKEN }} # Release account is a Solver Gatekeeper.
+        env:
+          GH_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}  # Release account is a Solver Gatekeeper.
+        shell: bash
+        run: |
+          ORG_MEMBERSHIP=`curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/orgs/TimefoldAI/memberships/${{ github.actor }}" | jq -r '.state == "active"'`
+          echo "authorized=$ORG_MEMBERSHIP" >> "$GITHUB_OUTPUT"
       - id: validation
         shell: bash
         run: |

--- a/.github/workflows/downstream_python_enterprise.yml
+++ b/.github/workflows/downstream_python_enterprise.yml
@@ -29,13 +29,12 @@ jobs:
       is_member_of_org: ${{ steps.auth_check.outputs.authorized }}
     steps:
       - id: auth_check
-        uses: morfien101/actions-authorized-user@v3
-        with:
-          username: ${{ github.actor }}
-          org: "TimefoldAI"
-          team: "trusted-committers"
-          whitelist: "timefold-release,dependabot[bot]" # We trust dependabot to not steal secrets.
-          github_token: ${{ secrets.JRELEASER_GITHUB_TOKEN }} # Release account is a Solver Gatekeeper.
+        env:
+          GH_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}  # Release account is a Solver Gatekeeper.
+        shell: bash
+        run: |
+          ORG_MEMBERSHIP=`curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/orgs/TimefoldAI/memberships/${{ github.actor }}" | jq -r '.state == "active"'`
+          echo "authorized=$ORG_MEMBERSHIP" >> "$GITHUB_OUTPUT"
       - id: validation
         shell: bash
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,13 +19,12 @@ jobs:
       is_member_of_org: ${{ steps.auth_check.outputs.authorized }}
     steps:
       - id: auth_check
-        uses: morfien101/actions-authorized-user@v3
-        with:
-          username: ${{ github.actor }}
-          org: "TimefoldAI"
-          team: "trusted-committers"
-          whitelist: "timefold-release,dependabot[bot]" # We trust dependabot to not steal secrets.
-          github_token: ${{ secrets.JRELEASER_GITHUB_TOKEN }} # Release account is a Solver Gatekeeper.
+        env:
+          GH_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}  # Release account is a Solver Gatekeeper.
+        shell: bash
+        run: |
+          ORG_MEMBERSHIP=`curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/orgs/TimefoldAI/memberships/${{ github.actor }}" | jq -r '.state == "active"'`
+          echo "authorized=$ORG_MEMBERSHIP" >> "$GITHUB_OUTPUT"
       - id: validation
         shell: bash
         run: |


### PR DESCRIPTION
Do not require a team when checking if the PR author is a member of the organisation in GH workflows.