### PR TITLE
fix: Python bytecode generation overrides, pop off result of setattr and delattr, fix enum

### DIFF
--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonClassTranslator.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/PythonClassTranslator.java
@@ -1,5 +1,7 @@
 package ai.timefold.jpyinterpreter;
 
+import static ai.timefold.jpyinterpreter.PythonBytecodeToJavaBytecodeTranslator.ARGUMENT_SPEC_INSTANCE_FIELD_NAME;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -60,8 +62,6 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.signature.SignatureVisitor;
 import org.objectweb.asm.signature.SignatureWriter;
-
-import static ai.timefold.jpyinterpreter.PythonBytecodeToJavaBytecodeTranslator.ARGUMENT_SPEC_INSTANCE_FIELD_NAME;
 
 public class PythonClassTranslator {
     static Map<FunctionSignature, InterfaceDeclaration> functionSignatureToInterfaceName = new HashMap<>();

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/DelegatingInterfaceImplementor.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/DelegatingInterfaceImplementor.java
@@ -105,7 +105,10 @@ public class DelegatingInterfaceImplementor extends JavaInterfaceImplementor {
         for (int i = 1; i < argumentCount; i++) {
             javaParameterTypes[i - 1] = methodType.getArgumentTypes()[i];
         }
-        String javaMethodDescriptor = Type.getMethodDescriptor(methodType.getReturnType(), javaParameterTypes);
+        var methodReturnType =
+                PythonClassTranslator.getVirtualFunctionReturnType(compiledClass.instanceFunctionNameToPythonBytecode
+                        .get(interfaceMethod.getName()));
+        String javaMethodDescriptor = Type.getMethodDescriptor(methodReturnType, javaParameterTypes);
 
         interfaceMethodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, internalClassName,
                 PythonClassTranslator.getJavaMethodName(interfaceMethod.getName()),

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/KnownCallImplementor.java
@@ -120,8 +120,13 @@ public class KnownCallImplementor {
                             Type.getType(PythonLikeObject.class),
                             Type.getType(Class.class)),
                     false);
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
-                    pythonFunctionSignature.getArgumentSpec().getArgumentTypeInternalName(i));
+            if (i == 0 && pythonFunctionSignature.isClassMethod()) {
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
+                        Type.getInternalName(PythonLikeType.class));
+            } else {
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
+                        pythonFunctionSignature.getArgumentSpec().getArgumentTypeInternalName(i));
+            }
         }
 
         // Load any arguments missing values

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ObjectImplementor.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/implementors/ObjectImplementor.java
@@ -124,6 +124,8 @@ public class ObjectImplementor {
             DunderOperatorImplementor.binaryOperator(methodVisitor,
                     stackMetadata.pushTemp(BuiltinTypes.STRING_TYPE),
                     PythonBinaryOperator.DELETE_ATTRIBUTE);
+            // Pop off the result of __delattr__
+            methodVisitor.visitInsn(Opcodes.POP);
         }
     }
 
@@ -167,6 +169,8 @@ public class ObjectImplementor {
                     .pushTemp(BuiltinTypes.STRING_TYPE)
                     .push(stackMetadata.getValueSourceForStackIndex(1)),
                     PythonTernaryOperator.SET_ATTRIBUTE);
+            // Pop off the result of __setattr__
+            methodVisitor.visitInsn(Opcodes.POP);
         }
     }
 

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/test/TestdataExtendedInterface.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/test/TestdataExtendedInterface.java
@@ -1,0 +1,22 @@
+package ai.timefold.jpyinterpreter.test;
+
+import ai.timefold.jpyinterpreter.types.PythonString;
+import ai.timefold.jpyinterpreter.types.numeric.PythonInteger;
+
+/**
+ * Not a real interface; in main sources instead of test sources
+ * so a Python test can use it.
+ */
+public interface TestdataExtendedInterface {
+    PythonString stringMethod(PythonString name);
+
+    PythonInteger intMethod(PythonInteger value);
+
+    static String getString(TestdataExtendedInterface instance, String name) {
+        return instance.stringMethod(PythonString.valueOf(name)).value;
+    }
+
+    static int getInt(TestdataExtendedInterface instance, int value) {
+        return instance.intMethod(PythonInteger.valueOf(value)).value.intValue();
+    }
+}

--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/util/OverrideMethod.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/util/OverrideMethod.java
@@ -1,0 +1,12 @@
+package ai.timefold.jpyinterpreter.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Marks a generated method as an override implementation.
+ * Needed since {@link Override} is not retained at runtime.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OverrideMethod {
+}

--- a/python/jpyinterpreter/src/main/python/translator.py
+++ b/python/jpyinterpreter/src/main/python/translator.py
@@ -2,8 +2,9 @@ import ctypes
 import dis
 import inspect
 import sys
-from jpype import JInt, JBoolean, JProxy, JClass, JArray
 from typing import Protocol
+
+from jpype import JInt, JBoolean, JProxy, JClass, JArray
 
 MINIMUM_SUPPORTED_PYTHON_VERSION = (3, 10)
 MAXIMUM_SUPPORTED_PYTHON_VERSION = (3, 12)
@@ -754,7 +755,11 @@ def translate_python_class_to_java_class(python_class):
     python_compiled_class.staticAttributeNameToClassInstance = static_attributes_to_class_instance_map
     python_compiled_class.staticAttributeDescriptorNames = static_attribute_descriptor_names
 
-    out = PythonClassTranslator.translatePythonClass(python_compiled_class, prepared_class_info)
-    PythonClassTranslator.setSelfStaticInstances(python_compiled_class, out.getJavaClass(), out,
-                                                 CPythonBackedPythonInterpreter.pythonObjectIdToConvertedObjectMap)
+    try:
+        out = PythonClassTranslator.translatePythonClass(python_compiled_class, prepared_class_info)
+        PythonClassTranslator.setSelfStaticInstances(python_compiled_class, out.getJavaClass(), out,
+                                                     CPythonBackedPythonInterpreter.pythonObjectIdToConvertedObjectMap)
+    except Exception as e:
+        e.printStackTrace()
+        raise e
     return out

--- a/python/jpyinterpreter/src/main/python/translator.py
+++ b/python/jpyinterpreter/src/main/python/translator.py
@@ -755,11 +755,7 @@ def translate_python_class_to_java_class(python_class):
     python_compiled_class.staticAttributeNameToClassInstance = static_attributes_to_class_instance_map
     python_compiled_class.staticAttributeDescriptorNames = static_attribute_descriptor_names
 
-    try:
-        out = PythonClassTranslator.translatePythonClass(python_compiled_class, prepared_class_info)
-        PythonClassTranslator.setSelfStaticInstances(python_compiled_class, out.getJavaClass(), out,
-                                                     CPythonBackedPythonInterpreter.pythonObjectIdToConvertedObjectMap)
-    except Exception as e:
-        e.printStackTrace()
-        raise e
+    out = PythonClassTranslator.translatePythonClass(python_compiled_class, prepared_class_info)
+    PythonClassTranslator.setSelfStaticInstances(python_compiled_class, out.getJavaClass(), out,
+                                                 CPythonBackedPythonInterpreter.pythonObjectIdToConvertedObjectMap)
     return out

--- a/python/jpyinterpreter/tests/test_classes.py
+++ b/python/jpyinterpreter/tests/test_classes.py
@@ -1,5 +1,6 @@
-import pytest
 from typing import Type
+
+import pytest
 
 from .conftest import verifier_for
 
@@ -1096,6 +1097,38 @@ def test_functional_interface():
     assert ToIntFunction.class_.isAssignableFrom(translated_class)
     java_object = translated_class.getConstructor().newInstance()
     assert java_object.applyAsInt(1) == 2
+
+
+def test_extend_interface_wrapper():
+    from ai.timefold.jpyinterpreter.test import TestdataExtendedInterface
+    from jpyinterpreter import translate_python_class_to_java_class, add_java_interface
+
+    @add_java_interface(TestdataExtendedInterface)
+    class A:
+        def stringMethod(self, name):
+            return self.string_method(name)
+
+        def intMethod(self, value):
+            return self.int_method(value)
+
+        def string_method(self, name):
+            raise NotImplementedError
+
+        def int_method(self, value):
+            raise NotImplementedError
+
+    class B(A):
+        def string_method(self, name: str) -> str:
+            return f'Hello {name}!'
+
+        def int_method(self, value: int) -> int:
+            return value + 1
+
+    translated_class = translate_python_class_to_java_class(B).getJavaClass()
+    assert TestdataExtendedInterface.class_.isAssignableFrom(translated_class)
+    java_object = translated_class.getConstructor().newInstance()
+    assert TestdataExtendedInterface.getString(java_object, 'World') == 'Hello World!'
+    assert TestdataExtendedInterface.getInt(java_object, 1) == 2
 
 
 def test_python_java_type_mapping():

--- a/python/jpyinterpreter/tests/test_classes.py
+++ b/python/jpyinterpreter/tests/test_classes.py
@@ -906,8 +906,16 @@ def test_enum_translate_to_class():
         GREEN = 'GREEN'
         BLUE = 'BLUE'
 
+    def is_red(color: Color):
+        return color is Color.RED
+
     translated_class = translate_python_class_to_java_class(Color)
     assert not isinstance(translated_class, CPythonType)
+
+    verifier = verifier_for(is_red)
+    verifier.verify(Color.RED, expected_result=True)
+    verifier.verify(Color.GREEN, expected_result=False)
+    verifier.verify(Color.BLUE, expected_result=False)
 
 
 def test_class_annotations():

--- a/python/jpyinterpreter/tests/test_loops.py
+++ b/python/jpyinterpreter/tests/test_loops.py
@@ -19,6 +19,29 @@ def test_while_loops():
     function_verifier.verify(5, expected_result=15)
 
 
+def test_attribute_assignment_in_loops():
+    class A:
+        x: int
+
+        def __init__(self):
+            self.x = 0
+
+    def my_function(count: int):
+        current = A()
+
+        while current.x != count:
+            current.x = count
+
+        return current.x
+
+    function_verifier = verifier_for(my_function)
+
+    function_verifier.verify(0, expected_result=0)
+    function_verifier.verify(1, expected_result=1)
+    function_verifier.verify(2, expected_result=2)
+    function_verifier.verify(3, expected_result=3)
+
+
 def test_inner_loops():
     def my_function(x: int, y: int) -> int:
         total = 0

--- a/python/python-core/src/main/python/domain/_variable_listener.py
+++ b/python/python-core/src/main/python/domain/_variable_listener.py
@@ -1,9 +1,10 @@
-from ..score import ScoreDirector
 from _jpyinterpreter import add_java_interface
 from typing import TYPE_CHECKING, TypeVar
 
+from ..score import ScoreDirector
+
 if TYPE_CHECKING:
-    from ai.timefold.solver.core.api.domain.variable import VariableListener
+    pass
 
 Solution_ = TypeVar('Solution_')
 Entity_ = TypeVar('Entity_')
@@ -57,48 +58,48 @@ class VariableListener:
 if not TYPE_CHECKING:  # We do not want these methods to appear in the API
     def afterEntityAdded(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        type(self).after_entity_added(self, score_director, entity)
+        self.after_entity_added(score_director, entity)
 
     VariableListener.afterEntityAdded = afterEntityAdded
 
     def afterEntityRemoved(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        type(self).after_entity_removed(self, score_director, entity)
+        self.after_entity_removed(score_director, entity)
 
     VariableListener.afterEntityRemoved = afterEntityRemoved
 
     def beforeEntityAdded(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        type(self).before_entity_added(self, score_director, entity)
+        self.before_entity_added(score_director, entity)
 
     VariableListener.beforeEntityAdded = beforeEntityAdded
 
     def beforeEntityRemoved(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        type(self).before_entity_removed(self, score_director, entity)
+        self.before_entity_removed(score_director, entity)
 
     VariableListener.beforeEntityRemoved = beforeEntityRemoved
 
     def resetWorkingSolution(self, java_score_director) -> None:
         score_director = ScoreDirector(java_score_director)
-        type(self).reset_working_solution(self, score_director)
+        self.reset_working_solution(score_director)
 
     VariableListener.resetWorkingSolution = resetWorkingSolution
 
     def afterVariableChanged(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        type(self).after_variable_changed(self, score_director, entity)
+        self.after_variable_changed(score_director, entity)
 
     VariableListener.afterVariableChanged = afterVariableChanged
 
     def beforeVariableChanged(self, java_score_director, entity) -> None:
         score_director = ScoreDirector(java_score_director)
-        type(self).before_variable_changed(self, score_director, entity)
+        self.before_variable_changed(score_director, entity)
 
     VariableListener.beforeVariableChanged = beforeVariableChanged
 
     def requiresUniqueEntityEvents(self) -> bool:
-        return type(self).requires_unique_entity_events(self)
+        return self.requires_unique_entity_events()
 
     VariableListener.requiresUniqueEntityEvents = requiresUniqueEntityEvents
 

--- a/python/python-core/src/main/python/domain/_variable_listener.py
+++ b/python/python-core/src/main/python/domain/_variable_listener.py
@@ -10,8 +10,16 @@ Solution_ = TypeVar('Solution_')
 Entity_ = TypeVar('Entity_')
 
 
+class VariableListenerMeta(type):
+    def __new__(cls, clsname, bases, attrs):
+        from .._timefold_java_interop import _add_to_compilation_queue
+        out = super().__new__(cls, clsname, bases, attrs)
+        _add_to_compilation_queue(out)
+        return out
+
+
 @add_java_interface('ai.timefold.solver.core.api.domain.variable.VariableListener')
-class VariableListener:
+class VariableListener(metaclass=VariableListenerMeta):
     """
     A listener sourced on a basic PlanningVariable.
 

--- a/python/python-core/src/main/python/score/_incremental_score_calculator.py
+++ b/python/python-core/src/main/python/score/_incremental_score_calculator.py
@@ -1,6 +1,6 @@
 from _jpyinterpreter import add_java_interface
-from typing import TYPE_CHECKING
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 
 @add_java_interface('ai.timefold.solver.core.api.score.calculator.IncrementalScoreCalculator')
@@ -107,92 +107,88 @@ class ConstraintMatchAwareIncrementalScoreCalculator(IncrementalScoreCalculator)
 
 
 if not TYPE_CHECKING:
-    # Use type(self).method(self, ...)
-    # Since if the arguments are typed, they might have different signatures and
-    # thus not override one another, meaning the generated interface method will
-    # call the original method and not the "overridden" one!
     def afterEntityAdded(self, entity) -> None:
-        type(self).after_entity_added(self, entity)
+        self.after_entity_added(entity)
 
     IncrementalScoreCalculator.afterEntityAdded = afterEntityAdded
 
     def afterEntityRemoved(self, entity) -> None:
-        type(self).after_entity_removed(self, entity)
+        self.after_entity_removed(entity)
 
     IncrementalScoreCalculator.afterEntityRemoved = afterEntityRemoved
 
     def afterListVariableChanged(self, entity, variable_name, start, end) -> None:
-        type(self).after_list_variable_changed(self, entity, variable_name, start, end)
+        self.after_list_variable_changed(entity, variable_name, start, end)
 
     IncrementalScoreCalculator.afterListVariableChanged = afterListVariableChanged
 
     def afterListVariableElementAssigned(self, variable_name, element) -> None:
-        type(self).after_list_variable_element_assigned(self, variable_name, element)
+        self.after_list_variable_element_assigned(variable_name, element)
 
     IncrementalScoreCalculator.afterListVariableElementAssigned = afterListVariableElementAssigned
 
     def afterListVariableElementUnassigned(self, variable_name, element) -> None:
-        type(self).after_list_variable_element_unassigned(self, variable_name, element)
+        self.after_list_variable_element_unassigned(variable_name, element)
 
     IncrementalScoreCalculator.afterListVariableElementUnassigned = afterListVariableElementUnassigned
 
     def afterVariableChanged(self, entity, variable_name) -> None:
-        type(self).after_variable_changed(self, entity, variable_name)
+        self.after_variable_changed(entity, variable_name)
 
     IncrementalScoreCalculator.afterVariableChanged = afterVariableChanged
 
     def beforeEntityAdded(self, entity) -> None:
-        type(self).before_entity_added(self, entity)
+        self.before_entity_added(entity)
 
     IncrementalScoreCalculator.beforeEntityAdded = beforeEntityAdded
 
     def beforeEntityRemoved(self, entity) -> None:
-        type(self).before_entity_removed(self, entity)
+        self.before_entity_removed(entity)
 
     IncrementalScoreCalculator.beforeEntityRemoved = beforeEntityRemoved
 
     def beforeListVariableChanged(self, entity, variable_name, start, end) -> None:
-        type(self).before_list_variable_changed(self, entity, variable_name, start, end)
+        self.before_list_variable_changed(entity, variable_name, start, end)
 
     IncrementalScoreCalculator.beforeListVariableChanged = beforeListVariableChanged
 
     def beforeListVariableElementAssigned(self, variable_name, element) -> None:
-        type(self).before_list_variable_element_assigned(self, variable_name, element)
+        self.before_list_variable_element_assigned(variable_name, element)
 
     IncrementalScoreCalculator.beforeListVariableElementAssigned = beforeListVariableElementAssigned
 
     def beforeListVariableElementUnassigned(self, variable_name, element) -> None:
-        type(self).before_list_variable_element_unassigned(self, variable_name, element)
+        self.before_list_variable_element_unassigned(variable_name, element)
 
     IncrementalScoreCalculator.beforeListVariableElementUnassigned = beforeListVariableElementUnassigned
 
     def beforeVariableChanged(self, entity, variable_name) -> None:
-        type(self).before_variable_changed(self, entity, variable_name)
+        self.before_variable_changed(entity, variable_name)
 
     IncrementalScoreCalculator.beforeVariableChanged = beforeVariableChanged
 
     def calculateScore(self):
-        return type(self).calculate_score(self)._to_java_score()
+        return self.calculate_score()._to_java_score()
 
     IncrementalScoreCalculator.calculateScore = calculateScore
 
     def resetWorkingSolution(self, solution) -> None:
-        type(self).reset_working_solution(self, solution)
+        self.reset_working_solution(solution)
 
     IncrementalScoreCalculator.resetWorkingSolution = resetWorkingSolution
 
     def getConstraintMatchTotals(self) -> list:
-        return type(self).get_constraint_match_totals(self)
+        return self.get_constraint_match_totals()
 
     ConstraintMatchAwareIncrementalScoreCalculator.getConstraintMatchTotals = getConstraintMatchTotals
 
     def getIndictmentMap(self) -> dict:
-        return type(self).get_indictment_map(self)
+        return self.get_indictment_map()
 
     ConstraintMatchAwareIncrementalScoreCalculator.getIndictmentMap = getIndictmentMap
 
     def resetWorkingSolution(self, solution, constraint_match_enabled=False) -> None:
-        type(self).reset_working_solution(self, solution, constraint_match_enabled)
+        self.reset_working_solution(solution, constraint_match_enabled)
 
     ConstraintMatchAwareIncrementalScoreCalculator.resetWorkingSolution = resetWorkingSolution
 

--- a/python/python-core/tests/test_custom_shadow_variables.py
+++ b/python/python-core/tests/test_custom_shadow_variables.py
@@ -1,10 +1,10 @@
-from typing import Annotated, Optional, List
 from dataclasses import dataclass, field
-
+from datetime import datetime, timedelta
 from timefold.solver import *
-from timefold.solver.domain import *
 from timefold.solver.config import *
+from timefold.solver.domain import *
 from timefold.solver.score import *
+from typing import Annotated, Optional, List
 
 
 def test_custom_shadow_variable():
@@ -119,3 +119,306 @@ def test_custom_shadow_variable_with_variable_listener_ref():
     assert solution.score.score == 1
     assert solution.entity_list[0].value == 2
     assert solution.entity_list[0].value_squared == 4
+
+
+@dataclass
+class Location:
+    latitude: float
+    longitude: float
+    driving_time_seconds: dict[int, int] = field(default_factory=dict)
+
+    def driving_time_to(self, other: 'Location') -> int:
+        return self.driving_time_seconds[id(other)]
+
+
+class ArrivalTimeUpdatingVariableListener(VariableListener):
+    def after_variable_changed(self, score_director: ScoreDirector, visit: 'Visit') -> None:
+        if visit.vehicle is None:
+            if visit.arrival_time is not None:
+                score_director.before_variable_changed(visit, 'arrival_time')
+                visit.arrival_time = None
+                score_director.after_variable_changed(visit, 'arrival_time')
+            return
+        previous_visit = visit.previous_visit
+        departure_time = visit.vehicle.departure_time if previous_visit is None else previous_visit.departure_time()
+        next_visit = visit
+        arrival_time = ArrivalTimeUpdatingVariableListener.calculate_arrival_time(next_visit, departure_time)
+        while next_visit is not None and next_visit.arrival_time != arrival_time:
+            score_director.before_variable_changed(next_visit, 'arrival_time')
+            next_visit.arrival_time = arrival_time
+            score_director.after_variable_changed(next_visit, 'arrival_time')
+            departure_time = next_visit.departure_time()
+            next_visit = next_visit.next_visit
+            arrival_time = ArrivalTimeUpdatingVariableListener.calculate_arrival_time(next_visit, departure_time)
+
+    @staticmethod
+    def calculate_arrival_time(visit: Optional['Visit'], previous_departure_time: Optional[datetime]) \
+            -> datetime | None:
+        if visit is None or previous_departure_time is None:
+            return None
+        return previous_departure_time + timedelta(seconds=visit.driving_time_seconds_from_previous_standstill())
+
+
+@planning_entity
+@dataclass
+class Visit:
+    id: Annotated[str, PlanningId]
+    name: str
+    location: Location
+    demand: int
+    min_start_time: datetime
+    max_end_time: datetime
+    service_duration: timedelta
+    vehicle: Annotated[Optional['Vehicle'], InverseRelationShadowVariable(source_variable_name='visits')] = (
+        field(default=None))
+    previous_visit: Annotated[Optional['Visit'], PreviousElementShadowVariable(source_variable_name='visits')] = (
+        field(default=None))
+    next_visit: Annotated[Optional['Visit'],
+    NextElementShadowVariable(source_variable_name='visits')] = field(default=None)
+    arrival_time: Annotated[Optional[datetime],
+    ShadowVariable(variable_listener_class=ArrivalTimeUpdatingVariableListener,
+                   source_variable_name='vehicle'),
+    ShadowVariable(variable_listener_class=ArrivalTimeUpdatingVariableListener,
+                   source_variable_name='previous_visit')] = field(default=None)
+
+    def departure_time(self) -> Optional[datetime]:
+        if self.arrival_time is None:
+            return None
+
+        return self.arrival_time + self.service_duration
+
+    def start_service_time(self) -> Optional[datetime]:
+        if self.arrival_time is None:
+            return None
+        return self.min_start_time if (self.min_start_time < self.arrival_time) else self.arrival_time
+
+    def is_service_finished_after_max_end_time(self) -> bool:
+        return self.arrival_time is not None and self.departure_time() > self.max_end_time
+
+    def service_finished_delay_in_minutes(self) -> int:
+        if self.arrival_time is None:
+            return 0
+        return (self.max_end_time - self.departure_time()).seconds // 60
+
+    def driving_time_seconds_from_previous_standstill(self) -> int:
+        if self.vehicle is None:
+            raise ValueError("This method must not be called when the shadow variables are not initialized yet.")
+
+        if self.previous_visit is None:
+            return self.vehicle.home_location.driving_time_to(self.location)
+        else:
+            return self.previous_visit.location.driving_time_to(self.location)
+
+    def driving_time_seconds_from_previous_standstill_or_none(self) -> Optional[int]:
+        if self.vehicle is None:
+            return None
+        return self.driving_time_seconds_from_previous_standstill()
+
+    def __str__(self):
+        return self.id
+
+
+@planning_entity
+@dataclass
+class Vehicle:
+    id: Annotated[str, PlanningId]
+    capacity: int
+    home_location: Location
+    departure_time: datetime
+    visits: Annotated[list[Visit], PlanningListVariable] = field(default_factory=list)
+
+    def total_demand(self) -> int:
+        total_demand = 0
+        for visit in self.visits:
+            total_demand += visit.demand
+        return total_demand
+
+    def total_driving_time_seconds(self) -> int:
+        if len(self.visits) == 0:
+            return 0
+        total_driving_time_seconds = 0
+        previous_location = self.home_location
+
+        for visit in self.visits:
+            total_driving_time_seconds += previous_location.driving_time_to(visit.location)
+            previous_location = visit.location
+
+        total_driving_time_seconds += previous_location.driving_time_to(self.home_location)
+        return total_driving_time_seconds
+
+    def arrival_time(self):
+        if len(self.visits) == 0:
+            return self.departure_time
+
+        last_visit = self.visits[-1]
+        return (last_visit.departure_time() +
+                timedelta(seconds=last_visit.location.driving_time_to(self.home_location)))
+
+
+@planning_solution
+@dataclass
+class VehicleRoutePlan:
+    vehicles: Annotated[list[Vehicle], PlanningEntityCollectionProperty]
+    visits: Annotated[list[Visit], PlanningEntityCollectionProperty, ValueRangeProvider]
+    score: Annotated[HardSoftScore, PlanningScore] = field(default=None)
+
+
+@constraint_provider
+def vehicle_routing_constraints(factory: ConstraintFactory):
+    return [
+        vehicle_capacity(factory),
+        service_finished_after_max_end_time(factory),
+        minimize_travel_time(factory)
+    ]
+
+
+##############################################
+# Hard constraints
+##############################################
+
+def vehicle_capacity(factory: ConstraintFactory):
+    return (factory.for_each(Vehicle)
+            .filter(lambda vehicle: vehicle.total_demand() > vehicle.capacity)
+            .penalize(HardSoftScore.ONE_HARD,
+                      lambda vehicle: vehicle.total_demand() - vehicle.capacity)
+            .as_constraint('VEHICLE_CAPACITY')
+            )
+
+
+def service_finished_after_max_end_time(factory: ConstraintFactory):
+    return (factory.for_each(Visit)
+            .filter(lambda visit: visit.is_service_finished_after_max_end_time())
+            .penalize(HardSoftScore.ONE_HARD,
+                      lambda visit: visit.service_finished_delay_in_minutes())
+            .as_constraint('SERVICE_FINISHED_AFTER_MAX_END_TIME')
+            )
+
+
+##############################################
+# Soft constraints
+##############################################
+
+def minimize_travel_time(factory: ConstraintFactory):
+    return (
+        factory.for_each(Vehicle)
+        .penalize(HardSoftScore.ONE_SOFT,
+                  lambda vehicle: vehicle.total_driving_time_seconds())
+        .as_constraint('MINIMIZE_TRAVEL_TIME')
+    )
+
+
+def test_complex_shadow_variable():
+    solver_config = SolverConfig(
+        solution_class=VehicleRoutePlan,
+        entity_class_list=[Vehicle, Visit],
+        score_director_factory_config=ScoreDirectorFactoryConfig(
+            constraint_provider_function=vehicle_routing_constraints
+        ),
+        termination_config=TerminationConfig(
+            best_score_limit='0hard/-300soft',
+        )
+    )
+
+    solver = SolverFactory.create(solver_config).build_solver()
+    l1 = Location(1, 1)
+    l2 = Location(2, 2)
+    l3 = Location(3, 3)
+    l4 = Location(4, 4)
+    l5 = Location(5, 5)
+
+    l1.driving_time_seconds = {
+        id(l1): 0,
+        id(l2): 60,
+        id(l3): 60 * 60,
+        id(l4): 60 * 60,
+        id(l5): 60 * 60
+    }
+
+    l2.driving_time_seconds = {
+        id(l1): 60 * 60,
+        id(l2): 0,
+        id(l3): 60,
+        id(l4): 60 * 60,
+        id(l5): 60 * 60
+    }
+
+    l3.driving_time_seconds = {
+        id(l1): 60,
+        id(l2): 60 * 60,
+        id(l3): 0,
+        id(l4): 60 * 60,
+        id(l5): 60 * 60
+    }
+
+    l4.driving_time_seconds = {
+        id(l1): 60 * 60,
+        id(l2): 60 * 60,
+        id(l3): 60 * 60,
+        id(l4): 0,
+        id(l5): 60
+    }
+
+    l5.driving_time_seconds = {
+        id(l1): 60 * 60,
+        id(l2): 60 * 60,
+        id(l3): 60 * 60,
+        id(l4): 60,
+        id(l5): 0
+    }
+
+    problem = VehicleRoutePlan(
+        vehicles=[
+            Vehicle(
+                id='A',
+                capacity=3,
+                home_location=l1,
+                departure_time=datetime(2020, 1, 1),
+            ),
+            Vehicle(
+                id='B',
+                capacity=3,
+                home_location=l4,
+                departure_time=datetime(2020, 1, 1),
+            ),
+        ],
+        visits=[
+            Visit(
+                id='1',
+                name='1',
+                location=l2,
+                demand=1,
+                min_start_time=datetime(2020, 1, 1),
+                max_end_time=datetime(2020, 1, 1, hour=10),
+                service_duration=timedelta(hours=1),
+            ),
+            Visit(
+                id='2',
+                name='2',
+                location=l3,
+                demand=1,
+                min_start_time=datetime(2020, 1, 1),
+                max_end_time=datetime(2020, 1, 1, hour=10),
+                service_duration=timedelta(hours=1),
+            ),
+            Visit(
+                id='3',
+                name='3',
+                location=l5,
+                demand=1,
+                min_start_time=datetime(2020, 1, 1),
+                max_end_time=datetime(2020, 1, 1, hour=10),
+                service_duration=timedelta(hours=1),
+            ),
+        ]
+    )
+    solution = solver.solve(problem)
+    assert [visit.arrival_time for visit in solution.visits] == [
+        # Visit 1: 1-minute travel time from Vehicle A start
+        datetime(2020, 1, 1, hour=0, minute=1),
+        # Visit 2: 1-minute travel time from visit 1 + 1-hour service
+        datetime(2020, 1, 1, hour=1, minute=2),
+        # Visit 3: 1-minute travel time from Vehicle B start
+        datetime(2020, 1, 1, hour=0, minute=1)
+    ]
+    assert [visit.id for visit in solution.vehicles[0].visits] == ['1', '2']
+    assert [visit.id for visit in solution.vehicles[1].visits] == ['3']


### PR DESCRIPTION
- Python bytecode generation now generates overrides for all signatures, meaning the `type(...).method` workaround can be removed.

- The bug in the variable listener was due to the generic case of setattr and delattr (when field infomation is not available due to cyclical dependencies), which call the object's `__setattr__` and `__delattr__` respectively, but did not pop off the result, causing an inconsistent stack size when an object attribute is assigned or deleted inside a loop.

- Enum values are now stored in the CPythonInterpreter's shared instance map, meaning objects will get the same Java instance for the same Python value regardless of the time of conversion.