### PR TITLE
fix: Allow relative imports in translated functions

### DIFF
--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/CPythonBackedPythonInterpreter.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/CPythonBackedPythonInterpreter.java
@@ -15,7 +15,6 @@ import java.util.function.Function;
 
 import ai.timefold.jpyinterpreter.builtins.GlobalBuiltins;
 import ai.timefold.jpyinterpreter.types.CPythonBackedPythonLikeObject;
-import ai.timefold.jpyinterpreter.types.PythonModule;
 import ai.timefold.jpyinterpreter.types.PythonString;
 import ai.timefold.jpyinterpreter.types.collections.PythonLikeTuple;
 import ai.timefold.jpyinterpreter.types.errors.PythonTraceback;
@@ -33,7 +32,7 @@ public class CPythonBackedPythonInterpreter implements PythonInterpreter {
     PrintStream standardOutput;
     Scanner inputScanner;
 
-    Map<ModuleSpec, PythonModule> moduleSpecToModuleMap = new HashMap<>();
+    Map<ModuleSpec, PythonLikeObject> moduleSpecToModuleMap = new HashMap<>();
 
     final Set<PythonLikeObject> hasReferenceSet =
             Collections.newSetFromMap(new ConcurrentWeakIdentityHashMap<>());
@@ -54,7 +53,7 @@ public class CPythonBackedPythonInterpreter implements PythonInterpreter {
     public static BiFunction<OpaquePythonReference, Map<Number, PythonLikeObject>, Map<String, PythonLikeObject>> lookupDictOnPythonReferencePythonFunction;
     public static TriFunction<OpaquePythonReference, List<PythonLikeObject>, Map<PythonString, PythonLikeObject>, PythonLikeObject> callPythonFunction;
 
-    public static PentaFunction<String, Map<String, PythonLikeObject>, Map<String, PythonLikeObject>, List<String>, Long, PythonModule> importModuleFunction;
+    public static PentaFunction<String, Map<String, PythonLikeObject>, Map<String, PythonLikeObject>, List<String>, Long, PythonLikeObject> importModuleFunction;
     public static QuadFunction<OpaquePythonReference, Map<String, PythonLikeObject>, PythonLikeTuple, PythonString, PythonObjectWrapper> createFunctionFromCodeFunction;
 
     public CPythonBackedPythonInterpreter() {
@@ -178,7 +177,8 @@ public class CPythonBackedPythonInterpreter implements PythonInterpreter {
     }
 
     @Override
-    public PythonModule importModule(PythonInteger level, List<PythonString> fromList, Map<String, PythonLikeObject> globalsMap,
+    public PythonLikeObject importModule(PythonInteger level, List<PythonString> fromList,
+            Map<String, PythonLikeObject> globalsMap,
             Map<String, PythonLikeObject> localsMap, String moduleName) {
         // See https://docs.python.org/3/library/functions.html#import__ for semantics
         ModuleSpec moduleSpec = new ModuleSpec(level, fromList, globalsMap, localsMap, moduleName);

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonInterpreter.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonInterpreter.java
@@ -3,7 +3,6 @@ package ai.timefold.jpyinterpreter;
 import java.util.List;
 import java.util.Map;
 
-import ai.timefold.jpyinterpreter.types.PythonModule;
 import ai.timefold.jpyinterpreter.types.PythonString;
 import ai.timefold.jpyinterpreter.types.errors.PythonTraceback;
 import ai.timefold.jpyinterpreter.types.numeric.PythonInteger;
@@ -22,7 +21,7 @@ public interface PythonInterpreter {
 
     void deleteGlobal(Map<String, PythonLikeObject> globalsMap, String name);
 
-    PythonModule importModule(PythonInteger level, List<PythonString> fromList, Map<String, PythonLikeObject> globalsMap,
+    PythonLikeObject importModule(PythonInteger level, List<PythonString> fromList, Map<String, PythonLikeObject> globalsMap,
             Map<String, PythonLikeObject> localsMap, String moduleName);
 
     /**

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
@@ -125,13 +125,15 @@ public class KnownCallImplementor {
         }
 
         // Load any arguments missing values
+        int defaultOffset = pythonFunctionSignature.getArgumentSpec().getTotalArgumentCount()
+                - pythonFunctionSignature.getDefaultArgumentList().size();
         for (int i = specPositionalArgumentCount - missingValues; i < specPositionalArgumentCount; i++) {
             if (pythonFunctionSignature.getArgumentSpec().isArgumentNullable(i)) {
                 methodVisitor.visitInsn(Opcodes.ACONST_NULL);
             } else {
                 methodVisitor.visitFieldInsn(Opcodes.GETSTATIC,
                         pythonFunctionSignature.getDefaultArgumentHolderClassInternalName(),
-                        PythonDefaultArgumentImplementor.getConstantName(i),
+                        PythonDefaultArgumentImplementor.getConstantName(i - defaultOffset),
                         "L" + pythonFunctionSignature.getArgumentSpec().getArgumentTypeInternalName(i) + ";");
             }
         }

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ModuleImplementor.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ModuleImplementor.java
@@ -10,7 +10,6 @@ import ai.timefold.jpyinterpreter.PythonBytecodeToJavaBytecodeTranslator;
 import ai.timefold.jpyinterpreter.PythonInterpreter;
 import ai.timefold.jpyinterpreter.PythonLikeObject;
 import ai.timefold.jpyinterpreter.StackMetadata;
-import ai.timefold.jpyinterpreter.types.PythonModule;
 import ai.timefold.jpyinterpreter.types.numeric.PythonInteger;
 
 import org.objectweb.asm.Label;
@@ -90,7 +89,7 @@ public class ModuleImplementor {
 
         // Now call the interpreter's importModule function
         methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonInterpreter.class),
-                "importModule", Type.getMethodDescriptor(Type.getType(PythonModule.class),
+                "importModule", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
                         Type.getType(PythonInteger.class), Type.getType(List.class),
                         Type.getType(Map.class), Type.getType(Map.class), Type.getType(String.class)),
                 true);

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/module/ImportNameOpcode.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/opcodes/module/ImportNameOpcode.java
@@ -6,7 +6,7 @@ import ai.timefold.jpyinterpreter.StackMetadata;
 import ai.timefold.jpyinterpreter.ValueSourceInfo;
 import ai.timefold.jpyinterpreter.implementors.ModuleImplementor;
 import ai.timefold.jpyinterpreter.opcodes.AbstractOpcode;
-import ai.timefold.jpyinterpreter.types.PythonModule;
+import ai.timefold.jpyinterpreter.types.BuiltinTypes;
 
 public class ImportNameOpcode extends AbstractOpcode {
 
@@ -17,7 +17,7 @@ public class ImportNameOpcode extends AbstractOpcode {
     @Override
     protected StackMetadata getStackMetadataAfterInstruction(FunctionMetadata functionMetadata, StackMetadata stackMetadata) {
         return stackMetadata.pop(2)
-                .push(ValueSourceInfo.of(this, PythonModule.MODULE_TYPE,
+                .push(ValueSourceInfo.of(this, BuiltinTypes.BASE_TYPE,
                         stackMetadata.getValueSourcesUpToStackIndex(2)));
     }
 

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonModule.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/PythonModule.java
@@ -7,7 +7,7 @@ import ai.timefold.jpyinterpreter.PythonLikeObject;
 import ai.timefold.jpyinterpreter.types.wrappers.OpaquePythonReference;
 
 public class PythonModule extends AbstractPythonLikeObject {
-    public static PythonLikeType MODULE_TYPE = new PythonLikeType("module", PythonModule.class);
+    public static PythonLikeType MODULE_TYPE = BuiltinTypes.MODULE_TYPE;
     public static PythonLikeType $TYPE = MODULE_TYPE;
 
     private OpaquePythonReference pythonReference;

--- a/python/jpyinterpreter/src/main/python/jvm_setup.py
+++ b/python/jpyinterpreter/src/main/python/jvm_setup.py
@@ -1,11 +1,10 @@
 import importlib.resources
+import jpype
+import jpype.imports
 import locale
 import os
 import pathlib
 from typing import List, ContextManager
-
-import jpype
-import jpype.imports
 
 
 def _normalize_path(path):
@@ -272,9 +271,14 @@ class ImportModule:
         python_globals = unwrap_python_like_object(globals_map, None)
         python_locals = unwrap_python_like_object(locals_map, None)
         python_from_list = unwrap_python_like_object(from_list, None)
-        return convert_to_java_python_like_object(
-            __import__(module_name, python_globals, python_locals, python_from_list, level),
-            CPythonBackedPythonInterpreter.pythonObjectIdToConvertedObjectMap
+
+        try:
+            item = __import__(module_name, python_globals, python_locals, python_from_list, level)
+        except KeyError:
+            from ai.timefold.jpyinterpreter.types.errors.lookup import KeyError as JavaKeyError
+            raise JavaKeyError(f'Failed to import "{module_name}"')
+        return convert_to_java_python_like_object(item,
+                                                  CPythonBackedPythonInterpreter.pythonObjectIdToConvertedObjectMap
         )
 
 

--- a/python/jpyinterpreter/tests/pkg/__init__.py
+++ b/python/jpyinterpreter/tests/pkg/__init__.py
@@ -1,0 +1,1 @@
+variable = 10

--- a/python/jpyinterpreter/tests/test_builtins.py
+++ b/python/jpyinterpreter/tests/test_builtins.py
@@ -1,9 +1,8 @@
 import jpyinterpreter
 import pytest
 import sys
-from typing import SupportsAbs, Iterable, Callable, Sequence, Union, Iterator, Sized, Reversible, SupportsIndex
-
 from jpype import JImplementationFor
+from typing import SupportsAbs, Iterable, Callable, Sequence, Union, Iterator, Sized, Reversible, SupportsIndex
 
 from .conftest import verifier_for
 

--- a/python/jpyinterpreter/tests/test_import.py
+++ b/python/jpyinterpreter/tests/test_import.py
@@ -1,0 +1,10 @@
+from .conftest import verifier_for
+
+
+def test_relative_import():
+    def func() -> int:
+        from .pkg import variable
+        return variable
+
+    verifier = verifier_for(func)
+    verifier.verify(expected_result=10)

--- a/python/python-core/src/main/python/score/_group_by.py
+++ b/python/python-core/src/main/python/score/_group_by.py
@@ -1,6 +1,8 @@
 import dataclasses
-from jpype import JClass
 from typing import Callable, Any, Sequence, TypeVar, List, Set, Dict, TYPE_CHECKING, overload
+
+from jpype import JClass
+
 if TYPE_CHECKING:
     from ai.timefold.solver.core.api.score.stream.common import SequenceChain
     from ai.timefold.solver.core.api.score.stream.common import LoadBalance
@@ -10,60 +12,68 @@ if TYPE_CHECKING:
     from ai.timefold.solver.core.api.score.stream.quad import QuadConstraintCollector
 
 
+class _ConstraintCollectorData:
+    def __hash__(self):
+        raise TypeError('A ConstraintCollector should not be used as a key. '
+                        'Maybe you accidentally used a constraint collector in a lambda? '
+                        '(i.e. instead of doing `lambda shift: ConstraintCollectors.sum(shift.duration)`, '
+                        'do `ConstraintCollectors.sum(lambda shift: shift.duration)` instead).')
+
+
 @dataclasses.dataclass
-class NoArgsConstraintCollector:
+class NoArgsConstraintCollector(_ConstraintCollectorData):
     collector_creator: Callable
 
 
 @dataclasses.dataclass
-class GroupMappingSingleArgConstraintCollector:
+class GroupMappingSingleArgConstraintCollector(_ConstraintCollectorData):
     collector_creator: Callable
     group_mapping: Callable
 
 
 @dataclasses.dataclass
-class KeyValueMappingConstraintCollector:
+class KeyValueMappingConstraintCollector(_ConstraintCollectorData):
     collector_creator: Callable
     key_mapping: Callable
     value_mapping: Callable
 
 
 @dataclasses.dataclass
-class GroupIntMappingSingleArgConstraintCollector:
+class GroupIntMappingSingleArgConstraintCollector(_ConstraintCollectorData):
     collector_creator: Callable
     group_mapping: Callable
 
 
 @dataclasses.dataclass
-class GroupMappingIntMappingTwoArgConstraintCollector:
+class GroupMappingIntMappingTwoArgConstraintCollector(_ConstraintCollectorData):
     collector_creator: Callable
     group_mapping: Callable
     index_mapping: Callable
 
 
 @dataclasses.dataclass
-class ComposeConstraintCollector:
+class ComposeConstraintCollector(_ConstraintCollectorData):
     collector_creator: Callable
     subcollectors: Sequence[Any]
     compose_function: Callable
 
 
 @dataclasses.dataclass
-class ConditionalConstraintCollector:
+class ConditionalConstraintCollector(_ConstraintCollectorData):
     collector_creator: Callable
     predicate: Callable
     delegate: Any
 
 
 @dataclasses.dataclass
-class CollectAndThenCollector:
+class CollectAndThenCollector(_ConstraintCollectorData):
     collector_creator: Callable
     delegate_collector: Any
     mapping_function: Callable
 
 
 @dataclasses.dataclass
-class LoadBalanceCollector:
+class LoadBalanceCollector(_ConstraintCollectorData):
     collector_creator: Callable
     balanced_item_function: Callable
     load_function: Callable | None


### PR DESCRIPTION
- CPython will check globals for `__name__`, which it uses to determine the absolute package name from a relative package name

  - This means that we need to add the `__name__` entry to all Python global maps, even if `__name__` is not used directly by any function in the module

- Fix default loading for one call signature

- Make `ConstraintCollector.__hash__` raise a TypeError, to give an informative error message

- Make PythonInterpreter importModule return a PythonLikeObject, so C modules can be imported

- Use an WrappedExceptionMeta to rename the WrappedException class returned

Fixes #967 