### PR TITLE
fix: allow @PlanningId to be defined on interfaces

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
@@ -372,12 +372,19 @@ public class ConfigUtils {
                     .filter(field -> field.isAnnotationPresent(annotationClass) && !field.isSynthetic())
                     .sorted(alphabeticMemberComparator);
             var methodStream = Stream.of(clazz.getDeclaredMethods())
-                    .filter(method -> method.isAnnotationPresent(annotationClass) && !method.isSynthetic())
-                    .sorted(alphabeticMemberComparator);
+                    .filter(method -> method.isAnnotationPresent(annotationClass) && !method.isSynthetic());
+
+            for (var implementedInterface : clazz.getInterfaces()) {
+                methodStream = Stream.concat(
+                        methodStream,
+                        Arrays.stream(implementedInterface.getMethods())
+                                .filter(method -> method.isAnnotationPresent(annotationClass) && !method.isSynthetic()));
+            }
+            methodStream = methodStream.sorted(alphabeticMemberComparator);
             memberStream = Stream.concat(memberStream, Stream.concat(fieldStream, methodStream));
             clazz = clazz.getSuperclass();
         }
-        return memberStream.collect(Collectors.toList());
+        return memberStream.distinct().collect(Collectors.toList());
     }
 
     @SafeVarargs

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/lookup/LookUpManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/lookup/LookUpManagerTest.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 
 import ai.timefold.solver.core.api.domain.lookup.LookUpStrategyType;
 import ai.timefold.solver.core.impl.testdata.domain.clone.lookup.TestdataObjectIntegerId;
+import ai.timefold.solver.core.impl.testdata.domain.interface_domain.TestdataInterfaceEntity;
+import ai.timefold.solver.core.impl.testdata.domain.interface_domain.TestdataInterfaceValue;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +34,45 @@ class LookUpManagerTest extends AbstractLookupTest {
         // So it's possible to look up and remove them
         assertThat(lookUpManager.lookUpWorkingObject(new TestdataObjectIntegerId(0))).isSameAs(o);
         assertThat(lookUpManager.lookUpWorkingObject(new TestdataObjectIntegerId(1))).isSameAs(p);
+        lookUpManager.removeWorkingObject(o);
+        lookUpManager.removeWorkingObject(p);
+    }
+
+    public static class InterfaceEntity implements TestdataInterfaceEntity {
+        final String id;
+
+        public InterfaceEntity(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public TestdataInterfaceValue getValue() {
+            return null;
+        }
+
+        @Override
+        public void setValue(TestdataInterfaceValue value) {
+
+        }
+    }
+
+    @Test
+    void lookupInterfaceEntity() {
+        var o = new InterfaceEntity("0");
+        var p = new InterfaceEntity("1");
+        // The objects should be added during the reset
+        lookUpManager.reset();
+        for (Object fact : Arrays.asList(o, p)) {
+            lookUpManager.addWorkingObject(fact);
+        }
+        // So it's possible to look up and remove them
+        assertThat(lookUpManager.lookUpWorkingObject(new InterfaceEntity("0"))).isSameAs(o);
+        assertThat(lookUpManager.lookUpWorkingObject(new InterfaceEntity("1"))).isSameAs(p);
         lookUpManager.removeWorkingObject(o);
         lookUpManager.removeWorkingObject(p);
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceEntity.java
@@ -1,10 +1,14 @@
 package ai.timefold.solver.core.impl.testdata.domain.interface_domain;
 
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.lookup.PlanningId;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 
 @PlanningEntity
 public interface TestdataInterfaceEntity {
+    @PlanningId
+    String getId();
+
     @PlanningVariable
     TestdataInterfaceValue getValue();
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/interface_domain/TestdataInterfaceSolution.java
@@ -57,6 +57,11 @@ public interface TestdataInterfaceSolution {
                     private TestdataInterfaceValue value;
 
                     @Override
+                    public String getId() {
+                        return "entity";
+                    }
+
+                    @Override
                     public TestdataInterfaceValue getValue() {
                         return value;
                     }


### PR DESCRIPTION
Previously, `getAllMembers` excluded members defined in interfaces. Presumably, this was because methods would have implementations in the implementing class.
However, there is a flaw in that logic: implementations of a method do not inherit the annotations of the declared method. As a result, when LookupManager looks up the accessor of a class whose @PlanningId is defined in an interface,
it finds none.

`getAllMembers` is changed to add all interface methods to the member list, thus allowing interface members to be used in lookups.