### PR TITLE
fix: Avoid duplicating nearby configuration

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
@@ -35,10 +35,17 @@ public class UnionMoveSelectorFactory<Solution_>
                                         Remove the Nearby setting from the selector configuration or remove the top-level nearbyDistanceMeterClass."""
                                         .formatted(nearbySelectorConfig, configPolicy.getNearbyDistanceMeterClass()));
                     }
+                    // We delay the autoconfiguration to the deepest UnionMoveSelectorConfig node in the tree
+                    // to avoid duplicating configuration
+                    // when there are nested unionMoveSelector configurations
+                    if (selectorConfig instanceof UnionMoveSelectorConfig) {
+                        continue;
+                    }
                     // Add a new configuration with Nearby Selection enabled
                     moveSelectorConfigList
                             .add(nearbySelectorConfig.enableNearbySelection(configPolicy.getNearbyDistanceMeterClass(),
                                     configPolicy.getRandom()));
+
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a bug when there are nested `UnionMoveSelectorConfig` configurations and does not duplicate configurations, which causes the following:

```
java.lang.IllegalArgumentException: The selector configuration (ListChangeMoveSelectorConfig(ValueSelectorConfig(null), DestinationSelectorConfig(null, null))) already includes the Nearby Selection setting, making it incompatible with the top-level property nearbyDistanceMeterClass (class ai.timefold.solver.benchmarks.examples.vehiclerouting.domain.solver.nearby.CustomerNearbyDistanceMeter).
Remove the Nearby setting from the selector configuration or remove the top-level nearbyDistanceMeterClass.
```