### PR TITLE
fix: address scale equal to NaN

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/api/solver/ProblemSizeStatistics.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/ProblemSizeStatistics.java
@@ -39,6 +39,10 @@ public record ProblemSizeStatistics(long entityCount,
     }
 
     String approximateProblemScaleAsFormattedString(Locale locale) {
+        if (Double.isNaN(approximateProblemSizeLog) || Double.isInfinite(approximateProblemSizeLog)) {
+            return "0";
+        }
+
         if (approximateProblemSizeLog < 10) { // log_10(10_000_000_000) = 10
             return "%s".formatted(format(Math.pow(10d, approximateProblemSizeLog), BASIC_FORMATTER, locale));
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -1095,7 +1095,11 @@ public class SolutionDescriptor<Solution_> {
             result += MathUtils.getPossibleArrangementsScaledApproximateLog(MathUtils.LOG_PRECISION, logBase,
                     totalListMovableValueCount, possibleTargetsForListValue);
         }
-        return (result / (double) MathUtils.LOG_PRECISION) / MathUtils.getLogInBase(logBase, 10d);
+        var scale = (result / (double) MathUtils.LOG_PRECISION) / MathUtils.getLogInBase(logBase, 10d);
+        if (Double.isNaN(scale) || Double.isInfinite(scale)) {
+            return 0;
+        }
+        return scale;
     }
 
     public ProblemSizeStatistics getProblemSizeStatistics(ScoreDirector<Solution_> scoreDirector, Solution_ solution) {

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/ProblemSizeStatisticsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/ProblemSizeStatisticsTest.java
@@ -67,5 +67,25 @@ class ProblemSizeStatisticsTest {
         statistics = getProblemSizeStatistics(321_123_456_789L);
         assertThat(statistics.approximateProblemScaleAsFormattedString())
                 .isEqualTo("3.211235 × 10^11");
+
+        // scale = -infinity
+        statistics = new ProblemSizeStatistics(0L, 0L, 0L, Double.NEGATIVE_INFINITY);
+        assertThat(statistics.approximateProblemScaleAsFormattedString())
+                .isEqualTo("0");
+
+        // scale = +infinity
+        statistics = new ProblemSizeStatistics(0L, 0L, 0L, Double.POSITIVE_INFINITY);
+        assertThat(statistics.approximateProblemScaleAsFormattedString())
+                .isEqualTo("0");
+
+        // scale = NaN
+        statistics = new ProblemSizeStatistics(0L, 0L, 0L, Double.NaN);
+        assertThat(statistics.approximateProblemScaleAsFormattedString())
+                .isEqualTo("0");
+
+        // scale = 0
+        statistics = new ProblemSizeStatistics(0L, 0L, 0L, 0);
+        assertThat(statistics.approximateProblemScaleAsFormattedString())
+                .isEqualTo("1");
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -410,6 +410,23 @@ class SolutionDescriptorTest {
     }
 
     @Test
+    void emptyProblemScale() {
+        int valueCount = 27;
+        int entityCount = 27;
+        SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
+        TestdataSolution solution = TestdataSolution.generateSolution(valueCount, entityCount);
+        solution.getValueList().clear();
+        assertSoftly(softly -> {
+            softly.assertThat(solutionDescriptor.getGenuineEntityCount(solution)).isEqualTo(entityCount);
+            softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(entityCount);
+            softly.assertThat(solutionDescriptor.getMaximumValueRangeSize(solution)).isEqualTo(0);
+            softly.assertThat(solutionDescriptor.getApproximateValueCount(solution)).isEqualTo(0);
+            softly.assertThat(solutionDescriptor.getProblemScale(null, solution))
+                    .isEqualTo(0);
+        });
+    }
+
+    @Test
     void problemScaleMultipleValueRanges() {
         var solutionDescriptor = TestdataValueRangeSolution.buildSolutionDescriptor();
         var solution = new TestdataValueRangeSolution("Solution");


### PR DESCRIPTION
This pull request addresses the issue with the statistics when the range value list is empty.