### PR TITLE
feat: update the best solution for custom construction heuristics

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/CustomPhaseCommand.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/CustomPhaseCommand.java
@@ -52,7 +52,7 @@ public interface CustomPhaseCommand<Solution_> {
      * That doesn't mean the solution should not be accepted, as the phase is building an initial solution.
      * 
      * @return false, update the best solution only if it is improved;
-     *         otherwise, update it if it differs from the starting phase solution.
+     *         otherwise, update it whichever the score is.
      */
     default boolean requireUpdateBestSolution() {
         return false;

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/CustomPhaseCommand.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/CustomPhaseCommand.java
@@ -6,6 +6,7 @@ import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.api.solver.ProblemFactChange;
 import ai.timefold.solver.core.api.solver.Solver;
 import ai.timefold.solver.core.impl.phase.Phase;
+import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 
 /**
@@ -34,5 +35,27 @@ public interface CustomPhaseCommand<Solution_> {
      * @param scoreDirector never null, the {@link ScoreDirector} that needs to get notified of the changes.
      */
     void changeWorkingSolution(ScoreDirector<Solution_> scoreDirector);
+
+    /**
+     * By default,
+     * when the solution returned by the custom phase is worse than the {@link AbstractPhaseScope#getStartingScore() starting
+     * solution} from the phase,
+     * it is expected to be ignored as it needs to improve the current best solution.
+     * <p>
+     * However, in some cases,
+     * the current best solution needs to be updated with a new one to avoid losing the result
+     * and ending up in an inconsistent state for the next phase.
+     * <p>
+     * For example, let's consider a custom construction heuristic phase for a model
+     * using a planning list variable that accepts unassigned values.
+     * The initial score might be better than the result of the custom phase, as some constraints may be violated.
+     * That doesn't mean the solution should not be accepted, as the phase is building an initial solution.
+     * 
+     * @return false, update the best solution only if it is improved;
+     *         otherwise, update it if it differs from the starting phase solution.
+     */
+    default boolean requireUpdateBestSolution() {
+        return false;
+    }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
@@ -55,7 +55,7 @@ final class DefaultCustomPhase<Solution_> extends AbstractPhase<Solution_> imple
         InnerScoreDirector<Solution_, ?> scoreDirector = stepScope.getScoreDirector();
         customPhaseCommand.changeWorkingSolution(scoreDirector);
         calculateWorkingStepScore(stepScope, customPhaseCommand);
-        if (triggersFirstInitializedSolutionEvent()) {
+        if (customPhaseCommand.requireUpdateBestSolution()) {
             solver.getBestSolutionRecaller().processWorkingSolutionDuringConstructionHeuristicsStep(stepScope);
         } else {
             solver.getBestSolutionRecaller().processWorkingSolutionDuringStep(stepScope);
@@ -78,10 +78,6 @@ final class DefaultCustomPhase<Solution_> extends AbstractPhase<Solution_> imple
 
     public void phaseEnded(CustomPhaseScope<Solution_> phaseScope) {
         super.phaseEnded(phaseScope);
-        // Only update the best solution if the custom phase first initializes the solution and made any change.
-        if (triggersFirstInitializedSolutionEvent() && !phaseScope.getStartingScore().equals(phaseScope.getBestScore())) {
-            solver.getBestSolutionRecaller().updateBestSolutionAndFire(phaseScope.getSolverScope());
-        }
         phaseScope.endingNow();
         logger.info("{}Custom phase ({}) ended: time spent ({}), best score ({}),"
                 + " score calculation speed ({}/sec), step total ({}).",

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/AllowsUnassignedValuesListVariableSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/AllowsUnassignedValuesListVariableSolverTest.java
@@ -101,8 +101,7 @@ class AllowsUnassignedValuesListVariableSolverTest {
                                         .withMoveTabuSize(1))
                                 .withForagerConfig(new LocalSearchForagerConfig()
                                         .withAcceptedCountLimit(1))
-                                .withTerminationConfig(new TerminationConfig().withStepCountLimit(1))
-                        );
+                                .withTerminationConfig(new TerminationConfig().withStepCountLimit(1)));
         var solverFactory = SolverFactory.create(solverConfig);
         var solver = solverFactory.buildSolver();
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/AllowsUnassignedValuesListVariableSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/AllowsUnassignedValuesListVariableSolverTest.java
@@ -124,6 +124,11 @@ class AllowsUnassignedValuesListVariableSolverTest {
             scoreDirector.afterListVariableChanged(solution.getEntityList().get(0), "valueList", 0, 1);
             scoreDirector.triggerVariableListeners();
         }
+
+        @Override
+        public boolean requireUpdateBestSolution() {
+            return true;
+        }
     }
 
     enum ListVariableMoveType {

--- a/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
+++ b/docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
@@ -723,10 +723,12 @@ The `CustomPhaseCommand` interface appears as follows:
 [source,java,options="nowrap"]
 ----
 public interface CustomPhaseCommand<Solution_> {
-    ...
 
     void changeWorkingSolution(ScoreDirector<Solution_> scoreDirector);
-
+    ...
+    default boolean requireUpdateBestSolution() {
+        return false;
+    }
 }
 ----
 
@@ -740,6 +742,13 @@ Any change on the planning entities in a `CustomPhaseCommand` must be notified t
 Do not change any of the problem facts in a `CustomPhaseCommand`.
 That will corrupt the `Solver` because any previous score or solution was for a different problem.
 To do that, read about xref:responding-to-change/responding-to-change.adoc[repeated planning] and do it with a xref:responding-to-change/responding-to-change.adoc#problemChange[ProblemChange] instead.
+====
+
+[NOTE]
+====
+When initializing the solution for a planning list variable model that accepts unassigned values,
+the custom command may override `requireUpdateBestSolution`
+to return `true` in order to ensure the best solution is updated.
 ====
 
 Configure the `CustomPhaseCommand` in the solver configuration:


### PR DESCRIPTION
This pull request modifies the logic of `DefaultCustomPhase` to update the best solution when the returned solution is not better than the starting phase one.

When the planning list variable accepts unassigned list values, the custom CH does not update the best solution because it may be possible that it does not improve the starting score (`0hard/0soft`).