### PR TITLE
perf: decrease lambda creation on the hot path during tuple update

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractIndexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractIndexedJoinNode.java
@@ -76,7 +76,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends AbstractTuple, 
             // No need for re-indexing because the index properties didn't change
             // Prefer an update over retract-insert if possible
             indexerRight.forEach(oldIndexProperties,
-                    rightTuple -> innerRightUpdater.accept(leftTuple, rightTuple));
+                    rightTuple -> rightTupleUpdater.accept(leftTuple, rightTuple));
         } else {
             ElementAwareListEntry<LeftTuple_> leftEntry = leftTuple.getStore(inputStoreIndexLeftEntry);
             ElementAwareList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
@@ -92,7 +92,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends AbstractTuple, 
         leftTuple.setStore(inputStoreIndexLeftProperties, indexProperties);
         ElementAwareListEntry<LeftTuple_> leftEntry = indexerLeft.put(indexProperties, leftTuple);
         leftTuple.setStore(inputStoreIndexLeftEntry, leftEntry);
-        indexerRight.forEach(indexProperties, rightTuple -> tupleInserter.accept(leftTuple, rightTuple));
+        indexerRight.forEach(indexProperties, rightTuple -> outTupleInserter.accept(leftTuple, rightTuple));
     }
 
     @Override
@@ -134,7 +134,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends AbstractTuple, 
             // No need for re-indexing because the index properties didn't change
             // Prefer an update over retract-insert if possible
             indexerLeft.forEach(oldIndexProperties,
-                    leftTuple -> innerLeftUpdater.accept(leftTuple, rightTuple));
+                    leftTuple -> leftTupleUpdater.accept(leftTuple, rightTuple));
         } else {
             ElementAwareListEntry<UniTuple<Right_>> rightEntry = rightTuple.getStore(inputStoreIndexRightEntry);
             ElementAwareList<OutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
@@ -150,7 +150,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends AbstractTuple, 
         rightTuple.setStore(inputStoreIndexRightProperties, indexProperties);
         ElementAwareListEntry<UniTuple<Right_>> rightEntry = indexerRight.put(indexProperties, rightTuple);
         rightTuple.setStore(inputStoreIndexRightEntry, rightEntry);
-        indexerLeft.forEach(indexProperties, leftTuple -> tupleInserter.accept(leftTuple, rightTuple));
+        indexerLeft.forEach(indexProperties, leftTuple -> outTupleInserter.accept(leftTuple, rightTuple));
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractIndexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractIndexedJoinNode.java
@@ -92,7 +92,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends AbstractTuple, 
         leftTuple.setStore(inputStoreIndexLeftProperties, indexProperties);
         ElementAwareListEntry<LeftTuple_> leftEntry = indexerLeft.put(indexProperties, leftTuple);
         leftTuple.setStore(inputStoreIndexLeftEntry, leftEntry);
-        indexerRight.forEach(indexProperties, rightTuple -> insertOutTupleFiltered(leftTuple, rightTuple));
+        indexerRight.forEach(indexProperties, rightTuple -> tupleInserter.accept(leftTuple, rightTuple));
     }
 
     @Override
@@ -150,7 +150,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends AbstractTuple, 
         rightTuple.setStore(inputStoreIndexRightProperties, indexProperties);
         ElementAwareListEntry<UniTuple<Right_>> rightEntry = indexerRight.put(indexProperties, rightTuple);
         rightTuple.setStore(inputStoreIndexRightEntry, rightEntry);
-        indexerLeft.forEach(indexProperties, leftTuple -> insertOutTupleFiltered(leftTuple, rightTuple));
+        indexerLeft.forEach(indexProperties, leftTuple -> tupleInserter.accept(leftTuple, rightTuple));
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractIndexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractIndexedJoinNode.java
@@ -75,7 +75,8 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends AbstractTuple, 
         if (oldIndexProperties.equals(newIndexProperties)) {
             // No need for re-indexing because the index properties didn't change
             // Prefer an update over retract-insert if possible
-            innerUpdateLeft(leftTuple, consumer -> indexerRight.forEach(oldIndexProperties, consumer));
+            indexerRight.forEach(oldIndexProperties,
+                    rightTuple -> innerRightUpdater.accept(leftTuple, rightTuple));
         } else {
             ElementAwareListEntry<LeftTuple_> leftEntry = leftTuple.getStore(inputStoreIndexLeftEntry);
             ElementAwareList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
@@ -132,7 +133,8 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends AbstractTuple, 
         if (oldIndexProperties.equals(newIndexProperties)) {
             // No need for re-indexing because the index properties didn't change
             // Prefer an update over retract-insert if possible
-            innerUpdateRight(rightTuple, consumer -> indexerLeft.forEach(oldIndexProperties, consumer));
+            indexerLeft.forEach(oldIndexProperties,
+                    leftTuple -> innerLeftUpdater.accept(leftTuple, rightTuple));
         } else {
             ElementAwareListEntry<UniTuple<Right_>> rightEntry = rightTuple.getStore(inputStoreIndexRightEntry);
             ElementAwareList<OutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractUnindexedJoinNode.java
@@ -45,7 +45,7 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
         ElementAwareList<OutTuple_> outTupleListLeft = new ElementAwareList<>();
         leftTuple.setStore(inputStoreIndexLeftOutTupleList, outTupleListLeft);
         for (UniTuple<Right_> tuple : rightTupleList) {
-            tupleInserter.accept(leftTuple, tuple);
+            outTupleInserter.accept(leftTuple, tuple);
         }
     }
 
@@ -57,7 +57,7 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
             insertLeft(leftTuple);
             return;
         }
-        rightTupleList.forEach(rightTuple -> innerLeftUpdater.accept(leftTuple, rightTuple));
+        rightTupleList.forEach(rightTuple -> leftTupleUpdater.accept(leftTuple, rightTuple));
     }
 
     @Override
@@ -83,7 +83,7 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
         ElementAwareList<OutTuple_> outTupleListRight = new ElementAwareList<>();
         rightTuple.setStore(inputStoreIndexRightOutTupleList, outTupleListRight);
         for (LeftTuple_ tuple : leftTupleList) {
-            tupleInserter.accept(tuple, rightTuple);
+            outTupleInserter.accept(tuple, rightTuple);
         }
     }
 
@@ -95,7 +95,7 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
             insertRight(rightTuple);
             return;
         }
-        leftTupleList.forEach(leftTuple -> innerRightUpdater.accept(leftTuple, rightTuple));
+        leftTupleList.forEach(leftTuple -> rightTupleUpdater.accept(leftTuple, rightTuple));
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractUnindexedJoinNode.java
@@ -57,7 +57,7 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
             insertLeft(leftTuple);
             return;
         }
-        innerUpdateLeft(leftTuple, rightTupleList::forEach);
+        rightTupleList.forEach(rightTuple -> innerLeftUpdater.accept(leftTuple, rightTuple));
     }
 
     @Override
@@ -95,7 +95,7 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
             insertRight(rightTuple);
             return;
         }
-        innerUpdateRight(rightTuple, leftTupleList::forEach);
+        leftTupleList.forEach(leftTuple -> innerRightUpdater.accept(leftTuple, rightTuple));
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/AbstractUnindexedJoinNode.java
@@ -45,7 +45,7 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
         ElementAwareList<OutTuple_> outTupleListLeft = new ElementAwareList<>();
         leftTuple.setStore(inputStoreIndexLeftOutTupleList, outTupleListLeft);
         for (UniTuple<Right_> tuple : rightTupleList) {
-            insertOutTupleFiltered(leftTuple, tuple);
+            tupleInserter.accept(leftTuple, tuple);
         }
     }
 
@@ -83,7 +83,7 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends AbstractTuple
         ElementAwareList<OutTuple_> outTupleListRight = new ElementAwareList<>();
         rightTuple.setStore(inputStoreIndexRightOutTupleList, outTupleListRight);
         for (LeftTuple_ tuple : leftTupleList) {
-            insertOutTupleFiltered(tuple, rightTuple);
+            tupleInserter.accept(tuple, rightTuple);
         }
     }
 


### PR DESCRIPTION
Tuple updates are done very frequently.
As I was benchmarking a different issue, I noticed that we create gigabytes of large capturing lambdas during tuple update, and therefore on the hot path.
This refactoring intends to decrease the number of lambdas created, as well as make them capture less and contain less conditional logic, helping with branch predictions.