### PR TITLE
fix: Do not override value with loop variable

### DIFF
--- a/python/jpyinterpreter/src/main/python/conversions.py
+++ b/python/jpyinterpreter/src/main/python/conversions.py
@@ -307,8 +307,8 @@ def convert_object_to_java_python_like_object(value, instance_map=None):
 
         if isinstance(out, AbstractPythonLikeObject):
             try:
-                for (key, value) in object.__getattribute__(value, '__dict__').items():
-                    out.setAttribute(key, convert_to_java_python_like_object(value, instance_map))
+                for (attribute_name, attribute_value) in object.__getattribute__(value, '__dict__').items():
+                    out.setAttribute(attribute_name, convert_to_java_python_like_object(attribute_value, instance_map))
             except AttributeError:
                 pass
 

--- a/python/jpyinterpreter/tests/test_classes.py
+++ b/python/jpyinterpreter/tests/test_classes.py
@@ -918,6 +918,28 @@ def test_enum_translate_to_class():
     verifier.verify(Color.BLUE, expected_result=False)
 
 
+def test_enum_as_attribute_in_class():
+    from enum import Enum
+    from dataclasses import dataclass
+
+    class Color(Enum):
+        RED = 'RED'
+        GREEN = 'GREEN'
+        BLUE = 'BLUE'
+
+    @dataclass
+    class Order:
+        color: Color
+
+    def is_red(order: Order):
+        return order.color is Color.RED
+
+    verifier = verifier_for(is_red)
+    verifier.verify(Order(Color.RED), expected_result=True)
+    verifier.verify(Order(Color.GREEN), expected_result=False)
+    verifier.verify(Order(Color.BLUE), expected_result=False)
+
+
 def test_class_annotations():
     from typing import Annotated
     from java.lang import Deprecated


### PR DESCRIPTION
- The enum conversion code uses value, which was also used as the name for a loop variable that iterates attributes. As a result, the loop variable overrode value, which is then checked if it is an enum. If the last attribute in a class instance happens to be an enum, the class instance will replace that enum value in the map.