### PR TITLE
fix: prevent excessive logging of constraint weights

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorFactory.java
@@ -100,8 +100,8 @@ public abstract class AbstractScoreDirectorFactory<Solution_, Score_ extends Sco
     @Override
     public void assertScoreFromScratch(Solution_ solution) {
         // Get the score before uncorruptedScoreDirector.calculateScore() modifies it
-        Score_ score = (Score_) getSolutionDescriptor().getScore(solution);
-        try (InnerScoreDirector<Solution_, Score_> uncorruptedScoreDirector = buildScoreDirector(false, true)) {
+        Score_ score = getSolutionDescriptor().getScore(solution);
+        try (var uncorruptedScoreDirector = buildDerivedScoreDirector(false, true)) {
             uncorruptedScoreDirector.setWorkingSolution(solution);
             Score_ uncorruptedScore = uncorruptedScoreDirector.calculateScore();
             if (!score.equals(uncorruptedScore)) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -203,7 +203,9 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
      *
      * @return never null, planning clone
      */
-    Solution_ cloneWorkingSolution();
+    default Solution_ cloneWorkingSolution() {
+        return cloneSolution(getWorkingSolution());
+    }
 
     /**
      * Returns a planning clone of the solution,
@@ -227,17 +229,6 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
      * @return never null
      */
     SupplyManager getSupplyManager();
-
-    /**
-     * Clones this {@link ScoreDirector} and its {@link PlanningSolution working solution}.
-     * Use {@link #getWorkingSolution()} to retrieve the {@link PlanningSolution working solution} of that clone.
-     * <p>
-     * This is heavy method, because it usually breaks incremental score calculation. Use it sparingly.
-     * Therefore it's best to clone lazily by delaying the clone call as long as possible.
-     *
-     * @return never null
-     */
-    InnerScoreDirector<Solution_, Score_> clone();
 
     InnerScoreDirector<Solution_, Score_> createChildThreadScoreDirector(ChildThreadType childThreadType);
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
@@ -63,6 +63,25 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
             boolean expectShadowVariablesInCorrectState);
 
     /**
+     * Like {@link #buildScoreDirector(boolean, boolean)}, but makes the score director a derived one.
+     * Derived score directors may make choices which the main score director can not make, such as reducing logging.
+     * Derived score directors are typically used for multithreaded solving, testing and assert modes.
+     *
+     * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
+     *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
+     * @param constraintMatchEnabledPreference false if a {@link ScoreDirector} implementation
+     *        should not do {@link ConstraintMatch} tracking even if it supports it.
+     * @return never null
+     * @see InnerScoreDirector#isConstraintMatchEnabled()
+     * @see InnerScoreDirector#getConstraintMatchTotalMap()
+     */
+    default InnerScoreDirector<Solution_, Score_> buildDerivedScoreDirector(boolean lookUpEnabled,
+            boolean constraintMatchEnabledPreference) {
+        // Most score directors don't need derived status; CS will override this.
+        return buildScoreDirector(lookUpEnabled, constraintMatchEnabledPreference, true);
+    }
+
+    /**
      * @return never null
      */
     InitializingScoreTrend getInitializingScoreTrend();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
@@ -25,11 +25,19 @@ import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintSession;
 public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends Score<Score_>>
         extends AbstractScoreDirector<Solution_, Score_, BavetConstraintStreamScoreDirectorFactory<Solution_, Score_>> {
 
+    private final boolean derived;
     private BavetConstraintSession<Score_> session;
 
     public BavetConstraintStreamScoreDirector(BavetConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
             boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState) {
+        this(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState, false);
+    }
+
+    public BavetConstraintStreamScoreDirector(BavetConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
+            boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState,
+            boolean derived) {
         super(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState);
+        this.derived = derived;
     }
 
     // ************************************************************************
@@ -38,7 +46,7 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
 
     @Override
     public void setWorkingSolution(Solution_ workingSolution) {
-        session = scoreDirectorFactory.newSession(workingSolution, constraintMatchEnabledPreference);
+        session = scoreDirectorFactory.newSession(workingSolution, constraintMatchEnabledPreference, derived);
         getSolutionDescriptor().visitAll(workingSolution, session::insert);
         super.setWorkingSolution(workingSolution);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirectorFactory.java
@@ -13,6 +13,7 @@ import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.enterprise.TimefoldSolverEnterpriseService;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintFactory;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintSession;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintSessionFactory;
@@ -72,13 +73,21 @@ public final class BavetConstraintStreamScoreDirectorFactory<Solution_, Score_ e
                 expectShadowVariablesInCorrectState);
     }
 
-    public BavetConstraintSession<Score_> newSession(Solution_ workingSolution, boolean constraintMatchEnabled) {
-        return constraintSessionFactory.buildSession(workingSolution, constraintMatchEnabled);
+    @Override
+    public InnerScoreDirector<Solution_, Score_> buildDerivedScoreDirector(boolean lookUpEnabled,
+            boolean constraintMatchEnabledPreference) {
+        return new BavetConstraintStreamScoreDirector<>(this, lookUpEnabled, constraintMatchEnabledPreference,
+                true, true);
+    }
+
+    public BavetConstraintSession<Score_> newSession(Solution_ workingSolution, boolean constraintMatchEnabled,
+            boolean scoreDirectorDerived) {
+        return constraintSessionFactory.buildSession(workingSolution, constraintMatchEnabled, scoreDirectorDerived);
     }
 
     @Override
     public AbstractScoreInliner<Score_> fireAndForget(Object... facts) {
-        var session = newSession(null, true);
+        var session = newSession(null, true, true);
         Arrays.stream(facts).forEach(session::insert);
         session.calculateScore(0);
         return session.getScoreInliner();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintFactory.java
@@ -65,11 +65,10 @@ public final class BavetConstraintFactory<Solution_>
 
     /**
      * Enables node sharing.
-     * If a constraint already exists in this factory, it replaces it by the old copy.
+     * If a constraint already exists in this factory, it replaces it with the old copy.
      * {@link BavetAbstractConstraintStream} implement equals/hashcode ignoring child streams.
      * <p>
-     * {@link BavetConstraintSessionFactory#buildSession(Object, boolean)} relies on this
-     * occurring for all streams.
+     * {@link BavetConstraintSessionFactory#buildSession(Object, boolean, boolean)} needs this to happen for all streams.
      * <p>
      * This must be called before the stream receives child streams.
      *

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintSession.java
@@ -16,7 +16,7 @@ import ai.timefold.solver.core.impl.score.stream.common.inliner.AbstractScoreInl
 
 /**
  * The type is public to make it easier for Bavet-specific minimal bug reproducers to be created.
- * Instances should be created through {@link BavetConstraintStreamScoreDirectorFactory#newSession(Object, boolean)}.
+ * Instances should be created through {@link BavetConstraintStreamScoreDirectorFactory#newSession(Object, boolean, boolean)}.
  *
  * @see PropagationQueue Description of the tuple propagation mechanism.
  * @param <Score_>

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/NodeNetwork.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/NodeNetwork.java
@@ -1,0 +1,85 @@
+package ai.timefold.solver.core.impl.score.stream.bavet;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import ai.timefold.solver.core.impl.score.stream.bavet.common.Propagator;
+import ai.timefold.solver.core.impl.score.stream.bavet.uni.AbstractForEachUniNode;
+
+/**
+ * Represents Bavet's network of nodes, specific to a particular session.
+ * Nodes only used by disabled constraints have already been removed.
+ *
+ * @param declaredClassToNodeMap starting nodes, one for each class used in the constraints;
+ *        root nodes, layer index 0.
+ * @param layeredNodes nodes grouped first by their layer, then by their index within the layer;
+ *        propagation needs to happen in this order.
+ */
+record NodeNetwork(Map<Class<?>, List<AbstractForEachUniNode<Object>>> declaredClassToNodeMap, Propagator[][] layeredNodes) {
+
+    public static final NodeNetwork EMPTY = new NodeNetwork(Map.of(), new Propagator[0][0]);
+
+    public int forEachNodeCount() {
+        return declaredClassToNodeMap.size();
+    }
+
+    public int layerCount() {
+        return layeredNodes.length;
+    }
+
+    @SuppressWarnings("unchecked")
+    public AbstractForEachUniNode<Object>[] getApplicableForEachNodes(Class<?> factClass) {
+        return declaredClassToNodeMap.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().isAssignableFrom(factClass))
+                .map(Map.Entry::getValue)
+                .flatMap(List::stream)
+                .toArray(AbstractForEachUniNode[]::new);
+    }
+
+    public void propagate() {
+        for (var layerIndex = 0; layerIndex < layerCount(); layerIndex++) {
+            propagateInLayer(layeredNodes[layerIndex]);
+        }
+    }
+
+    private static void propagateInLayer(Propagator[] nodesInLayer) {
+        var nodeCount = nodesInLayer.length;
+        if (nodeCount == 1) {
+            nodesInLayer[0].propagateEverything();
+        } else {
+            for (var node : nodesInLayer) {
+                node.propagateRetracts();
+            }
+            for (var node : nodesInLayer) {
+                node.propagateUpdates();
+            }
+            for (var node : nodesInLayer) {
+                node.propagateInserts();
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof NodeNetwork that))
+            return false;
+        return Objects.equals(declaredClassToNodeMap, that.declaredClassToNodeMap)
+                && Objects.deepEquals(layeredNodes, that.layeredNodes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(declaredClassToNodeMap, Arrays.deepHashCode(layeredNodes));
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + " with " + forEachNodeCount() + " forEach nodes.";
+    }
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamScoreDirectorFactory.java
@@ -4,6 +4,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirectorFactory;
+import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.stream.common.inliner.AbstractScoreInliner;
 
@@ -35,4 +36,9 @@ public abstract class AbstractConstraintStreamScoreDirectorFactory<Solution_, Sc
     public boolean supportsConstraintMatching() {
         return true;
     }
+
+    @Override
+    public abstract InnerScoreDirector<Solution_, Score_> buildDerivedScoreDirector(boolean lookUpEnabled,
+            boolean constraintMatchEnabledPreference);
+
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -48,7 +48,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
                     + ".update() with this solutionUpdatePolicy (" + solutionUpdatePolicy + ").");
         }
         return callScoreDirector(solution, solutionUpdatePolicy,
-                s -> (Score_) s.getSolutionDescriptor().getScore(s.getWorkingSolution()), false, false);
+                s -> s.getSolutionDescriptor().getScore(s.getWorkingSolution()), false, false);
     }
 
     private <Result_> Result_ callScoreDirector(Solution_ solution,

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolverFactoryTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolverFactoryTest.java
@@ -168,8 +168,7 @@ class SolverFactoryTest {
         TestdataSolution solution = new TestdataSolution("s1");
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3")));
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
-        try (InnerScoreDirector<TestdataSolution, SimpleScore> scoreDirector =
-                scoreDirectorFactory.buildScoreDirector()) {
+        try (InnerScoreDirector<TestdataSolution, SimpleScore> scoreDirector = scoreDirectorFactory.buildScoreDirector()) {
             scoreDirector.setWorkingSolution(solution);
             SimpleScore score = scoreDirector.calculateScore();
             assertThat(score).isNotNull();

--- a/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultMultiConstraintVerification.java
+++ b/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultMultiConstraintVerification.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
-import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.test.api.score.stream.MultiConstraintVerification;
 
@@ -28,8 +27,7 @@ public final class DefaultMultiConstraintVerification<Solution_, Score_ extends 
 
     @Override
     public DefaultMultiConstraintAssertion<Score_> givenSolution(Solution_ solution) {
-        try (InnerScoreDirector<Solution_, Score_> scoreDirector =
-                scoreDirectorFactory.buildScoreDirector(true, true)) {
+        try (var scoreDirector = scoreDirectorFactory.buildDerivedScoreDirector(true, true)) {
             scoreDirector.setWorkingSolution(Objects.requireNonNull(solution));
             return new DefaultMultiConstraintAssertion<>(constraintProvider, scoreDirector.calculateScore(),
                     scoreDirector.getConstraintMatchTotalMap(), scoreDirector.getIndictmentMap());

--- a/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintVerification.java
+++ b/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintVerification.java
@@ -3,7 +3,6 @@ package ai.timefold.solver.test.impl.score.stream;
 import java.util.Objects;
 
 import ai.timefold.solver.core.api.score.Score;
-import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.test.api.score.stream.SingleConstraintVerification;
 
@@ -23,7 +22,7 @@ public final class DefaultSingleConstraintVerification<Solution_, Score_ extends
 
     @Override
     public DefaultSingleConstraintAssertion<Solution_, Score_> givenSolution(Solution_ solution) {
-        try (InnerScoreDirector<Solution_, Score_> scoreDirector = scoreDirectorFactory.buildScoreDirector(true, true)) {
+        try (var scoreDirector = scoreDirectorFactory.buildDerivedScoreDirector(true, true)) {
             scoreDirector.setWorkingSolution(Objects.requireNonNull(solution));
             return new DefaultSingleConstraintAssertion<>(scoreDirectorFactory, scoreDirector.calculateScore(),
                     scoreDirector.getConstraintMatchTotalMap(), scoreDirector.getIndictmentMap());


### PR DESCRIPTION
Contains two commits:

- First fixes the actual issue.
- Second refactors some of the code to decrease complexity, as recommended by Sonar. The logic of the code did not change, only who calls what from where.

Merge individually, do not squash.