### PR TITLE
feat: add solver job start event

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/api/solver/SolverJobBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/SolverJobBuilder.java
@@ -84,10 +84,10 @@ public interface SolverJobBuilder<Solution_, ProblemId_> {
     /**
      * Sets the consumer for when the solver starts its solving process.
      *
-     * @param startSolverJobConsumer never null, called only once when the solver is starting the solving process
+     * @param solverJobStartedConsumer never null, called only once when the solver is starting the solving process
      * @return this, never null
      */
-    SolverJobBuilder<Solution_, ProblemId_> withStartSolverJobConsumer(Consumer<? super Solution_> startSolverJobConsumer);
+    SolverJobBuilder<Solution_, ProblemId_> withSolverJobStartedConsumer(Consumer<? super Solution_> solverJobStartedConsumer);
 
     /**
      * Sets the custom exception handler.

--- a/core/src/main/java/ai/timefold/solver/core/api/solver/SolverJobBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/SolverJobBuilder.java
@@ -82,6 +82,14 @@ public interface SolverJobBuilder<Solution_, ProblemId_> {
             withFirstInitializedSolutionConsumer(Consumer<? super Solution_> firstInitializedSolutionConsumer);
 
     /**
+     * Sets the runnable action for when the solver starts its solving process.
+     *
+     * @param startSolverJobHandler never null, called only once when the solver is starting the solving process
+     * @return this, never null
+     */
+    SolverJobBuilder<Solution_, ProblemId_> withStartSolverJobHandler(Runnable startSolverJobHandler);
+
+    /**
      * Sets the custom exception handler.
      *
      * @param exceptionHandler never null, called if an exception or error occurs. If null it defaults to logging the

--- a/core/src/main/java/ai/timefold/solver/core/api/solver/SolverJobBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/SolverJobBuilder.java
@@ -82,12 +82,12 @@ public interface SolverJobBuilder<Solution_, ProblemId_> {
             withFirstInitializedSolutionConsumer(Consumer<? super Solution_> firstInitializedSolutionConsumer);
 
     /**
-     * Sets the runnable action for when the solver starts its solving process.
+     * Sets the consumer for when the solver starts its solving process.
      *
-     * @param startSolverJobHandler never null, called only once when the solver is starting the solving process
+     * @param startSolverJobConsumer never null, called only once when the solver is starting the solving process
      * @return this, never null
      */
-    SolverJobBuilder<Solution_, ProblemId_> withStartSolverJobHandler(Runnable startSolverJobHandler);
+    SolverJobBuilder<Solution_, ProblemId_> withStartSolverJobConsumer(Consumer<? super Solution_> startSolverJobConsumer);
 
     /**
      * Sets the custom exception handler.

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/ConsumerSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/ConsumerSupport.java
@@ -34,10 +34,11 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
         this.finalBestSolutionConsumer = finalBestSolutionConsumer == null ? finalBestSolution -> {
         } : finalBestSolutionConsumer;
         this.firstInitializedSolutionConsumer = firstInitializedSolutionConsumer;
+        this.solverJobStartedConsumer = solverJobStartedConsumer;
         this.exceptionHandler = exceptionHandler;
         this.bestSolutionHolder = bestSolutionHolder;
         this.firstInitializedSolution = null;
-        this.solverJobStartedConsumer = solverJobStartedConsumer;
+        this.initialSolution = null;
     }
 
     // Called on the Solver thread.
@@ -115,6 +116,7 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
                 // Cancel problem changes that arrived after the solver terminated.
                 bestSolutionHolder.cancelPendingChanges();
                 activeConsumption.release();
+                startSolverJobConsumption.release();
                 firstSolutionConsumption.release();
                 disposeConsumerThread();
             }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/ConsumerSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/ConsumerSupport.java
@@ -14,7 +14,7 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
     private final Consumer<? super Solution_> bestSolutionConsumer;
     private final Consumer<? super Solution_> finalBestSolutionConsumer;
     private final Consumer<? super Solution_> firstInitializedSolutionConsumer;
-    private final Consumer<? super Solution_> startSolverJobConsumer;
+    private final Consumer<? super Solution_> solverJobStartedConsumer;
     private final BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler;
     private final Semaphore activeConsumption = new Semaphore(1);
     private final Semaphore firstSolutionConsumption = new Semaphore(1);
@@ -26,7 +26,7 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
 
     public ConsumerSupport(ProblemId_ problemId, Consumer<? super Solution_> bestSolutionConsumer,
             Consumer<? super Solution_> finalBestSolutionConsumer, Consumer<? super Solution_> firstInitializedSolutionConsumer,
-            Consumer<? super Solution_> startSolverJobConsumer,
+            Consumer<? super Solution_> solverJobStartedConsumer,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler,
             BestSolutionHolder<Solution_> bestSolutionHolder) {
         this.problemId = problemId;
@@ -37,7 +37,7 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
         this.exceptionHandler = exceptionHandler;
         this.bestSolutionHolder = bestSolutionHolder;
         this.firstInitializedSolution = null;
-        this.startSolverJobConsumer = startSolverJobConsumer;
+        this.solverJobStartedConsumer = solverJobStartedConsumer;
     }
 
     // Called on the Solver thread.
@@ -170,7 +170,7 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
      * because the consumption may not be executed before the final best solution is executed.
      */
     private void scheduleStartJobConsumption() {
-        scheduleConsumption(startSolverJobConsumption, startSolverJobConsumer, initialSolution);
+        scheduleConsumption(startSolverJobConsumption, solverJobStartedConsumer, initialSolution);
     }
 
     private void scheduleConsumption(Semaphore semaphore, Consumer<? super Solution_> consumer, Solution_ solution) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
@@ -25,7 +25,6 @@ import ai.timefold.solver.core.api.solver.event.BestSolutionChangedEvent;
 import ai.timefold.solver.core.impl.phase.AbstractPhase;
 import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListenerAdapter;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
-import ai.timefold.solver.core.impl.solver.event.SolverLifecycleListenerAdapter;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.Termination;
 
@@ -47,7 +46,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
     private final Consumer<? super Solution_> bestSolutionConsumer;
     private final Consumer<? super Solution_> finalBestSolutionConsumer;
     private final Consumer<? super Solution_> firstInitializedSolutionConsumer;
-    private final Consumer<? super Solution_> startSolverJobConsumer;
+    private final Consumer<? super Solution_> solverJobStartedConsumer;
     private final BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler;
 
     private volatile SolverStatus solverStatus;
@@ -65,7 +64,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
             Consumer<? super Solution_> bestSolutionConsumer,
             Consumer<? super Solution_> finalBestSolutionConsumer,
             Consumer<? super Solution_> firstInitializedSolutionConsumer,
-            Consumer<? super Solution_> startSolverJobConsumer,
+            Consumer<? super Solution_> solverJobStartedConsumer,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler) {
         this.solverManager = solverManager;
         this.problemId = problemId;
@@ -78,7 +77,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
         this.bestSolutionConsumer = bestSolutionConsumer;
         this.finalBestSolutionConsumer = finalBestSolutionConsumer;
         this.firstInitializedSolutionConsumer = firstInitializedSolutionConsumer;
-        this.startSolverJobConsumer = startSolverJobConsumer;
+        this.solverJobStartedConsumer = solverJobStartedConsumer;
         this.exceptionHandler = exceptionHandler;
         solverStatus = SolverStatus.SOLVING_SCHEDULED;
         terminatedLatch = new CountDownLatch(1);
@@ -112,7 +111,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
             solverStatus = SolverStatus.SOLVING_ACTIVE;
             // Create the consumer thread pool only when this solver job is active.
             consumerSupport = new ConsumerSupport<>(getProblemId(), bestSolutionConsumer, finalBestSolutionConsumer,
-                    firstInitializedSolutionConsumer, startSolverJobConsumer, exceptionHandler, bestSolutionHolder);
+                    firstInitializedSolutionConsumer, solverJobStartedConsumer, exceptionHandler, bestSolutionHolder);
 
             Solution_ problem = problemFinder.apply(problemId);
             // add a phase lifecycle listener that unlock the solver status lock when solving started

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
@@ -25,6 +25,7 @@ import ai.timefold.solver.core.api.solver.event.BestSolutionChangedEvent;
 import ai.timefold.solver.core.impl.phase.AbstractPhase;
 import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListenerAdapter;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
+import ai.timefold.solver.core.impl.solver.event.SolverLifecycleListenerAdapter;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.Termination;
 
@@ -324,11 +325,8 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
         }
 
         @Override
-        public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
-            // The event is triggered once in the first phase of the solving process
-            if (phaseScope.getPhaseIndex() == 0) {
-                consumerSupport.consumeStartSolverJob(phaseScope.getWorkingSolution());
-            }
+        public void solvingStarted(SolverScope<Solution_> solverScope) {
+            consumerSupport.consumeStartSolverJob(solverScope.getWorkingSolution());
         }
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
@@ -151,6 +151,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
         solverStatus = SolverStatus.NOT_SOLVING;
         solverManager.unregisterSolverJob(problemId);
         terminatedLatch.countDown();
+        close();
     }
 
     // TODO Future features

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJobBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJobBuilder.java
@@ -23,6 +23,7 @@ public final class DefaultSolverJobBuilder<Solution_, ProblemId_> implements Sol
     private Consumer<? super Solution_> bestSolutionConsumer;
     private Consumer<? super Solution_> finalBestSolutionConsumer;
     private Consumer<? super Solution_> initializedSolutionConsumer;
+    private Runnable startSolverJobHandler;
     private BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler;
     private SolverConfigOverride<Solution_> solverConfigOverride;
 
@@ -68,6 +69,14 @@ public final class DefaultSolverJobBuilder<Solution_, ProblemId_> implements Sol
 
     @Override
     public SolverJobBuilder<Solution_, ProblemId_>
+            withStartSolverJobHandler(Runnable startSolverJobHandler) {
+        this.startSolverJobHandler = Objects.requireNonNull(startSolverJobHandler,
+                "Invalid startSolverJobHandler (null) given to SolverJobBuilder.");
+        return this;
+    }
+
+    @Override
+    public SolverJobBuilder<Solution_, ProblemId_>
             withExceptionHandler(BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler) {
         this.exceptionHandler =
                 Objects.requireNonNull(exceptionHandler, "Invalid exceptionHandler (null) given to SolverJobBuilder.");
@@ -90,10 +99,10 @@ public final class DefaultSolverJobBuilder<Solution_, ProblemId_> implements Sol
 
         if (this.bestSolutionConsumer == null) {
             return solverManager.solve(problemId, problemFinder, null, finalBestSolutionConsumer,
-                    initializedSolutionConsumer, exceptionHandler, solverConfigOverride);
+                    initializedSolutionConsumer, startSolverJobHandler, exceptionHandler, solverConfigOverride);
         } else {
             return solverManager.solveAndListen(problemId, problemFinder, bestSolutionConsumer, finalBestSolutionConsumer,
-                    initializedSolutionConsumer, exceptionHandler, solverConfigOverride);
+                    initializedSolutionConsumer, startSolverJobHandler, exceptionHandler, solverConfigOverride);
         }
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJobBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJobBuilder.java
@@ -23,7 +23,7 @@ public final class DefaultSolverJobBuilder<Solution_, ProblemId_> implements Sol
     private Consumer<? super Solution_> bestSolutionConsumer;
     private Consumer<? super Solution_> finalBestSolutionConsumer;
     private Consumer<? super Solution_> initializedSolutionConsumer;
-    private Consumer<? super Solution_> startSolverJobConsumer;
+    private Consumer<? super Solution_> solverJobStartedConsumer;
     private BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler;
     private SolverConfigOverride<Solution_> solverConfigOverride;
 
@@ -69,8 +69,8 @@ public final class DefaultSolverJobBuilder<Solution_, ProblemId_> implements Sol
 
     @Override
     public SolverJobBuilder<Solution_, ProblemId_>
-            withStartSolverJobConsumer(Consumer<? super Solution_> startSolverJobConsumer) {
-        this.startSolverJobConsumer = Objects.requireNonNull(startSolverJobConsumer,
+            withSolverJobStartedConsumer(Consumer<? super Solution_> solverJobStartedConsumer) {
+        this.solverJobStartedConsumer = Objects.requireNonNull(solverJobStartedConsumer,
                 "Invalid startSolverJobHandler (null) given to SolverJobBuilder.");
         return this;
     }
@@ -99,10 +99,10 @@ public final class DefaultSolverJobBuilder<Solution_, ProblemId_> implements Sol
 
         if (this.bestSolutionConsumer == null) {
             return solverManager.solve(problemId, problemFinder, null, finalBestSolutionConsumer,
-                    initializedSolutionConsumer, startSolverJobConsumer, exceptionHandler, solverConfigOverride);
+                    initializedSolutionConsumer, solverJobStartedConsumer, exceptionHandler, solverConfigOverride);
         } else {
             return solverManager.solveAndListen(problemId, problemFinder, bestSolutionConsumer, finalBestSolutionConsumer,
-                    initializedSolutionConsumer, startSolverJobConsumer, exceptionHandler, solverConfigOverride);
+                    initializedSolutionConsumer, solverJobStartedConsumer, exceptionHandler, solverConfigOverride);
         }
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJobBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJobBuilder.java
@@ -23,7 +23,7 @@ public final class DefaultSolverJobBuilder<Solution_, ProblemId_> implements Sol
     private Consumer<? super Solution_> bestSolutionConsumer;
     private Consumer<? super Solution_> finalBestSolutionConsumer;
     private Consumer<? super Solution_> initializedSolutionConsumer;
-    private Runnable startSolverJobHandler;
+    private Consumer<? super Solution_> startSolverJobConsumer;
     private BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler;
     private SolverConfigOverride<Solution_> solverConfigOverride;
 
@@ -69,8 +69,8 @@ public final class DefaultSolverJobBuilder<Solution_, ProblemId_> implements Sol
 
     @Override
     public SolverJobBuilder<Solution_, ProblemId_>
-            withStartSolverJobHandler(Runnable startSolverJobHandler) {
-        this.startSolverJobHandler = Objects.requireNonNull(startSolverJobHandler,
+            withStartSolverJobConsumer(Consumer<? super Solution_> startSolverJobConsumer) {
+        this.startSolverJobConsumer = Objects.requireNonNull(startSolverJobConsumer,
                 "Invalid startSolverJobHandler (null) given to SolverJobBuilder.");
         return this;
     }
@@ -99,10 +99,10 @@ public final class DefaultSolverJobBuilder<Solution_, ProblemId_> implements Sol
 
         if (this.bestSolutionConsumer == null) {
             return solverManager.solve(problemId, problemFinder, null, finalBestSolutionConsumer,
-                    initializedSolutionConsumer, startSolverJobHandler, exceptionHandler, solverConfigOverride);
+                    initializedSolutionConsumer, startSolverJobConsumer, exceptionHandler, solverConfigOverride);
         } else {
             return solverManager.solveAndListen(problemId, problemFinder, bestSolutionConsumer, finalBestSolutionConsumer,
-                    initializedSolutionConsumer, startSolverJobHandler, exceptionHandler, solverConfigOverride);
+                    initializedSolutionConsumer, startSolverJobConsumer, exceptionHandler, solverConfigOverride);
         }
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
@@ -83,13 +83,14 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
             Consumer<? super Solution_> bestSolutionConsumer,
             Consumer<? super Solution_> finalBestSolutionConsumer,
             Consumer<? super Solution_> initializedSolutionConsumer,
+            Runnable startSolverJobHandler,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler,
             SolverConfigOverride<Solution_> solverConfigOverride) {
         if (bestSolutionConsumer == null) {
             throw new IllegalStateException("The consumer bestSolutionConsumer is required.");
         }
         return solve(getProblemIdOrThrow(problemId), problemFinder, bestSolutionConsumer, finalBestSolutionConsumer,
-                initializedSolutionConsumer, exceptionHandler, solverConfigOverride);
+                initializedSolutionConsumer, startSolverJobHandler, exceptionHandler, solverConfigOverride);
     }
 
     protected SolverJob<Solution_, ProblemId_> solve(ProblemId_ problemId,
@@ -97,6 +98,7 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
             Consumer<? super Solution_> bestSolutionConsumer,
             Consumer<? super Solution_> finalBestSolutionConsumer,
             Consumer<? super Solution_> initializedSolutionConsumer,
+            Runnable startSolverJobHandler,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler,
             SolverConfigOverride<Solution_> configOverride) {
         Solver<Solution_> solver = solverFactory.buildSolver(configOverride);
@@ -111,7 +113,8 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
                         throw new IllegalStateException("The problemId (" + problemId + ") is already solving.");
                     } else {
                         return new DefaultSolverJob<>(this, solver, problemId, problemFinder, bestSolutionConsumer,
-                                finalBestSolutionConsumer, initializedSolutionConsumer, finalExceptionHandler);
+                                finalBestSolutionConsumer, initializedSolutionConsumer, startSolverJobHandler,
+                                finalExceptionHandler);
                     }
                 });
         Future<Solution_> future = solverThreadPool.submit(solverJob);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
@@ -83,14 +83,14 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
             Consumer<? super Solution_> bestSolutionConsumer,
             Consumer<? super Solution_> finalBestSolutionConsumer,
             Consumer<? super Solution_> initializedSolutionConsumer,
-            Consumer<? super Solution_> startSolverJobConsumer,
+            Consumer<? super Solution_> solverJobStartedConsumer,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler,
             SolverConfigOverride<Solution_> solverConfigOverride) {
         if (bestSolutionConsumer == null) {
             throw new IllegalStateException("The consumer bestSolutionConsumer is required.");
         }
         return solve(getProblemIdOrThrow(problemId), problemFinder, bestSolutionConsumer, finalBestSolutionConsumer,
-                initializedSolutionConsumer, startSolverJobConsumer, exceptionHandler, solverConfigOverride);
+                initializedSolutionConsumer, solverJobStartedConsumer, exceptionHandler, solverConfigOverride);
     }
 
     protected SolverJob<Solution_, ProblemId_> solve(ProblemId_ problemId,
@@ -98,7 +98,7 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
             Consumer<? super Solution_> bestSolutionConsumer,
             Consumer<? super Solution_> finalBestSolutionConsumer,
             Consumer<? super Solution_> initializedSolutionConsumer,
-            Consumer<? super Solution_> startSolverJobConsumer,
+            Consumer<? super Solution_> solverJobStartedConsumer,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler,
             SolverConfigOverride<Solution_> configOverride) {
         Solver<Solution_> solver = solverFactory.buildSolver(configOverride);
@@ -113,7 +113,7 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
                         throw new IllegalStateException("The problemId (" + problemId + ") is already solving.");
                     } else {
                         return new DefaultSolverJob<>(this, solver, problemId, problemFinder, bestSolutionConsumer,
-                                finalBestSolutionConsumer, initializedSolutionConsumer, startSolverJobConsumer,
+                                finalBestSolutionConsumer, initializedSolutionConsumer, solverJobStartedConsumer,
                                 finalExceptionHandler);
                     }
                 });

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
@@ -1,8 +1,5 @@
 package ai.timefold.solver.core.impl.solver;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -43,7 +40,6 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
     private final SolverFactory<Solution_> solverFactory;
     private final ExecutorService solverThreadPool;
     private final ConcurrentMap<Object, DefaultSolverJob<Solution_, ProblemId_>> problemIdToSolverJobMap;
-    private final List<DefaultSolverJob<Solution_, ProblemId_>> resourcesToRelease;
 
     public DefaultSolverManager(SolverFactory<Solution_> solverFactory,
             SolverManagerConfig solverManagerConfig) {
@@ -59,7 +55,6 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
         }
         solverThreadPool = Executors.newFixedThreadPool(parallelSolverCount, threadFactory);
         problemIdToSolverJobMap = new ConcurrentHashMap<>(parallelSolverCount * 10);
-        resourcesToRelease = Collections.synchronizedList(new ArrayList<>(parallelSolverCount * 10));
     }
 
     public SolverFactory<Solution_> getSolverFactory() {
@@ -175,12 +170,10 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
     public void close() {
         solverThreadPool.shutdownNow();
         problemIdToSolverJobMap.values().forEach(DefaultSolverJob::close);
-        resourcesToRelease.forEach(DefaultSolverJob::close);
     }
 
     void unregisterSolverJob(ProblemId_ problemId) {
-        var job = problemIdToSolverJobMap.remove(getProblemIdOrThrow(problemId));
-        resourcesToRelease.add(job);
+        problemIdToSolverJobMap.remove(getProblemIdOrThrow(problemId));
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
@@ -83,14 +83,14 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
             Consumer<? super Solution_> bestSolutionConsumer,
             Consumer<? super Solution_> finalBestSolutionConsumer,
             Consumer<? super Solution_> initializedSolutionConsumer,
-            Runnable startSolverJobHandler,
+            Consumer<? super Solution_> startSolverJobConsumer,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler,
             SolverConfigOverride<Solution_> solverConfigOverride) {
         if (bestSolutionConsumer == null) {
             throw new IllegalStateException("The consumer bestSolutionConsumer is required.");
         }
         return solve(getProblemIdOrThrow(problemId), problemFinder, bestSolutionConsumer, finalBestSolutionConsumer,
-                initializedSolutionConsumer, startSolverJobHandler, exceptionHandler, solverConfigOverride);
+                initializedSolutionConsumer, startSolverJobConsumer, exceptionHandler, solverConfigOverride);
     }
 
     protected SolverJob<Solution_, ProblemId_> solve(ProblemId_ problemId,
@@ -98,7 +98,7 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
             Consumer<? super Solution_> bestSolutionConsumer,
             Consumer<? super Solution_> finalBestSolutionConsumer,
             Consumer<? super Solution_> initializedSolutionConsumer,
-            Runnable startSolverJobHandler,
+            Consumer<? super Solution_> startSolverJobConsumer,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler,
             SolverConfigOverride<Solution_> configOverride) {
         Solver<Solution_> solver = solverFactory.buildSolver(configOverride);
@@ -113,7 +113,7 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
                         throw new IllegalStateException("The problemId (" + problemId + ") is already solving.");
                     } else {
                         return new DefaultSolverJob<>(this, solver, problemId, problemFinder, bestSolutionConsumer,
-                                finalBestSolutionConsumer, initializedSolutionConsumer, startSolverJobHandler,
+                                finalBestSolutionConsumer, initializedSolutionConsumer, startSolverJobConsumer,
                                 finalExceptionHandler);
                     }
                 });

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
@@ -463,7 +463,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    void testStartJobRunnable() throws ExecutionException, InterruptedException {
+    void testStartJobConsumer() throws ExecutionException, InterruptedException {
         SolverConfig solverConfig = PlannerTestUtils
                 .buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         solverManager = SolverManager
@@ -477,7 +477,7 @@ class SolverManagerTest {
         SolverJob<TestdataSolution, Long> solverJob = solverManager.solveBuilder()
                 .withProblemId(1L)
                 .withProblemFinder(problemFinder)
-                .withStartSolverJobHandler(() -> started.setValue(Boolean.TRUE))
+                .withStartSolverJobConsumer((solution) -> started.setValue(Boolean.TRUE))
                 .run();
         solverJob.getFinalBestSolution();
         assertThat(started.getValue()).isTrue();

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
@@ -53,6 +53,7 @@ import ai.timefold.solver.core.impl.testdata.domain.extended.TestdataUnannotated
 import ai.timefold.solver.core.impl.testdata.util.PlannerTestUtils;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -472,15 +473,15 @@ class SolverManagerTest {
         Function<Object, TestdataUnannotatedExtendedSolution> problemFinder = o -> new TestdataUnannotatedExtendedSolution(
                 PlannerTestUtils.generateTestdataSolution("s1"));
 
-        MutableObject<Boolean> started = new MutableObject<>(Boolean.FALSE);
+        MutableInt started = new MutableInt(0);
 
         SolverJob<TestdataSolution, Long> solverJob = solverManager.solveBuilder()
                 .withProblemId(1L)
                 .withProblemFinder(problemFinder)
-                .withStartSolverJobConsumer((solution) -> started.setValue(Boolean.TRUE))
+                .withSolverJobStartedConsumer((solution) -> started.increment())
                 .run();
         solverJob.getFinalBestSolution();
-        assertThat(started.getValue()).isTrue();
+        assertThat(started.getValue()).isOne();
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
@@ -462,6 +462,28 @@ class SolverManagerTest {
     }
 
     @Test
+    @Timeout(60)
+    void testStartJobRunnable() throws ExecutionException, InterruptedException {
+        SolverConfig solverConfig = PlannerTestUtils
+                .buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
+        solverManager = SolverManager
+                .create(solverConfig, new SolverManagerConfig());
+
+        Function<Object, TestdataUnannotatedExtendedSolution> problemFinder = o -> new TestdataUnannotatedExtendedSolution(
+                PlannerTestUtils.generateTestdataSolution("s1"));
+
+        MutableObject<Boolean> started = new MutableObject<>(Boolean.FALSE);
+
+        SolverJob<TestdataSolution, Long> solverJob = solverManager.solveBuilder()
+                .withProblemId(1L)
+                .withProblemFinder(problemFinder)
+                .withStartSolverJobHandler(() -> started.setValue(Boolean.TRUE))
+                .run();
+        solverJob.getFinalBestSolution();
+        assertThat(started.getValue()).isTrue();
+    }
+
+    @Test
     void solveWithOverride() {
         // Default spent limit is 1L
         TerminationConfig terminationConfig = new TerminationConfig()

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
@@ -478,7 +478,7 @@ class SolverManagerTest {
         SolverJob<TestdataSolution, Long> solverJob = solverManager.solveBuilder()
                 .withProblemId(1L)
                 .withProblemFinder(problemFinder)
-                .withSolverJobStartedConsumer((solution) -> started.increment())
+                .withSolverJobStartedConsumer(solution -> started.increment())
                 .run();
         solverJob.getFinalBestSolution();
         assertThat(started.getValue()).isOne();

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/ConsumerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/ConsumerSupportTest.java
@@ -52,7 +52,7 @@ class ConsumerSupportTest {
             } catch (InterruptedException e) {
                 error.set(new IllegalStateException("Interrupted waiting.", e));
             }
-        }, null, null, null, bestSolutionHolder);
+        }, null, null, null, null, bestSolutionHolder);
 
         consumeIntermediateBestSolution(TestdataSolution.generateSolution(1, 1));
         consumptionStarted.await();
@@ -78,7 +78,7 @@ class ConsumerSupportTest {
         BestSolutionHolder<TestdataSolution> bestSolutionHolder = new BestSolutionHolder<>();
         AtomicReference<TestdataSolution> finalBestSolutionRef = new AtomicReference<>();
         consumerSupport = new ConsumerSupport<>(1L, null,
-                finalBestSolution -> finalBestSolutionRef.set(finalBestSolution), null, null, bestSolutionHolder);
+                finalBestSolution -> finalBestSolutionRef.set(finalBestSolution), null, null, null, bestSolutionHolder);
 
         CompletableFuture<Void> futureProblemChange = addProblemChange(bestSolutionHolder);
 
@@ -99,7 +99,7 @@ class ConsumerSupportTest {
         Consumer<TestdataSolution> errorneousConsumer = bestSolution -> {
             throw new RuntimeException(errorMessage);
         };
-        consumerSupport = new ConsumerSupport<>(1L, errorneousConsumer, null, null, null, bestSolutionHolder);
+        consumerSupport = new ConsumerSupport<>(1L, errorneousConsumer, null, null, null, null, bestSolutionHolder);
 
         CompletableFuture<Void> futureProblemChange = addProblemChange(bestSolutionHolder);
         consumeIntermediateBestSolution(TestdataSolution.generateSolution());
@@ -116,7 +116,7 @@ class ConsumerSupportTest {
     void pendingProblemChangesAreCanceled_afterFinalBestSolutionIsConsumed() throws ExecutionException, InterruptedException {
         BestSolutionHolder<TestdataSolution> bestSolutionHolder = new BestSolutionHolder<>();
         consumerSupport = new ConsumerSupport<>(1L, null, null,
-                null, null, bestSolutionHolder);
+                null, null, null, bestSolutionHolder);
 
         CompletableFuture<Void> futureProblemChange = addProblemChange(bestSolutionHolder);
 

--- a/python/python-core/src/main/python/_solver_manager.py
+++ b/python/python-core/src/main/python/_solver_manager.py
@@ -308,13 +308,13 @@ class SolverJobBuilder(Generic[Solution_, ProblemId_]):
         return SolverJobBuilder(
             self._delegate.withFirstInitializedSolutionConsumer(java_consumer))
 
-    def with_start_solver_job_handler(self, start_solver_job_handler: Callable[[], None]) -> 'SolverJobBuilder':
+    def with_start_solver_job_consumer(self, start_solver_job_consumer: Callable[[Solution_], None]) -> 'SolverJobBuilder':
         """
-        Sets the runnable action for when the solver starts its solving process.
+        Sets the consumer for when the solver starts its solving process.
 
         Parameters
         ----------
-        start_solver_job_handler : Callable[[], None]
+        start_solver_job_consumer : Callable[[Solution_], None]
             called only once when the solver is starting the solving process
 
         Returns
@@ -322,11 +322,12 @@ class SolverJobBuilder(Generic[Solution_, ProblemId_]):
         SolverJobBuilder
             This `SolverJobBuilder`.
         """
-        from java.lang import Runnable
+        from java.util.function import Consumer
+        from _jpyinterpreter import unwrap_python_like_object
 
-        java_runnable = Runnable @ (lambda: start_solver_job_handler())
+        java_consumer = Consumer @ (lambda solution: start_solver_job_consumer(unwrap_python_like_object(solution)))
         return SolverJobBuilder(
-            self._delegate.withStartSolverJobHandler(java_runnable))
+            self._delegate.withStartSolverJobConsumer(java_consumer))
 
     def with_exception_handler(self, exception_handler: Callable[[ProblemId_, Exception], None]) -> 'SolverJobBuilder':
         """

--- a/python/python-core/src/main/python/_solver_manager.py
+++ b/python/python-core/src/main/python/_solver_manager.py
@@ -285,6 +285,49 @@ class SolverJobBuilder(Generic[Solution_, ProblemId_]):
         return SolverJobBuilder(
             self._delegate.withFinalBestSolutionConsumer(java_consumer))
 
+    def with_first_initialized_solution_consumer(self, first_initialized_solution_consumer: Callable[[Solution_], None]) -> 'SolverJobBuilder':
+        """
+        Sets the consumer of the first initialized solution. First initialized solution is the solution at the end of
+        the last phase that immediately precedes the first local search phase. This solution marks the beginning of
+        actual optimization process.
+
+        Parameters
+        ----------
+        first_initialized_solution_consumer : Callable[[Solution_], None]
+            called only once before starting the first Local Search phase
+
+        Returns
+        -------
+        SolverJobBuilder
+            This `SolverJobBuilder`.
+        """
+        from java.util.function import Consumer
+        from _jpyinterpreter import unwrap_python_like_object
+
+        java_consumer = Consumer @ (lambda solution: first_initialized_solution_consumer(unwrap_python_like_object(solution)))
+        return SolverJobBuilder(
+            self._delegate.withFirstInitializedSolutionConsumer(java_consumer))
+
+    def with_start_solver_job_handler(self, start_solver_job_handler: Callable[[], None]) -> 'SolverJobBuilder':
+        """
+        Sets the runnable action for when the solver starts its solving process.
+
+        Parameters
+        ----------
+        start_solver_job_handler : Callable[[], None]
+            called only once when the solver is starting the solving process
+
+        Returns
+        -------
+        SolverJobBuilder
+            This `SolverJobBuilder`.
+        """
+        from java.lang import Runnable
+
+        java_runnable = Runnable @ (lambda: start_solver_job_handler())
+        return SolverJobBuilder(
+            self._delegate.withStartSolverJobHandler(java_runnable))
+
     def with_exception_handler(self, exception_handler: Callable[[ProblemId_, Exception], None]) -> 'SolverJobBuilder':
         """
         Sets the custom exception handler.

--- a/python/python-core/src/main/python/_solver_manager.py
+++ b/python/python-core/src/main/python/_solver_manager.py
@@ -308,13 +308,13 @@ class SolverJobBuilder(Generic[Solution_, ProblemId_]):
         return SolverJobBuilder(
             self._delegate.withFirstInitializedSolutionConsumer(java_consumer))
 
-    def with_start_solver_job_consumer(self, start_solver_job_consumer: Callable[[Solution_], None]) -> 'SolverJobBuilder':
+    def with_solver_job_started_consumer(self, solver_job_started_consumer: Callable[[Solution_], None]) -> 'SolverJobBuilder':
         """
         Sets the consumer for when the solver starts its solving process.
 
         Parameters
         ----------
-        start_solver_job_consumer : Callable[[Solution_], None]
+        solver_job_started_consumer : Callable[[Solution_], None]
             called only once when the solver is starting the solving process
 
         Returns
@@ -325,9 +325,9 @@ class SolverJobBuilder(Generic[Solution_, ProblemId_]):
         from java.util.function import Consumer
         from _jpyinterpreter import unwrap_python_like_object
 
-        java_consumer = Consumer @ (lambda solution: start_solver_job_consumer(unwrap_python_like_object(solution)))
+        java_consumer = Consumer @ (lambda solution: solver_job_started_consumer(unwrap_python_like_object(solution)))
         return SolverJobBuilder(
-            self._delegate.withStartSolverJobConsumer(java_consumer))
+            self._delegate.withSolverJobStartedConsumer(java_consumer))
 
     def with_exception_handler(self, exception_handler: Callable[[ProblemId_, Exception], None]) -> 'SolverJobBuilder':
         """

--- a/python/python-core/tests/test_solver_manager.py
+++ b/python/python-core/tests/test_solver_manager.py
@@ -243,7 +243,6 @@ def test_error():
         assert the_problem_id == 1
         assert the_exception is not None
 
-
 def test_solver_config():
     @dataclass
     class Value:

--- a/python/python-core/tests/test_solver_manager.py
+++ b/python/python-core/tests/test_solver_manager.py
@@ -286,13 +286,13 @@ def test_solver_config():
     problem: Solution = Solution([Entity('A')], [Value(1), Value(2), Value(3)],
                                  SimpleScore.ONE)
     first_initialized_solution_consumer_called = []
-    start_solver_job_handler_called = []
+    start_solver_job_consumer_called = []
 
     def on_first_initialized_solution_consumer(solution):
         first_initialized_solution_consumer_called.append(1)
 
-    def on_start_solver_job_handler():
-        start_solver_job_handler_called.append(1)
+    def on_start_solver_job_consumer(solution):
+        start_solver_job_consumer_called.append(1)
 
     with SolverManager.create(SolverFactory.create(solver_config)) as solver_manager:
         solver_job = (solver_manager.solve_builder()
@@ -304,10 +304,10 @@ def test_solver_config():
                            )
                       ))
                       .with_first_initialized_solution_consumer(on_first_initialized_solution_consumer)
-                      .with_start_solver_job_handler(on_start_solver_job_handler)
+                      .with_start_solver_job_consumer(on_start_solver_job_consumer)
                       .run())
 
         solution = solver_job.get_final_best_solution()
         assert solution.score.score == 3
         assert len(first_initialized_solution_consumer_called) == 1
-        assert len(start_solver_job_handler_called) == 1
+        assert len(start_solver_job_consumer_called) == 1

--- a/python/python-core/tests/test_solver_manager.py
+++ b/python/python-core/tests/test_solver_manager.py
@@ -286,13 +286,13 @@ def test_solver_config():
     problem: Solution = Solution([Entity('A')], [Value(1), Value(2), Value(3)],
                                  SimpleScore.ONE)
     first_initialized_solution_consumer_called = []
-    start_solver_job_consumer_called = []
+    solver_job_started_consumer_called = []
 
     def on_first_initialized_solution_consumer(solution):
-        first_initialized_solution_consumer_called.append(1)
+        first_initialized_solution_consumer_called.append(solution)
 
-    def on_start_solver_job_consumer(solution):
-        start_solver_job_consumer_called.append(1)
+    def on_solver_job_started_consumer(solution):
+        solver_job_started_consumer_called.append(solution)
 
     with SolverManager.create(SolverFactory.create(solver_config)) as solver_manager:
         solver_job = (solver_manager.solve_builder()
@@ -304,10 +304,10 @@ def test_solver_config():
                            )
                       ))
                       .with_first_initialized_solution_consumer(on_first_initialized_solution_consumer)
-                      .with_start_solver_job_consumer(on_start_solver_job_consumer)
+                      .with_solver_job_started_consumer(on_solver_job_started_consumer)
                       .run())
 
         solution = solver_job.get_final_best_solution()
         assert solution.score.score == 3
         assert len(first_initialized_solution_consumer_called) == 1
-        assert len(start_solver_job_consumer_called) == 1
+        assert len(solver_job_started_consumer_called) == 1


### PR DESCRIPTION
This pull request adds a new job configuration that allows an action to be run when the solver starts the solving process. The current approach uses a `PhaseLifecycleListenerAdapter` to trigger the event because the API `SolverEventListener` would need to be changed in order to add a new solver event.