### PR TITLE
feat: add nullness annotations to public API part 2

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/api/score/stream/penta/PentaJoiner.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/stream/penta/PentaJoiner.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.api.score.stream.penta;
 
 import ai.timefold.solver.core.api.score.stream.Joiners;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintStream;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Created with {@link Joiners}.
@@ -11,6 +12,7 @@ import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintStream;
  */
 public interface PentaJoiner<A, B, C, D, E> {
 
-    PentaJoiner<A, B, C, D, E> and(PentaJoiner<A, B, C, D, E> otherJoiner);
+    @NonNull
+    PentaJoiner<A, B, C, D, E> and(@NonNull PentaJoiner<A, B, C, D, E> otherJoiner);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/score/stream/quad/QuadConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/stream/quad/QuadConstraintStream.java
@@ -36,6 +36,8 @@ import ai.timefold.solver.core.api.score.stream.tri.TriConstraintStream;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintStream;
 import ai.timefold.solver.core.impl.util.ConstantLambdaUtils;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * A {@link ConstraintStream} that matches four facts.
  *
@@ -60,10 +62,9 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * (such as {@link Joiners#equal(TriFunction, Function)},
      * because the latter applies hashing and/or indexing, so it doesn't create every combination just to filter it out.
      *
-     * @param predicate never null
-     * @return never null
      */
-    QuadConstraintStream<A, B, C, D> filter(QuadPredicate<A, B, C, D> predicate);
+    @NonNull
+    QuadConstraintStream<A, B, C, D> filter(@NonNull QuadPredicate<A, B, C, D> predicate);
 
     // ************************************************************************
     // If (not) exists
@@ -80,13 +81,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * a different definition of exists applies.
      * (See {@link ConstraintFactory#from(Class)} Javadoc.)
      *
-     * @param otherClass never null
-     * @param joiner never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner} is true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E> joiner) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner) {
         return ifExists(otherClass, new PentaJoiner[] { joiner });
     }
 
@@ -94,15 +94,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifExists(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E> joiner1,
-            PentaJoiner<A, B, C, D, E> joiner2) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner2) {
         return ifExists(otherClass, new PentaJoiner[] { joiner1, joiner2 });
     }
 
@@ -110,16 +108,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifExists(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E> joiner1,
-            PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3) {
         return ifExists(otherClass, new PentaJoiner[] { joiner1, joiner2, joiner3 });
     }
 
@@ -127,18 +122,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifExists(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
-     * @param joiner4 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E> joiner1,
-            PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3,
-            PentaJoiner<A, B, C, D, E> joiner4) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3, @NonNull PentaJoiner<A, B, C, D, E> joiner4) {
         return ifExists(otherClass, new PentaJoiner[] { joiner1, joiner2, joiner3, joiner4 });
     }
 
@@ -150,13 +140,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * but we can't fix it with a {@link SafeVarargs} annotation because it's an interface method.
      * Therefore, there are overloaded methods with up to 4 {@link PentaJoiner} parameters.
      *
-     * @param otherClass never null
-     * @param joiners never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    <E> QuadConstraintStream<A, B, C, D> ifExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E>... joiners);
+    <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E>... joiners);
 
     /**
      * Create a new {@link QuadConstraintStream} for every tuple of A, B, C and D where E exists for which the
@@ -164,14 +153,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * <p>
      * This method has overloaded methods with multiple {@link PentaJoiner} parameters.
      *
-     * @param otherStream never null
-     * @param joiner never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner} is true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExists(UniConstraintStream<E> otherStream,
-            PentaJoiner<A, B, C, D, E> joiner) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner) {
         return ifExists(otherStream, new PentaJoiner[] { joiner });
     }
 
@@ -179,16 +166,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifExists(UniConstraintStream, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherStream never null
-     * @param joiner1 never null
-     * @param joiner2 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExists(UniConstraintStream<E> otherStream,
-            PentaJoiner<A, B, C, D, E> joiner1,
-            PentaJoiner<A, B, C, D, E> joiner2) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2) {
         return ifExists(otherStream, new PentaJoiner[] { joiner1, joiner2 });
     }
 
@@ -196,17 +179,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifExists(UniConstraintStream, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherStream never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExists(UniConstraintStream<E> otherStream,
-            PentaJoiner<A, B, C, D, E> joiner1,
-            PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3) {
         return ifExists(otherStream, new PentaJoiner[] { joiner1, joiner2, joiner3 });
     }
 
@@ -214,18 +193,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifExists(UniConstraintStream, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherStream never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
-     * @param joiner4 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExists(UniConstraintStream<E> otherStream,
-            PentaJoiner<A, B, C, D, E> joiner1,
-            PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3, PentaJoiner<A, B, C, D, E> joiner4) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3, @NonNull PentaJoiner<A, B, C, D, E> joiner4) {
         return ifExists(otherStream, new PentaJoiner[] { joiner1, joiner2, joiner3, joiner4 });
     }
 
@@ -237,13 +211,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * but we can't fix it with a {@link SafeVarargs} annotation because it's an interface method.
      * Therefore, there are overloaded methods with up to 4 {@link PentaJoiner} parameters.
      *
-     * @param otherStream never null
-     * @param joiners never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    <E> QuadConstraintStream<A, B, C, D> ifExists(UniConstraintStream<E> otherStream, PentaJoiner<A, B, C, D, E>... joiners);
+    <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E>... joiners);
 
     /**
      * Create a new {@link QuadConstraintStream} for every tuple of A, B, C and D where E exists for which the
@@ -254,14 +227,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * <p>
      * This method has overloaded methods with multiple {@link PentaJoiner} parameters.
      *
-     * @param otherClass never null
-     * @param joiner never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner} is true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E> joiner) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner) {
         return ifExistsIncludingUnassigned(otherClass, new PentaJoiner[] { joiner });
     }
 
@@ -269,15 +240,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifExistsIncludingUnassigned(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E> joiner1, PentaJoiner<A, B, C, D, E> joiner2) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2) {
         return ifExistsIncludingUnassigned(otherClass, new PentaJoiner[] { joiner1, joiner2 });
     }
 
@@ -285,16 +253,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifExistsIncludingUnassigned(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E> joiner1, PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3) {
         return ifExistsIncludingUnassigned(otherClass, new PentaJoiner[] { joiner1, joiner2, joiner3 });
     }
 
@@ -302,18 +267,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifExistsIncludingUnassigned(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
-     * @param joiner4 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E> joiner1, PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3,
-            PentaJoiner<A, B, C, D, E> joiner4) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3, @NonNull PentaJoiner<A, B, C, D, E> joiner4) {
         return ifExistsIncludingUnassigned(otherClass, new PentaJoiner[] { joiner1, joiner2, joiner3, joiner4 });
     }
 
@@ -325,14 +285,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * but we can't fix it with a {@link SafeVarargs} annotation because it's an interface method.
      * Therefore, there are overloaded methods with up to 4 {@link PentaJoiner} parameters.
      *
-     * @param otherClass never null
-     * @param joiners never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E exists for which the
+     * @return a stream that matches every tuple of A, B, C and D where E exists for which the
      *         {@link PentaJoiner}s are true
      */
-    <E> QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E>... joiners);
+    <E> @NonNull QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E>... joiners);
 
     /**
      * Create a new {@link QuadConstraintStream} for every tuple of A, B, C and D where E does not exist for which the
@@ -345,13 +303,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * a different definition of exists applies.
      * (See {@link ConstraintFactory#from(Class)} Javadoc.)
      *
-     * @param otherClass never null
-     * @param joiner never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner} is true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E> joiner) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner) {
         return ifNotExists(otherClass, new PentaJoiner[] { joiner });
     }
 
@@ -359,15 +316,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifNotExists(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E> joiner1,
-            PentaJoiner<A, B, C, D, E> joiner2) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2) {
         return ifNotExists(otherClass, new PentaJoiner[] { joiner1, joiner2 });
     }
 
@@ -375,16 +329,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifNotExists(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E> joiner1,
-            PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3) {
         return ifNotExists(otherClass, new PentaJoiner[] { joiner1, joiner2, joiner3 });
     }
 
@@ -392,17 +343,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifNotExists(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
-     * @param joiner4 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E> joiner1,
-            PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3, PentaJoiner<A, B, C, D, E> joiner4) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3, @NonNull PentaJoiner<A, B, C, D, E> joiner4) {
         return ifNotExists(otherClass, new PentaJoiner[] { joiner1, joiner2, joiner3, joiner4 });
     }
 
@@ -415,12 +362,11 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * Therefore, there are overloaded methods with up to 4 {@link PentaJoiner} parameters.
      *
      * @param <E> the type of the fifth matched fact
-     * @param otherClass never null
-     * @param joiners never null
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    <E> QuadConstraintStream<A, B, C, D> ifNotExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E>... joiners);
+    <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E>... joiners);
 
     /**
      * Create a new {@link QuadConstraintStream} for every tuple of A, B, C and D where E does not exist for which the
@@ -428,14 +374,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * <p>
      * This method has overloaded methods with multiple {@link PentaJoiner} parameters.
      *
-     * @param otherStream never null
-     * @param joiner never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner} is true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExists(UniConstraintStream<E> otherStream,
-            PentaJoiner<A, B, C, D, E> joiner) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner) {
         return ifNotExists(otherStream, new PentaJoiner[] { joiner });
     }
 
@@ -443,15 +387,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifNotExists(UniConstraintStream, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherStream never null
-     * @param joiner1 never null
-     * @param joiner2 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExists(UniConstraintStream<E> otherStream,
-            PentaJoiner<A, B, C, D, E> joiner1, PentaJoiner<A, B, C, D, E> joiner2) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2) {
         return ifNotExists(otherStream, new PentaJoiner[] { joiner1, joiner2 });
     }
 
@@ -459,16 +400,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifNotExists(UniConstraintStream, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherStream never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExists(UniConstraintStream<E> otherStream,
-            PentaJoiner<A, B, C, D, E> joiner1, PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3) {
         return ifNotExists(otherStream, new PentaJoiner[] { joiner1, joiner2, joiner3 });
     }
 
@@ -476,18 +414,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifNotExists(UniConstraintStream, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherStream never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
-     * @param joiner4 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExists(UniConstraintStream<E> otherStream,
-            PentaJoiner<A, B, C, D, E> joiner1, PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3,
-            PentaJoiner<A, B, C, D, E> joiner4) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3, @NonNull PentaJoiner<A, B, C, D, E> joiner4) {
         return ifNotExists(otherStream, new PentaJoiner[] { joiner1, joiner2, joiner3, joiner4 });
     }
 
@@ -500,12 +433,11 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * Therefore, there are overloaded methods with up to 4 {@link PentaJoiner} parameters.
      *
      * @param <E> the type of the fifth matched fact
-     * @param otherStream never null
-     * @param joiners never null
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    <E> QuadConstraintStream<A, B, C, D> ifNotExists(UniConstraintStream<E> otherStream, PentaJoiner<A, B, C, D, E>... joiners);
+    <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E>... joiners);
 
     /**
      * Create a new {@link QuadConstraintStream} for every tuple of A, B, C and D where E does not exist for which the
@@ -516,14 +448,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * <p>
      * This method has overloaded methods with multiple {@link PentaJoiner} parameters.
      *
-     * @param otherClass never null
-     * @param joiner never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner} is true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E> joiner) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner) {
         return ifNotExistsIncludingUnassigned(otherClass, new PentaJoiner[] { joiner });
     }
 
@@ -531,15 +461,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifNotExistsIncludingUnassigned(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E> joiner1, PentaJoiner<A, B, C, D, E> joiner2) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2) {
         return ifNotExistsIncludingUnassigned(otherClass, new PentaJoiner[] { joiner1, joiner2 });
     }
 
@@ -547,16 +474,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifNotExistsIncludingUnassigned(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E> joiner1, PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3) {
         return ifNotExistsIncludingUnassigned(otherClass, new PentaJoiner[] { joiner1, joiner2, joiner3 });
     }
 
@@ -564,18 +488,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #ifNotExistsIncludingUnassigned(Class, PentaJoiner)}.
      * For performance reasons, indexing joiners must be placed before filtering joiners.
      *
-     * @param otherClass never null
-     * @param joiner1 never null
-     * @param joiner2 never null
-     * @param joiner3 never null
-     * @param joiner4 never null
      * @param <E> the type of the fifth matched fact
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E> joiner1, PentaJoiner<A, B, C, D, E> joiner2, PentaJoiner<A, B, C, D, E> joiner3,
-            PentaJoiner<A, B, C, D, E> joiner4) {
+    default <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner1, @NonNull PentaJoiner<A, B, C, D, E> joiner2,
+            @NonNull PentaJoiner<A, B, C, D, E> joiner3, @NonNull PentaJoiner<A, B, C, D, E> joiner4) {
         return ifNotExistsIncludingUnassigned(otherClass, new PentaJoiner[] { joiner1, joiner2, joiner3, joiner4 });
     }
 
@@ -588,13 +507,11 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * Therefore, there are overloaded methods with up to 4 {@link PentaJoiner} parameters.
      *
      * @param <E> the type of the fifth matched fact
-     * @param otherClass never null
-     * @param joiners never null
-     * @return never null, a stream that matches every tuple of A, B, C and D where E does not exist for which the
+     * @return a stream that matches every tuple of A, B, C and D where E does not exist for which the
      *         {@link PentaJoiner}s are true
      */
-    <E> QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E>... joiners);
+    <E> @NonNull QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E>... joiners);
 
     // ************************************************************************
     // Group by
@@ -606,42 +523,40 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * {@link UniConstraintStream} which only has a single tuple, the result of applying
      * {@link QuadConstraintCollector}.
      *
-     * @param collector never null, the collector to perform the grouping operation with
+     * @param collector the collector to perform the grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <ResultContainer_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <Result_> the type of a fact in the destination {@link UniConstraintStream}'s tuple
-     * @return never null
      */
-    <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
-            QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector);
+    <ResultContainer_, Result_> @NonNull UniConstraintStream<Result_> groupBy(
+            @NonNull QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector);
 
     /**
      * Convert the {@link QuadConstraintStream} to a {@link BiConstraintStream}, containing only a single tuple,
      * the result of applying two {@link QuadConstraintCollector}s.
      *
-     * @param collectorA never null, the collector to perform the first grouping operation with
+     * @param collectorA the collector to perform the first grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorB never null, the collector to perform the second grouping operation with
+     * @param collectorB the collector to perform the second grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <ResultContainerA_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultA_> the type of the first fact in the destination {@link BiConstraintStream}'s tuple
      * @param <ResultContainerB_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultB_> the type of the second fact in the destination {@link BiConstraintStream}'s tuple
-     * @return never null
      */
-    <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_> BiConstraintStream<ResultA_, ResultB_> groupBy(
-            QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
-            QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB);
+    <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_> @NonNull BiConstraintStream<ResultA_, ResultB_> groupBy(
+            @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
+            @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB);
 
     /**
      * Convert the {@link QuadConstraintStream} to a {@link TriConstraintStream}, containing only a single tuple,
      * the result of applying three {@link QuadConstraintCollector}s.
      *
-     * @param collectorA never null, the collector to perform the first grouping operation with
+     * @param collectorA the collector to perform the first grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorB never null, the collector to perform the second grouping operation with
+     * @param collectorB the collector to perform the second grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorC never null, the collector to perform the third grouping operation with
+     * @param collectorC the collector to perform the third grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <ResultContainerA_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultA_> the type of the first fact in the destination {@link TriConstraintStream}'s tuple
@@ -649,25 +564,24 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * @param <ResultB_> the type of the second fact in the destination {@link TriConstraintStream}'s tuple
      * @param <ResultContainerC_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultC_> the type of the third fact in the destination {@link TriConstraintStream}'s tuple
-     * @return never null
      */
     <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_>
-            TriConstraintStream<ResultA_, ResultB_, ResultC_> groupBy(
-                    QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC);
+            @NonNull TriConstraintStream<ResultA_, ResultB_, ResultC_> groupBy(
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC);
 
     /**
      * Convert the {@link QuadConstraintStream} to a {@link QuadConstraintStream}, containing only a single tuple,
      * the result of applying four {@link QuadConstraintCollector}s.
      *
-     * @param collectorA never null, the collector to perform the first grouping operation with
+     * @param collectorA the collector to perform the first grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorB never null, the collector to perform the second grouping operation with
+     * @param collectorB the collector to perform the second grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorC never null, the collector to perform the third grouping operation with
+     * @param collectorC the collector to perform the third grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorD never null, the collector to perform the fourth grouping operation with
+     * @param collectorD the collector to perform the fourth grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <ResultContainerA_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultA_> the type of the first fact in the destination {@link QuadConstraintStream}'s tuple
@@ -677,26 +591,24 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * @param <ResultC_> the type of the third fact in the destination {@link QuadConstraintStream}'s tuple
      * @param <ResultContainerD_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultD_> the type of the fourth fact in the destination {@link QuadConstraintStream}'s tuple
-     * @return never null
      */
     <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
-            QuadConstraintStream<ResultA_, ResultB_, ResultC_, ResultD_> groupBy(
-                    QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
+            @NonNull QuadConstraintStream<ResultA_, ResultB_, ResultC_, ResultD_> groupBy(
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
 
     /**
      * Convert the {@link QuadConstraintStream} to a {@link UniConstraintStream}, containing the set of tuples resulting
      * from applying the group key mapping function on all tuples of the original stream.
      * Neither tuple of the new stream {@link Objects#equals(Object, Object)} any other.
      *
-     * @param groupKeyMapping never null, mapping function to convert each element in the stream to a different element
+     * @param groupKeyMapping mapping function to convert each element in the stream to a different element
      * @param <GroupKey_> the type of a fact in the destination {@link UniConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
-     * @return never null
      */
-    <GroupKey_> UniConstraintStream<GroupKey_> groupBy(QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping);
+    <GroupKey_> @NonNull UniConstraintStream<GroupKey_> groupBy(@NonNull QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping);
 
     /**
      * Convert the {@link QuadConstraintStream} to a {@link BiConstraintStream}, consisting of unique tuples.
@@ -705,18 +617,17 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * The second fact is the return value of a given {@link QuadConstraintCollector} applied on all incoming tuples
      * with the same first fact.
      *
-     * @param groupKeyMapping never null, function to convert the fact in the original tuple to a different fact
-     * @param collector never null, the collector to perform the grouping operation with
+     * @param groupKeyMapping function to convert the fact in the original tuple to a different fact
+     * @param collector the collector to perform the grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <GroupKey_> the type of the first fact in the destination {@link BiConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
      * @param <ResultContainer_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <Result_> the type of the second fact in the destination {@link BiConstraintStream}'s tuple
-     * @return never null
      */
-    <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(
-            QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
-            QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector);
+    <GroupKey_, ResultContainer_, Result_> @NonNull BiConstraintStream<GroupKey_, Result_> groupBy(
+            @NonNull QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
+            @NonNull QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector);
 
     /**
      * Convert the {@link QuadConstraintStream} to a {@link TriConstraintStream}, consisting of unique tuples with three
@@ -726,10 +637,10 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * The remaining facts are the return value of the respective {@link QuadConstraintCollector} applied on all
      * incoming tuples with the same first fact.
      *
-     * @param groupKeyMapping never null, function to convert the fact in the original tuple to a different fact
-     * @param collectorB never null, the collector to perform the first grouping operation with
+     * @param groupKeyMapping function to convert the fact in the original tuple to a different fact
+     * @param collectorB the collector to perform the first grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorC never null, the collector to perform the second grouping operation with
+     * @param collectorC the collector to perform the second grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <GroupKey_> the type of the first fact in the destination {@link TriConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
@@ -737,13 +648,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * @param <ResultB_> the type of the second fact in the destination {@link TriConstraintStream}'s tuple
      * @param <ResultContainerC_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultC_> the type of the third fact in the destination {@link TriConstraintStream}'s tuple
-     * @return never null
      */
     <GroupKey_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_>
-            TriConstraintStream<GroupKey_, ResultB_, ResultC_> groupBy(
-                    QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC);
+            @NonNull TriConstraintStream<GroupKey_, ResultB_, ResultC_> groupBy(
+                    @NonNull QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC);
 
     /**
      * Convert the {@link QuadConstraintStream} to a {@link QuadConstraintStream}, consisting of unique tuples with four
@@ -753,12 +663,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * The remaining facts are the return value of the respective {@link QuadConstraintCollector} applied on all
      * incoming tuples with the same first fact.
      *
-     * @param groupKeyMapping never null, function to convert the fact in the original tuple to a different fact
-     * @param collectorB never null, the collector to perform the first grouping operation with
+     * @param groupKeyMapping function to convert the fact in the original tuple to a different fact
+     * @param collectorB the collector to perform the first grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorC never null, the collector to perform the second grouping operation with
+     * @param collectorC the collector to perform the second grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorD never null, the collector to perform the third grouping operation with
+     * @param collectorD the collector to perform the third grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <GroupKey_> the type of the first fact in the destination {@link QuadConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
@@ -768,14 +678,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * @param <ResultC_> the type of the third fact in the destination {@link QuadConstraintStream}'s tuple
      * @param <ResultContainerD_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultD_> the type of the fourth fact in the destination {@link QuadConstraintStream}'s tuple
-     * @return never null
      */
     <GroupKey_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
-            QuadConstraintStream<GroupKey_, ResultB_, ResultC_, ResultD_> groupBy(
-                    QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
+            @NonNull QuadConstraintStream<GroupKey_, ResultB_, ResultC_, ResultD_> groupBy(
+                    @NonNull QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
 
     /**
      * Convert the {@link QuadConstraintStream} to a {@link BiConstraintStream}, consisting of unique tuples.
@@ -784,16 +693,16 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * The second fact is the return value of the second group key mapping function, applied on all incoming tuples with
      * the same first fact.
      *
-     * @param groupKeyAMapping never null, function to convert the facts in the original tuple to a new fact
-     * @param groupKeyBMapping never null, function to convert the facts in the original tuple to another new fact
+     * @param groupKeyAMapping function to convert the facts in the original tuple to a new fact
+     * @param groupKeyBMapping function to convert the facts in the original tuple to another new fact
      * @param <GroupKeyA_> the type of the first fact in the destination {@link BiConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
      * @param <GroupKeyB_> the type of the second fact in the destination {@link BiConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
-     * @return never null
      */
-    <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
-            QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping, QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping);
+    <GroupKeyA_, GroupKeyB_> @NonNull BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
+            @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+            @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping);
 
     /**
      * Combines the semantics of {@link #groupBy(QuadFunction, QuadFunction)} and
@@ -803,9 +712,9 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * and the third fact is the result of applying {@link QuadConstraintCollector#finisher()} on all the tuples of the
      * original {@link UniConstraintStream} that belong to the group.
      *
-     * @param groupKeyAMapping never null, function to convert the original tuple into a first fact
-     * @param groupKeyBMapping never null, function to convert the original tuple into a second fact
-     * @param collector never null, the collector to perform the grouping operation with
+     * @param groupKeyAMapping function to convert the original tuple into a first fact
+     * @param groupKeyBMapping function to convert the original tuple into a second fact
+     * @param collector the collector to perform the grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <GroupKeyA_> the type of the first fact in the destination {@link TriConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
@@ -813,11 +722,11 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
      * @param <ResultContainer_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <Result_> the type of the third fact in the destination {@link TriConstraintStream}'s tuple
-     * @return never null
      */
-    <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
-            QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping, QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-            QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector);
+    <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> @NonNull TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
+            @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+            @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+            @NonNull QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector);
 
     /**
      * Combines the semantics of {@link #groupBy(QuadFunction, QuadFunction)} and
@@ -829,11 +738,11 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * The fourth fact is the result of applying the second {@link QuadConstraintCollector#finisher()} on all the tuples
      * of the original {@link QuadConstraintStream} that belong to the group
      *
-     * @param groupKeyAMapping never null, function to convert the original tuple into a first fact
-     * @param groupKeyBMapping never null, function to convert the original tuple into a second fact
-     * @param collectorC never null, the collector to perform the first grouping operation with
+     * @param groupKeyAMapping function to convert the original tuple into a first fact
+     * @param groupKeyBMapping function to convert the original tuple into a second fact
+     * @param collectorC the collector to perform the first grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
-     * @param collectorD never null, the collector to perform the second grouping operation with
+     * @param collectorD the collector to perform the second grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <GroupKeyA_> the type of the first fact in the destination {@link QuadConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
@@ -843,14 +752,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * @param <ResultC_> the type of the third fact in the destination {@link QuadConstraintStream}'s tuple
      * @param <ResultContainerD_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultD_> the type of the fourth fact in the destination {@link QuadConstraintStream}'s tuple
-     * @return never null
      */
     <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
-            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-                    QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-                    QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
+            @NonNull QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
 
     /**
      * Convert the {@link QuadConstraintStream} to a {@link TriConstraintStream}, consisting of unique tuples with three
@@ -862,21 +770,20 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * The third fact is the return value of the third group key mapping function, applied on all incoming tuples with
      * the same first fact.
      *
-     * @param groupKeyAMapping never null, function to convert the original tuple into a first fact
-     * @param groupKeyBMapping never null, function to convert the original tuple into a second fact
-     * @param groupKeyCMapping never null, function to convert the original tuple into a third fact
+     * @param groupKeyAMapping function to convert the original tuple into a first fact
+     * @param groupKeyBMapping function to convert the original tuple into a second fact
+     * @param groupKeyCMapping function to convert the original tuple into a third fact
      * @param <GroupKeyA_> the type of the first fact in the destination {@link TriConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
      * @param <GroupKeyB_> the type of the second fact in the destination {@link TriConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
      * @param <GroupKeyC_> the type of the third fact in the destination {@link TriConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
-     * @return never null
      */
-    <GroupKeyA_, GroupKeyB_, GroupKeyC_> TriConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_> groupBy(
-            QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-            QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-            QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping);
+    <GroupKeyA_, GroupKeyB_, GroupKeyC_> @NonNull TriConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_> groupBy(
+            @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+            @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+            @NonNull QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping);
 
     /**
      * Combines the semantics of {@link #groupBy(QuadFunction, QuadFunction)} and {@link #groupBy(QuadConstraintCollector)}.
@@ -884,10 +791,10 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * The final fact is the result of applying the first {@link QuadConstraintCollector#finisher()} on all the tuples
      * of the original {@link QuadConstraintStream} that belong to the group.
      *
-     * @param groupKeyAMapping never null, function to convert the original tuple into a first fact
-     * @param groupKeyBMapping never null, function to convert the original tuple into a second fact
-     * @param groupKeyCMapping never null, function to convert the original tuple into a third fact
-     * @param collectorD never null, the collector to perform the grouping operation with
+     * @param groupKeyAMapping function to convert the original tuple into a first fact
+     * @param groupKeyBMapping function to convert the original tuple into a second fact
+     * @param groupKeyCMapping function to convert the original tuple into a third fact
+     * @param collectorD the collector to perform the grouping operation with
      *        See {@link ConstraintCollectors} for common operations, such as {@code count()}, {@code sum()} and others.
      * @param <GroupKeyA_> the type of the first fact in the destination {@link QuadConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
@@ -897,14 +804,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
      * @param <ResultContainerD_> the mutable accumulation type (often hidden as an implementation detail)
      * @param <ResultD_> the type of the fourth fact in the destination {@link QuadConstraintStream}'s tuple
-     * @return never null
      */
     <GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultContainerD_, ResultD_>
-            QuadConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_> groupBy(
-                    QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-                    QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-                    QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
+            @NonNull QuadConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_> groupBy(
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
 
     /**
      * Convert the {@link TriConstraintStream} to a {@link QuadConstraintStream}, consisting of unique tuples with four
@@ -918,10 +824,10 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * The fourth fact is the return value of the fourth group key mapping function, applied on all incoming tuples with
      * the same first fact.
      *
-     * @param groupKeyAMapping never null, function to convert the original tuple into a first fact
-     * @param groupKeyBMapping never null, function to convert the original tuple into a second fact
-     * @param groupKeyCMapping never null, function to convert the original tuple into a third fact
-     * @param groupKeyDMapping never null, function to convert the original tuple into a fourth fact
+     * @param groupKeyAMapping function to convert the original tuple into a first fact
+     * @param groupKeyBMapping function to convert the original tuple into a second fact
+     * @param groupKeyCMapping function to convert the original tuple into a third fact
+     * @param groupKeyDMapping function to convert the original tuple into a fourth fact
      * @param <GroupKeyA_> the type of the first fact in the destination {@link QuadConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
      * @param <GroupKeyB_> the type of the second fact in the destination {@link QuadConstraintStream}'s tuple;
@@ -930,14 +836,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
      * @param <GroupKeyD_> the type of the fourth fact in the destination {@link QuadConstraintStream}'s tuple;
      *        must honor {@link Object#hashCode() the general contract of hashCode}.
-     * @return never null
      */
     <GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>
-            QuadConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_> groupBy(
-                    QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-                    QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-                    QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping,
-                    QuadFunction<A, B, C, D, GroupKeyD_> groupKeyDMapping);
+            @NonNull QuadConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_> groupBy(
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyD_> groupKeyDMapping);
 
     // ************************************************************************
     // Operations with duplicate tuple possibility
@@ -946,55 +851,51 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
     /**
      * As defined by {@link UniConstraintStream#map(Function)}.
      *
-     * @param mapping never null, function to convert the original tuple into the new tuple
+     * @param mapping function to convert the original tuple into the new tuple
      * @param <ResultA_> the type of the only fact in the resulting {@link UniConstraintStream}'s tuple
-     * @return never null
      */
-    <ResultA_> UniConstraintStream<ResultA_> map(QuadFunction<A, B, C, D, ResultA_> mapping);
+    <ResultA_> @NonNull UniConstraintStream<ResultA_> map(@NonNull QuadFunction<A, B, C, D, ResultA_> mapping);
 
     /**
      * As defined by {@link #map(QuadFunction)}, only resulting in {@link BiConstraintStream}.
      *
-     * @param mappingA never null, function to convert the original tuple into the first fact of a new tuple
-     * @param mappingB never null, function to convert the original tuple into the second fact of a new tuple
+     * @param mappingA function to convert the original tuple into the first fact of a new tuple
+     * @param mappingB function to convert the original tuple into the second fact of a new tuple
      * @param <ResultA_> the type of the first fact in the resulting {@link BiConstraintStream}'s tuple
      * @param <ResultB_> the type of the first fact in the resulting {@link BiConstraintStream}'s tuple
-     * @return never null
      */
-    <ResultA_, ResultB_> BiConstraintStream<ResultA_, ResultB_> map(QuadFunction<A, B, C, D, ResultA_> mappingA,
-            QuadFunction<A, B, C, D, ResultB_> mappingB);
+    <ResultA_, ResultB_> @NonNull BiConstraintStream<ResultA_, ResultB_> map(
+            @NonNull QuadFunction<A, B, C, D, ResultA_> mappingA, @NonNull QuadFunction<A, B, C, D, ResultB_> mappingB);
 
     /**
      * As defined by {@link #map(QuadFunction)}, only resulting in {@link TriConstraintStream}.
      *
-     * @param mappingA never null, function to convert the original tuple into the first fact of a new tuple
-     * @param mappingB never null, function to convert the original tuple into the second fact of a new tuple
-     * @param mappingC never null, function to convert the original tuple into the third fact of a new tuple
+     * @param mappingA function to convert the original tuple into the first fact of a new tuple
+     * @param mappingB function to convert the original tuple into the second fact of a new tuple
+     * @param mappingC function to convert the original tuple into the third fact of a new tuple
      * @param <ResultA_> the type of the first fact in the resulting {@link TriConstraintStream}'s tuple
      * @param <ResultB_> the type of the first fact in the resulting {@link TriConstraintStream}'s tuple
      * @param <ResultC_> the type of the third fact in the resulting {@link TriConstraintStream}'s tuple
-     * @return never null
      */
-    <ResultA_, ResultB_, ResultC_> TriConstraintStream<ResultA_, ResultB_, ResultC_> map(
-            QuadFunction<A, B, C, D, ResultA_> mappingA, QuadFunction<A, B, C, D, ResultB_> mappingB,
-            QuadFunction<A, B, C, D, ResultC_> mappingC);
+    <ResultA_, ResultB_, ResultC_> @NonNull TriConstraintStream<ResultA_, ResultB_, ResultC_> map(
+            @NonNull QuadFunction<A, B, C, D, ResultA_> mappingA, @NonNull QuadFunction<A, B, C, D, ResultB_> mappingB,
+            @NonNull QuadFunction<A, B, C, D, ResultC_> mappingC);
 
     /**
      * As defined by {@link #map(QuadFunction)}, only resulting in {@link QuadConstraintStream}.
      *
-     * @param mappingA never null, function to convert the original tuple into the first fact of a new tuple
-     * @param mappingB never null, function to convert the original tuple into the second fact of a new tuple
-     * @param mappingC never null, function to convert the original tuple into the third fact of a new tuple
-     * @param mappingD never null, function to convert the original tuple into the fourth fact of a new tuple
+     * @param mappingA function to convert the original tuple into the first fact of a new tuple
+     * @param mappingB function to convert the original tuple into the second fact of a new tuple
+     * @param mappingC function to convert the original tuple into the third fact of a new tuple
+     * @param mappingD function to convert the original tuple into the fourth fact of a new tuple
      * @param <ResultA_> the type of the first fact in the resulting {@link QuadConstraintStream}'s tuple
      * @param <ResultB_> the type of the first fact in the resulting {@link QuadConstraintStream}'s tuple
      * @param <ResultC_> the type of the third fact in the resulting {@link QuadConstraintStream}'s tuple
      * @param <ResultD_> the type of the third fact in the resulting {@link QuadConstraintStream}'s tuple
-     * @return never null
      */
-    <ResultA_, ResultB_, ResultC_, ResultD_> QuadConstraintStream<ResultA_, ResultB_, ResultC_, ResultD_> map(
-            QuadFunction<A, B, C, D, ResultA_> mappingA, QuadFunction<A, B, C, D, ResultB_> mappingB,
-            QuadFunction<A, B, C, D, ResultC_> mappingC, QuadFunction<A, B, C, D, ResultD_> mappingD);
+    <ResultA_, ResultB_, ResultC_, ResultD_> @NonNull QuadConstraintStream<ResultA_, ResultB_, ResultC_, ResultD_> map(
+            @NonNull QuadFunction<A, B, C, D, ResultA_> mappingA, @NonNull QuadFunction<A, B, C, D, ResultB_> mappingB,
+            @NonNull QuadFunction<A, B, C, D, ResultC_> mappingC, @NonNull QuadFunction<A, B, C, D, ResultD_> mappingD);
 
     /**
      * As defined by {@link BiConstraintStream#flattenLast(Function)}.
@@ -1003,11 +904,10 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      *        It is recommended that this type be deeply immutable.
      *        Not following this recommendation may lead to hard-to-debug hashing issues down the stream,
      *        especially if this value is ever used as a group key.
-     * @param mapping never null, function to convert the last fact in the original tuple into {@link Iterable}.
+     * @param mapping function to convert the last fact in the original tuple into {@link Iterable}.
      *        For performance, returning an implementation of {@link java.util.Collection} is preferred.
-     * @return never null
      */
-    <ResultD_> QuadConstraintStream<A, B, C, ResultD_> flattenLast(Function<D, Iterable<ResultD_>> mapping);
+    <ResultD_> @NonNull QuadConstraintStream<A, B, C, ResultD_> flattenLast(@NonNull Function<D, Iterable<ResultD_>> mapping);
 
     /**
      * Transforms the stream in such a way that all the tuples going through it are distinct.
@@ -1018,9 +918,8 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * However, operations such as {@link #map(QuadFunction)} may create a stream which breaks that promise.
      * By calling this method on such a stream,
      * duplicate copies of the same tuple will be omitted at a performance cost.
-     *
-     * @return never null
      */
+    @NonNull
     QuadConstraintStream<A, B, C, D> distinct();
 
     /**
@@ -1035,11 +934,8 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * {@code [(A1, A2, A3, A4), (B1, B2, B3, B4), (C1, C2, C3, C4), (C, null, null, null), (D, null, null, null), (E, null, null, null)]}.
      * <p>
      * This operation can be thought of as an or between streams.
-     *
-     * @param otherStream never null
-     * @return never null
      */
-    default QuadConstraintStream<A, B, C, D> concat(UniConstraintStream<A> otherStream) {
+    default @NonNull QuadConstraintStream<A, B, C, D> concat(@NonNull UniConstraintStream<A> otherStream) {
         return concat(otherStream, uniConstantNull(), uniConstantNull(), uniConstantNull());
     }
 
@@ -1056,14 +952,14 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * <p>
      * This operation can be thought of as an or between streams.
      *
-     * @param otherStream never null
-     * @param paddingFunctionB never null, function to find the padding for the second fact
-     * @param paddingFunctionC never null, function to find the padding for the third fact
-     * @param paddingFunctionD never null, function to find the padding for the fourth fact
-     * @return never null
+     * @param paddingFunctionB function to find the padding for the second fact
+     * @param paddingFunctionC function to find the padding for the third fact
+     * @param paddingFunctionD function to find the padding for the fourth fact
      */
-    QuadConstraintStream<A, B, C, D> concat(UniConstraintStream<A> otherStream, Function<A, B> paddingFunctionB,
-            Function<A, C> paddingFunctionC, Function<A, D> paddingFunctionD);
+    @NonNull
+    QuadConstraintStream<A, B, C, D> concat(@NonNull UniConstraintStream<A> otherStream,
+            @NonNull Function<A, B> paddingFunctionB, @NonNull Function<A, C> paddingFunctionC,
+            @NonNull Function<A, D> paddingFunctionD);
 
     /**
      * Returns a new {@link QuadConstraintStream} containing all the tuples of both this {@link QuadConstraintStream}
@@ -1077,11 +973,8 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * {@code [(A1, A2, A3, A4), (B1, B2, B3, B4), (C1, C2, C3, C4), (C1, C2, null, null), (D1, D2, null, null), (E1, E2, null, null)]}.
      * <p>
      * This operation can be thought of as an or between streams.
-     *
-     * @param otherStream never null
-     * @return never null
      */
-    default QuadConstraintStream<A, B, C, D> concat(BiConstraintStream<A, B> otherStream) {
+    default @NonNull QuadConstraintStream<A, B, C, D> concat(@NonNull BiConstraintStream<A, B> otherStream) {
         return concat(otherStream, biConstantNull(), biConstantNull());
     }
 
@@ -1098,13 +991,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * <p>
      * This operation can be thought of as an or between streams.
      *
-     * @param otherStream never null
-     * @param paddingFunctionC never null, function to find the padding for the third fact
-     * @param paddingFunctionD never null, function to find the padding for the fourth fact
-     * @return never null
+     * @param paddingFunctionC function to find the padding for the third fact
+     * @param paddingFunctionD function to find the padding for the fourth fact
      */
-    QuadConstraintStream<A, B, C, D> concat(BiConstraintStream<A, B> otherStream, BiFunction<A, B, C> paddingFunctionC,
-            BiFunction<A, B, D> paddingFunctionD);
+    @NonNull
+    QuadConstraintStream<A, B, C, D> concat(@NonNull BiConstraintStream<A, B> otherStream,
+            @NonNull BiFunction<A, B, C> paddingFunctionC, @NonNull BiFunction<A, B, D> paddingFunctionD);
 
     /**
      * Returns a new {@link QuadConstraintStream} containing all the tuples of both this {@link QuadConstraintStream}
@@ -1118,11 +1010,8 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * {@code [(A1, A2, A3, A4), (B1, B2, B3, B4), (C1, C2, C3, C4), (C1, C2, C3, null), (D1, D2, D3, null), (E1, E2, E3, null)]}.
      * <p>
      * This operation can be thought of as an or between streams.
-     *
-     * @param otherStream never null
-     * @return never null
      */
-    default QuadConstraintStream<A, B, C, D> concat(TriConstraintStream<A, B, C> otherStream) {
+    default @NonNull QuadConstraintStream<A, B, C, D> concat(@NonNull TriConstraintStream<A, B, C> otherStream) {
         return concat(otherStream, triConstantNull());
     }
 
@@ -1139,11 +1028,11 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * <p>
      * This operation can be thought of as an or between streams.
      *
-     * @param otherStream never null
-     * @param paddingFunction never null, function to find the padding for the fourth fact
-     * @return never null
+     * @param paddingFunction function to find the padding for the fourth fact
      */
-    QuadConstraintStream<A, B, C, D> concat(TriConstraintStream<A, B, C> otherStream, TriFunction<A, B, C, D> paddingFunction);
+    @NonNull
+    QuadConstraintStream<A, B, C, D> concat(@NonNull TriConstraintStream<A, B, C> otherStream,
+            @NonNull TriFunction<A, B, C, D> paddingFunction);
 
     /**
      * Returns a new {@link QuadConstraintStream} containing all the tuples of both this {@link QuadConstraintStream}
@@ -1158,11 +1047,9 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * {@code [(A, 1, -1, a), (B, 2, -2, b), (C, 3, -3, c), (C, 3, -3, c), (D, 4, -4, d), (E, 5, -5,e)]}.
      * <p>
      * This operation can be thought of as an or between streams.
-     *
-     * @param otherStream never null
-     * @return never null
      */
-    QuadConstraintStream<A, B, C, D> concat(QuadConstraintStream<A, B, C, D> otherStream);
+    @NonNull
+    QuadConstraintStream<A, B, C, D> concat(@NonNull QuadConstraintStream<A, B, C, D> otherStream);
 
     // ************************************************************************
     // complement
@@ -1172,7 +1059,7 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * As defined by {@link #complement(Class, Function, Function, Function)},
      * where the padding function pads with null.
      */
-    default QuadConstraintStream<A, B, C, D> complement(Class<A> otherClass) {
+    default @NonNull QuadConstraintStream<A, B, C, D> complement(@NonNull Class<A> otherClass) {
         return complement(otherClass, uniConstantNull(), uniConstantNull(), uniConstantNull());
     }
 
@@ -1187,14 +1074,13 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * The rest of the tuple will be padded with the results of the padding functions,
      * applied on the new instance.
      *
-     * @param otherClass never null
-     * @param paddingFunctionB never null, function to find the padding for the second fact
-     * @param paddingFunctionC never null, function to find the padding for the third fact
-     * @param paddingFunctionD never null, function to find the padding for the fourth fact
-     * @return never null
+     * @param paddingFunctionB function to find the padding for the second fact
+     * @param paddingFunctionC function to find the padding for the third fact
+     * @param paddingFunctionD function to find the padding for the fourth fact
      */
-    default QuadConstraintStream<A, B, C, D> complement(Class<A> otherClass, Function<A, B> paddingFunctionB,
-            Function<A, C> paddingFunctionC, Function<A, D> paddingFunctionD) {
+    default @NonNull QuadConstraintStream<A, B, C, D> complement(@NonNull Class<A> otherClass,
+            @NonNull Function<A, B> paddingFunctionB, @NonNull Function<A, C> paddingFunctionC,
+            @NonNull Function<A, D> paddingFunctionD) {
         var firstStream = this;
         var remapped = firstStream.map(ConstantLambdaUtils.quadPickFirst());
         var secondStream = getConstraintFactory().forEach(otherClass)
@@ -1208,29 +1094,25 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
 
     /**
      * As defined by {@link #penalize(Score, ToIntQuadFunction)}, where the match weight is one (1).
-     *
-     * @return never null
      */
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalize(Score_ constraintWeight) {
+    default <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_>
+            penalize(@NonNull Score_ constraintWeight) {
         return penalize(constraintWeight, quadConstantOne());
     }
 
     /**
      * As defined by {@link #penalizeLong(Score, ToLongQuadFunction)}, where the match weight is one (1).
-     *
-     * @return never null
      */
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeLong(Score_ constraintWeight) {
+    default <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_>
+            penalizeLong(@NonNull Score_ constraintWeight) {
         return penalizeLong(constraintWeight, quadConstantOneLong());
     }
 
     /**
      * As defined by {@link #penalizeBigDecimal(Score, QuadFunction)}, where the match weight is one (1).
-     *
-     * @return never null
      */
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_>
-            penalizeBigDecimal(Score_ constraintWeight) {
+    default <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_>
+            penalizeBigDecimal(@NonNull Score_ constraintWeight) {
         return penalizeBigDecimal(constraintWeight, quadConstantOneBigDecimal());
     }
 
@@ -1245,24 +1127,22 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * For non-int {@link Score} types use {@link #penalizeLong(Score, ToLongQuadFunction)} or
      * {@link #penalizeBigDecimal(Score, QuadFunction)} instead.
      *
-     * @param constraintWeight never null
-     * @param matchWeigher never null, the result of this function (matchWeight) is multiplied by the constraintWeight
-     * @return never null
+     * @param matchWeigher the result of this function (matchWeight) is multiplied by the constraintWeight
      */
-    <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalize(Score_ constraintWeight,
-            ToIntQuadFunction<A, B, C, D> matchWeigher);
+    <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_> penalize(@NonNull Score_ constraintWeight,
+            @NonNull ToIntQuadFunction<A, B, C, D> matchWeigher);
 
     /**
      * As defined by {@link #penalize(Score, ToIntQuadFunction)}, with a penalty of type long.
      */
-    <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeLong(Score_ constraintWeight,
-            ToLongQuadFunction<A, B, C, D> matchWeigher);
+    <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_> penalizeLong(
+            @NonNull Score_ constraintWeight, @NonNull ToLongQuadFunction<A, B, C, D> matchWeigher);
 
     /**
      * As defined by {@link #penalize(Score, ToIntQuadFunction)}, with a penalty of type {@link BigDecimal}.
      */
-    <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeBigDecimal(Score_ constraintWeight,
-            QuadFunction<A, B, C, D, BigDecimal> matchWeigher);
+    <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_> penalizeBigDecimal(
+            @NonNull Score_ constraintWeight, @NonNull QuadFunction<A, B, C, D, BigDecimal> matchWeigher);
 
     /**
      * Negatively impacts the {@link Score},
@@ -1299,7 +1179,7 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
 
     /**
      * As defined by {@link #penalizeConfigurable(ToIntQuadFunction)}, with a penalty of type long.
-     * 
+     *
      * @deprecated Prefer {@link #penalizeLong(Score, ToLongQuadFunction)} and {@link ConstraintWeightOverrides}.
      */
     @Deprecated(forRemoval = true, since = "1.13.0")
@@ -1307,7 +1187,7 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
 
     /**
      * As defined by {@link #penalizeConfigurable(ToIntQuadFunction)}, with a penalty of type {@link BigDecimal}.
-     * 
+     *
      * @deprecated Prefer {@link #penalizeBigDecimal(Score, QuadFunction)} and {@link ConstraintWeightOverrides}.
      */
     @Deprecated(forRemoval = true, since = "1.13.0")
@@ -1315,10 +1195,9 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
 
     /**
      * As defined by {@link #reward(Score, ToIntQuadFunction)}, where the match weight is one (1).
-     *
-     * @return never null
      */
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> reward(Score_ constraintWeight) {
+    default <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_>
+            reward(@NonNull Score_ constraintWeight) {
         return reward(constraintWeight, quadConstantOne());
     }
 
@@ -1333,24 +1212,22 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * For non-int {@link Score} types use {@link #rewardLong(Score, ToLongQuadFunction)} or
      * {@link #rewardBigDecimal(Score, QuadFunction)} instead.
      *
-     * @param constraintWeight never null
-     * @param matchWeigher never null, the result of this function (matchWeight) is multiplied by the constraintWeight
-     * @return never null
+     * @param matchWeigher the result of this function (matchWeight) is multiplied by the constraintWeight
      */
-    <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> reward(Score_ constraintWeight,
-            ToIntQuadFunction<A, B, C, D> matchWeigher);
+    <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_> reward(@NonNull Score_ constraintWeight,
+            @NonNull ToIntQuadFunction<A, B, C, D> matchWeigher);
 
     /**
      * As defined by {@link #reward(Score, ToIntQuadFunction)}, with a penalty of type long.
      */
-    <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> rewardLong(Score_ constraintWeight,
-            ToLongQuadFunction<A, B, C, D> matchWeigher);
+    <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_> rewardLong(
+            @NonNull Score_ constraintWeight, @NonNull ToLongQuadFunction<A, B, C, D> matchWeigher);
 
     /**
      * As defined by {@link #reward(Score, ToIntQuadFunction)}, with a penalty of type {@link BigDecimal}.
      */
-    <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> rewardBigDecimal(Score_ constraintWeight,
-            QuadFunction<A, B, C, D, BigDecimal> matchWeigher);
+    <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_> rewardBigDecimal(
+            @NonNull Score_ constraintWeight, @NonNull QuadFunction<A, B, C, D, BigDecimal> matchWeigher);
 
     /**
      * Positively impacts the {@link Score},
@@ -1387,7 +1264,7 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
 
     /**
      * As defined by {@link #rewardConfigurable(ToIntQuadFunction)}, with a penalty of type long.
-     * 
+     *
      * @deprecated Prefer {@link #rewardLong(Score, ToLongQuadFunction)} and {@link ConstraintWeightOverrides}.
      */
     @Deprecated(forRemoval = true, since = "1.13.0")
@@ -1395,7 +1272,7 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
 
     /**
      * As defined by {@link #rewardConfigurable(ToIntQuadFunction)}, with a penalty of type {@link BigDecimal}.
-     * 
+     *
      * @deprecated Prefer {@link #rewardBigDecimal(Score, QuadFunction)} and {@link ConstraintWeightOverrides}.
      */
     @Deprecated(forRemoval = true, since = "1.13.0")
@@ -1407,11 +1284,9 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * <p>
      * Use {@code penalize(...)} or {@code reward(...)} instead, unless this constraint can both have positive and
      * negative weights.
-     *
-     * @param constraintWeight never null
-     * @return never null
      */
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impact(Score_ constraintWeight) {
+    default <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_>
+            impact(@NonNull Score_ constraintWeight) {
         return impact(constraintWeight, quadConstantOne());
     }
 
@@ -1425,24 +1300,23 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * Use {@code penalize(...)} or {@code reward(...)} instead, unless this constraint can both have positive and
      * negative weights.
      *
-     * @param constraintWeight never null
-     * @param matchWeigher never null, the result of this function (matchWeight) is multiplied by the constraintWeight
-     * @return never null
+     * @param matchWeigher the result of this function (matchWeight) is multiplied by the constraintWeight
      */
-    <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impact(Score_ constraintWeight,
-            ToIntQuadFunction<A, B, C, D> matchWeigher);
+    <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_> impact(@NonNull Score_ constraintWeight,
+            @NonNull ToIntQuadFunction<A, B, C, D> matchWeigher);
 
     /**
      * As defined by {@link #impact(Score, ToIntQuadFunction)}, with an impact of type long.
      */
-    <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impactLong(Score_ constraintWeight,
-            ToLongQuadFunction<A, B, C, D> matchWeigher);
+    <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_> impactLong(
+            @NonNull Score_ constraintWeight,
+            @NonNull ToLongQuadFunction<A, B, C, D> matchWeigher);
 
     /**
      * As defined by {@link #impact(Score, ToIntQuadFunction)}, with an impact of type {@link BigDecimal}.
      */
-    <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impactBigDecimal(Score_ constraintWeight,
-            QuadFunction<A, B, C, D, BigDecimal> matchWeigher);
+    <Score_ extends Score<Score_>> @NonNull QuadConstraintBuilder<A, B, C, D, Score_> impactBigDecimal(
+            @NonNull Score_ constraintWeight, @NonNull QuadFunction<A, B, C, D, BigDecimal> matchWeigher);
 
     /**
      * Positively impacts the {@link Score} by the {@link ConstraintWeight} for each match,
@@ -1476,7 +1350,7 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
 
     /**
      * As defined by {@link #impactConfigurable(ToIntQuadFunction)}, with an impact of type long.
-     * 
+     *
      * @deprecated Prefer {@link #impactLong(Score, ToLongQuadFunction)} and {@link ConstraintWeightOverrides}.
      */
     @Deprecated(forRemoval = true, since = "1.13.0")
@@ -1484,7 +1358,7 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
 
     /**
      * As defined by {@link #impactConfigurable(ToIntQuadFunction)}, with an impact of type BigDecimal.
-     * 
+     *
      * @deprecated Prefer {@link #impactBigDecimal(Score, QuadFunction)} and {@link ConstraintWeightOverrides}.
      */
     @Deprecated(forRemoval = true, since = "1.13.0")

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetAbstractQuadConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetAbstractQuadConstraintStream.java
@@ -48,6 +48,8 @@ import ai.timefold.solver.core.impl.score.stream.common.penta.PentaJoinerComber;
 import ai.timefold.solver.core.impl.score.stream.common.quad.InnerQuadConstraintStream;
 import ai.timefold.solver.core.impl.score.stream.common.quad.QuadConstraintBuilderImpl;
 
+import org.jspecify.annotations.NonNull;
+
 public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         extends BavetAbstractConstraintStream<Solution_>
         implements InnerQuadConstraintStream<A, B, C, D> {
@@ -67,7 +69,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     // ************************************************************************
 
     @Override
-    public BavetAbstractQuadConstraintStream<Solution_, A, B, C, D> filter(QuadPredicate<A, B, C, D> predicate) {
+    public @NonNull BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
+            filter(@NonNull QuadPredicate<A, B, C, D> predicate) {
         return shareAndAddChild(new BavetFilterQuadConstraintStream<>(constraintFactory, this, predicate));
     }
 
@@ -77,15 +80,15 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
 
     @SafeVarargs
     @Override
-    public final <E> QuadConstraintStream<A, B, C, D> ifExists(UniConstraintStream<E> otherStream,
+    public final <E> @NonNull QuadConstraintStream<A, B, C, D> ifExists(@NonNull UniConstraintStream<E> otherStream,
             PentaJoiner<A, B, C, D, E>... joiners) {
         return ifExistsOrNot(true, otherStream, joiners);
     }
 
     @SafeVarargs
     @Override
-    public final <E> QuadConstraintStream<A, B, C, D> ifNotExists(UniConstraintStream<E> otherStream,
-            PentaJoiner<A, B, C, D, E>... joiners) {
+    public final @NonNull <E> QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull UniConstraintStream<E> otherStream,
+            @NonNull PentaJoiner<A, B, C, D, E> @NonNull... joiners) {
         return ifExistsOrNot(false, otherStream, joiners);
     }
 
@@ -105,8 +108,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     // ************************************************************************
 
     @Override
-    public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
-            QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
+    public @NonNull <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
+            @NonNull QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
         GroupNodeConstructor<UniTuple<Result_>> nodeConstructor =
                 GroupNodeConstructor.zeroKeysGroupBy(collector, Group0Mapping1CollectorQuadNode::new);
         return buildUniGroupBy(nodeConstructor);
@@ -119,9 +122,9 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_> BiConstraintStream<ResultA_, ResultB_> groupBy(
-            QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
-            QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB) {
+    public @NonNull <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_> BiConstraintStream<ResultA_, ResultB_> groupBy(
+            @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
+            @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB) {
         GroupNodeConstructor<BiTuple<ResultA_, ResultB_>> nodeConstructor =
                 GroupNodeConstructor.zeroKeysGroupBy(collectorA, collectorB, Group0Mapping2CollectorQuadNode::new);
         return buildBiGroupBy(nodeConstructor);
@@ -134,11 +137,11 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_>
+    public @NonNull <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_>
             TriConstraintStream<ResultA_, ResultB_, ResultC_>
-            groupBy(QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC) {
+            groupBy(@NonNull QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC) {
         GroupNodeConstructor<TriTuple<ResultA_, ResultB_, ResultC_>> nodeConstructor =
                 GroupNodeConstructor.zeroKeysGroupBy(collectorA, collectorB, collectorC, Group0Mapping3CollectorQuadNode::new);
         return buildTriGroupBy(nodeConstructor);
@@ -152,12 +155,12 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+    public @NonNull <ResultContainerA_, ResultA_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
             QuadConstraintStream<ResultA_, ResultB_, ResultC_, ResultD_>
-            groupBy(QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
+            groupBy(@NonNull QuadConstraintCollector<A, B, C, D, ResultContainerA_, ResultA_> collectorA,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
         GroupNodeConstructor<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 GroupNodeConstructor.zeroKeysGroupBy(collectorA, collectorB, collectorC, collectorD,
                         Group0Mapping4CollectorQuadNode::new);
@@ -172,17 +175,19 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping) {
+    public @NonNull <GroupKey_> UniConstraintStream<GroupKey_>
+            groupBy(@NonNull QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping) {
         GroupNodeConstructor<UniTuple<GroupKey_>> nodeConstructor =
                 GroupNodeConstructor.oneKeyGroupBy(groupKeyMapping, Group1Mapping0CollectorQuadNode::new);
         return buildUniGroupBy(nodeConstructor);
     }
 
     @Override
-    public <GroupKey_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_>
-            TriConstraintStream<GroupKey_, ResultB_, ResultC_> groupBy(QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC) {
+    public @NonNull <GroupKey_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_>
+            TriConstraintStream<GroupKey_, ResultB_, ResultC_>
+            groupBy(@NonNull QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC) {
         GroupNodeConstructor<TriTuple<GroupKey_, ResultB_, ResultC_>> nodeConstructor =
                 GroupNodeConstructor.oneKeyGroupBy(groupKeyMapping, collectorB, collectorC,
                         Group1Mapping2CollectorQuadNode::new);
@@ -190,12 +195,12 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <GroupKey_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+    public @NonNull <GroupKey_, ResultContainerB_, ResultB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
             QuadConstraintStream<GroupKey_, ResultB_, ResultC_, ResultD_>
-            groupBy(QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
+            groupBy(@NonNull QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
         GroupNodeConstructor<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 GroupNodeConstructor.oneKeyGroupBy(groupKeyMapping, collectorB, collectorC, collectorD,
                         Group1Mapping3CollectorQuadNode::new);
@@ -203,28 +208,29 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(
-            QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
-            QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
+    public @NonNull <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(
+            @NonNull QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping,
+            @NonNull QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
         GroupNodeConstructor<BiTuple<GroupKey_, Result_>> nodeConstructor =
                 GroupNodeConstructor.oneKeyGroupBy(groupKeyMapping, collector, Group1Mapping1CollectorQuadNode::new);
         return buildBiGroupBy(nodeConstructor);
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
-            QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-            QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping) {
+    public @NonNull <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
+            @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+            @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping) {
         GroupNodeConstructor<BiTuple<GroupKeyA_, GroupKeyB_>> nodeConstructor =
                 GroupNodeConstructor.twoKeysGroupBy(groupKeyAMapping, groupKeyBMapping, Group2Mapping0CollectorQuadNode::new);
         return buildBiGroupBy(nodeConstructor);
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
-            QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-            QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-            QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
+    public @NonNull <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_>
+            groupBy(
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> nodeConstructor =
                 GroupNodeConstructor.twoKeysGroupBy(groupKeyAMapping, groupKeyBMapping, collector,
                         Group2Mapping1CollectorQuadNode::new);
@@ -232,12 +238,12 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+    public @NonNull <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
             QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-                    QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-                    QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
         GroupNodeConstructor<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> nodeConstructor =
                 GroupNodeConstructor.twoKeysGroupBy(groupKeyAMapping, groupKeyBMapping, collectorC, collectorD,
                         Group2Mapping2CollectorQuadNode::new);
@@ -245,9 +251,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, GroupKeyC_> TriConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_> groupBy(
-            QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping, QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-            QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping) {
+    public @NonNull <GroupKeyA_, GroupKeyB_, GroupKeyC_> TriConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_> groupBy(
+            @NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+            @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+            @NonNull QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping) {
         GroupNodeConstructor<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> nodeConstructor =
                 GroupNodeConstructor.threeKeysGroupBy(groupKeyAMapping, groupKeyBMapping, groupKeyCMapping,
                         Group3Mapping0CollectorQuadNode::new);
@@ -255,12 +262,12 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultContainerD_, ResultD_>
+    public @NonNull <GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultContainerD_, ResultD_>
             QuadConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>
-            groupBy(QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-                    QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-                    QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping,
-                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
+            groupBy(@NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping,
+                    @NonNull QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
         GroupNodeConstructor<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> nodeConstructor =
                 GroupNodeConstructor.threeKeysGroupBy(groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, collectorD,
                         Group3Mapping1CollectorQuadNode::new);
@@ -268,11 +275,12 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>
-            groupBy(QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-                    QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-                    QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping,
-                    QuadFunction<A, B, C, D, GroupKeyD_> groupKeyDMapping) {
+    public @NonNull <GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>
+            groupBy(@NonNull QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping,
+                    @NonNull QuadFunction<A, B, C, D, GroupKeyD_> groupKeyDMapping) {
         GroupNodeConstructor<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> nodeConstructor =
                 GroupNodeConstructor.fourKeysGroupBy(groupKeyAMapping, groupKeyBMapping, groupKeyCMapping, groupKeyDMapping,
                         Group4Mapping0CollectorQuadNode::new);
@@ -284,8 +292,9 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     // ************************************************************************
 
     @Override
-    public QuadConstraintStream<A, B, C, D> concat(UniConstraintStream<A> otherStream, Function<A, B> paddingFunctionB,
-            Function<A, C> paddingFunctionC, Function<A, D> paddingFunctionD) {
+    public @NonNull QuadConstraintStream<A, B, C, D> concat(@NonNull UniConstraintStream<A> otherStream,
+            @NonNull Function<A, B> paddingFunctionB,
+            @NonNull Function<A, C> paddingFunctionC, @NonNull Function<A, D> paddingFunctionD) {
         var other = (BavetAbstractUniConstraintStream<Solution_, A>) otherStream;
         var leftBridge = new BavetForeBridgeQuadConstraintStream<>(constraintFactory, this);
         var rightBridge = new BavetForeBridgeUniConstraintStream<>(constraintFactory, other);
@@ -300,8 +309,9 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public QuadConstraintStream<A, B, C, D> concat(BiConstraintStream<A, B> otherStream, BiFunction<A, B, C> paddingFunctionC,
-            BiFunction<A, B, D> paddingFunctionD) {
+    public @NonNull QuadConstraintStream<A, B, C, D> concat(@NonNull BiConstraintStream<A, B> otherStream,
+            @NonNull BiFunction<A, B, C> paddingFunctionC,
+            @NonNull BiFunction<A, B, D> paddingFunctionD) {
         var other = (BavetAbstractBiConstraintStream<Solution_, A, B>) otherStream;
         var leftBridge = new BavetForeBridgeQuadConstraintStream<>(constraintFactory, this);
         var rightBridge = new BavetForeBridgeBiConstraintStream<>(constraintFactory, other);
@@ -315,8 +325,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public QuadConstraintStream<A, B, C, D> concat(TriConstraintStream<A, B, C> otherStream,
-            TriFunction<A, B, C, D> paddingFunction) {
+    public @NonNull QuadConstraintStream<A, B, C, D> concat(@NonNull TriConstraintStream<A, B, C> otherStream,
+            @NonNull TriFunction<A, B, C, D> paddingFunction) {
         var other = (BavetAbstractTriConstraintStream<Solution_, A, B, C>) otherStream;
         var leftBridge = new BavetForeBridgeQuadConstraintStream<>(constraintFactory, this);
         var rightBridge = new BavetForeBridgeTriConstraintStream<>(constraintFactory, other);
@@ -330,7 +340,7 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public QuadConstraintStream<A, B, C, D> concat(QuadConstraintStream<A, B, C, D> otherStream) {
+    public @NonNull QuadConstraintStream<A, B, C, D> concat(@NonNull QuadConstraintStream<A, B, C, D> otherStream) {
         var other = (BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>) otherStream;
         var leftBridge = new BavetForeBridgeQuadConstraintStream<>(constraintFactory, this);
         var rightBridge = new BavetForeBridgeQuadConstraintStream<>(constraintFactory, other);
@@ -343,23 +353,24 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <ResultA_> UniConstraintStream<ResultA_> map(QuadFunction<A, B, C, D, ResultA_> mapping) {
+    public @NonNull <ResultA_> UniConstraintStream<ResultA_> map(@NonNull QuadFunction<A, B, C, D, ResultA_> mapping) {
         var stream = shareAndAddChild(new BavetUniMapQuadConstraintStream<>(constraintFactory, this, mapping));
         return constraintFactory.share(new BavetAftBridgeUniConstraintStream<>(constraintFactory, stream),
                 stream::setAftBridge);
     }
 
     @Override
-    public <ResultA_, ResultB_> BiConstraintStream<ResultA_, ResultB_> map(QuadFunction<A, B, C, D, ResultA_> mappingA,
-            QuadFunction<A, B, C, D, ResultB_> mappingB) {
+    public @NonNull <ResultA_, ResultB_> BiConstraintStream<ResultA_, ResultB_> map(
+            @NonNull QuadFunction<A, B, C, D, ResultA_> mappingA,
+            @NonNull QuadFunction<A, B, C, D, ResultB_> mappingB) {
         var stream = shareAndAddChild(new BavetBiMapQuadConstraintStream<>(constraintFactory, this, mappingA, mappingB));
         return constraintFactory.share(new BavetAftBridgeBiConstraintStream<>(constraintFactory, stream), stream::setAftBridge);
     }
 
     @Override
-    public <ResultA_, ResultB_, ResultC_> TriConstraintStream<ResultA_, ResultB_, ResultC_> map(
-            QuadFunction<A, B, C, D, ResultA_> mappingA, QuadFunction<A, B, C, D, ResultB_> mappingB,
-            QuadFunction<A, B, C, D, ResultC_> mappingC) {
+    public @NonNull <ResultA_, ResultB_, ResultC_> TriConstraintStream<ResultA_, ResultB_, ResultC_> map(
+            @NonNull QuadFunction<A, B, C, D, ResultA_> mappingA, @NonNull QuadFunction<A, B, C, D, ResultB_> mappingB,
+            @NonNull QuadFunction<A, B, C, D, ResultC_> mappingC) {
         var stream = shareAndAddChild(
                 new BavetTriMapQuadConstraintStream<>(constraintFactory, this, mappingA, mappingB, mappingC));
         return constraintFactory.share(new BavetAftBridgeTriConstraintStream<>(constraintFactory, stream),
@@ -367,9 +378,9 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <ResultA_, ResultB_, ResultC_, ResultD_> QuadConstraintStream<ResultA_, ResultB_, ResultC_, ResultD_> map(
-            QuadFunction<A, B, C, D, ResultA_> mappingA, QuadFunction<A, B, C, D, ResultB_> mappingB,
-            QuadFunction<A, B, C, D, ResultC_> mappingC, QuadFunction<A, B, C, D, ResultD_> mappingD) {
+    public @NonNull <ResultA_, ResultB_, ResultC_, ResultD_> QuadConstraintStream<ResultA_, ResultB_, ResultC_, ResultD_> map(
+            @NonNull QuadFunction<A, B, C, D, ResultA_> mappingA, @NonNull QuadFunction<A, B, C, D, ResultB_> mappingB,
+            @NonNull QuadFunction<A, B, C, D, ResultC_> mappingC, @NonNull QuadFunction<A, B, C, D, ResultD_> mappingD) {
         var stream = shareAndAddChild(
                 new BavetQuadMapQuadConstraintStream<>(constraintFactory, this, mappingA, mappingB, mappingC, mappingD));
         return constraintFactory.share(new BavetAftBridgeQuadConstraintStream<>(constraintFactory, stream),
@@ -377,7 +388,8 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     }
 
     @Override
-    public <ResultD_> QuadConstraintStream<A, B, C, ResultD_> flattenLast(Function<D, Iterable<ResultD_>> mapping) {
+    public @NonNull <ResultD_> QuadConstraintStream<A, B, C, ResultD_>
+            flattenLast(@NonNull Function<D, Iterable<ResultD_>> mapping) {
         var stream = shareAndAddChild(new BavetFlattenLastQuadConstraintStream<>(constraintFactory, this, mapping));
         return constraintFactory.share(new BavetAftBridgeQuadConstraintStream<>(constraintFactory, stream),
                 stream::setAftBridge);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/penta/DefaultPentaJoiner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/penta/DefaultPentaJoiner.java
@@ -10,6 +10,8 @@ import ai.timefold.solver.core.api.score.stream.penta.PentaJoiner;
 import ai.timefold.solver.core.impl.score.stream.JoinerType;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractJoiner;
 
+import org.jspecify.annotations.NonNull;
+
 public final class DefaultPentaJoiner<A, B, C, D, E> extends AbstractJoiner<E> implements PentaJoiner<A, B, C, D, E> {
 
     private static final DefaultPentaJoiner NONE =
@@ -36,7 +38,7 @@ public final class DefaultPentaJoiner<A, B, C, D, E> extends AbstractJoiner<E> i
     }
 
     @Override
-    public DefaultPentaJoiner<A, B, C, D, E> and(PentaJoiner<A, B, C, D, E> otherJoiner) {
+    public @NonNull DefaultPentaJoiner<A, B, C, D, E> and(@NonNull PentaJoiner<A, B, C, D, E> otherJoiner) {
         DefaultPentaJoiner<A, B, C, D, E> castJoiner = (DefaultPentaJoiner<A, B, C, D, E>) otherJoiner;
         int joinerCount = getJoinerCount();
         int castJoinerCount = castJoiner.getJoinerCount();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/penta/FilteringPentaJoiner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/penta/FilteringPentaJoiner.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 import ai.timefold.solver.core.api.function.PentaPredicate;
 import ai.timefold.solver.core.api.score.stream.penta.PentaJoiner;
 
+import org.jspecify.annotations.NonNull;
+
 public final class FilteringPentaJoiner<A, B, C, D, E> implements PentaJoiner<A, B, C, D, E> {
 
     private final PentaPredicate<A, B, C, D, E> filter;
@@ -14,7 +16,7 @@ public final class FilteringPentaJoiner<A, B, C, D, E> implements PentaJoiner<A,
     }
 
     @Override
-    public FilteringPentaJoiner<A, B, C, D, E> and(PentaJoiner<A, B, C, D, E> otherJoiner) {
+    public @NonNull FilteringPentaJoiner<A, B, C, D, E> and(@NonNull PentaJoiner<A, B, C, D, E> otherJoiner) {
         FilteringPentaJoiner<A, B, C, D, E> castJoiner = (FilteringPentaJoiner<A, B, C, D, E>) otherJoiner;
         return new FilteringPentaJoiner<>(filter.and(castJoiner.getFilter()));
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/quad/InnerQuadConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/quad/InnerQuadConstraintStream.java
@@ -42,7 +42,8 @@ public interface InnerQuadConstraintStream<A, B, C, D> extends QuadConstraintStr
     boolean guaranteesDistinct();
 
     @Override
-    default <E> QuadConstraintStream<A, B, C, D> ifExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E>... joiners) {
+    default @NonNull <E> QuadConstraintStream<A, B, C, D> ifExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> @NonNull... joiners) {
         if (getRetrievalSemantics() == RetrievalSemantics.STANDARD) {
             return ifExists(getConstraintFactory().forEach(otherClass), joiners);
         } else {
@@ -52,8 +53,8 @@ public interface InnerQuadConstraintStream<A, B, C, D> extends QuadConstraintStr
     }
 
     @Override
-    default <E> QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E>... joiners) {
+    default @NonNull <E> QuadConstraintStream<A, B, C, D> ifExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> @NonNull... joiners) {
         if (getRetrievalSemantics() == RetrievalSemantics.STANDARD) {
             return ifExists(getConstraintFactory().forEachIncludingUnassigned(otherClass), joiners);
         } else {
@@ -62,7 +63,8 @@ public interface InnerQuadConstraintStream<A, B, C, D> extends QuadConstraintStr
     }
 
     @Override
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExists(Class<E> otherClass, PentaJoiner<A, B, C, D, E>... joiners) {
+    default @NonNull <E> QuadConstraintStream<A, B, C, D> ifNotExists(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> @NonNull... joiners) {
         if (getRetrievalSemantics() == RetrievalSemantics.STANDARD) {
             return ifNotExists(getConstraintFactory().forEach(otherClass), joiners);
         } else {
@@ -72,8 +74,8 @@ public interface InnerQuadConstraintStream<A, B, C, D> extends QuadConstraintStr
     }
 
     @Override
-    default <E> QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(Class<E> otherClass,
-            PentaJoiner<A, B, C, D, E>... joiners) {
+    default @NonNull <E> QuadConstraintStream<A, B, C, D> ifNotExistsIncludingUnassigned(@NonNull Class<E> otherClass,
+            @NonNull PentaJoiner<A, B, C, D, E> @NonNull... joiners) {
         if (getRetrievalSemantics() == RetrievalSemantics.STANDARD) {
             return ifNotExists(getConstraintFactory().forEachIncludingUnassigned(otherClass), joiners);
         } else {
@@ -82,7 +84,7 @@ public interface InnerQuadConstraintStream<A, B, C, D> extends QuadConstraintStr
     }
 
     @Override
-    default QuadConstraintStream<A, B, C, D> distinct() {
+    default @NonNull QuadConstraintStream<A, B, C, D> distinct() {
         if (guaranteesDistinct()) {
             return this;
         } else {
@@ -94,20 +96,23 @@ public interface InnerQuadConstraintStream<A, B, C, D> extends QuadConstraintStr
     }
 
     @Override
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalize(Score_ constraintWeight,
-            ToIntQuadFunction<A, B, C, D> matchWeigher) {
+    default @NonNull <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalize(
+            @NonNull Score_ constraintWeight,
+            @NonNull ToIntQuadFunction<A, B, C, D> matchWeigher) {
         return innerImpact(constraintWeight, matchWeigher, ScoreImpactType.PENALTY);
     }
 
     @Override
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeLong(Score_ constraintWeight,
-            ToLongQuadFunction<A, B, C, D> matchWeigher) {
+    default @NonNull <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeLong(
+            @NonNull Score_ constraintWeight,
+            @NonNull ToLongQuadFunction<A, B, C, D> matchWeigher) {
         return innerImpact(constraintWeight, matchWeigher, ScoreImpactType.PENALTY);
     }
 
     @Override
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeBigDecimal(Score_ constraintWeight,
-            QuadFunction<A, B, C, D, BigDecimal> matchWeigher) {
+    default @NonNull <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> penalizeBigDecimal(
+            @NonNull Score_ constraintWeight,
+            @NonNull QuadFunction<A, B, C, D, BigDecimal> matchWeigher) {
         return innerImpact(constraintWeight, matchWeigher, ScoreImpactType.PENALTY);
     }
 
@@ -128,20 +133,23 @@ public interface InnerQuadConstraintStream<A, B, C, D> extends QuadConstraintStr
     }
 
     @Override
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> reward(Score_ constraintWeight,
-            ToIntQuadFunction<A, B, C, D> matchWeigher) {
+    default @NonNull <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> reward(
+            @NonNull Score_ constraintWeight,
+            @NonNull ToIntQuadFunction<A, B, C, D> matchWeigher) {
         return innerImpact(constraintWeight, matchWeigher, ScoreImpactType.REWARD);
     }
 
     @Override
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> rewardLong(Score_ constraintWeight,
-            ToLongQuadFunction<A, B, C, D> matchWeigher) {
+    default @NonNull <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> rewardLong(
+            @NonNull Score_ constraintWeight,
+            @NonNull ToLongQuadFunction<A, B, C, D> matchWeigher) {
         return innerImpact(constraintWeight, matchWeigher, ScoreImpactType.REWARD);
     }
 
     @Override
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> rewardBigDecimal(Score_ constraintWeight,
-            QuadFunction<A, B, C, D, BigDecimal> matchWeigher) {
+    default @NonNull <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> rewardBigDecimal(
+            @NonNull Score_ constraintWeight,
+            @NonNull QuadFunction<A, B, C, D, BigDecimal> matchWeigher) {
         return innerImpact(constraintWeight, matchWeigher, ScoreImpactType.REWARD);
     }
 
@@ -162,20 +170,23 @@ public interface InnerQuadConstraintStream<A, B, C, D> extends QuadConstraintStr
     }
 
     @Override
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impact(Score_ constraintWeight,
-            ToIntQuadFunction<A, B, C, D> matchWeigher) {
+    default @NonNull <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impact(
+            @NonNull Score_ constraintWeight,
+            @NonNull ToIntQuadFunction<A, B, C, D> matchWeigher) {
         return innerImpact(constraintWeight, matchWeigher, ScoreImpactType.MIXED);
     }
 
     @Override
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impactLong(Score_ constraintWeight,
-            ToLongQuadFunction<A, B, C, D> matchWeigher) {
+    default @NonNull <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impactLong(
+            @NonNull Score_ constraintWeight,
+            @NonNull ToLongQuadFunction<A, B, C, D> matchWeigher) {
         return innerImpact(constraintWeight, matchWeigher, ScoreImpactType.MIXED);
     }
 
     @Override
-    default <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impactBigDecimal(Score_ constraintWeight,
-            QuadFunction<A, B, C, D, BigDecimal> matchWeigher) {
+    default @NonNull <Score_ extends Score<Score_>> QuadConstraintBuilder<A, B, C, D, Score_> impactBigDecimal(
+            @NonNull Score_ constraintWeight,
+            @NonNull QuadFunction<A, B, C, D, BigDecimal> matchWeigher) {
         return innerImpact(constraintWeight, matchWeigher, ScoreImpactType.MIXED);
     }
 


### PR DESCRIPTION
As discussed, this is a continuation of #1009. Opening again as draft. 

#### Open items

- [ ] missing annotations in score.stream.common.ConstraintCollectors
- [x] score.stream.penta
- [x] score.stream.quad
- [ ] check impl related to score package
- [ ] check if all impl related to solver package has been annotated
- [ ] config
- [ ] timefold-solver-benchmark
- [ ] timefold-solver-test