### PR TITLE
feat: enable score analysis without justifications

### DIFF
--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/SubSingleBenchmarkRunner.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/SubSingleBenchmarkRunner.java
@@ -128,7 +128,8 @@ public class SubSingleBenchmarkRunner<Solution_> implements Callable<SubSingleBe
             subSingleBenchmarkResult.setMoveEvaluationCount(solverScope.getMoveEvaluationCount());
 
             SolutionManager<Solution_, ?> solutionManager = SolutionManager.create(solverFactory);
-            boolean isConstraintMatchEnabled = solver.getSolverScope().getScoreDirector().isConstraintMatchEnabled();
+            boolean isConstraintMatchEnabled = solver.getSolverScope().getScoreDirector().getConstraintMatchPolicy()
+                    .isEnabled();
             if (isConstraintMatchEnabled) { // Easy calculator fails otherwise.
                 ScoreExplanation<Solution_, ?> scoreExplanation =
                         solutionManager.explain(solution, SolutionUpdatePolicy.NO_UPDATE);

--- a/core/src/main/java/ai/timefold/solver/core/api/score/ScoreExplanation.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/ScoreExplanation.java
@@ -100,6 +100,7 @@ public interface ScoreExplanation<Solution_, Score_ extends Score<Score_>> {
      * Explains the {@link Score} of {@link #getScore()} for all constraints
      * justified with a given {@link ConstraintJustification} type.
      * Otherwise, as defined by {@link #getJustificationList()}.
+     * May be empty, if the score explanation ran with justification support disabled.
      *
      * @return all constraint matches associated with the given justification class
      * @see #getIndictmentMap()

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ConstraintAnalysis.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ConstraintAnalysis.java
@@ -31,6 +31,8 @@ import org.jspecify.annotations.Nullable;
  *        non-empty if constraint has matches.
  *        This is a {@link List} to simplify access to individual elements,
  *        but it contains no duplicates just like {@link HashSet} wouldn't.
+ * @param matchCount -1 if {@link #matches()} is null, 0 if {@link #matches()} is empty,
+ *        and {@link #matches() matches() size} otherwise.
  */
 public record ConstraintAnalysis<Score_ extends Score<Score_>>(@NonNull ConstraintRef constraintRef, @NonNull Score_ weight,
         @NonNull Score_ score, @Nullable List<MatchAnalysis<Score_>> matches, int matchCount) {
@@ -56,15 +58,6 @@ public record ConstraintAnalysis<Score_ extends Score<Score_>>(@NonNull Constrai
         if (matches != null && matchCount != matches.size()) {
             throw new IllegalArgumentException("The match count must be equal to the size of the matches list.");
         }
-    }
-
-    /**
-     * Return the match count of the constraint.
-     *
-     * @return -1 if {@link #matches()} is null, 0 if #matches is empty, and #matches.size() otherwise.
-     */
-    public int matchCount() {
-        return matchCount;
     }
 
     ConstraintAnalysis<Score_> negate() {

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ConstraintAnalysis.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ConstraintAnalysis.java
@@ -31,8 +31,9 @@ import org.jspecify.annotations.Nullable;
  *        non-empty if constraint has matches.
  *        This is a {@link List} to simplify access to individual elements,
  *        but it contains no duplicates just like {@link HashSet} wouldn't.
- * @param matchCount -1 if {@link #matches()} is null, 0 if {@link #matches()} is empty,
- *        and {@link #matches() matches() size} otherwise.
+ * @param matchCount -1 if analysis not available,
+ *        0 if constraint has no matches,
+ *        positive if constraint has matches.
  */
 public record ConstraintAnalysis<Score_ extends Score<Score_>>(@NonNull ConstraintRef constraintRef, @NonNull Score_ weight,
         @NonNull Score_ score, @Nullable List<MatchAnalysis<Score_>> matches, int matchCount) {

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ConstraintAnalysis.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ConstraintAnalysis.java
@@ -33,13 +33,11 @@ import org.jspecify.annotations.Nullable;
  *        but it contains no duplicates just like {@link HashSet} wouldn't.
  */
 public record ConstraintAnalysis<Score_ extends Score<Score_>>(@NonNull ConstraintRef constraintRef, @NonNull Score_ weight,
-        @NonNull Score_ score, @Nullable List<MatchAnalysis<Score_>> matches) {
+        @NonNull Score_ score, @Nullable List<MatchAnalysis<Score_>> matches, int matchCount) {
 
-    static <Score_ extends Score<Score_>> @NonNull ConstraintAnalysis<Score_> of(
-            @NonNull ConstraintRef constraintRef,
-            @NonNull Score_ constraintWeight,
-            @NonNull Score_ score) {
-        return new ConstraintAnalysis<>(constraintRef, constraintWeight, score, null);
+    public ConstraintAnalysis(@NonNull ConstraintRef constraintRef, @NonNull Score_ weight, @NonNull Score_ score,
+            @Nullable List<MatchAnalysis<Score_>> matches) {
+        this(constraintRef, weight, score, matches, matches == null ? -1 : matches.size());
     }
 
     public ConstraintAnalysis {
@@ -55,26 +53,23 @@ public record ConstraintAnalysis<Score_ extends Score<Score_>>(@NonNull Constrai
                 .formatted(DefaultConstraintMatchTotal.class.getSimpleName(),
                         ConstraintMatchAwareIncrementalScoreCalculator.class.getSimpleName()));
         Objects.requireNonNull(score);
+        if (matches != null && matchCount != matches.size()) {
+            throw new IllegalArgumentException("The match count must be equal to the size of the matches list.");
+        }
     }
 
     /**
      * Return the match count of the constraint.
      *
-     * @throws IllegalStateException if the {@link ConstraintAnalysis#matches()} is null
+     * @return -1 if {@link #matches()} is null, 0 if #matches is empty, and #matches.size() otherwise.
      */
     public int matchCount() {
-        if (matches == null) {
-            throw new IllegalArgumentException("""
-                    The constraint matches must be non-null.
-                    Maybe use ScoreAnalysisFetchPolicy.FETCH_ALL to request the score analysis
-                    """);
-        }
-        return matches.size();
+        return matchCount;
     }
 
     ConstraintAnalysis<Score_> negate() {
         if (matches == null) {
-            return ConstraintAnalysis.of(constraintRef, weight.negate(), score.negate());
+            return new ConstraintAnalysis<>(constraintRef, weight.negate(), score.negate(), null, matchCount);
         } else {
             var negatedMatchAnalyses = matches.stream()
                     .map(MatchAnalysis::negate)
@@ -102,14 +97,22 @@ public record ConstraintAnalysis<Score_ extends Score<Score_>>(@NonNull Constrai
         var otherMatchAnalyses = otherConstraintAnalysis.matches();
         if ((matchAnalyses == null && otherMatchAnalyses != null) || (matchAnalyses != null && otherMatchAnalyses == null)) {
             throw new IllegalStateException(
-                    "Impossible state: Only one of the score analyses (%s, %s) provided match analyses for a constraint (%s)."
+                    "Impossible state: One of the score analyses (%s, %s) provided no match analysis for a constraint (%s)."
                             .formatted(constraintAnalysis, otherConstraintAnalysis, constraintRef));
         }
         // Compute the diff.
         var constraintWeightDifference = constraintAnalysis.weight().subtract(otherConstraintAnalysis.weight());
         var scoreDifference = constraintAnalysis.score().subtract(otherConstraintAnalysis.score());
         if (matchAnalyses == null) {
-            return ConstraintAnalysis.of(constraintRef, constraintWeightDifference, scoreDifference);
+            var leftCount = constraintAnalysis.matchCount();
+            var rightCount = otherConstraintAnalysis.matchCount();
+            if ((leftCount == -1 && rightCount != -1) || (leftCount != -1 && rightCount == -1)) {
+                throw new IllegalStateException(
+                        "Impossible state: One of the score analyses (%s, %s) provided no match count for a constraint (%s)."
+                                .formatted(constraintAnalysis, otherConstraintAnalysis, constraintRef));
+            }
+            return new ConstraintAnalysis<>(constraintRef, constraintWeightDifference, scoreDifference, null,
+                    leftCount - rightCount);
         }
         var matchAnalysisMap = mapMatchesToJustifications(matchAnalyses);
         var otherMatchAnalysisMap = mapMatchesToJustifications(otherMatchAnalyses);

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/MatchAnalysis.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/MatchAnalysis.java
@@ -22,8 +22,10 @@ public record MatchAnalysis<Score_ extends Score<Score_>>(@NonNull ConstraintRef
     public MatchAnalysis {
         Objects.requireNonNull(constraintRef);
         Objects.requireNonNull(score);
-        Objects.requireNonNull(justification, """
-                Received a null justification.
+        // Null justification is impossible;
+        // if the fetch policy doesn't requre match analysis, the code shouldn't even get here.
+        Objects.requireNonNull(justification, () -> """
+                Impossible state: Received a null justification.
                 Maybe check your %s's justifyWith() implementation for that constraint?"""
                 .formatted(ConstraintProvider.class));
     }
@@ -42,8 +44,9 @@ public record MatchAnalysis<Score_ extends Score<Score_>>(@NonNull ConstraintRef
         if (scoreComparison != 0) {
             return scoreComparison;
         } else {
-            if (this.justification instanceof Comparable && other.justification instanceof Comparable) {
-                return ((Comparable) this.justification).compareTo(other.justification);
+            if (this.justification instanceof Comparable comparableJustification
+                    && other.justification instanceof Comparable otherComparableJustification) {
+                return comparableJustification.compareTo(otherComparableJustification);
             } else {
                 return 0;
             }

--- a/core/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintJustification.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintJustification.java
@@ -14,7 +14,7 @@ import ai.timefold.solver.core.api.solver.SolutionManager;
  * All classes used as constraint justifications must implement this interface.
  *
  * <p>
- * Implementing classes ("implementations") may decide to implement {@link Comparable}
+ * Implementations may decide to implement {@link Comparable}
  * to preserve order of instances when displayed in user interfaces, logs etc.
  * This is entirely optional.
  *

--- a/core/src/main/java/ai/timefold/solver/core/api/solver/ScoreAnalysisFetchPolicy.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/ScoreAnalysisFetchPolicy.java
@@ -5,7 +5,7 @@ import ai.timefold.solver.core.api.score.analysis.ScoreAnalysis;
 
 /**
  * Determines the depth of {@link SolutionManager#analyze(Object) score analysis}.
- * If unsure, pick {@link #FETCH_ALL}.
+ * If unsure, pick {@link #FETCH_MATCH_COUNT}.
  *
  */
 public enum ScoreAnalysisFetchPolicy {
@@ -17,9 +17,18 @@ public enum ScoreAnalysisFetchPolicy {
     FETCH_ALL,
     /**
      * {@link ConstraintAnalysis} included in {@link ScoreAnalysis}
-     * does not include {@link ConstraintAnalysis#matches() match analysis}.
+     * provides neither {@link ConstraintAnalysis#matches() match analysis}
+     * nor {@link ConstraintAnalysis#matchCount() match count}.
      * This is useful for performance reasons when the match analysis is not needed.
      */
-    FETCH_SHALLOW
+    FETCH_SHALLOW,
+    /**
+     * {@link ConstraintAnalysis} included in {@link ScoreAnalysis}
+     * does not provide {@link ConstraintAnalysis#matches() match analysis},
+     * but does provide {@link ConstraintAnalysis#matchCount() match count}.
+     * This is useful when there are too many matches to send over the wire
+     * or meaningfully present to users.
+     */
+    FETCH_MATCH_COUNT
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/solver/SolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/SolutionManager.java
@@ -126,7 +126,7 @@ public interface SolutionManager<Solution_, Score_ extends Score<Score_>> {
      * This is a faster, JSON-friendly version of {@link #explain(Object)}.
      *
      * @param solution must be fully initialized otherwise an exception is thrown
-     * @param fetchPolicy if unsure, pick {@link ScoreAnalysisFetchPolicy#FETCH_ALL}
+     * @param fetchPolicy if unsure, pick {@link ScoreAnalysisFetchPolicy#FETCH_MATCH_COUNT}
      * @param solutionUpdatePolicy if unsure, pick {@link SolutionUpdatePolicy#UPDATE_ALL}
      * @throws IllegalStateException when constraint matching is disabled or not supported by the underlying score
      *         calculator, such as {@link EasyScoreCalculator}.

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -155,7 +155,7 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
                 || solverScope.isMetricEnabled(SolverMetric.CONSTRAINT_MATCH_TOTAL_BEST_SCORE)) {
             InnerScoreDirector<Solution_, ?> scoreDirector = stepScope.getScoreDirector();
             ScoreDefinition<?> scoreDefinition = solverScope.getScoreDefinition();
-            if (scoreDirector.isConstraintMatchEnabled()) {
+            if (scoreDirector.getConstraintMatchPolicy().isEnabled()) {
                 for (ConstraintMatchTotal<?> constraintMatchTotal : scoreDirector.getConstraintMatchTotalMap()
                         .values()) {
                     Tags tags = solverScope.getMonitoringTags().and(

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/DefaultScoreExplanation.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/DefaultScoreExplanation.java
@@ -4,6 +4,7 @@ import static java.util.Comparator.comparing;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -62,10 +63,18 @@ public final class DefaultScoreExplanation<Solution_, Score_ extends Score<Score
                     constraintMatchSet.stream()
                             .sorted(constraintMatchComparator)
                             .limit(constraintMatchLimit)
-                            .forEach(constraintMatch -> scoreExplanation.append("""
-                                                %s: justified with (%s)
-                                    """.formatted(constraintMatch.getScore().toShortString(),
-                                    constraintMatch.getJustification())));
+                            .forEach(constraintMatch -> {
+                                if (constraintMatch.getJustification() == null) {
+                                    scoreExplanation.append("""
+                                                       %s: unjustified
+                                            """.formatted(constraintMatch.getScore().toShortString()));
+                                } else {
+                                    scoreExplanation.append("""
+                                                        %s: justified with (%s)
+                                            """.formatted(constraintMatch.getScore().toShortString(),
+                                            constraintMatch.getJustification()));
+                                }
+                            });
                     if (constraintMatchSet.size() > constraintMatchLimit) {
                         scoreExplanation.append("""
                                             ...
@@ -131,10 +140,13 @@ public final class DefaultScoreExplanation<Solution_, Score_ extends Score<Score
         for (ConstraintMatchTotal<Score_> constraintMatchTotal : constraintMatchTotalMap.values()) {
             for (ConstraintMatch<Score_> constraintMatch : constraintMatchTotal.getConstraintMatchSet()) {
                 ConstraintJustification justification = constraintMatch.getJustification();
-                workingConstraintJustificationList.add(justification);
+                if (justification != null) {
+                    workingConstraintJustificationList.add(justification);
+                }
             }
         }
-        this.constraintJustificationList = workingConstraintJustificationList;
+        this.constraintJustificationList =
+                workingConstraintJustificationList.isEmpty() ? Collections.emptyList() : workingConstraintJustificationList;
         this.indictmentMap = indictmentMap;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/ConstraintMatchPolicy.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/ConstraintMatchPolicy.java
@@ -10,9 +10,8 @@ public enum ConstraintMatchPolicy {
 
     public static ConstraintMatchPolicy match(ScoreAnalysisFetchPolicy scoreAnalysisFetchPolicy) {
         return switch (scoreAnalysisFetchPolicy) {
+            case FETCH_MATCH_COUNT, FETCH_SHALLOW -> ENABLED_WITHOUT_JUSTIFICATIONS;
             case FETCH_ALL -> ENABLED;
-            case FETCH_MATCH_COUNT -> ENABLED_WITHOUT_JUSTIFICATIONS;
-            case FETCH_SHALLOW -> DISABLED;
         };
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/ConstraintMatchPolicy.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/ConstraintMatchPolicy.java
@@ -2,12 +2,31 @@ package ai.timefold.solver.core.impl.score.constraint;
 
 import ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy;
 
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Determines whether constraint match is enabled and whether constraint match justification is enabled.
+ *
+ * @see ai.timefold.solver.core.api.score.constraint.ConstraintMatch
+ * @see ai.timefold.solver.core.api.score.stream.ConstraintJustification
+ */
+@NullMarked
 public enum ConstraintMatchPolicy {
 
     DISABLED(false, false),
     ENABLED_WITHOUT_JUSTIFICATIONS(true, false),
     ENABLED(true, true);
 
+    /**
+     * To achieve the most performance out of the underlying solver,
+     * the policy should match whatever policy was used for score analysis.
+     * For example, if the fetch policy specifies that only match counts are necessary and not matches themselves
+     * ({@link ScoreAnalysisFetchPolicy#FETCH_MATCH_COUNT}),
+     * we can configure the solver to not produce justifications ({@link #ENABLED_WITHOUT_JUSTIFICATIONS}).
+     *
+     * @param scoreAnalysisFetchPolicy
+     * @return Match policy best suited for the given fetch policy.
+     */
     public static ConstraintMatchPolicy match(ScoreAnalysisFetchPolicy scoreAnalysisFetchPolicy) {
         return switch (scoreAnalysisFetchPolicy) {
             case FETCH_MATCH_COUNT, FETCH_SHALLOW -> ENABLED_WITHOUT_JUSTIFICATIONS;

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/ConstraintMatchPolicy.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/ConstraintMatchPolicy.java
@@ -1,0 +1,25 @@
+package ai.timefold.solver.core.impl.score.constraint;
+
+public enum ConstraintMatchPolicy {
+
+    DISABLED(false, false),
+    ENABLED_WITHOUT_JUSTIFICATIONS(true, false),
+    ENABLED(true, true);
+
+    private final boolean enabled;
+    private final boolean justificationsEnabled;
+
+    ConstraintMatchPolicy(boolean enabled, boolean justificationsEnabled) {
+        this.enabled = enabled;
+        this.justificationsEnabled = justificationsEnabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public boolean isJustificationEnabled() {
+        return justificationsEnabled;
+    }
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/ConstraintMatchPolicy.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/ConstraintMatchPolicy.java
@@ -1,17 +1,27 @@
 package ai.timefold.solver.core.impl.score.constraint;
 
+import ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy;
+
 public enum ConstraintMatchPolicy {
 
     DISABLED(false, false),
     ENABLED_WITHOUT_JUSTIFICATIONS(true, false),
     ENABLED(true, true);
 
-    private final boolean enabled;
-    private final boolean justificationsEnabled;
+    public static ConstraintMatchPolicy match(ScoreAnalysisFetchPolicy scoreAnalysisFetchPolicy) {
+        return switch (scoreAnalysisFetchPolicy) {
+            case FETCH_ALL -> ENABLED;
+            case FETCH_MATCH_COUNT -> ENABLED_WITHOUT_JUSTIFICATIONS;
+            case FETCH_SHALLOW -> DISABLED;
+        };
+    }
 
-    ConstraintMatchPolicy(boolean enabled, boolean justificationsEnabled) {
+    private final boolean enabled;
+    private final boolean justificationEnabled;
+
+    ConstraintMatchPolicy(boolean enabled, boolean justificationEnabled) {
         this.enabled = enabled;
-        this.justificationsEnabled = justificationsEnabled;
+        this.justificationEnabled = justificationEnabled;
     }
 
     public boolean isEnabled() {
@@ -19,7 +29,7 @@ public enum ConstraintMatchPolicy {
     }
 
     public boolean isJustificationEnabled() {
-        return justificationsEnabled;
+        return justificationEnabled;
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/DefaultConstraintMatchTotal.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/DefaultConstraintMatchTotal.java
@@ -16,6 +16,8 @@ import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 import ai.timefold.solver.core.api.solver.SolutionManager;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * If possible, prefer using {@link SolutionManager#analyze(Object)} instead.
  *
@@ -71,22 +73,22 @@ public final class DefaultConstraintMatchTotal<Score_ extends Score<Score_>> imp
     }
 
     @Override
-    public ConstraintRef getConstraintRef() {
+    public @NonNull ConstraintRef getConstraintRef() {
         return constraintRef;
     }
 
     @Override
-    public Score_ getConstraintWeight() {
+    public @NonNull Score_ getConstraintWeight() {
         return constraintWeight;
     }
 
     @Override
-    public Set<ConstraintMatch<Score_>> getConstraintMatchSet() {
+    public @NonNull Set<ConstraintMatch<Score_>> getConstraintMatchSet() {
         return constraintMatchSet;
     }
 
     @Override
-    public Score_ getScore() {
+    public @NonNull Score_ getScore() {
         return score;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/DefaultIndictment.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/constraint/DefaultIndictment.java
@@ -11,6 +11,8 @@ import ai.timefold.solver.core.api.score.constraint.Indictment;
 import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
 import ai.timefold.solver.core.impl.util.CollectionUtils;
 
+import org.jspecify.annotations.NonNull;
+
 public final class DefaultIndictment<Score_ extends Score<Score_>> implements Indictment<Score_> {
 
     private final Object indictedObject;
@@ -24,17 +26,17 @@ public final class DefaultIndictment<Score_ extends Score<Score_>> implements In
     }
 
     @Override
-    public <IndictedObject_> IndictedObject_ getIndictedObject() {
+    public <IndictedObject_> @NonNull IndictedObject_ getIndictedObject() {
         return (IndictedObject_) indictedObject;
     }
 
     @Override
-    public Set<ConstraintMatch<Score_>> getConstraintMatchSet() {
+    public @NonNull Set<ConstraintMatch<Score_>> getConstraintMatchSet() {
         return constraintMatchSet;
     }
 
     @Override
-    public List<ConstraintJustification> getJustificationList() {
+    public @NonNull List<ConstraintJustification> getJustificationList() {
         if (constraintJustificationList == null) {
             constraintJustificationList = buildConstraintJustificationList();
         }
@@ -61,7 +63,7 @@ public final class DefaultIndictment<Score_ extends Score<Score_>> implements In
     }
 
     @Override
-    public Score_ getScore() {
+    public @NonNull Score_ getScore() {
         return score;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -714,12 +714,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
      */
     protected String buildScoreCorruptionAnalysis(InnerScoreDirector<Solution_, Score_> uncorruptedScoreDirector,
             boolean predicted) {
-        if (!isConstraintMatchEnabled() || !uncorruptedScoreDirector.isConstraintMatchEnabled()) {
+        if (!getConstraintMatchPolicy().isEnabled() || !uncorruptedScoreDirector.getConstraintMatchPolicy().isEnabled()) {
             return """
                     Score corruption analysis could not be generated because either corrupted constraintMatchPolicy (%s) \
                     or uncorrupted constraintMatchPolicy (%s) is %s.
                       Check your score constraints manually."""
-                    .formatted(constraintMatchPolicy, uncorruptedScoreDirector.isConstraintMatchEnabled(),
+                    .formatted(constraintMatchPolicy, uncorruptedScoreDirector.getConstraintMatchPolicy(),
                             ConstraintMatchPolicy.DISABLED);
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -19,6 +19,7 @@ import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.analysis.ConstraintAnalysis;
 import ai.timefold.solver.core.api.score.analysis.MatchAnalysis;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
+import ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy;
 import ai.timefold.solver.core.api.solver.change.ProblemChange;
 import ai.timefold.solver.core.api.solver.change.ProblemChangeDirector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -721,8 +722,9 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
                     .formatted(constraintMatchEnabledPreference, uncorruptedScoreDirector.isConstraintMatchEnabled());
         }
 
-        var corruptedAnalysis = buildScoreAnalysis(true, ScoreAnalysisMode.SCORE_CORRUPTION);
-        var uncorruptedAnalysis = uncorruptedScoreDirector.buildScoreAnalysis(true, ScoreAnalysisMode.SCORE_CORRUPTION);
+        var corruptedAnalysis = buildScoreAnalysis(ScoreAnalysisFetchPolicy.FETCH_ALL, ScoreAnalysisMode.SCORE_CORRUPTION);
+        var uncorruptedAnalysis = uncorruptedScoreDirector.buildScoreAnalysis(ScoreAnalysisFetchPolicy.FETCH_ALL,
+                ScoreAnalysisMode.SCORE_CORRUPTION);
 
         var excessSet = new LinkedHashSet<MatchAnalysis<Score_>>();
         var missingSet = new LinkedHashSet<MatchAnalysis<Score_>>();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -64,11 +64,11 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     private final boolean lookUpEnabled;
     private final LookUpManager lookUpManager;
+    protected final ConstraintMatchPolicy constraintMatchPolicy;
     private final boolean expectShadowVariablesInCorrectState;
     protected final Factory_ scoreDirectorFactory;
     private final VariableDescriptorCache<Solution_> variableDescriptorCache;
     protected final VariableListenerSupport<Solution_> variableListenerSupport;
-    protected final ConstraintMatchPolicy constraintMatchPolicy;
 
     private long workingEntityListRevision = 0L;
     private int workingGenuineEntityCount = 0;
@@ -93,12 +93,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         this.lookUpManager = lookUpEnabled
                 ? new LookUpManager(solutionDescriptor.getLookUpStrategyResolver())
                 : null;
+        this.constraintMatchPolicy = constraintMatchPolicy;
         this.expectShadowVariablesInCorrectState = expectShadowVariablesInCorrectState;
         this.scoreDirectorFactory = scoreDirectorFactory;
         this.variableDescriptorCache = new VariableDescriptorCache<>(solutionDescriptor);
         this.variableListenerSupport = VariableListenerSupport.create(this);
         this.variableListenerSupport.linkVariableListeners();
-        this.constraintMatchPolicy = constraintMatchPolicy;
         if (scoreDirectorFactory.isTrackingWorkingSolution()) {
             this.solutionTracker = new SolutionTracker<>(getSolutionDescriptor(),
                     getSupplyManager());
@@ -113,6 +113,11 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         } else {
             this.listVariableStateSupply = getSupplyManager().demand(listVariableDescriptor.getStateDemand());
         }
+    }
+
+    @Override
+    public final ConstraintMatchPolicy getConstraintMatchPolicy() {
+        return constraintMatchPolicy;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorFactory.java
@@ -95,7 +95,7 @@ public abstract class AbstractScoreDirectorFactory<Solution_, Score_ extends Sco
 
     @Override
     public InnerScoreDirector<Solution_, Score_> buildScoreDirector() {
-        return buildScoreDirector(true, ConstraintMatchPolicy.ENABLED);
+        return buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorFactory.java
@@ -94,11 +94,6 @@ public abstract class AbstractScoreDirectorFactory<Solution_, Score_ extends Sco
     // ************************************************************************
 
     @Override
-    public InnerScoreDirector<Solution_, Score_> buildScoreDirector() {
-        return buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
-    }
-
-    @Override
     public void assertScoreFromScratch(Solution_ solution) {
         // Get the score before uncorruptedScoreDirector.calculateScore() modifies it
         Score_ score = getSolutionDescriptor().getScore(solution);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorFactory.java
@@ -6,6 +6,7 @@ import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.score.trend.InitializingScoreTrend;
 
@@ -94,14 +95,14 @@ public abstract class AbstractScoreDirectorFactory<Solution_, Score_ extends Sco
 
     @Override
     public InnerScoreDirector<Solution_, Score_> buildScoreDirector() {
-        return buildScoreDirector(true, true);
+        return buildScoreDirector(true, ConstraintMatchPolicy.ENABLED);
     }
 
     @Override
     public void assertScoreFromScratch(Solution_ solution) {
         // Get the score before uncorruptedScoreDirector.calculateScore() modifies it
         Score_ score = getSolutionDescriptor().getScore(solution);
-        try (var uncorruptedScoreDirector = buildDerivedScoreDirector(false, true)) {
+        try (var uncorruptedScoreDirector = buildDerivedScoreDirector(false, ConstraintMatchPolicy.ENABLED)) {
             uncorruptedScoreDirector.setWorkingSolution(solution);
             Score_ uncorruptedScore = uncorruptedScoreDirector.calculateScore();
             if (!score.equals(uncorruptedScore)) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -35,6 +35,7 @@ import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescr
 import ai.timefold.solver.core.impl.domain.variable.supply.SupplyManager;
 import ai.timefold.solver.core.impl.move.director.MoveDirector;
 import ai.timefold.solver.core.impl.phase.scope.SolverLifecyclePoint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
@@ -101,9 +102,12 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
     Score_ calculateScore();
 
     /**
-     * @return true if {@link #getConstraintMatchTotalMap()} and {@link #getIndictmentMap} can be called
+     * @return {@link ConstraintMatchPolicy#ENABLED} if {@link #getConstraintMatchTotalMap()} and {@link #getIndictmentMap()}
+     *         can be called.
+     *         {@link ConstraintMatchPolicy#ENABLED_WITHOUT_JUSTIFICATIONS} if only the former can be called.
+     *         {@link ConstraintMatchPolicy#DISABLED} if neither can be called.
      */
-    boolean isConstraintMatchEnabled();
+    ConstraintMatchPolicy getConstraintMatchPolicy();
 
     /**
      * Explains the {@link Score} of {@link #calculateScore()} by splitting it up per {@link Constraint}.
@@ -117,7 +121,7 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
      *         (to create one, use {@link ConstraintRef#composeConstraintId(String, String)}).
      *         If a constraint is present in the problem but resulted in no matches,
      *         it will still be in the map with a {@link ConstraintMatchTotal#getConstraintMatchSet()} size of 0.
-     * @throws IllegalStateException if {@link #isConstraintMatchEnabled()} returns false
+     * @throws IllegalStateException if {@link #getConstraintMatchPolicy()} returns {@link ConstraintMatchPolicy#DISABLED}.
      * @see #getIndictmentMap()
      */
     Map<String, ConstraintMatchTotal<Score_>> getConstraintMatchTotalMap();
@@ -136,7 +140,7 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
      *
      * @return never null, the key is a {@link ProblemFactCollectionProperty problem fact} or a
      *         {@link PlanningEntity planning entity}
-     * @throws IllegalStateException if {@link #isConstraintMatchEnabled()} returns false
+     * @throws IllegalStateException unless {@link #getConstraintMatchPolicy()} returns {@link ConstraintMatchPolicy#ENABLED}.
      * @see #getConstraintMatchTotalMap()
      */
     Map<Object, Indictment<Score_>> getIndictmentMap();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -50,7 +50,12 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
             ConstraintMatchTotal<Score_> constraintMatchTotal, ScoreAnalysisFetchPolicy scoreAnalysisFetchPolicy) {
         return switch (scoreAnalysisFetchPolicy) {
             case FETCH_ALL -> {
-                var deduplicatedConstraintMatchMap = groupMatchesWithSameJustification(constraintMatchTotal);
+                // Justification can not be null here, because they are enabled by FETCH_ALL.
+                var deduplicatedConstraintMatchMap = constraintMatchTotal.getConstraintMatchSet()
+                        .stream()
+                        .collect(groupingBy(
+                                c -> (ConstraintJustification) c.getJustification(),
+                                toList()));
                 var matchAnalyses = sumMatchesWithSameJustification(constraintMatchTotal, deduplicatedConstraintMatchMap);
                 yield new ConstraintAnalysis<>(constraintMatchTotal.getConstraintRef(),
                         constraintMatchTotal.getConstraintWeight(), constraintMatchTotal.getScore(), matchAnalyses);
@@ -62,15 +67,6 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
                 new ConstraintAnalysis<>(constraintMatchTotal.getConstraintRef(), constraintMatchTotal.getConstraintWeight(),
                         constraintMatchTotal.getScore(), null);
         };
-    }
-
-    private static <Score_ extends Score<Score_>> Map<ConstraintJustification, List<ConstraintMatch<Score_>>>
-            groupMatchesWithSameJustification(ConstraintMatchTotal<Score_> constraintMatchTotal) {
-        return constraintMatchTotal.getConstraintMatchSet()
-                .stream()
-                .collect(groupingBy(
-                        ConstraintMatch::getJustification,
-                        toList()));
     }
 
     private static <Score_ extends Score<Score_>> List<MatchAnalysis<Score_>>

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
@@ -27,37 +27,12 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
     ScoreDefinition<Score_> getScoreDefinition();
 
     @Override
-    InnerScoreDirector<Solution_, Score_> buildScoreDirector();
-
-    /**
-     * Like {@link #buildScoreDirector()}, but optionally enables {@link ConstraintMatch} tracking and look up
-     * where possible and necessary.
-     *
-     * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
-     *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
-     * @param constraintMatchPolicy how should the {@link ScoreDirector} track {@link ConstraintMatch}es
-     * @return never null
-     * @see InnerScoreDirector#getConstraintMatchPolicy()
-     * @see InnerScoreDirector#getConstraintMatchTotalMap()
-     */
     default InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
             ConstraintMatchPolicy constraintMatchPolicy) {
         return buildScoreDirector(lookUpEnabled, constraintMatchPolicy, true);
     }
 
-    /**
-     * Like {@link #buildScoreDirector()}, but optionally enables {@link ConstraintMatch} tracking and look up
-     * where possible and necessary.
-     *
-     * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
-     *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
-     * @param constraintMatchPolicy how should the {@link ScoreDirector} implementation do {@link ConstraintMatch}, if at all.
-     * @param expectShadowVariablesInCorrectState true, unless you have an exceptional reason.
-     *        See {@link InnerScoreDirector#expectShadowVariablesInCorrectState()} for details.
-     * @return never null
-     * @see InnerScoreDirector#getConstraintMatchPolicy()
-     * @see InnerScoreDirector#getConstraintMatchTotalMap()
-     */
+    @Override
     InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy,
             boolean expectShadowVariablesInCorrectState);
 
@@ -76,7 +51,7 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
     default InnerScoreDirector<Solution_, Score_> buildDerivedScoreDirector(boolean lookUpEnabled,
             ConstraintMatchPolicy constraintMatchPolicy) {
         // Most score directors don't need derived status; CS will override this.
-        return buildScoreDirector(lookUpEnabled, constraintMatchPolicy, true);
+        return buildScoreDirector(lookUpEnabled, constraintMatchPolicy);
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
@@ -5,6 +5,7 @@ import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.constraint.ConstraintMatch;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.score.trend.InitializingScoreTrend;
 
@@ -34,15 +35,14 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
      *
      * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
      *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
-     * @param constraintMatchEnabledPreference false if a {@link ScoreDirector} implementation
-     *        should not do {@link ConstraintMatch} tracking even if it supports it.
+     * @param constraintMatchPolicy how should the {@link ScoreDirector} track {@link ConstraintMatch}es
      * @return never null
      * @see InnerScoreDirector#isConstraintMatchEnabled()
      * @see InnerScoreDirector#getConstraintMatchTotalMap()
      */
     default InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
-            boolean constraintMatchEnabledPreference) {
-        return buildScoreDirector(lookUpEnabled, constraintMatchEnabledPreference, true);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        return buildScoreDirector(lookUpEnabled, constraintMatchPolicy, true);
     }
 
     /**
@@ -51,34 +51,32 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
      *
      * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
      *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
-     * @param constraintMatchEnabledPreference false if a {@link ScoreDirector} implementation
-     *        should not do {@link ConstraintMatch} tracking even if it supports it.
+     * @param constraintMatchPolicy how should the {@link ScoreDirector} implementation do {@link ConstraintMatch}, if at all.
      * @param expectShadowVariablesInCorrectState true, unless you have an exceptional reason.
      *        See {@link InnerScoreDirector#expectShadowVariablesInCorrectState()} for details.
      * @return never null
      * @see InnerScoreDirector#isConstraintMatchEnabled()
      * @see InnerScoreDirector#getConstraintMatchTotalMap()
      */
-    InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled, boolean constraintMatchEnabledPreference,
+    InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy,
             boolean expectShadowVariablesInCorrectState);
 
     /**
-     * Like {@link #buildScoreDirector(boolean, boolean)}, but makes the score director a derived one.
+     * Like {@link #buildScoreDirector(boolean, ConstraintMatchPolicy)}, but makes the score director a derived one.
      * Derived score directors may make choices which the main score director can not make, such as reducing logging.
      * Derived score directors are typically used for multithreaded solving, testing and assert modes.
      *
      * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
      *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
-     * @param constraintMatchEnabledPreference false if a {@link ScoreDirector} implementation
-     *        should not do {@link ConstraintMatch} tracking even if it supports it.
+     * @param constraintMatchPolicy how should the {@link ScoreDirector} implementation do {@link ConstraintMatch}, if at all.
      * @return never null
      * @see InnerScoreDirector#isConstraintMatchEnabled()
      * @see InnerScoreDirector#getConstraintMatchTotalMap()
      */
     default InnerScoreDirector<Solution_, Score_> buildDerivedScoreDirector(boolean lookUpEnabled,
-            boolean constraintMatchEnabledPreference) {
+            ConstraintMatchPolicy constraintMatchPolicy) {
         // Most score directors don't need derived status; CS will override this.
-        return buildScoreDirector(lookUpEnabled, constraintMatchEnabledPreference, true);
+        return buildScoreDirector(lookUpEnabled, constraintMatchPolicy, true);
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
@@ -30,8 +30,8 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
     InnerScoreDirector<Solution_, Score_> buildScoreDirector();
 
     /**
-     * Like {@link #buildScoreDirector()}, but optionally disables {@link ConstraintMatch} tracking and look up
-     * for more performance (presuming the {@link ScoreDirector} implementation actually supports it to begin with).
+     * Like {@link #buildScoreDirector()}, but optionally enables {@link ConstraintMatch} tracking and look up
+     * where possible and necessary.
      *
      * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
      *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
@@ -46,8 +46,8 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
     }
 
     /**
-     * Like {@link #buildScoreDirector()}, but optionally disables {@link ConstraintMatch} tracking and look up
-     * for more performance (presuming the {@link ScoreDirector} implementation actually supports it to begin with).
+     * Like {@link #buildScoreDirector()}, but optionally enables {@link ConstraintMatch} tracking and look up
+     * where possible and necessary.
      *
      * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
      *        for {@link ScoreDirector#lookUpWorkingObject(Object)}

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirectorFactory.java
@@ -37,7 +37,7 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
      *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
      * @param constraintMatchPolicy how should the {@link ScoreDirector} track {@link ConstraintMatch}es
      * @return never null
-     * @see InnerScoreDirector#isConstraintMatchEnabled()
+     * @see InnerScoreDirector#getConstraintMatchPolicy()
      * @see InnerScoreDirector#getConstraintMatchTotalMap()
      */
     default InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
@@ -55,7 +55,7 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
      * @param expectShadowVariablesInCorrectState true, unless you have an exceptional reason.
      *        See {@link InnerScoreDirector#expectShadowVariablesInCorrectState()} for details.
      * @return never null
-     * @see InnerScoreDirector#isConstraintMatchEnabled()
+     * @see InnerScoreDirector#getConstraintMatchPolicy()
      * @see InnerScoreDirector#getConstraintMatchTotalMap()
      */
     InnerScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy,
@@ -70,7 +70,7 @@ public interface InnerScoreDirectorFactory<Solution_, Score_ extends Score<Score
      *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
      * @param constraintMatchPolicy how should the {@link ScoreDirector} implementation do {@link ConstraintMatch}, if at all.
      * @return never null
-     * @see InnerScoreDirector#isConstraintMatchEnabled()
+     * @see InnerScoreDirector#getConstraintMatchPolicy()
      * @see InnerScoreDirector#getConstraintMatchTotalMap()
      */
     default InnerScoreDirector<Solution_, Score_> buildDerivedScoreDirector(boolean lookUpEnabled,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ScoreDirectorFactory.java
@@ -1,7 +1,9 @@
 package ai.timefold.solver.core.impl.score.director;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.score.constraint.ConstraintMatch;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 
 /**
  * Builds a {@link ScoreDirector}.
@@ -11,10 +13,19 @@ import ai.timefold.solver.core.api.score.director.ScoreDirector;
 public interface ScoreDirectorFactory<Solution_> {
 
     /**
-     * Creates a new {@link ScoreDirector} instance.
+     * Like {@link #buildScoreDirector(boolean, ConstraintMatchPolicy, boolean)},
+     * with the final parameter set to true.
      *
+     * @param lookUpEnabled true if a {@link ScoreDirector} implementation should track all working objects
+     *        for {@link ScoreDirector#lookUpWorkingObject(Object)}
+     * @param constraintMatchPolicy how should the {@link ScoreDirector} track {@link ConstraintMatch constraint matches}.
      * @return never null
      */
-    ScoreDirector<Solution_> buildScoreDirector();
+    default ScoreDirector<Solution_> buildScoreDirector(boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy) {
+        return buildScoreDirector(lookUpEnabled, constraintMatchPolicy, true);
+    }
+
+    ScoreDirector<Solution_> buildScoreDirector(boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy,
+            boolean expectShadowVariablesInCorrectState);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
@@ -70,8 +70,8 @@ public final class EasyScoreDirector<Solution_, Score_ extends Score<Score_>>
      * @return false
      */
     @Override
-    public boolean isConstraintMatchEnabled() {
-        return false;
+    public ConstraintMatchPolicy getConstraintMatchPolicy() {
+        return ConstraintMatchPolicy.DISABLED;
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.core.api.score.constraint.ConstraintMatch;
 import ai.timefold.solver.core.api.score.constraint.ConstraintMatchTotal;
 import ai.timefold.solver.core.api.score.constraint.Indictment;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirector;
 
 /**
@@ -28,9 +29,9 @@ public final class EasyScoreDirector<Solution_, Score_ extends Score<Score_>>
     private final EasyScoreCalculator<Solution_, Score_> easyScoreCalculator;
 
     public EasyScoreDirector(EasyScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
-            boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState,
+            boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy, boolean expectShadowVariablesInCorrectState,
             EasyScoreCalculator<Solution_, Score_> easyScoreCalculator) {
-        super(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState);
+        super(scoreDirectorFactory, lookUpEnabled, constraintMatchPolicy, expectShadowVariablesInCorrectState);
         this.easyScoreCalculator = easyScoreCalculator;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
@@ -29,9 +29,9 @@ public final class EasyScoreDirector<Solution_, Score_ extends Score<Score_>>
     private final EasyScoreCalculator<Solution_, Score_> easyScoreCalculator;
 
     public EasyScoreDirector(EasyScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
-            boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy, boolean expectShadowVariablesInCorrectState,
+            boolean lookUpEnabled, boolean expectShadowVariablesInCorrectState,
             EasyScoreCalculator<Solution_, Score_> easyScoreCalculator) {
-        super(scoreDirectorFactory, lookUpEnabled, constraintMatchPolicy, expectShadowVariablesInCorrectState);
+        super(scoreDirectorFactory, lookUpEnabled, ConstraintMatchPolicy.DISABLED, expectShadowVariablesInCorrectState);
         this.easyScoreCalculator = easyScoreCalculator;
     }
 
@@ -62,16 +62,6 @@ public final class EasyScoreDirector<Solution_, Score_ extends Score<Score_>>
         }
         setCalculatedScore(score);
         return score;
-    }
-
-    /**
-     * Always false, {@link ConstraintMatchTotal}s are not supported by this {@link ScoreDirector} implementation.
-     *
-     * @return false
-     */
-    @Override
-    public ConstraintMatchPolicy getConstraintMatchPolicy() {
-        return ConstraintMatchPolicy.DISABLED;
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactory.java
@@ -48,10 +48,9 @@ public final class EasyScoreDirectorFactory<Solution_, Score_ extends Score<Scor
     // ************************************************************************
 
     @Override
-    public EasyScoreDirector<Solution_, Score_> buildScoreDirector(
-            boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy, boolean expectShadowVariablesInCorrectState) {
-        return new EasyScoreDirector<>(this, lookUpEnabled, constraintMatchPolicy, expectShadowVariablesInCorrectState,
-                easyScoreCalculator);
+    public EasyScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
+            ConstraintMatchPolicy constraintMatchPolicy, boolean expectShadowVariablesInCorrectState) {
+        return new EasyScoreDirector<>(this, lookUpEnabled, expectShadowVariablesInCorrectState, easyScoreCalculator);
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactory.java
@@ -6,6 +6,7 @@ import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
 import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 
@@ -48,9 +49,8 @@ public final class EasyScoreDirectorFactory<Solution_, Score_ extends Score<Scor
 
     @Override
     public EasyScoreDirector<Solution_, Score_> buildScoreDirector(
-            boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState) {
-        return new EasyScoreDirector<>(this, lookUpEnabled, constraintMatchEnabledPreference,
-                expectShadowVariablesInCorrectState,
+            boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy, boolean expectShadowVariablesInCorrectState) {
+        return new EasyScoreDirector<>(this, lookUpEnabled, constraintMatchPolicy, expectShadowVariablesInCorrectState,
                 easyScoreCalculator);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirector.java
@@ -56,7 +56,7 @@ public final class IncrementalScoreDirector<Solution_, Score_ extends Score<Scor
         super.setWorkingSolution(workingSolution);
         if (incrementalScoreCalculator instanceof ConstraintMatchAwareIncrementalScoreCalculator) {
             ((ConstraintMatchAwareIncrementalScoreCalculator<Solution_, ?>) incrementalScoreCalculator)
-                    .resetWorkingSolution(workingSolution, isConstraintMatchEnabled());
+                    .resetWorkingSolution(workingSolution, getConstraintMatchPolicy().isEnabled());
         } else {
             incrementalScoreCalculator.resetWorkingSolution(workingSolution);
         }
@@ -84,14 +84,18 @@ public final class IncrementalScoreDirector<Solution_, Score_ extends Score<Scor
     }
 
     @Override
-    public boolean isConstraintMatchEnabled() {
-        return constraintMatchPolicy.isEnabled()
-                && incrementalScoreCalculator instanceof ConstraintMatchAwareIncrementalScoreCalculator;
+    public ConstraintMatchPolicy getConstraintMatchPolicy() {
+        if (!constraintMatchPolicy.isEnabled()) {
+            return ConstraintMatchPolicy.DISABLED;
+        }
+        return incrementalScoreCalculator instanceof ConstraintMatchAwareIncrementalScoreCalculator
+                ? constraintMatchPolicy
+                : ConstraintMatchPolicy.DISABLED;
     }
 
     @Override
     public Map<String, ConstraintMatchTotal<Score_>> getConstraintMatchTotalMap() {
-        if (!isConstraintMatchEnabled()) {
+        if (!getConstraintMatchPolicy().isEnabled()) {
             throw new IllegalStateException("When constraint matching (" + constraintMatchPolicy
                     + ") is disabled in the constructor, this method should not be called.");
         }
@@ -104,8 +108,8 @@ public final class IncrementalScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public Map<Object, Indictment<Score_>> getIndictmentMap() {
-        if (!isConstraintMatchEnabled()) {
-            throw new IllegalStateException("When constraint matching (" + constraintMatchPolicy
+        if (!getConstraintMatchPolicy().isJustificationEnabled()) {
+            throw new IllegalStateException("When constraint matching with justifications (" + constraintMatchPolicy
                     + ") is disabled in the constructor, this method should not be called.");
         }
         Map<Object, Indictment<Score_>> incrementalIndictmentMap =

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirectorFactory.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.core.api.score.calculator.IncrementalScoreCalculator;
 import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 
@@ -55,9 +56,8 @@ public final class IncrementalScoreDirectorFactory<Solution_, Score_ extends Sco
 
     @Override
     public IncrementalScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
-            boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState) {
-        return new IncrementalScoreDirector<>(this,
-                lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState,
+            ConstraintMatchPolicy constraintMatchPolicy, boolean expectShadowVariablesInCorrectState) {
+        return new IncrementalScoreDirector<>(this, lookUpEnabled, constraintMatchPolicy, expectShadowVariablesInCorrectState,
                 incrementalScoreCalculatorSupplier.get());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
@@ -11,6 +11,7 @@ import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirector;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintSession;
 
@@ -29,14 +30,14 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
     private BavetConstraintSession<Score_> session;
 
     public BavetConstraintStreamScoreDirector(BavetConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
-            boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState) {
-        this(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState, false);
+            boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy, boolean expectShadowVariablesInCorrectState) {
+        this(scoreDirectorFactory, lookUpEnabled, constraintMatchPolicy, expectShadowVariablesInCorrectState, false);
     }
 
     public BavetConstraintStreamScoreDirector(BavetConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
-            boolean lookUpEnabled, boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState,
+            boolean lookUpEnabled, ConstraintMatchPolicy constraintMatchPolicy, boolean expectShadowVariablesInCorrectState,
             boolean derived) {
-        super(scoreDirectorFactory, lookUpEnabled, constraintMatchEnabledPreference, expectShadowVariablesInCorrectState);
+        super(scoreDirectorFactory, lookUpEnabled, constraintMatchPolicy, expectShadowVariablesInCorrectState);
         this.derived = derived;
     }
 
@@ -46,7 +47,7 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
 
     @Override
     public void setWorkingSolution(Solution_ workingSolution) {
-        session = scoreDirectorFactory.newSession(workingSolution, constraintMatchEnabledPreference, derived);
+        session = scoreDirectorFactory.newSession(workingSolution, constraintMatchPolicy, derived);
         getSolutionDescriptor().visitAll(workingSolution, session::insert);
         super.setWorkingSolution(workingSolution);
     }
@@ -61,7 +62,7 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
 
     @Override
     public boolean isConstraintMatchEnabled() {
-        return constraintMatchEnabledPreference;
+        return constraintMatchPolicy.isEnabled();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
@@ -62,23 +62,23 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
 
     @Override
     public Map<String, ConstraintMatchTotal<Score_>> getConstraintMatchTotalMap() {
-        if (workingSolution == null) {
+        if (!constraintMatchPolicy.isEnabled()) {
+            throw new IllegalStateException("When constraint matching is disabled, this method should not be called.");
+        } else if (workingSolution == null) {
             throw new IllegalStateException(
                     "The method setWorkingSolution() must be called before the method getConstraintMatchTotalMap().");
-        } else if (!constraintMatchPolicy.isEnabled()) {
-            throw new IllegalStateException("When constraint matching is disabled, this method should not be called.");
         }
         return session.getConstraintMatchTotalMap();
     }
 
     @Override
     public Map<Object, Indictment<Score_>> getIndictmentMap() {
-        if (workingSolution == null) {
-            throw new IllegalStateException(
-                    "The method setWorkingSolution() must be called before the method getIndictmentMap().");
-        } else if (!constraintMatchPolicy.isJustificationEnabled()) {
+        if (!constraintMatchPolicy.isJustificationEnabled()) {
             throw new IllegalStateException(
                     "When constraint matching with justifications is disabled, this method should not be called.");
+        } else if (workingSolution == null) {
+            throw new IllegalStateException(
+                    "The method setWorkingSolution() must be called before the method getIndictmentMap().");
         }
         return session.getIndictmentMap();
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
@@ -61,11 +61,6 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
     }
 
     @Override
-    public ConstraintMatchPolicy getConstraintMatchPolicy() {
-        return constraintMatchPolicy;
-    }
-
-    @Override
     public Map<String, ConstraintMatchTotal<Score_>> getConstraintMatchTotalMap() {
         if (workingSolution == null) {
             throw new IllegalStateException(

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
@@ -61,8 +61,8 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
     }
 
     @Override
-    public boolean isConstraintMatchEnabled() {
-        return constraintMatchPolicy.isEnabled();
+    public ConstraintMatchPolicy getConstraintMatchPolicy() {
+        return constraintMatchPolicy;
     }
 
     @Override
@@ -70,6 +70,8 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
         if (workingSolution == null) {
             throw new IllegalStateException(
                     "The method setWorkingSolution() must be called before the method getConstraintMatchTotalMap().");
+        } else if (!constraintMatchPolicy.isEnabled()) {
+            throw new IllegalStateException("When constraint matching is disabled, this method should not be called.");
         }
         return session.getConstraintMatchTotalMap();
     }
@@ -79,6 +81,9 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
         if (workingSolution == null) {
             throw new IllegalStateException(
                     "The method setWorkingSolution() must be called before the method getIndictmentMap().");
+        } else if (!constraintMatchPolicy.isJustificationEnabled()) {
+            throw new IllegalStateException(
+                    "When constraint matching with justifications is disabled, this method should not be called.");
         }
         return session.getIndictmentMap();
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirectorFactory.java
@@ -14,6 +14,7 @@ import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.enterprise.TimefoldSolverEnterpriseService;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintFactory;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintSession;
@@ -69,26 +70,25 @@ public final class BavetConstraintStreamScoreDirectorFactory<Solution_, Score_ e
 
     @Override
     public BavetConstraintStreamScoreDirector<Solution_, Score_> buildScoreDirector(boolean lookUpEnabled,
-            boolean constraintMatchEnabledPreference, boolean expectShadowVariablesInCorrectState) {
-        return new BavetConstraintStreamScoreDirector<>(this, lookUpEnabled, constraintMatchEnabledPreference,
+            ConstraintMatchPolicy constraintMatchPolicy, boolean expectShadowVariablesInCorrectState) {
+        return new BavetConstraintStreamScoreDirector<>(this, lookUpEnabled, constraintMatchPolicy,
                 expectShadowVariablesInCorrectState);
     }
 
     @Override
     public InnerScoreDirector<Solution_, Score_> buildDerivedScoreDirector(boolean lookUpEnabled,
-            boolean constraintMatchEnabledPreference) {
-        return new BavetConstraintStreamScoreDirector<>(this, lookUpEnabled, constraintMatchEnabledPreference,
-                true, true);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        return new BavetConstraintStreamScoreDirector<>(this, lookUpEnabled, constraintMatchPolicy, true, true);
     }
 
-    public BavetConstraintSession<Score_> newSession(Solution_ workingSolution, boolean constraintMatchEnabled,
+    public BavetConstraintSession<Score_> newSession(Solution_ workingSolution, ConstraintMatchPolicy constraintMatchPolicy,
             boolean scoreDirectorDerived) {
-        return constraintSessionFactory.buildSession(workingSolution, constraintMatchEnabled, scoreDirectorDerived);
+        return constraintSessionFactory.buildSession(workingSolution, constraintMatchPolicy, scoreDirectorDerived);
     }
 
     @Override
     public AbstractScoreInliner<Score_> fireAndForget(Object... facts) {
-        var session = newSession(null, true, true);
+        var session = newSession(null, ConstraintMatchPolicy.ENABLED, true);
         Arrays.stream(facts).forEach(session::insert);
         session.calculateScore(0);
         return session.getScoreInliner();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintFactory.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.core.api.score.stream.Joiners;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintStream;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.common.BavetAbstractConstraintStream;
 import ai.timefold.solver.core.impl.score.stream.bavet.uni.BavetForEachUniConstraintStream;
 import ai.timefold.solver.core.impl.score.stream.common.InnerConstraintFactory;
@@ -69,7 +70,8 @@ public final class BavetConstraintFactory<Solution_>
      * If a constraint already exists in this factory, it replaces it with the old copy.
      * {@link BavetAbstractConstraintStream} implement equals/hashcode ignoring child streams.
      * <p>
-     * {@link BavetConstraintSessionFactory#buildSession(Object, boolean, boolean)} needs this to happen for all streams.
+     * {@link BavetConstraintSessionFactory#buildSession(Object, ConstraintMatchPolicy, boolean)} needs this to happen for all
+     * streams.
      * <p>
      * This must be called before the stream receives child streams.
      *

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintSession.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.constraint.ConstraintMatchTotal;
 import ai.timefold.solver.core.api.score.constraint.Indictment;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.stream.BavetConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.stream.bavet.common.PropagationQueue;
 import ai.timefold.solver.core.impl.score.stream.bavet.uni.AbstractForEachUniNode;
@@ -13,7 +14,8 @@ import ai.timefold.solver.core.impl.score.stream.common.inliner.AbstractScoreInl
 
 /**
  * The type is public to make it easier for Bavet-specific minimal bug reproducers to be created.
- * Instances should be created through {@link BavetConstraintStreamScoreDirectorFactory#newSession(Object, boolean, boolean)}.
+ * Instances should be created through
+ * {@link BavetConstraintStreamScoreDirectorFactory#newSession(Object, ConstraintMatchPolicy, boolean)}.
  *
  * @see PropagationQueue Description of the tuple propagation mechanism.
  * @param <Score_>

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintSessionFactory.java
@@ -14,6 +14,7 @@ import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.api.score.stream.ConstraintMetaModel;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.common.AbstractConcatNode;
 import ai.timefold.solver.core.impl.score.stream.bavet.common.AbstractIfExistsNode;
 import ai.timefold.solver.core.impl.score.stream.bavet.common.AbstractJoinNode;
@@ -53,7 +54,7 @@ public final class BavetConstraintSessionFactory<Solution_, Score_ extends Score
     // ************************************************************************
 
     @SuppressWarnings("unchecked")
-    public BavetConstraintSession<Score_> buildSession(Solution_ workingSolution, boolean constraintMatchEnabled,
+    public BavetConstraintSession<Score_> buildSession(Solution_ workingSolution, ConstraintMatchPolicy constraintMatchPolicy,
             boolean scoreDirectorDerived) {
         var constraintWeightSupplier = solutionDescriptor.getConstraintWeightSupplier();
         var constraints = constraintMetaModel.getConstraints();
@@ -108,7 +109,7 @@ public final class BavetConstraintSessionFactory<Solution_, Score_ extends Score
             }
         }
 
-        var scoreInliner = AbstractScoreInliner.buildScoreInliner(scoreDefinition, constraintWeightMap, constraintMatchEnabled);
+        var scoreInliner = AbstractScoreInliner.buildScoreInliner(scoreDefinition, constraintWeightMap, constraintMatchPolicy);
         if (constraintStreamSet.isEmpty()) {
             LOGGER.warn("No constraints enabled for solution ({}).", workingSolution);
             return new BavetConstraintSession<>(scoreInliner);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetScoringBiConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetScoringBiConstraintStream.java
@@ -69,7 +69,7 @@ final class BavetScoringBiConstraintStream<Solution_, A, B>
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         assertEmptyChildStreamList();
-        var constraintMatchEnabled = buildHelper.getScoreInliner().isConstraintMatchEnabled();
+        var constraintMatchEnabled = buildHelper.getScoreInliner().getConstraintMatchPolicy().isEnabled();
         var scoreImpacter = constraintMatchEnabled ? buildScoreImpacterWithConstraintMatch() : buildScoreImpacter();
         var weightedScoreImpacter = buildHelper.getScoreInliner().buildWeightedScoreImpacter(constraint);
         var scorer = new BiScorer<>(weightedScoreImpacter, scoreImpacter,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/BavetScoringConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/BavetScoringConstraintStream.java
@@ -1,13 +1,36 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.common;
 
+import java.math.BigDecimal;
 import java.util.Set;
 
+import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraint;
+import ai.timefold.solver.core.impl.score.stream.common.inliner.ConstraintMatchSupplier;
+import ai.timefold.solver.core.impl.score.stream.common.inliner.UndoScoreImpacter;
+import ai.timefold.solver.core.impl.score.stream.common.inliner.WeightedScoreImpacter;
 
 public interface BavetScoringConstraintStream<Solution_> {
 
     void setConstraint(BavetConstraint<Solution_> constraint);
 
     void collectActiveConstraintStreams(Set<BavetAbstractConstraintStream<Solution_>> constraintStreamSet);
+
+    static <Score_ extends Score<Score_>> UndoScoreImpacter
+            impactWithConstraintMatchNoJustifications(WeightedScoreImpacter<Score_, ?> impacter, int matchWeight) {
+        var constraintMatchSupplier = ConstraintMatchSupplier.<Score_> empty();
+        return impacter.impactScore(matchWeight, constraintMatchSupplier);
+    }
+
+    static <Score_ extends Score<Score_>> UndoScoreImpacter
+            impactWithConstraintMatchNoJustifications(WeightedScoreImpacter<Score_, ?> impacter, long matchWeight) {
+        var constraintMatchSupplier = ConstraintMatchSupplier.<Score_> empty();
+        return impacter.impactScore(matchWeight, constraintMatchSupplier);
+    }
+
+    static <Score_ extends Score<Score_>> UndoScoreImpacter
+            impactWithConstraintMatchNoJustifications(WeightedScoreImpacter<Score_, ?> impacter, BigDecimal matchWeight) {
+        var constraintMatchSupplier = ConstraintMatchSupplier.<Score_> empty();
+        return impacter.impactScore(matchWeight, constraintMatchSupplier);
+    }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetScoringQuadConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetScoringQuadConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.quad;
 
+import static ai.timefold.solver.core.impl.score.stream.bavet.common.BavetScoringConstraintStream.impactWithConstraintMatchNoJustifications;
+
 import java.math.BigDecimal;
 
 import ai.timefold.solver.core.api.function.PentaFunction;
@@ -7,6 +9,7 @@ import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.api.function.ToIntQuadFunction;
 import ai.timefold.solver.core.api.function.ToLongQuadFunction;
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraint;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintFactory;
 import ai.timefold.solver.core.impl.score.stream.bavet.common.BavetScoringConstraintStream;
@@ -70,12 +73,20 @@ final class BavetScoringQuadConstraintStream<Solution_, A, B, C, D>
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         assertEmptyChildStreamList();
-        var constraintMatchEnabled = buildHelper.getScoreInliner().getConstraintMatchPolicy().isEnabled();
-        var scoreImpacter = constraintMatchEnabled ? buildScoreImpacterWithConstraintMatch() : buildScoreImpacter();
+        var scoreImpacter = buildScoreImpacter(buildHelper.getScoreInliner().getConstraintMatchPolicy());
         var weightedScoreImpacter = buildHelper.getScoreInliner().buildWeightedScoreImpacter(constraint);
         var scorer = new QuadScorer<>(weightedScoreImpacter, scoreImpacter,
                 buildHelper.reserveTupleStoreIndex(parent.getTupleSource()));
         buildHelper.putInsertUpdateRetract(this, scorer);
+    }
+
+    private PentaFunction<WeightedScoreImpacter<?, ?>, A, B, C, D, UndoScoreImpacter>
+            buildScoreImpacter(ConstraintMatchPolicy constraintMatchPolicy) {
+        return switch (constraintMatchPolicy) {
+            case DISABLED -> buildScoreImpacter();
+            case ENABLED -> buildScoreImpacterWithConstraintMatch();
+            case ENABLED_WITHOUT_JUSTIFICATIONS -> buildScoreImpacterWithConstraintMatchNoJustifications();
+        };
     }
 
     private PentaFunction<WeightedScoreImpacter<?, ?>, A, B, C, D, UndoScoreImpacter> buildScoreImpacter() {
@@ -142,6 +153,28 @@ final class BavetScoringQuadConstraintStream<Solution_, A, B, C, D>
         var constraintMatchSupplier = ConstraintMatchSupplier.<A, B, C, D, Score_> of(constraint.getJustificationMapping(),
                 constraint.getIndictedObjectsMapping(), a, b, c, d);
         return impacter.impactScore(matchWeight, constraintMatchSupplier);
+    }
+
+    private PentaFunction<WeightedScoreImpacter<?, ?>, A, B, C, D, UndoScoreImpacter>
+            buildScoreImpacterWithConstraintMatchNoJustifications() {
+        if (intMatchWeigher != null) {
+            return (impacter, a, b, c, d) -> {
+                int matchWeight = intMatchWeigher.applyAsInt(a, b, c, d);
+                return impactWithConstraintMatchNoJustifications(impacter, matchWeight);
+            };
+        } else if (longMatchWeigher != null) {
+            return (impacter, a, b, c, d) -> {
+                long matchWeight = longMatchWeigher.applyAsLong(a, b, c, d);
+                return impactWithConstraintMatchNoJustifications(impacter, matchWeight);
+            };
+        } else if (bigDecimalMatchWeigher != null) {
+            return (impacter, a, b, c, d) -> {
+                BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b, c, d);
+                return impactWithConstraintMatchNoJustifications(impacter, matchWeight);
+            };
+        } else {
+            throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
+        }
     }
 
     // ************************************************************************

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetScoringQuadConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetScoringQuadConstraintStream.java
@@ -70,7 +70,7 @@ final class BavetScoringQuadConstraintStream<Solution_, A, B, C, D>
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         assertEmptyChildStreamList();
-        var constraintMatchEnabled = buildHelper.getScoreInliner().isConstraintMatchEnabled();
+        var constraintMatchEnabled = buildHelper.getScoreInliner().getConstraintMatchPolicy().isEnabled();
         var scoreImpacter = constraintMatchEnabled ? buildScoreImpacterWithConstraintMatch() : buildScoreImpacter();
         var weightedScoreImpacter = buildHelper.getScoreInliner().buildWeightedScoreImpacter(constraint);
         var scorer = new QuadScorer<>(weightedScoreImpacter, scoreImpacter,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetScoringTriConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetScoringTriConstraintStream.java
@@ -70,7 +70,7 @@ final class BavetScoringTriConstraintStream<Solution_, A, B, C>
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         assertEmptyChildStreamList();
-        var constraintMatchEnabled = buildHelper.getScoreInliner().isConstraintMatchEnabled();
+        var constraintMatchEnabled = buildHelper.getScoreInliner().getConstraintMatchPolicy().isEnabled();
         var scoreImpacter = constraintMatchEnabled ? buildScoreImpacterWithConstraintMatch() : buildScoreImpacter();
         var weightedScoreImpacter = buildHelper.getScoreInliner().buildWeightedScoreImpacter(constraint);
         var scorer = new TriScorer<>(weightedScoreImpacter, scoreImpacter,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetScoringTriConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetScoringTriConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.tri;
 
+import static ai.timefold.solver.core.impl.score.stream.bavet.common.BavetScoringConstraintStream.impactWithConstraintMatchNoJustifications;
+
 import java.math.BigDecimal;
 
 import ai.timefold.solver.core.api.function.QuadFunction;
@@ -7,6 +9,7 @@ import ai.timefold.solver.core.api.function.ToIntTriFunction;
 import ai.timefold.solver.core.api.function.ToLongTriFunction;
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraint;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintFactory;
 import ai.timefold.solver.core.impl.score.stream.bavet.common.BavetScoringConstraintStream;
@@ -70,12 +73,20 @@ final class BavetScoringTriConstraintStream<Solution_, A, B, C>
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         assertEmptyChildStreamList();
-        var constraintMatchEnabled = buildHelper.getScoreInliner().getConstraintMatchPolicy().isEnabled();
-        var scoreImpacter = constraintMatchEnabled ? buildScoreImpacterWithConstraintMatch() : buildScoreImpacter();
+        var scoreImpacter = buildScoreImpacter(buildHelper.getScoreInliner().getConstraintMatchPolicy());
         var weightedScoreImpacter = buildHelper.getScoreInliner().buildWeightedScoreImpacter(constraint);
         var scorer = new TriScorer<>(weightedScoreImpacter, scoreImpacter,
                 buildHelper.reserveTupleStoreIndex(parent.getTupleSource()));
         buildHelper.putInsertUpdateRetract(this, scorer);
+    }
+
+    private QuadFunction<WeightedScoreImpacter<?, ?>, A, B, C, UndoScoreImpacter>
+            buildScoreImpacter(ConstraintMatchPolicy constraintMatchPolicy) {
+        return switch (constraintMatchPolicy) {
+            case DISABLED -> buildScoreImpacter();
+            case ENABLED -> buildScoreImpacterWithConstraintMatch();
+            case ENABLED_WITHOUT_JUSTIFICATIONS -> buildScoreImpacterWithConstraintMatchNoJustifications();
+        };
     }
 
     private QuadFunction<WeightedScoreImpacter<?, ?>, A, B, C, UndoScoreImpacter> buildScoreImpacter() {
@@ -142,6 +153,28 @@ final class BavetScoringTriConstraintStream<Solution_, A, B, C>
         var constraintMatchSupplier = ConstraintMatchSupplier.<A, B, C, Score_> of(constraint.getJustificationMapping(),
                 constraint.getIndictedObjectsMapping(), a, b, c);
         return impacter.impactScore(matchWeight, constraintMatchSupplier);
+    }
+
+    private QuadFunction<WeightedScoreImpacter<?, ?>, A, B, C, UndoScoreImpacter>
+            buildScoreImpacterWithConstraintMatchNoJustifications() {
+        if (intMatchWeigher != null) {
+            return (impacter, a, b, c) -> {
+                int matchWeight = intMatchWeigher.applyAsInt(a, b, c);
+                return impactWithConstraintMatchNoJustifications(impacter, matchWeight);
+            };
+        } else if (longMatchWeigher != null) {
+            return (impacter, a, b, c) -> {
+                long matchWeight = longMatchWeigher.applyAsLong(a, b, c);
+                return impactWithConstraintMatchNoJustifications(impacter, matchWeight);
+            };
+        } else if (bigDecimalMatchWeigher != null) {
+            return (impacter, a, b, c) -> {
+                BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b, c);
+                return impactWithConstraintMatchNoJustifications(impacter, matchWeight);
+            };
+        } else {
+            throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
+        }
     }
 
     // ************************************************************************

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetScoringUniConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetScoringUniConstraintStream.java
@@ -69,7 +69,7 @@ final class BavetScoringUniConstraintStream<Solution_, A>
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         assertEmptyChildStreamList();
-        var constraintMatchEnabled = buildHelper.getScoreInliner().isConstraintMatchEnabled();
+        var constraintMatchEnabled = buildHelper.getScoreInliner().getConstraintMatchPolicy().isEnabled();
         var scoreImpacter = constraintMatchEnabled ? buildScoreImpacterWithConstraintMatch() : buildScoreImpacter();
         var weightedScoreImpacter = buildHelper.getScoreInliner().buildWeightedScoreImpacter(constraint);
         var scorer = new UniScorer<>(weightedScoreImpacter, scoreImpacter,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetScoringUniConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetScoringUniConstraintStream.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.uni;
 
+import static ai.timefold.solver.core.impl.score.stream.bavet.common.BavetScoringConstraintStream.impactWithConstraintMatchNoJustifications;
+
 import java.math.BigDecimal;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -7,6 +9,7 @@ import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
 
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraint;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintFactory;
 import ai.timefold.solver.core.impl.score.stream.bavet.common.BavetScoringConstraintStream;
@@ -69,12 +72,20 @@ final class BavetScoringUniConstraintStream<Solution_, A>
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         assertEmptyChildStreamList();
-        var constraintMatchEnabled = buildHelper.getScoreInliner().getConstraintMatchPolicy().isEnabled();
-        var scoreImpacter = constraintMatchEnabled ? buildScoreImpacterWithConstraintMatch() : buildScoreImpacter();
+        var scoreImpacter = buildScoreImpacter(buildHelper.getScoreInliner().getConstraintMatchPolicy());
         var weightedScoreImpacter = buildHelper.getScoreInliner().buildWeightedScoreImpacter(constraint);
         var scorer = new UniScorer<>(weightedScoreImpacter, scoreImpacter,
                 buildHelper.reserveTupleStoreIndex(parent.getTupleSource()));
         buildHelper.putInsertUpdateRetract(this, scorer);
+    }
+
+    private BiFunction<WeightedScoreImpacter<?, ?>, A, UndoScoreImpacter>
+            buildScoreImpacter(ConstraintMatchPolicy constraintMatchPolicy) {
+        return switch (constraintMatchPolicy) {
+            case DISABLED -> buildScoreImpacter();
+            case ENABLED -> buildScoreImpacterWithConstraintMatch();
+            case ENABLED_WITHOUT_JUSTIFICATIONS -> buildScoreImpacterWithConstraintMatchNoJustifications();
+        };
     }
 
     private BiFunction<WeightedScoreImpacter<?, ?>, A, UndoScoreImpacter> buildScoreImpacter() {
@@ -141,6 +152,28 @@ final class BavetScoringUniConstraintStream<Solution_, A>
         var constraintMatchSupplier = ConstraintMatchSupplier.<A, Score_> of(constraint.getJustificationMapping(),
                 constraint.getIndictedObjectsMapping(), a);
         return impacter.impactScore(matchWeight, constraintMatchSupplier);
+    }
+
+    private BiFunction<WeightedScoreImpacter<?, ?>, A, UndoScoreImpacter>
+            buildScoreImpacterWithConstraintMatchNoJustifications() {
+        if (intMatchWeigher != null) {
+            return (impacter, a) -> {
+                int matchWeight = intMatchWeigher.applyAsInt(a);
+                return impactWithConstraintMatchNoJustifications(impacter, matchWeight);
+            };
+        } else if (longMatchWeigher != null) {
+            return (impacter, a) -> {
+                long matchWeight = longMatchWeigher.applyAsLong(a);
+                return impactWithConstraintMatchNoJustifications(impacter, matchWeight);
+            };
+        } else if (bigDecimalMatchWeigher != null) {
+            return (impacter, a) -> {
+                BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a);
+                return impactWithConstraintMatchNoJustifications(impacter, matchWeight);
+            };
+        } else {
+            throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
+        }
     }
 
     // ************************************************************************

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamScoreDirectorFactory.java
@@ -4,6 +4,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.stream.ConstraintMetaModel;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
@@ -40,6 +41,6 @@ public abstract class AbstractConstraintStreamScoreDirectorFactory<Solution_, Sc
 
     @Override
     public abstract InnerScoreDirector<Solution_, Score_> buildDerivedScoreDirector(boolean lookUpEnabled,
-            boolean constraintMatchEnabledPreference);
+            ConstraintMatchPolicy constraintMatchPolicy);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/AbstractScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/AbstractScoreInliner.java
@@ -175,8 +175,8 @@ public abstract class AbstractScoreInliner<Score_ extends Score<Score_>> {
         indictmentMap = null;
     }
 
-    public boolean isConstraintMatchEnabled() {
-        return constraintMatchPolicy.isEnabled();
+    public ConstraintMatchPolicy getConstraintMatchPolicy() {
+        return constraintMatchPolicy;
     }
 
     public final Map<String, ConstraintMatchTotal<Score_>> getConstraintIdToConstraintMatchTotalMap() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/AbstractScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/AbstractScoreInliner.java
@@ -23,6 +23,7 @@ import ai.timefold.solver.core.impl.score.buildin.HardSoftScoreDefinition;
 import ai.timefold.solver.core.impl.score.buildin.SimpleBigDecimalScoreDefinition;
 import ai.timefold.solver.core.impl.score.buildin.SimpleLongScoreDefinition;
 import ai.timefold.solver.core.impl.score.buildin.SimpleScoreDefinition;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.constraint.DefaultConstraintMatchTotal;
 import ai.timefold.solver.core.impl.score.constraint.DefaultIndictment;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
@@ -45,35 +46,34 @@ public abstract class AbstractScoreInliner<Score_ extends Score<Score_>> {
 
     public static <Score_ extends Score<Score_>, ScoreInliner_ extends AbstractScoreInliner<Score_>> ScoreInliner_
             buildScoreInliner(ScoreDefinition<Score_> scoreDefinition, Map<Constraint, Score_> constraintWeightMap,
-                    boolean constraintMatchEnabled) {
+                    ConstraintMatchPolicy constraintMatchPolicy) {
         if (scoreDefinition instanceof SimpleScoreDefinition) {
-            return (ScoreInliner_) new SimpleScoreInliner((Map) constraintWeightMap, constraintMatchEnabled);
+            return (ScoreInliner_) new SimpleScoreInliner((Map) constraintWeightMap, constraintMatchPolicy);
         } else if (scoreDefinition instanceof SimpleLongScoreDefinition) {
-            return (ScoreInliner_) new SimpleLongScoreInliner((Map) constraintWeightMap, constraintMatchEnabled);
+            return (ScoreInliner_) new SimpleLongScoreInliner((Map) constraintWeightMap, constraintMatchPolicy);
         } else if (scoreDefinition instanceof SimpleBigDecimalScoreDefinition) {
-            return (ScoreInliner_) new SimpleBigDecimalScoreInliner((Map) constraintWeightMap, constraintMatchEnabled);
+            return (ScoreInliner_) new SimpleBigDecimalScoreInliner((Map) constraintWeightMap, constraintMatchPolicy);
         } else if (scoreDefinition instanceof HardSoftScoreDefinition) {
-            return (ScoreInliner_) new HardSoftScoreInliner((Map) constraintWeightMap, constraintMatchEnabled);
+            return (ScoreInliner_) new HardSoftScoreInliner((Map) constraintWeightMap, constraintMatchPolicy);
         } else if (scoreDefinition instanceof HardSoftLongScoreDefinition) {
-            return (ScoreInliner_) new HardSoftLongScoreInliner((Map) constraintWeightMap, constraintMatchEnabled);
+            return (ScoreInliner_) new HardSoftLongScoreInliner((Map) constraintWeightMap, constraintMatchPolicy);
         } else if (scoreDefinition instanceof HardSoftBigDecimalScoreDefinition) {
-            return (ScoreInliner_) new HardSoftBigDecimalScoreInliner((Map) constraintWeightMap, constraintMatchEnabled);
+            return (ScoreInliner_) new HardSoftBigDecimalScoreInliner((Map) constraintWeightMap, constraintMatchPolicy);
         } else if (scoreDefinition instanceof HardMediumSoftScoreDefinition) {
-            return (ScoreInliner_) new HardMediumSoftScoreInliner((Map) constraintWeightMap, constraintMatchEnabled);
+            return (ScoreInliner_) new HardMediumSoftScoreInliner((Map) constraintWeightMap, constraintMatchPolicy);
         } else if (scoreDefinition instanceof HardMediumSoftLongScoreDefinition) {
-            return (ScoreInliner_) new HardMediumSoftLongScoreInliner((Map) constraintWeightMap, constraintMatchEnabled);
+            return (ScoreInliner_) new HardMediumSoftLongScoreInliner((Map) constraintWeightMap, constraintMatchPolicy);
         } else if (scoreDefinition instanceof HardMediumSoftBigDecimalScoreDefinition) {
-            return (ScoreInliner_) new HardMediumSoftBigDecimalScoreInliner((Map) constraintWeightMap, constraintMatchEnabled);
+            return (ScoreInliner_) new HardMediumSoftBigDecimalScoreInliner((Map) constraintWeightMap, constraintMatchPolicy);
         } else if (scoreDefinition instanceof BendableScoreDefinition bendableScoreDefinition) {
-            return (ScoreInliner_) new BendableScoreInliner((Map) constraintWeightMap, constraintMatchEnabled,
-                    bendableScoreDefinition.getHardLevelsSize(),
-                    bendableScoreDefinition.getSoftLevelsSize());
+            return (ScoreInliner_) new BendableScoreInliner((Map) constraintWeightMap, constraintMatchPolicy,
+                    bendableScoreDefinition.getHardLevelsSize(), bendableScoreDefinition.getSoftLevelsSize());
         } else if (scoreDefinition instanceof BendableLongScoreDefinition bendableScoreDefinition) {
-            return (ScoreInliner_) new BendableLongScoreInliner((Map) constraintWeightMap, constraintMatchEnabled,
+            return (ScoreInliner_) new BendableLongScoreInliner((Map) constraintWeightMap, constraintMatchPolicy,
                     bendableScoreDefinition.getHardLevelsSize(),
                     bendableScoreDefinition.getSoftLevelsSize());
         } else if (scoreDefinition instanceof BendableBigDecimalScoreDefinition bendableScoreDefinition) {
-            return (ScoreInliner_) new BendableBigDecimalScoreInliner((Map) constraintWeightMap, constraintMatchEnabled,
+            return (ScoreInliner_) new BendableBigDecimalScoreInliner((Map) constraintWeightMap, constraintMatchPolicy,
                     bendableScoreDefinition.getHardLevelsSize(), bendableScoreDefinition.getSoftLevelsSize());
         } else {
             String customScoreInlinerClassName = System.getProperty(CUSTOM_SCORE_INLINER_CLASS_PROPERTY_NAME);
@@ -104,19 +104,19 @@ public abstract class AbstractScoreInliner<Score_ extends Score<Score_>> {
         }
     }
 
-    protected final boolean constraintMatchEnabled;
+    protected final ConstraintMatchPolicy constraintMatchPolicy;
     protected final Map<Constraint, Score_> constraintWeightMap;
     private final Map<Constraint, ElementAwareList<ConstraintMatchCarrier<Score_>>> constraintMatchMap;
     private Map<String, ConstraintMatchTotal<Score_>> constraintIdToConstraintMatchTotalMap = null;
     private Map<Object, Indictment<Score_>> indictmentMap = null;
 
-    protected AbstractScoreInliner(Map<Constraint, Score_> constraintWeightMap, boolean constraintMatchEnabled) {
-        this.constraintMatchEnabled = constraintMatchEnabled;
+    protected AbstractScoreInliner(Map<Constraint, Score_> constraintWeightMap, ConstraintMatchPolicy constraintMatchPolicy) {
+        this.constraintMatchPolicy = constraintMatchPolicy;
         constraintWeightMap.forEach(this::validateConstraintWeight);
         this.constraintWeightMap = constraintWeightMap;
         this.constraintMatchMap =
-                constraintMatchEnabled ? CollectionUtils.newIdentityHashMap(constraintWeightMap.size()) : null;
-        if (constraintMatchEnabled) {
+                constraintMatchPolicy.isEnabled() ? CollectionUtils.newIdentityHashMap(constraintWeightMap.size()) : null;
+        if (constraintMatchPolicy.isEnabled()) {
             for (var constraint : constraintWeightMap.keySet()) {
                 // Ensure that even constraints without matches have their entry.
                 constraintMatchMap.put(constraint, new ElementAwareList<>());
@@ -176,7 +176,7 @@ public abstract class AbstractScoreInliner<Score_ extends Score<Score_>> {
     }
 
     public boolean isConstraintMatchEnabled() {
-        return constraintMatchEnabled;
+        return constraintMatchPolicy.isEnabled();
     }
 
     public final Map<String, ConstraintMatchTotal<Score_>> getConstraintIdToConstraintMatchTotalMap() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreContext.java
@@ -33,7 +33,7 @@ final class BendableBigDecimalScoreContext extends ScoreContext<BendableBigDecim
         parent.softScores[scoreLevel] = parent.softScores[scoreLevel].add(softImpact);
         UndoScoreImpacter undoScoreImpact =
                 () -> parent.softScores[scoreLevel] = parent.softScores[scoreLevel].subtract(softImpact);
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact,
@@ -47,7 +47,7 @@ final class BendableBigDecimalScoreContext extends ScoreContext<BendableBigDecim
         parent.hardScores[scoreLevel] = parent.hardScores[scoreLevel].add(hardImpact);
         UndoScoreImpacter undoScoreImpact =
                 () -> parent.hardScores[scoreLevel] = parent.hardScores[scoreLevel].subtract(hardImpact);
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact,
@@ -77,7 +77,7 @@ final class BendableBigDecimalScoreContext extends ScoreContext<BendableBigDecim
                 parent.softScores[softScoreLevel] = parent.softScores[softScoreLevel].subtract(softImpacts[softScoreLevel]);
             }
         };
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, BendableBigDecimalScore.of(hardImpacts, softImpacts),

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreInliner.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class BendableBigDecimalScoreInliner extends AbstractScoreInliner<BendableBigDecimalScore> {
@@ -13,9 +14,9 @@ final class BendableBigDecimalScoreInliner extends AbstractScoreInliner<Bendable
     final BigDecimal[] hardScores;
     final BigDecimal[] softScores;
 
-    BendableBigDecimalScoreInliner(Map<Constraint, BendableBigDecimalScore> constraintWeightMap, boolean constraintMatchEnabled,
-            int hardLevelsSize, int softLevelsSize) {
-        super(constraintWeightMap, constraintMatchEnabled);
+    BendableBigDecimalScoreInliner(Map<Constraint, BendableBigDecimalScore> constraintWeightMap,
+            ConstraintMatchPolicy constraintMatchPolicy, int hardLevelsSize, int softLevelsSize) {
+        super(constraintWeightMap, constraintMatchPolicy);
         hardScores = new BigDecimal[hardLevelsSize];
         Arrays.fill(hardScores, BigDecimal.ZERO);
         softScores = new BigDecimal[softLevelsSize];

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreContext.java
@@ -31,7 +31,7 @@ final class BendableLongScoreContext extends ScoreContext<BendableLongScore, Ben
         parent.softScores[scoreLevel] += softImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.softScores[scoreLevel] -= softImpact;
         ;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact,
@@ -44,7 +44,7 @@ final class BendableLongScoreContext extends ScoreContext<BendableLongScore, Ben
         long hardImpact = scoreLevelWeight * matchWeight;
         parent.hardScores[scoreLevel] += hardImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.hardScores[scoreLevel] -= hardImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact,
@@ -74,7 +74,7 @@ final class BendableLongScoreContext extends ScoreContext<BendableLongScore, Ben
                 parent.softScores[softScoreLevel] -= softImpacts[softScoreLevel];
             }
         };
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, BendableLongScore.of(hardImpacts, softImpacts),

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreInliner.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.bendablelong.BendableLongScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 public final class BendableLongScoreInliner extends AbstractScoreInliner<BendableLongScore> {
@@ -12,9 +13,10 @@ public final class BendableLongScoreInliner extends AbstractScoreInliner<Bendabl
     final long[] hardScores;
     final long[] softScores;
 
-    BendableLongScoreInliner(Map<Constraint, BendableLongScore> constraintWeightMap, boolean constraintMatchEnabled,
+    BendableLongScoreInliner(Map<Constraint, BendableLongScore> constraintWeightMap,
+            ConstraintMatchPolicy constraintMatchPolicy,
             int hardLevelsSize, int softLevelsSize) {
-        super(constraintWeightMap, constraintMatchEnabled);
+        super(constraintWeightMap, constraintMatchPolicy);
         hardScores = new long[hardLevelsSize];
         softScores = new long[softLevelsSize];
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreContext.java
@@ -30,7 +30,7 @@ final class BendableScoreContext extends ScoreContext<BendableScore, BendableSco
         int softImpact = scoreLevelWeight * matchWeight;
         parent.softScores[scoreLevel] += softImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.softScores[scoreLevel] -= softImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact,
@@ -43,7 +43,7 @@ final class BendableScoreContext extends ScoreContext<BendableScore, BendableSco
         int hardImpact = scoreLevelWeight * matchWeight;
         parent.hardScores[scoreLevel] += hardImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.hardScores[scoreLevel] -= hardImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact,
@@ -72,7 +72,7 @@ final class BendableScoreContext extends ScoreContext<BendableScore, BendableSco
                 parent.softScores[softScoreLevel] -= softImpacts[softScoreLevel];
             }
         };
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, BendableScore.of(hardImpacts, softImpacts), constraintMatchSupplier);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreInliner.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.bendable.BendableScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class BendableScoreInliner extends AbstractScoreInliner<BendableScore> {
@@ -12,9 +13,10 @@ final class BendableScoreInliner extends AbstractScoreInliner<BendableScore> {
     final int[] hardScores;
     final int[] softScores;
 
-    BendableScoreInliner(Map<Constraint, BendableScore> constraintWeightMap, boolean constraintMatchEnabled, int hardLevelsSize,
+    BendableScoreInliner(Map<Constraint, BendableScore> constraintWeightMap, ConstraintMatchPolicy constraintMatchPolicy,
+            int hardLevelsSize,
             int softLevelsSize) {
-        super(constraintWeightMap, constraintMatchEnabled);
+        super(constraintWeightMap, constraintMatchPolicy);
         hardScores = new int[hardLevelsSize];
         softScores = new int[softLevelsSize];
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/ConstraintMatchSupplier.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/ConstraintMatchSupplier.java
@@ -15,7 +15,6 @@ import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.constraint.ConstraintMatch;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
-import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 
 /**
  * Allows creating {@link ConstraintMatch} instances lazily if and only if they are required by the end user.
@@ -33,10 +32,15 @@ import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 public interface ConstraintMatchSupplier<Score_ extends Score<Score_>>
         extends BiFunction<Constraint, Score_, ConstraintMatch<Score_>> {
 
+    /**
+     * 
+     * @return the constraint match returned by the supplier will have its justification set to null.
+     *         This is useful when the justifications are disabled, to save memory.
+     * @param <Score_>
+     */
     static <Score_ extends Score<Score_>> ConstraintMatchSupplier<Score_> empty() {
-        return (constraint, impact) -> new ConstraintMatch<>(constraint.getConstraintRef(),
-                DefaultConstraintJustification.of(impact),
-                Collections.emptyList(), impact);
+        return (constraint, impact) -> new ConstraintMatch<>(constraint.getConstraintRef(), null, Collections.emptyList(),
+                impact);
     }
 
     static <A, Score_ extends Score<Score_>> ConstraintMatchSupplier<Score_> of(

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftBigDecimalScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftBigDecimalScoreContext.java
@@ -18,7 +18,7 @@ final class HardMediumSoftBigDecimalScoreContext
         BigDecimal softImpact = constraintWeight.softScore().multiply(matchWeight);
         parent.softScore = parent.softScore.add(softImpact);
         UndoScoreImpacter undoScoreImpact = () -> parent.softScore = parent.softScore.subtract(softImpact);
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftBigDecimalScore.ofSoft(softImpact),
@@ -30,7 +30,7 @@ final class HardMediumSoftBigDecimalScoreContext
         BigDecimal mediumImpact = constraintWeight.mediumScore().multiply(matchWeight);
         parent.mediumScore = parent.mediumScore.add(mediumImpact);
         UndoScoreImpacter undoScoreImpact = () -> parent.mediumScore = parent.mediumScore.subtract(mediumImpact);
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftBigDecimalScore.ofMedium(mediumImpact),
@@ -42,7 +42,7 @@ final class HardMediumSoftBigDecimalScoreContext
         BigDecimal hardImpact = constraintWeight.hardScore().multiply(matchWeight);
         parent.hardScore = parent.hardScore.add(hardImpact);
         UndoScoreImpacter undoScoreImpact = () -> parent.hardScore = parent.hardScore.subtract(hardImpact);
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftBigDecimalScore.ofHard(hardImpact),
@@ -62,7 +62,7 @@ final class HardMediumSoftBigDecimalScoreContext
             parent.mediumScore = parent.mediumScore.subtract(mediumImpact);
             parent.softScore = parent.softScore.subtract(softImpact);
         };
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftBigDecimalScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftBigDecimalScoreInliner.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class HardMediumSoftBigDecimalScoreInliner extends AbstractScoreInliner<HardMediumSoftBigDecimalScore> {
@@ -14,8 +15,8 @@ final class HardMediumSoftBigDecimalScoreInliner extends AbstractScoreInliner<Ha
     BigDecimal softScore = BigDecimal.ZERO;
 
     HardMediumSoftBigDecimalScoreInliner(Map<Constraint, HardMediumSoftBigDecimalScore> constraintWeightMap,
-            boolean constraintMatchEnabled) {
-        super(constraintWeightMap, constraintMatchEnabled);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        super(constraintWeightMap, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreContext.java
@@ -15,7 +15,7 @@ final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLo
         long softImpact = constraintWeight.softScore() * matchWeight;
         parent.softScore += softImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.softScore -= softImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftLongScore.ofSoft(softImpact), constraintMatchSupplier);
@@ -26,7 +26,7 @@ final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLo
         long mediumImpact = constraintWeight.mediumScore() * matchWeight;
         parent.mediumScore += mediumImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.mediumScore -= mediumImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftLongScore.ofMedium(mediumImpact),
@@ -38,7 +38,7 @@ final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLo
         long hardImpact = constraintWeight.hardScore() * matchWeight;
         parent.hardScore += hardImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.hardScore -= hardImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftLongScore.ofHard(hardImpact), constraintMatchSupplier);
@@ -57,7 +57,7 @@ final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLo
             parent.mediumScore -= mediumImpact;
             parent.softScore -= softImpact;
         };
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftLongScore.of(hardImpact, mediumImpact, softImpact),

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreInliner.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class HardMediumSoftLongScoreInliner extends AbstractScoreInliner<HardMediumSoftLongScore> {
@@ -13,8 +14,8 @@ final class HardMediumSoftLongScoreInliner extends AbstractScoreInliner<HardMedi
     long softScore;
 
     HardMediumSoftLongScoreInliner(Map<Constraint, HardMediumSoftLongScore> constraintWeightMap,
-            boolean constraintMatchEnabled) {
-        super(constraintWeightMap, constraintMatchEnabled);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        super(constraintWeightMap, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreContext.java
@@ -15,7 +15,7 @@ final class HardMediumSoftScoreContext extends ScoreContext<HardMediumSoftScore,
         int softImpact = constraintWeight.softScore() * matchWeight;
         parent.softScore += softImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.softScore -= softImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftScore.ofSoft(softImpact), constraintMatchSupplier);
@@ -26,7 +26,7 @@ final class HardMediumSoftScoreContext extends ScoreContext<HardMediumSoftScore,
         int mediumImpact = constraintWeight.mediumScore() * matchWeight;
         parent.mediumScore += mediumImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.mediumScore -= mediumImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftScore.ofMedium(mediumImpact), constraintMatchSupplier);
@@ -37,7 +37,7 @@ final class HardMediumSoftScoreContext extends ScoreContext<HardMediumSoftScore,
         int hardImpact = constraintWeight.hardScore() * matchWeight;
         parent.hardScore += hardImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.hardScore -= hardImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftScore.ofHard(hardImpact), constraintMatchSupplier);
@@ -56,7 +56,7 @@ final class HardMediumSoftScoreContext extends ScoreContext<HardMediumSoftScore,
             parent.mediumScore -= mediumImpact;
             parent.softScore -= softImpact;
         };
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardMediumSoftScore.of(hardImpact, mediumImpact, softImpact),

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreInliner.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class HardMediumSoftScoreInliner extends AbstractScoreInliner<HardMediumSoftScore> {
@@ -12,8 +13,9 @@ final class HardMediumSoftScoreInliner extends AbstractScoreInliner<HardMediumSo
     int mediumScore;
     int softScore;
 
-    HardMediumSoftScoreInliner(Map<Constraint, HardMediumSoftScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        super(constraintWeightMap, constraintMatchEnabled);
+    HardMediumSoftScoreInliner(Map<Constraint, HardMediumSoftScore> constraintWeightMap,
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        super(constraintWeightMap, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreContext.java
@@ -17,7 +17,7 @@ final class HardSoftBigDecimalScoreContext extends ScoreContext<HardSoftBigDecim
         BigDecimal softImpact = constraintWeight.softScore().multiply(matchWeight);
         parent.softScore = parent.softScore.add(softImpact);
         UndoScoreImpacter undoScoreImpact = () -> parent.softScore = parent.softScore.subtract(softImpact);
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardSoftBigDecimalScore.ofSoft(softImpact), constraintMatchSupplier);
@@ -28,7 +28,7 @@ final class HardSoftBigDecimalScoreContext extends ScoreContext<HardSoftBigDecim
         BigDecimal hardImpact = constraintWeight.hardScore().multiply(matchWeight);
         parent.hardScore = parent.hardScore.add(hardImpact);
         UndoScoreImpacter undoScoreImpact = () -> parent.hardScore = parent.hardScore.subtract(hardImpact);
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardSoftBigDecimalScore.ofHard(hardImpact), constraintMatchSupplier);
@@ -44,7 +44,7 @@ final class HardSoftBigDecimalScoreContext extends ScoreContext<HardSoftBigDecim
             parent.hardScore = parent.hardScore.subtract(hardImpact);
             parent.softScore = parent.softScore.subtract(softImpact);
         };
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardSoftBigDecimalScore.of(hardImpact, softImpact),

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreInliner.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class HardSoftBigDecimalScoreInliner extends AbstractScoreInliner<HardSoftBigDecimalScore> {
@@ -13,8 +14,8 @@ final class HardSoftBigDecimalScoreInliner extends AbstractScoreInliner<HardSoft
     BigDecimal softScore = BigDecimal.ZERO;
 
     HardSoftBigDecimalScoreInliner(Map<Constraint, HardSoftBigDecimalScore> constraintWeightMap,
-            boolean constraintMatchEnabled) {
-        super(constraintWeightMap, constraintMatchEnabled);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        super(constraintWeightMap, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreContext.java
@@ -15,7 +15,7 @@ final class HardSoftLongScoreContext extends ScoreContext<HardSoftLongScore, Har
         long softImpact = constraintWeight.softScore() * matchWeight;
         parent.softScore += softImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.softScore -= softImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardSoftLongScore.ofSoft(softImpact), constraintMatchSupplier);
@@ -26,7 +26,7 @@ final class HardSoftLongScoreContext extends ScoreContext<HardSoftLongScore, Har
         long hardImpact = constraintWeight.hardScore() * matchWeight;
         parent.hardScore += hardImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.hardScore -= hardImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardSoftLongScore.ofHard(hardImpact), constraintMatchSupplier);
@@ -42,7 +42,7 @@ final class HardSoftLongScoreContext extends ScoreContext<HardSoftLongScore, Har
             parent.hardScore -= hardImpact;
             parent.softScore -= softImpact;
         };
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardSoftLongScore.of(hardImpact, softImpact),

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreInliner.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class HardSoftLongScoreInliner extends AbstractScoreInliner<HardSoftLongScore> {
@@ -11,8 +12,9 @@ final class HardSoftLongScoreInliner extends AbstractScoreInliner<HardSoftLongSc
     long hardScore;
     long softScore;
 
-    HardSoftLongScoreInliner(Map<Constraint, HardSoftLongScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        super(constraintWeightMap, constraintMatchEnabled);
+    HardSoftLongScoreInliner(Map<Constraint, HardSoftLongScore> constraintWeightMap,
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        super(constraintWeightMap, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreContext.java
@@ -15,7 +15,7 @@ final class HardSoftScoreContext extends ScoreContext<HardSoftScore, HardSoftSco
         int softImpact = constraintWeight.softScore() * matchWeight;
         parent.softScore += softImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.softScore -= softImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardSoftScore.ofSoft(softImpact), constraintMatchSupplier);
@@ -26,7 +26,7 @@ final class HardSoftScoreContext extends ScoreContext<HardSoftScore, HardSoftSco
         int hardImpact = constraintWeight.hardScore() * matchWeight;
         parent.hardScore += hardImpact;
         UndoScoreImpacter undoScoreImpact = () -> parent.hardScore -= hardImpact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardSoftScore.ofHard(hardImpact), constraintMatchSupplier);
@@ -41,7 +41,7 @@ final class HardSoftScoreContext extends ScoreContext<HardSoftScore, HardSoftSco
             parent.hardScore -= hardImpact;
             parent.softScore -= softImpact;
         };
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, HardSoftScore.of(hardImpact, softImpact), constraintMatchSupplier);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreInliner.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class HardSoftScoreInliner extends AbstractScoreInliner<HardSoftScore> {
@@ -11,8 +12,8 @@ final class HardSoftScoreInliner extends AbstractScoreInliner<HardSoftScore> {
     int hardScore;
     int softScore;
 
-    HardSoftScoreInliner(Map<Constraint, HardSoftScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        super(constraintWeightMap, constraintMatchEnabled);
+    HardSoftScoreInliner(Map<Constraint, HardSoftScore> constraintWeightMap, ConstraintMatchPolicy constraintMatchPolicy) {
+        super(constraintWeightMap, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/ScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/ScoreContext.java
@@ -26,10 +26,6 @@ public abstract class ScoreContext<Score_ extends Score<Score_>, ScoreInliner_ e
         return constraintWeight;
     }
 
-    public boolean isConstraintMatchEnabled() {
-        return constraintMatchPolicy.isEnabled();
-    }
-
     protected UndoScoreImpacter impactWithConstraintMatch(UndoScoreImpacter undoScoreImpact, Score_ score,
             ConstraintMatchSupplier<Score_> constraintMatchSupplier) {
         return parent.addConstraintMatch(constraint, score, constraintMatchSupplier, undoScoreImpact);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/ScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/ScoreContext.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.common.inliner;
 
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 public abstract class ScoreContext<Score_ extends Score<Score_>, ScoreInliner_ extends AbstractScoreInliner<Score_>> {
@@ -8,13 +9,13 @@ public abstract class ScoreContext<Score_ extends Score<Score_>, ScoreInliner_ e
     protected final ScoreInliner_ parent;
     protected final AbstractConstraint<?, ?, ?> constraint;
     protected final Score_ constraintWeight;
-    protected final boolean constraintMatchEnabled;
+    protected final ConstraintMatchPolicy constraintMatchPolicy;
 
     protected ScoreContext(ScoreInliner_ parent, AbstractConstraint<?, ?, ?> constraint, Score_ constraintWeight) {
         this.parent = parent;
         this.constraint = constraint;
         this.constraintWeight = constraintWeight;
-        this.constraintMatchEnabled = parent.constraintMatchEnabled;
+        this.constraintMatchPolicy = parent.constraintMatchPolicy;
     }
 
     public AbstractConstraint<?, ?, ?> getConstraint() {
@@ -26,7 +27,7 @@ public abstract class ScoreContext<Score_ extends Score<Score_>, ScoreInliner_ e
     }
 
     public boolean isConstraintMatchEnabled() {
-        return constraintMatchEnabled;
+        return constraintMatchPolicy.isEnabled();
     }
 
     protected UndoScoreImpacter impactWithConstraintMatch(UndoScoreImpacter undoScoreImpact, Score_ score,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleBigDecimalScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleBigDecimalScoreContext.java
@@ -17,7 +17,7 @@ final class SimpleBigDecimalScoreContext extends ScoreContext<SimpleBigDecimalSc
         BigDecimal impact = constraintWeight.score().multiply(matchWeight);
         parent.score = parent.score.add(impact);
         UndoScoreImpacter undoScoreImpact = () -> parent.score = parent.score.subtract(impact);
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, SimpleBigDecimalScore.of(impact), constraintMatchSupplier);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleBigDecimalScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleBigDecimalScoreInliner.java
@@ -5,14 +5,16 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class SimpleBigDecimalScoreInliner extends AbstractScoreInliner<SimpleBigDecimalScore> {
 
     BigDecimal score = BigDecimal.ZERO;
 
-    SimpleBigDecimalScoreInliner(Map<Constraint, SimpleBigDecimalScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        super(constraintWeightMap, constraintMatchEnabled);
+    SimpleBigDecimalScoreInliner(Map<Constraint, SimpleBigDecimalScore> constraintWeightMap,
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        super(constraintWeightMap, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreContext.java
@@ -14,7 +14,7 @@ final class SimpleLongScoreContext extends ScoreContext<SimpleLongScore, SimpleL
         long impact = constraintWeight.score() * matchWeight;
         parent.score += impact;
         UndoScoreImpacter undoScoreImpact = () -> parent.score -= impact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, SimpleLongScore.of(impact), constraintMatchSupplier);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreInliner.java
@@ -4,14 +4,15 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.simplelong.SimpleLongScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class SimpleLongScoreInliner extends AbstractScoreInliner<SimpleLongScore> {
 
     long score;
 
-    SimpleLongScoreInliner(Map<Constraint, SimpleLongScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        super(constraintWeightMap, constraintMatchEnabled);
+    SimpleLongScoreInliner(Map<Constraint, SimpleLongScore> constraintWeightMap, ConstraintMatchPolicy constraintMatchPolicy) {
+        super(constraintWeightMap, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreContext.java
@@ -13,7 +13,7 @@ final class SimpleScoreContext extends ScoreContext<SimpleScore, SimpleScoreInli
         int impact = constraintWeight.score() * matchWeight;
         parent.score += impact;
         UndoScoreImpacter undoScoreImpact = () -> parent.score -= impact;
-        if (!constraintMatchEnabled) {
+        if (!constraintMatchPolicy.isEnabled()) {
             return undoScoreImpact;
         }
         return impactWithConstraintMatch(undoScoreImpact, SimpleScore.of(impact), constraintMatchSupplier);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreInliner.java
@@ -4,14 +4,15 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 final class SimpleScoreInliner extends AbstractScoreInliner<SimpleScore> {
 
     int score;
 
-    SimpleScoreInliner(Map<Constraint, SimpleScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        super(constraintWeightMap, constraintMatchEnabled);
+    SimpleScoreInliner(Map<Constraint, SimpleScore> constraintWeightMap, ConstraintMatchPolicy constraintMatchPolicy) {
+        super(constraintWeightMap, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/Assigner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/Assigner.java
@@ -41,8 +41,8 @@ final class Assigner<Solution_, Score_ extends Score<Score_>, Recommendation_, I
                     Assignment Recommendation API requires at most one uninitialized element in the solution."""
                     .formatted(originalSolution, uninitializedCount));
         }
-        var originalScoreAnalysis = scoreDirector.buildScoreAnalysis(fetchPolicy == ScoreAnalysisFetchPolicy.FETCH_ALL,
-                InnerScoreDirector.ScoreAnalysisMode.RECOMMENDATION_API);
+        var originalScoreAnalysis =
+                scoreDirector.buildScoreAnalysis(fetchPolicy, InnerScoreDirector.ScoreAnalysisMode.RECOMMENDATION_API);
         var clonedElement = scoreDirector.lookUpWorkingObject(originalElement);
         var processor = new AssignmentProcessor<>(solverFactory, propositionFunction, recommendationConstructor, fetchPolicy,
                 clonedElement, originalScoreAnalysis);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/AssignmentProcessor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/AssignmentProcessor.java
@@ -153,7 +153,7 @@ final class AssignmentProcessor<Solution_, Score_ extends Score<Score_>, Recomme
             In_ clonedElement, Function<In_, Out_> propositionFunction) {
         try (var ephemeralMoveDirector = scoreDirector.getMoveDirector().ephemeral()) {
             move.execute(ephemeralMoveDirector);
-            var newScoreAnalysis = scoreDirector.buildScoreAnalysis(fetchPolicy == ScoreAnalysisFetchPolicy.FETCH_ALL);
+            var newScoreAnalysis = scoreDirector.buildScoreAnalysis(fetchPolicy);
             var newScoreDifference = newScoreAnalysis.diff(originalScoreAnalysis);
             var result = propositionFunction.apply(clonedElement);
             return recommendationConstructor.apply(moveIndex, result, newScoreDifference);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -66,7 +66,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
                 !isShadowVariableUpdateEnabled)) {
             nonNullSolution = cloneSolution ? scoreDirector.cloneSolution(nonNullSolution) : nonNullSolution;
             scoreDirector.setWorkingSolution(nonNullSolution);
-            if (enableConstraintMatch && !scoreDirector.isConstraintMatchEnabled()) {
+            if (enableConstraintMatch && !scoreDirector.getConstraintMatchPolicy().isEnabled()) {
                 throw new IllegalStateException("""
                         Requested constraint matching but score director doesn't support it.
                         Maybe use Constraint Streams instead of Easy or Incremental score calculator?""");

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -53,20 +53,19 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
                     + ".update() with this solutionUpdatePolicy (" + solutionUpdatePolicy + ").");
         }
         return callScoreDirector(solution, solutionUpdatePolicy,
-                s -> s.getSolutionDescriptor().getScore(s.getWorkingSolution()), false, false);
+                s -> s.getSolutionDescriptor().getScore(s.getWorkingSolution()), ConstraintMatchPolicy.DISABLED, false);
     }
 
     private <Result_> Result_ callScoreDirector(Solution_ solution,
             SolutionUpdatePolicy solutionUpdatePolicy, Function<InnerScoreDirector<Solution_, Score_>, Result_> function,
-            boolean enableConstraintMatch, boolean cloneSolution) {
+            ConstraintMatchPolicy constraintMatchPolicy, boolean cloneSolution) {
         var isShadowVariableUpdateEnabled = solutionUpdatePolicy.isShadowVariableUpdateEnabled();
         var nonNullSolution = Objects.requireNonNull(solution);
-        try (var scoreDirector = getScoreDirectorFactory().buildScoreDirector(cloneSolution,
-                enableConstraintMatch ? ConstraintMatchPolicy.ENABLED : ConstraintMatchPolicy.DISABLED,
+        try (var scoreDirector = getScoreDirectorFactory().buildScoreDirector(cloneSolution, constraintMatchPolicy,
                 !isShadowVariableUpdateEnabled)) {
             nonNullSolution = cloneSolution ? scoreDirector.cloneSolution(nonNullSolution) : nonNullSolution;
             scoreDirector.setWorkingSolution(nonNullSolution);
-            if (enableConstraintMatch && !scoreDirector.getConstraintMatchPolicy().isEnabled()) {
+            if (constraintMatchPolicy.isEnabled() && !scoreDirector.getConstraintMatchPolicy().isEnabled()) {
                 throw new IllegalStateException("""
                         Requested constraint matching but score director doesn't support it.
                         Maybe use Constraint Streams instead of Easy or Incremental score calculator?""");
@@ -86,7 +85,8 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
     public @NonNull ScoreExplanation<Solution_, Score_> explain(@NonNull Solution_ solution,
             @NonNull SolutionUpdatePolicy solutionUpdatePolicy) {
         var currentScore = (Score_) scoreDirectorFactory.getSolutionDescriptor().getScore(solution);
-        var explanation = callScoreDirector(solution, solutionUpdatePolicy, DefaultScoreExplanation::new, true, false);
+        var explanation = callScoreDirector(solution, solutionUpdatePolicy, DefaultScoreExplanation::new,
+                ConstraintMatchPolicy.ENABLED, false);
         assertFreshScore(solution, currentScore, explanation.getScore(), solutionUpdatePolicy);
         return explanation;
     }
@@ -116,7 +116,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
         Objects.requireNonNull(fetchPolicy, "fetchPolicy");
         var currentScore = (Score_) scoreDirectorFactory.getSolutionDescriptor().getScore(solution);
         var analysis = callScoreDirector(solution, solutionUpdatePolicy,
-                scoreDirector -> scoreDirector.buildScoreAnalysis(fetchPolicy), true,
+                scoreDirector -> scoreDirector.buildScoreAnalysis(fetchPolicy), ConstraintMatchPolicy.match(fetchPolicy),
                 false);
         assertFreshScore(solution, currentScore, analysis.score(), solutionUpdatePolicy);
         return analysis;
@@ -128,7 +128,8 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
             @NonNull ScoreAnalysisFetchPolicy fetchPolicy) {
         var assigner = new Assigner<Solution_, Score_, RecommendedAssignment<Out_, Score_>, In_, Out_>(solverFactory,
                 propositionFunction, DefaultRecommendedAssignment::new, fetchPolicy, solution, evaluatedEntityOrElement);
-        return callScoreDirector(solution, SolutionUpdatePolicy.UPDATE_ALL, assigner, true, true);
+        return callScoreDirector(solution, SolutionUpdatePolicy.UPDATE_ALL, assigner, ConstraintMatchPolicy.match(fetchPolicy),
+                true);
     }
 
     @Override
@@ -136,7 +137,8 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
             Function<In_, Out_> propositionFunction, ScoreAnalysisFetchPolicy fetchPolicy) {
         var assigner = new Assigner<Solution_, Score_, RecommendedFit<Out_, Score_>, In_, Out_>(solverFactory,
                 propositionFunction, DefaultRecommendedFit::new, fetchPolicy, solution, fittedEntityOrElement);
-        return callScoreDirector(solution, SolutionUpdatePolicy.UPDATE_ALL, assigner, true, true);
+        return callScoreDirector(solution, SolutionUpdatePolicy.UPDATE_ALL, assigner, ConstraintMatchPolicy.match(fetchPolicy),
+                true);
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -17,6 +17,7 @@ import ai.timefold.solver.core.api.solver.SolverFactory;
 import ai.timefold.solver.core.api.solver.SolverManager;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.score.DefaultScoreExplanation;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirectorFactory;
 
@@ -60,7 +61,8 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
             boolean enableConstraintMatch, boolean cloneSolution) {
         var isShadowVariableUpdateEnabled = solutionUpdatePolicy.isShadowVariableUpdateEnabled();
         var nonNullSolution = Objects.requireNonNull(solution);
-        try (var scoreDirector = getScoreDirectorFactory().buildScoreDirector(cloneSolution, enableConstraintMatch,
+        try (var scoreDirector = getScoreDirectorFactory().buildScoreDirector(cloneSolution,
+                enableConstraintMatch ? ConstraintMatchPolicy.ENABLED : ConstraintMatchPolicy.DISABLED,
                 !isShadowVariableUpdateEnabled)) {
             nonNullSolution = cloneSolution ? scoreDirector.cloneSolution(nonNullSolution) : nonNullSolution;
             scoreDirector.setWorkingSolution(nonNullSolution);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -114,7 +114,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
         Objects.requireNonNull(fetchPolicy, "fetchPolicy");
         var currentScore = (Score_) scoreDirectorFactory.getSolutionDescriptor().getScore(solution);
         var analysis = callScoreDirector(solution, solutionUpdatePolicy,
-                scoreDirector -> scoreDirector.buildScoreAnalysis(fetchPolicy == ScoreAnalysisFetchPolicy.FETCH_ALL), true,
+                scoreDirector -> scoreDirector.buildScoreAnalysis(fetchPolicy), true,
                 false);
         assertFreshScore(solution, currentScore, analysis.score(), solutionUpdatePolicy);
         return analysis;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -30,6 +30,7 @@ import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescr
 import ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicy;
 import ai.timefold.solver.core.impl.phase.Phase;
 import ai.timefold.solver.core.impl.phase.PhaseFactory;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactoryFactory;
 import ai.timefold.solver.core.impl.solver.change.DefaultProblemChangeDirector;
@@ -104,7 +105,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
                     metricsRequiringConstraintMatchSet);
         }
 
-        var castScoreDirector = scoreDirectorFactory.buildScoreDirector(true, constraintMatchEnabled);
+        var castScoreDirector = scoreDirectorFactory.buildScoreDirector(true, ConstraintMatchPolicy.ENABLED);
         solverScope.setScoreDirector(castScoreDirector);
         solverScope.setProblemChangeDirector(new DefaultProblemChangeDirector<>(castScoreDirector));
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -105,7 +105,8 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
                     metricsRequiringConstraintMatchSet);
         }
 
-        var castScoreDirector = scoreDirectorFactory.buildScoreDirector(true, ConstraintMatchPolicy.ENABLED);
+        var castScoreDirector = scoreDirectorFactory.buildScoreDirector(true,
+                constraintMatchEnabled ? ConstraintMatchPolicy.ENABLED : ConstraintMatchPolicy.DISABLED);
         solverScope.setScoreDirector(castScoreDirector);
         solverScope.setProblemChangeDirector(new DefaultProblemChangeDirector<>(castScoreDirector));
 

--- a/core/src/test/java/ai/timefold/solver/core/api/score/analysis/ScoreAnalysisTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/analysis/ScoreAnalysisTest.java
@@ -1,5 +1,8 @@
 package ai.timefold.solver.core.api.score.analysis;
 
+import static ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy.FETCH_ALL;
+import static ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy.FETCH_MATCH_COUNT;
+import static ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy.FETCH_SHALLOW;
 import static ai.timefold.solver.core.impl.score.director.InnerScoreDirector.getConstraintAnalysis;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -12,6 +15,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.constraint.ConstraintRef;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
+import ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy;
 import ai.timefold.solver.core.impl.score.constraint.DefaultConstraintMatchTotal;
 
 import org.junit.jupiter.api.Test;
@@ -61,9 +65,12 @@ class ScoreAnalysisTest {
         addConstraintMatch(constraintMatchTotal2, SimpleScore.of(12));
         var emptyConstraintMatchTotal1 = new DefaultConstraintMatchTotal<>(constraintId3, SimpleScore.of(0));
         var constraintAnalysisMap = Map.of(
-                constraintMatchTotal.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal, true),
-                constraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal2, true),
-                emptyConstraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(emptyConstraintMatchTotal1, true));
+                constraintMatchTotal.getConstraintRef(),
+                getConstraintAnalysis(constraintMatchTotal, ScoreAnalysisFetchPolicy.FETCH_ALL),
+                constraintMatchTotal2.getConstraintRef(),
+                getConstraintAnalysis(constraintMatchTotal2, ScoreAnalysisFetchPolicy.FETCH_ALL),
+                emptyConstraintMatchTotal1.getConstraintRef(),
+                getConstraintAnalysis(emptyConstraintMatchTotal1, ScoreAnalysisFetchPolicy.FETCH_ALL));
         var scoreAnalysis = new ScoreAnalysis<>(SimpleScore.of(67), constraintAnalysisMap);
 
         // Single constraint analysis
@@ -111,8 +118,10 @@ class ScoreAnalysisTest {
         var constraintMatchTotal = new DefaultConstraintMatchTotal<>(constraintId1, SimpleScore.of(0));
         var constraintMatchTotal2 = new DefaultConstraintMatchTotal<>(constraintId2, SimpleScore.of(0));
         var constraintAnalysisMap = Map.of(
-                constraintMatchTotal.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal, true),
-                constraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal2, true));
+                constraintMatchTotal.getConstraintRef(),
+                getConstraintAnalysis(constraintMatchTotal, ScoreAnalysisFetchPolicy.FETCH_ALL),
+                constraintMatchTotal2.getConstraintRef(),
+                getConstraintAnalysis(constraintMatchTotal2, ScoreAnalysisFetchPolicy.FETCH_ALL));
         var scoreAnalysis = new ScoreAnalysis<>(SimpleScore.ofUninitialized(3, 0), constraintAnalysisMap);
 
         // Single constraint analysis
@@ -145,14 +154,14 @@ class ScoreAnalysisTest {
         var constraintMatchTotal = new DefaultConstraintMatchTotal<>(constraintId1, SimpleScore.of(1));
         addConstraintMatch(constraintMatchTotal, SimpleScore.of(2), "A", "B", "C");
         var constraintAnalysisMap = Map.of(
-                constraintMatchTotal.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal, false));
+                constraintMatchTotal.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal, FETCH_SHALLOW));
         var scoreAnalysis = new ScoreAnalysis<>(SimpleScore.of(3), constraintAnalysisMap);
 
         assertThatThrownBy(scoreAnalysis::summarize)
                 .hasMessageContaining("The constraint matches must be non-null");
 
-        assertThatThrownBy(() -> constraintAnalysisMap.values().stream().findFirst().get().matchCount())
-                .hasMessageContaining("The constraint matches must be non-null");
+        assertThat(constraintAnalysisMap.values().stream().findFirst().get().matchCount())
+                .isEqualTo(-1);
     }
 
     @Test
@@ -177,9 +186,10 @@ class ScoreAnalysisTest {
         addConstraintMatch(constraintMatchTotal2, SimpleScore.of(12));
         var emptyConstraintMatchTotal1 = new DefaultConstraintMatchTotal<>(constraintId3, SimpleScore.of(0));
         var constraintAnalysisMap1 = Map.of(
-                constraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal1, false),
-                constraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal2, false),
-                emptyConstraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(emptyConstraintMatchTotal1, false));
+                constraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal1, FETCH_SHALLOW),
+                constraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal2, FETCH_SHALLOW),
+                emptyConstraintMatchTotal1.getConstraintRef(),
+                getConstraintAnalysis(emptyConstraintMatchTotal1, FETCH_SHALLOW));
         var scoreAnalysis1 = new ScoreAnalysis<>(SimpleScore.of(50), constraintAnalysisMap1);
 
         var emptyConstraintMatchTotal2 = new DefaultConstraintMatchTotal<>(constraintId1, SimpleScore.of(0));
@@ -193,9 +203,9 @@ class ScoreAnalysisTest {
         addConstraintMatch(constraintMatchTotal4, SimpleScore.of(9), "C", "D");
         addConstraintMatch(constraintMatchTotal4, SimpleScore.of(12));
         var constraintAnalysisMap2 = Map.of(
-                emptyConstraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(emptyConstraintMatchTotal2, false),
-                constraintMatchTotal3.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal3, false),
-                constraintMatchTotal4.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal4, false));
+                emptyConstraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(emptyConstraintMatchTotal2, FETCH_SHALLOW),
+                constraintMatchTotal3.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal3, FETCH_SHALLOW),
+                constraintMatchTotal4.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal4, FETCH_SHALLOW));
         var scoreAnalysis2 = new ScoreAnalysis<>(SimpleScore.of(42), constraintAnalysisMap2);
 
         var comparison = scoreAnalysis1.diff(scoreAnalysis2);
@@ -252,6 +262,110 @@ class ScoreAnalysisTest {
     }
 
     @Test
+    void compareWithConstraintMatchesWithMatchCountOnly() {
+        var constraintPackage = "constraintPackage";
+        var constraintName1 = "constraint1";
+        var constraintName2 = "constraint2";
+        var constraintName3 = "constraint3";
+        var constraintId1 = ConstraintRef.of(constraintPackage, constraintName1);
+        var constraintId2 = ConstraintRef.of(constraintPackage, constraintName2);
+        var constraintId3 = ConstraintRef.of(constraintPackage, constraintName3);
+
+        var constraintMatchTotal1 = new DefaultConstraintMatchTotal<>(constraintId1, SimpleScore.of(1));
+        addConstraintMatch(constraintMatchTotal1, SimpleScore.of(2), "A", "B", "C");
+        addConstraintMatch(constraintMatchTotal1, SimpleScore.of(4), "A", "B");
+        addConstraintMatch(constraintMatchTotal1, SimpleScore.of(6), "B", "C");
+        addConstraintMatch(constraintMatchTotal1, SimpleScore.of(8));
+        var constraintMatchTotal2 = new DefaultConstraintMatchTotal<>(constraintId2, SimpleScore.of(3));
+        addConstraintMatch(constraintMatchTotal2, SimpleScore.of(3), "B", "C", "D");
+        addConstraintMatch(constraintMatchTotal2, SimpleScore.of(6), "B", "C");
+        addConstraintMatch(constraintMatchTotal2, SimpleScore.of(9), "C", "D");
+        addConstraintMatch(constraintMatchTotal2, SimpleScore.of(12));
+        var emptyConstraintMatchTotal1 = new DefaultConstraintMatchTotal<>(constraintId3, SimpleScore.of(0));
+        var constraintAnalysisMap1 = Map.of(
+                constraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal1, FETCH_MATCH_COUNT),
+                constraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal2, FETCH_MATCH_COUNT),
+                emptyConstraintMatchTotal1.getConstraintRef(),
+                getConstraintAnalysis(emptyConstraintMatchTotal1, FETCH_MATCH_COUNT));
+        var scoreAnalysis1 = new ScoreAnalysis<>(SimpleScore.of(50), constraintAnalysisMap1);
+
+        var emptyConstraintMatchTotal2 = new DefaultConstraintMatchTotal<>(constraintId1, SimpleScore.of(0));
+        var constraintMatchTotal3 = new DefaultConstraintMatchTotal<>(constraintId2, SimpleScore.of(2));
+        addConstraintMatch(constraintMatchTotal3, SimpleScore.of(2), "A", "B", "C");
+        addConstraintMatch(constraintMatchTotal3, SimpleScore.of(4), "B", "C");
+        addConstraintMatch(constraintMatchTotal3, SimpleScore.of(6), "A", "B");
+        var constraintMatchTotal4 = new DefaultConstraintMatchTotal<>(constraintId3, SimpleScore.of(3));
+        addConstraintMatch(constraintMatchTotal4, SimpleScore.of(3), "B", "C", "D");
+        addConstraintMatch(constraintMatchTotal4, SimpleScore.of(6), "B", "C");
+        addConstraintMatch(constraintMatchTotal4, SimpleScore.of(9), "C", "D");
+        addConstraintMatch(constraintMatchTotal4, SimpleScore.of(12));
+        var constraintAnalysisMap2 = Map.of(
+                emptyConstraintMatchTotal2.getConstraintRef(),
+                getConstraintAnalysis(emptyConstraintMatchTotal2, FETCH_MATCH_COUNT),
+                constraintMatchTotal3.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal3, FETCH_MATCH_COUNT),
+                constraintMatchTotal4.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal4, FETCH_MATCH_COUNT));
+        var scoreAnalysis2 = new ScoreAnalysis<>(SimpleScore.of(42), constraintAnalysisMap2);
+
+        var comparison = scoreAnalysis1.diff(scoreAnalysis2);
+        assertSoftly(softly -> {
+            softly.assertThat(comparison.score()).isEqualTo(SimpleScore.of(8));
+            softly.assertThat(comparison.constraintMap())
+                    .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal2.getConstraintRef(),
+                            constraintMatchTotal4.getConstraintRef());
+        });
+        // Matches for constraint1 not present.
+        var constraintAnalysis1 = comparison.getConstraintAnalysis(constraintName1);
+        assertSoftly(softly -> {
+            softly.assertThat(constraintAnalysis1.score()).isEqualTo(SimpleScore.of(20));
+            softly.assertThat(constraintAnalysis1.matches()).isNull();
+            softly.assertThat(constraintAnalysis1.matchCount()).isGreaterThan(0);
+        });
+        // Matches for constraint2 still not present.
+        var constraintAnalysis2 = comparison.getConstraintAnalysis(constraintName2);
+        assertSoftly(softly -> {
+            softly.assertThat(constraintAnalysis2.score()).isEqualTo(SimpleScore.of(18));
+            softly.assertThat(constraintAnalysis2.matches()).isNull();
+            softly.assertThat(constraintAnalysis2.matchCount()).isGreaterThan(0);
+        });
+        // Matches for constraint3 not present.
+        var constraintAnalysis3 = comparison.getConstraintAnalysis(constraintName3);
+        assertSoftly(softly -> {
+            softly.assertThat(constraintAnalysis3.score()).isEqualTo(SimpleScore.of(-30));
+            softly.assertThat(constraintAnalysis3.matches()).isNull();
+            softly.assertThat(constraintAnalysis3.matchCount()).isLessThan(0);
+        });
+
+        var reverseComparison = scoreAnalysis2.diff(scoreAnalysis1);
+        assertSoftly(softly -> {
+            softly.assertThat(reverseComparison.score()).isEqualTo(SimpleScore.of(-8));
+            softly.assertThat(reverseComparison.constraintMap())
+                    .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal3.getConstraintRef(),
+                            constraintMatchTotal4.getConstraintRef());
+        });
+        // Matches for constraint1 not present.
+        var reverseConstraintAnalysis1 = reverseComparison.getConstraintAnalysis(constraintName1);
+        assertSoftly(softly -> {
+            softly.assertThat(reverseConstraintAnalysis1.score()).isEqualTo(SimpleScore.of(-20));
+            softly.assertThat(reverseConstraintAnalysis1.matches()).isNull();
+            softly.assertThat(reverseConstraintAnalysis1.matchCount()).isLessThan(0);
+        });
+        // Matches for constraint2 still not present.
+        var reverseConstraintAnalysis2 = reverseComparison.getConstraintAnalysis(constraintName2);
+        assertSoftly(softly -> {
+            softly.assertThat(reverseConstraintAnalysis2.score()).isEqualTo(SimpleScore.of(-18));
+            softly.assertThat(reverseConstraintAnalysis2.matches()).isNull();
+            softly.assertThat(reverseConstraintAnalysis2.matchCount()).isLessThan(0);
+        });
+        // Matches for constraint3 not present in reverse.
+        var reverseConstraintAnalysis3 = reverseComparison.getConstraintAnalysis(constraintName3);
+        assertSoftly(softly -> {
+            softly.assertThat(reverseConstraintAnalysis3.score()).isEqualTo(SimpleScore.of(30));
+            softly.assertThat(reverseConstraintAnalysis3.matches()).isNull();
+            softly.assertThat(reverseConstraintAnalysis3.matchCount()).isGreaterThan(0);
+        });
+    }
+
+    @Test
     void compareWithConstraintMatchesAndMatchAnalysis() {
         var constraintPackage = "constraintPackage";
         var constraintName1 = "constraint1";
@@ -273,9 +387,9 @@ class ScoreAnalysisTest {
         addConstraintMatch(constraintMatchTotal2, SimpleScore.of(12));
         var emptyConstraintMatchTotal1 = new DefaultConstraintMatchTotal<>(constraintId3, SimpleScore.of(0));
         var constraintAnalysisMap1 = Map.of(
-                constraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal1, true),
-                constraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal2, true),
-                emptyConstraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(emptyConstraintMatchTotal1, true));
+                constraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal1, FETCH_ALL),
+                constraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal2, FETCH_ALL),
+                emptyConstraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(emptyConstraintMatchTotal1, FETCH_ALL));
         var scoreAnalysis1 = new ScoreAnalysis<>(SimpleScore.of(50), constraintAnalysisMap1);
 
         var emptyConstraintMatchTotal2 = new DefaultConstraintMatchTotal<>(constraintId1, SimpleScore.of(0));
@@ -289,9 +403,9 @@ class ScoreAnalysisTest {
         addConstraintMatch(constraintMatchTotal4, SimpleScore.of(9), "C", "D");
         addConstraintMatch(constraintMatchTotal4, SimpleScore.of(12));
         var constraintAnalysisMap2 = Map.of(
-                emptyConstraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(emptyConstraintMatchTotal2, true),
-                constraintMatchTotal3.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal3, true),
-                constraintMatchTotal4.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal4, true));
+                emptyConstraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(emptyConstraintMatchTotal2, FETCH_ALL),
+                constraintMatchTotal3.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal3, FETCH_ALL),
+                constraintMatchTotal4.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal4, FETCH_ALL));
         var scoreAnalysis2 = new ScoreAnalysis<>(SimpleScore.of(42), constraintAnalysisMap2);
 
         var comparison = scoreAnalysis1.diff(scoreAnalysis2);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/ConstraintWeightOverridesTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/ConstraintWeightOverridesTest.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.constraint.ConstraintRef;
 import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.stream.BavetConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.core.impl.testdata.domain.constraintweightoverrides.TestdataConstraintWeightOverridesConstraintProvider;
 import ai.timefold.solver.core.impl.testdata.domain.constraintweightoverrides.TestdataConstraintWeightOverridesSolution;
@@ -80,7 +81,7 @@ class ConstraintWeightOverridesTest {
                 new ScoreDirectorFactoryConfig()
                         .withConstraintProviderClass(TestdataConstraintWeightOverridesConstraintProvider.class),
                 EnvironmentMode.REPRODUCIBLE)
-                .buildScoreDirector(false, false)) {
+                .buildScoreDirector(false, ConstraintMatchPolicy.DISABLED)) {
             // Default weights
             scoreDirector.setWorkingSolution(solution);
             scoreDirector.triggerVariableListeners();

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/ChangeMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/ChangeMoveTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.easy.EasyScoreDirectorFactory;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
@@ -60,7 +61,8 @@ class ChangeMoveTest {
         ScoreDirectorFactory<TestdataEntityProvidingSolution> scoreDirectorFactory =
                 new EasyScoreDirectorFactory<>(TestdataEntityProvidingSolution.buildSolutionDescriptor(),
                         solution -> SimpleScore.ZERO);
-        ScoreDirector<TestdataEntityProvidingSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector();
+        ScoreDirector<TestdataEntityProvidingSolution> scoreDirector =
+                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
 
         GenuineVariableDescriptor<TestdataEntityProvidingSolution> variableDescriptor =
                 TestdataEntityProvidingEntity.buildVariableDescriptorForValue();

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/PillarChangeMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/PillarChangeMoveTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.easy.EasyScoreDirectorFactory;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
@@ -75,7 +76,8 @@ class PillarChangeMoveTest {
         ScoreDirectorFactory<TestdataEntityProvidingSolution> scoreDirectorFactory =
                 new EasyScoreDirectorFactory<>(TestdataEntityProvidingSolution.buildSolutionDescriptor(),
                         solution -> SimpleScore.ZERO);
-        ScoreDirector<TestdataEntityProvidingSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector();
+        ScoreDirector<TestdataEntityProvidingSolution> scoreDirector =
+                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
         GenuineVariableDescriptor<TestdataEntityProvidingSolution> variableDescriptor = TestdataEntityProvidingEntity
                 .buildVariableDescriptorForValue();
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/PillarSwapMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/PillarSwapMoveTest.java
@@ -12,6 +12,7 @@ import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.easy.EasyScoreDirectorFactory;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
@@ -128,7 +129,8 @@ class PillarSwapMoveTest {
         ScoreDirectorFactory<TestdataEntityProvidingSolution> scoreDirectorFactory =
                 new EasyScoreDirectorFactory<>(TestdataEntityProvidingSolution.buildSolutionDescriptor(),
                         solution -> SimpleScore.ZERO);
-        ScoreDirector<TestdataEntityProvidingSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector();
+        ScoreDirector<TestdataEntityProvidingSolution> scoreDirector =
+                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
         List<GenuineVariableDescriptor<TestdataEntityProvidingSolution>> variableDescriptorList = TestdataEntityProvidingEntity
                 .buildEntityDescriptor().getGenuineVariableDescriptorList();
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveTest.java
@@ -12,6 +12,7 @@ import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.easy.EasyScoreDirectorFactory;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
@@ -103,7 +104,8 @@ class SwapMoveTest {
         ScoreDirectorFactory<TestdataEntityProvidingSolution> scoreDirectorFactory =
                 new EasyScoreDirectorFactory<>(TestdataEntityProvidingSolution.buildSolutionDescriptor(),
                         solution -> SimpleScore.ZERO);
-        ScoreDirector<TestdataEntityProvidingSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector();
+        ScoreDirector<TestdataEntityProvidingSolution> scoreDirector =
+                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
         EntityDescriptor<TestdataEntityProvidingSolution> entityDescriptor = TestdataEntityProvidingEntity
                 .buildEntityDescriptor();
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorSemanticsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorSemanticsTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.constraintconfiguration.TestdataConstraintConfiguration;
 import ai.timefold.solver.core.impl.testdata.domain.constraintconfiguration.TestdataConstraintConfigurationSolution;
@@ -46,7 +47,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
         TestdataConstraintConfigurationSolution solution1 =
                 TestdataConstraintConfigurationSolution.generateSolution(1, 1);
         InnerScoreDirector<TestdataConstraintConfigurationSolution, SimpleScore> scoreDirector1 =
-                scoreDirectorFactory.buildScoreDirector(false, false);
+                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
         scoreDirector1.setWorkingSolution(solution1);
         SimpleScore score1 = scoreDirector1.calculateScore();
         assertThat(score1).isEqualTo(SimpleScore.of(1));
@@ -55,7 +56,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
         TestdataConstraintConfigurationSolution solution2 =
                 TestdataConstraintConfigurationSolution.generateSolution(2, 2);
         InnerScoreDirector<TestdataConstraintConfigurationSolution, SimpleScore> scoreDirector2 =
-                scoreDirectorFactory.buildScoreDirector(false, false);
+                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
         scoreDirector2.setWorkingSolution(solution2);
         SimpleScore score2 = scoreDirector2.calculateScore();
         assertThat(score2).isEqualTo(SimpleScore.of(2));
@@ -90,7 +91,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
         TestdataConstraintConfigurationSolution solution1 =
                 TestdataConstraintConfigurationSolution.generateSolution(1, 1);
         InnerScoreDirector<TestdataConstraintConfigurationSolution, SimpleScore> scoreDirector =
-                scoreDirectorFactory.buildScoreDirector(false, false);
+                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
         scoreDirector.setWorkingSolution(solution1);
         SimpleScore score1 = scoreDirector.calculateScore();
         assertThat(score1).isEqualTo(SimpleScore.of(1));
@@ -121,7 +122,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
         TestdataConstraintConfigurationSolution solution =
                 TestdataConstraintConfigurationSolution.generateSolution(1, 1);
         InnerScoreDirector<TestdataConstraintConfigurationSolution, SimpleScore> scoreDirector =
-                scoreDirectorFactory.buildScoreDirector(false, false);
+                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
         scoreDirector.setWorkingSolution(solution);
         SimpleScore score1 = scoreDirector.calculateScore();
         assertThat(score1).isEqualTo(SimpleScore.of(1));
@@ -144,7 +145,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
 
         // Create score director, calculate score with a given constraint configuration.
         var solution = TestdataConstraintConfigurationSolution.generateSolution(1, 1);
-        try (var scoreDirector = scoreDirectorFactory.buildScoreDirector(false, true)) {
+        try (var scoreDirector = scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.ENABLED)) {
             scoreDirector.setWorkingSolution(solution);
             var score1 = scoreDirector.calculateScore();
             assertSoftly(softly -> {
@@ -177,7 +178,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
         firstEntity.setValueList(List.of(solution.getValueList().get(0)));
         firstEntity.setPinned(true);
 
-        try (var scoreDirector = scoreDirectorFactory.buildScoreDirector(false, false)) {
+        try (var scoreDirector = scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED)) {
             scoreDirector.setWorkingSolution(solution);
             var score1 = scoreDirector.calculateScore();
             assertThat(score1).isEqualTo(SimpleScore.ofUninitialized(-1, -2));
@@ -205,7 +206,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
         secondEntity.setValueList(List.of(solution.getValueList().get(1)));
         secondEntity.setPlanningPinToIndex(1);
 
-        try (var scoreDirector = scoreDirectorFactory.buildScoreDirector(false, false)) {
+        try (var scoreDirector = scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED)) {
             scoreDirector.setWorkingSolution(solution);
             var score1 = scoreDirector.calculateScore();
             assertThat(score1).isEqualTo(SimpleScore.ofUninitialized(-1, -3));

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/ScoreDirectorFactoryFactoryTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/ScoreDirectorFactoryFactoryTest.java
@@ -15,6 +15,7 @@ import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
 import ai.timefold.solver.core.api.score.stream.ConstraintStreamImplType;
 import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.incremental.IncrementalScoreDirector;
 import ai.timefold.solver.core.impl.score.director.stream.BavetConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
@@ -36,7 +37,8 @@ class ScoreDirectorFactoryFactoryTest {
 
         ScoreDirectorFactory<TestdataSolution> scoreDirectorFactory = buildTestdataScoreDirectoryFactory(config);
         IncrementalScoreDirector<TestdataSolution, ?> scoreDirector =
-                (IncrementalScoreDirector<TestdataSolution, ?>) scoreDirectorFactory.buildScoreDirector();
+                (IncrementalScoreDirector<TestdataSolution, ?>) scoreDirectorFactory.buildScoreDirector(false,
+                        ConstraintMatchPolicy.DISABLED);
         TestCustomPropertiesIncrementalScoreCalculator scoreCalculator =
                 (TestCustomPropertiesIncrementalScoreCalculator) scoreDirector
                         .getIncrementalScoreCalculator();
@@ -59,7 +61,8 @@ class ScoreDirectorFactoryFactoryTest {
         ScoreDirectorFactory<TestdataSolution> assertionScoreDirectorFactory =
                 scoreDirectorFactory.getAssertionScoreDirectorFactory();
         IncrementalScoreDirector<TestdataSolution, ?> assertionScoreDirector =
-                (IncrementalScoreDirector<TestdataSolution, ?>) assertionScoreDirectorFactory.buildScoreDirector();
+                (IncrementalScoreDirector<TestdataSolution, ?>) assertionScoreDirectorFactory.buildScoreDirector(false,
+                        ConstraintMatchPolicy.DISABLED);
         IncrementalScoreCalculator<TestdataSolution, ?> assertionScoreCalculator =
                 assertionScoreDirector.getIncrementalScoreCalculator();
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactoryTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorFactoryTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ class EasyScoreDirectorFactoryTest {
         EasyScoreDirectorFactory<TestdataSolution, SimpleScore> directorFactory = new EasyScoreDirectorFactory<>(
                 solutionDescriptor, scoreCalculator);
 
-        try (var director = directorFactory.buildScoreDirector(false, false)) {
+        try (var director = directorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED)) {
             TestdataSolution solution = new TestdataSolution();
             solution.setValueList(Collections.emptyList());
             solution.setEntityList(Collections.emptyList());

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorSemanticsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorSemanticsTest.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
 import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirectorSemanticsTest;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
@@ -70,7 +71,8 @@ final class EasyScoreDirectorSemanticsTest extends AbstractScoreDirectorSemantic
         config.setEasyScoreCalculatorCustomProperties(customProperties);
 
         EasyScoreDirector<TestdataSolution, ?> scoreDirector =
-                (EasyScoreDirector<TestdataSolution, ?>) buildTestdataScoreDirectoryFactory(config).buildScoreDirector();
+                (EasyScoreDirector<TestdataSolution, ?>) buildTestdataScoreDirectoryFactory(config)
+                        .buildScoreDirector(false, ConstraintMatchPolicy.DISABLED);
         TestCustomPropertiesEasyScoreCalculator scoreCalculator =
                 (TestCustomPropertiesEasyScoreCalculator) scoreDirector
                         .getEasyScoreCalculator();

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
@@ -25,7 +25,7 @@ class EasyScoreDirectorTest {
     void constraintMatchTotalsUnsupported() {
         EasyScoreDirector<Object, ?> director =
                 new EasyScoreDirector<>(mockEasyScoreDirectorFactory(), false, ConstraintMatchPolicy.ENABLED, true, null);
-        assertThat(director.isConstraintMatchEnabled()).isFalse();
+        assertThat(director.getConstraintMatchPolicy()).isEqualTo(ConstraintMatchPolicy.DISABLED);
         assertThatIllegalStateException()
                 .isThrownBy(director::getConstraintMatchTotalMap)
                 .withMessageContaining("not supported");

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
@@ -22,7 +22,7 @@ class EasyScoreDirectorTest {
                 (solution_) -> SimpleScore.of(0));
         scoreDirectorFactory
                 .setInitializingScoreTrend(InitializingScoreTrend.buildUniformTrend(InitializingScoreTrendLevel.ONLY_DOWN, 1));
-        try (var scoreDirector = scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED, true)) {
+        try (var scoreDirector = scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED)) {
             var solution = new TestdataCorruptedShadowedSolution("s1");
             var v1 = new TestdataValue("v1");
             var v2 = new TestdataValue("v2");

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.config.score.trend.InitializingScoreTrendLevel;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.trend.InitializingScoreTrend;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 import ai.timefold.solver.core.impl.testdata.domain.shadow.corrupted.TestdataCorruptedShadowedEntity;
@@ -23,7 +24,7 @@ class EasyScoreDirectorTest {
     @Test
     void constraintMatchTotalsUnsupported() {
         EasyScoreDirector<Object, ?> director =
-                new EasyScoreDirector<>(mockEasyScoreDirectorFactory(), false, true, true, null);
+                new EasyScoreDirector<>(mockEasyScoreDirectorFactory(), false, ConstraintMatchPolicy.ENABLED, true, null);
         assertThat(director.isConstraintMatchEnabled()).isFalse();
         assertThatIllegalStateException()
                 .isThrownBy(director::getConstraintMatchTotalMap)
@@ -45,7 +46,7 @@ class EasyScoreDirectorTest {
         scoreDirectorFactory.setInitializingScoreTrend(
                 InitializingScoreTrend.buildUniformTrend(InitializingScoreTrendLevel.ONLY_DOWN, 1));
         EasyScoreDirector<TestdataCorruptedShadowedSolution, SimpleScore> scoreDirector =
-                scoreDirectorFactory.buildScoreDirector(false, false, true);
+                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED, true);
 
         TestdataCorruptedShadowedSolution solution = new TestdataCorruptedShadowedSolution("s1");
         TestdataValue v1 = new TestdataValue("v1");

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirectorTest.java
@@ -1,16 +1,11 @@
 package ai.timefold.solver.core.impl.score.director.easy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.config.score.trend.InitializingScoreTrendLevel;
-import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.trend.InitializingScoreTrend;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
@@ -22,51 +17,32 @@ import org.junit.jupiter.api.Test;
 class EasyScoreDirectorTest {
 
     @Test
-    void constraintMatchTotalsUnsupported() {
-        EasyScoreDirector<Object, ?> director =
-                new EasyScoreDirector<>(mockEasyScoreDirectorFactory(), false, ConstraintMatchPolicy.ENABLED, true, null);
-        assertThat(director.getConstraintMatchPolicy()).isEqualTo(ConstraintMatchPolicy.DISABLED);
-        assertThatIllegalStateException()
-                .isThrownBy(director::getConstraintMatchTotalMap)
-                .withMessageContaining("not supported");
-    }
-
-    @SuppressWarnings("unchecked")
-    private EasyScoreDirectorFactory<Object, ?> mockEasyScoreDirectorFactory() {
-        EasyScoreDirectorFactory<Object, ?> factory = mock(EasyScoreDirectorFactory.class);
-        when(factory.getSolutionDescriptor()).thenReturn(mock(SolutionDescriptor.class));
-        return factory;
-    }
-
-    @Test
     void shadowVariableCorruption() {
-        EasyScoreDirectorFactory<TestdataCorruptedShadowedSolution, SimpleScore> scoreDirectorFactory =
-                new EasyScoreDirectorFactory<>(TestdataCorruptedShadowedSolution.buildSolutionDescriptor(),
-                        (solution_) -> SimpleScore.of(0));
-        scoreDirectorFactory.setInitializingScoreTrend(
-                InitializingScoreTrend.buildUniformTrend(InitializingScoreTrendLevel.ONLY_DOWN, 1));
-        EasyScoreDirector<TestdataCorruptedShadowedSolution, SimpleScore> scoreDirector =
-                scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED, true);
+        var scoreDirectorFactory = new EasyScoreDirectorFactory<>(TestdataCorruptedShadowedSolution.buildSolutionDescriptor(),
+                (solution_) -> SimpleScore.of(0));
+        scoreDirectorFactory
+                .setInitializingScoreTrend(InitializingScoreTrend.buildUniformTrend(InitializingScoreTrendLevel.ONLY_DOWN, 1));
+        try (var scoreDirector = scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED, true)) {
+            var solution = new TestdataCorruptedShadowedSolution("s1");
+            var v1 = new TestdataValue("v1");
+            var v2 = new TestdataValue("v2");
+            solution.setValueList(Arrays.asList(v1, v2));
+            var e1 = new TestdataCorruptedShadowedEntity("e1");
+            var e2 = new TestdataCorruptedShadowedEntity("e2");
+            solution.setEntityList(Arrays.asList(e1, e2));
+            scoreDirector.setWorkingSolution(solution);
 
-        TestdataCorruptedShadowedSolution solution = new TestdataCorruptedShadowedSolution("s1");
-        TestdataValue v1 = new TestdataValue("v1");
-        TestdataValue v2 = new TestdataValue("v2");
-        solution.setValueList(Arrays.asList(v1, v2));
-        TestdataCorruptedShadowedEntity e1 = new TestdataCorruptedShadowedEntity("e1");
-        TestdataCorruptedShadowedEntity e2 = new TestdataCorruptedShadowedEntity("e2");
-        solution.setEntityList(Arrays.asList(e1, e2));
-        scoreDirector.setWorkingSolution(solution);
-
-        scoreDirector.assertShadowVariablesAreNotStale(SimpleScore.ofUninitialized(-2, 0), "NoChange");
-        scoreDirector.beforeVariableChanged(e1, "value");
-        e1.setValue(v1);
-        scoreDirector.afterVariableChanged(e1, "value");
-        scoreDirector.beforeVariableChanged(e2, "value");
-        e2.setValue(v1);
-        scoreDirector.afterVariableChanged(e2, "value");
-        scoreDirector.triggerVariableListeners();
-        assertThatThrownBy(
-                () -> scoreDirector.assertShadowVariablesAreNotStale(SimpleScore.ofUninitialized(0, 0), "FirstChange"))
-                .isInstanceOf(IllegalStateException.class);
+            scoreDirector.assertShadowVariablesAreNotStale(SimpleScore.ofUninitialized(-2, 0), "NoChange");
+            scoreDirector.beforeVariableChanged(e1, "value");
+            e1.setValue(v1);
+            scoreDirector.afterVariableChanged(e1, "value");
+            scoreDirector.beforeVariableChanged(e2, "value");
+            e2.setValue(v1);
+            scoreDirector.afterVariableChanged(e2, "value");
+            scoreDirector.triggerVariableListeners();
+            assertThatThrownBy(
+                    () -> scoreDirector.assertShadowVariablesAreNotStale(SimpleScore.ofUninitialized(0, 0), "FirstChange"))
+                    .isInstanceOf(IllegalStateException.class);
+        }
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirectorTest.java
@@ -17,6 +17,7 @@ import ai.timefold.solver.core.api.score.calculator.ConstraintMatchAwareIncremen
 import ai.timefold.solver.core.api.score.calculator.IncrementalScoreCalculator;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.score.buildin.SimpleScoreDefinition;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.chained.shadow.TestdataShadowingChainedAnchor;
 import ai.timefold.solver.core.impl.testdata.domain.chained.shadow.TestdataShadowingChainedEntity;
 import ai.timefold.solver.core.impl.testdata.domain.chained.shadow.TestdataShadowingChainedSolution;
@@ -55,7 +56,8 @@ class IncrementalScoreDirectorTest {
                 mock(IncrementalScoreCalculator.class);
         when(incrementalScoreCalculator.calculateScore()).thenReturn(SimpleScore.of(100));
         try (var scoreDirector =
-                new IncrementalScoreDirector<>(scoreDirectorFactory, false, false, true, incrementalScoreCalculator)) {
+                new IncrementalScoreDirector<>(scoreDirectorFactory, false, ConstraintMatchPolicy.DISABLED, true,
+                        incrementalScoreCalculator)) {
             scoreDirector.setWorkingSolution(solution);
             reset(incrementalScoreCalculator);
 
@@ -78,18 +80,20 @@ class IncrementalScoreDirectorTest {
 
     @Test
     void illegalStateExceptionThrownWhenConstraintMatchNotEnabled() {
-        try (var director = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), false, false, true,
+        try (var director = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), false,
+                ConstraintMatchPolicy.DISABLED, true,
                 mockIncrementalScoreCalculator(false))) {
             director.setWorkingSolution(new Object());
             assertThatIllegalStateException()
                     .isThrownBy(director::getConstraintMatchTotalMap)
-                    .withMessageContaining("constraintMatchEnabled");
+                    .withMessageContaining(ConstraintMatchPolicy.DISABLED.name());
         }
     }
 
     @Test
     void constraintMatchTotalsNeverNull() {
-        try (var director = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), false, true, true,
+        try (var director = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), false,
+                ConstraintMatchPolicy.ENABLED, true,
                 mockIncrementalScoreCalculator(true))) {
             director.setWorkingSolution(new Object());
             assertThat(director.getConstraintMatchTotalMap()).isNotNull();
@@ -98,7 +102,8 @@ class IncrementalScoreDirectorTest {
 
     @Test
     void constraintMatchIsNotEnabledWhenScoreCalculatorNotConstraintMatchAware() {
-        try (var director = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), false, true, true,
+        try (var director = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), false,
+                ConstraintMatchPolicy.ENABLED, true,
                 mockIncrementalScoreCalculator(false))) {
             assertThat(director.isConstraintMatchEnabled()).isFalse();
         }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirectorTest.java
@@ -105,7 +105,7 @@ class IncrementalScoreDirectorTest {
         try (var director = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), false,
                 ConstraintMatchPolicy.ENABLED, true,
                 mockIncrementalScoreCalculator(false))) {
-            assertThat(director.isConstraintMatchEnabled()).isFalse();
+            assertThat(director.getConstraintMatchPolicy()).isEqualTo(ConstraintMatchPolicy.DISABLED);
         }
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetAdvancedGroupByConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetAdvancedGroupByConstraintStreamTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.Joiners;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractAdvancedGroupByConstraintStreamTest;
 import ai.timefold.solver.core.impl.testdata.domain.score.lavish.TestdataLavishEntity;
@@ -32,8 +33,8 @@ import org.junit.jupiter.api.TestTemplate;
 
 final class BavetAdvancedGroupByConstraintStreamTest extends AbstractAdvancedGroupByConstraintStreamTest {
 
-    public BavetAdvancedGroupByConstraintStreamTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    public BavetAdvancedGroupByConstraintStreamTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
     @TestTemplate

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintStreamImplSupport.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintStreamImplSupport.java
@@ -10,19 +10,8 @@ import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.stream.BavetConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.stream.common.ConstraintStreamImplSupport;
 
-public final class BavetConstraintStreamImplSupport
+public record BavetConstraintStreamImplSupport(ConstraintMatchPolicy constraintMatchPolicy)
         implements ConstraintStreamImplSupport {
-
-    private final ConstraintMatchPolicy constraintMatchPolicy;
-
-    public BavetConstraintStreamImplSupport(ConstraintMatchPolicy constraintMatchPolicy) {
-        this.constraintMatchPolicy = constraintMatchPolicy;
-    }
-
-    @Override
-    public boolean isConstreamMatchEnabled() {
-        return constraintMatchPolicy.isEnabled();
-    }
 
     @Override
     public <Score_ extends Score<Score_>, Solution_> InnerScoreDirector<Solution_, Score_> buildScoreDirector(

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintStreamImplSupport.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintStreamImplSupport.java
@@ -11,7 +11,8 @@ import ai.timefold.solver.core.impl.score.director.stream.BavetConstraintStreamS
 import ai.timefold.solver.core.impl.score.stream.common.ConstraintStreamImplSupport;
 
 public record BavetConstraintStreamImplSupport(ConstraintMatchPolicy constraintMatchPolicy)
-        implements ConstraintStreamImplSupport {
+        implements
+            ConstraintStreamImplSupport {
 
     @Override
     public <Score_ extends Score<Score_>, Solution_> InnerScoreDirector<Solution_, Score_> buildScoreDirector(

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintStreamImplSupport.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetConstraintStreamImplSupport.java
@@ -5,6 +5,7 @@ import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.stream.BavetConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.stream.common.ConstraintStreamImplSupport;
@@ -12,15 +13,15 @@ import ai.timefold.solver.core.impl.score.stream.common.ConstraintStreamImplSupp
 public final class BavetConstraintStreamImplSupport
         implements ConstraintStreamImplSupport {
 
-    private final boolean constraintMatchEnabled;
+    private final ConstraintMatchPolicy constraintMatchPolicy;
 
-    public BavetConstraintStreamImplSupport(boolean constraintMatchEnabled) {
-        this.constraintMatchEnabled = constraintMatchEnabled;
+    public BavetConstraintStreamImplSupport(ConstraintMatchPolicy constraintMatchPolicy) {
+        this.constraintMatchPolicy = constraintMatchPolicy;
     }
 
     @Override
     public boolean isConstreamMatchEnabled() {
-        return constraintMatchEnabled;
+        return constraintMatchPolicy.isEnabled();
     }
 
     @Override
@@ -28,7 +29,7 @@ public final class BavetConstraintStreamImplSupport
             SolutionDescriptor<Solution_> solutionDescriptorSupplier, ConstraintProvider constraintProvider) {
         return (InnerScoreDirector<Solution_, Score_>) new BavetConstraintStreamScoreDirectorFactory<>(
                 solutionDescriptorSupplier, constraintProvider, EnvironmentMode.REPRODUCIBLE)
-                .buildScoreDirector(false, constraintMatchEnabled);
+                .buildScoreDirector(false, constraintMatchPolicy);
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetRegressionTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetRegressionTest.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraintStreamTest;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
@@ -16,8 +17,8 @@ import org.junit.jupiter.api.TestTemplate;
 
 final class BavetRegressionTest extends AbstractConstraintStreamTest {
 
-    protected BavetRegressionTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    protected BavetRegressionTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
     /**

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetBiConstraintStreamNodeSharingTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetBiConstraintStreamNodeSharingTest.java
@@ -1,12 +1,13 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.bi;
 
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintStreamImplSupport;
 import ai.timefold.solver.core.impl.score.stream.common.bi.AbstractBiConstraintStreamNodeSharingTest;
 
 final class BavetBiConstraintStreamNodeSharingTest extends AbstractBiConstraintStreamNodeSharingTest {
 
-    public BavetBiConstraintStreamNodeSharingTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    public BavetBiConstraintStreamNodeSharingTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetBiConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetBiConstraintStreamTest.java
@@ -1,12 +1,13 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.bi;
 
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintStreamImplSupport;
 import ai.timefold.solver.core.impl.score.stream.common.bi.AbstractBiConstraintStreamTest;
 
 final class BavetBiConstraintStreamTest extends AbstractBiConstraintStreamTest {
 
-    public BavetBiConstraintStreamTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    public BavetBiConstraintStreamTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetQuadConstraintStreamNodeSharingTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetQuadConstraintStreamNodeSharingTest.java
@@ -1,12 +1,13 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.quad;
 
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintStreamImplSupport;
 import ai.timefold.solver.core.impl.score.stream.common.quad.AbstractQuadConstraintStreamNodeSharingTest;
 
 final class BavetQuadConstraintStreamNodeSharingTest extends AbstractQuadConstraintStreamNodeSharingTest {
 
-    public BavetQuadConstraintStreamNodeSharingTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    public BavetQuadConstraintStreamNodeSharingTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetQuadConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetQuadConstraintStreamTest.java
@@ -1,12 +1,13 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.quad;
 
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintStreamImplSupport;
 import ai.timefold.solver.core.impl.score.stream.common.quad.AbstractQuadConstraintStreamTest;
 
 final class BavetQuadConstraintStreamTest extends AbstractQuadConstraintStreamTest {
 
-    public BavetQuadConstraintStreamTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    public BavetQuadConstraintStreamTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetTriConstraintStreamNodeSharingTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetTriConstraintStreamNodeSharingTest.java
@@ -1,12 +1,13 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.tri;
 
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintStreamImplSupport;
 import ai.timefold.solver.core.impl.score.stream.common.tri.AbstractTriConstraintStreamNodeSharingTest;
 
 final class BavetTriConstraintStreamNodeSharingTest extends AbstractTriConstraintStreamNodeSharingTest {
 
-    public BavetTriConstraintStreamNodeSharingTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    public BavetTriConstraintStreamNodeSharingTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetTriConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetTriConstraintStreamTest.java
@@ -1,12 +1,13 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.tri;
 
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintStreamImplSupport;
 import ai.timefold.solver.core.impl.score.stream.common.tri.AbstractTriConstraintStreamTest;
 
 final class BavetTriConstraintStreamTest extends AbstractTriConstraintStreamTest {
 
-    public BavetTriConstraintStreamTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    public BavetTriConstraintStreamTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetUniConstraintStreamNodeSharingTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetUniConstraintStreamNodeSharingTest.java
@@ -1,12 +1,13 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.uni;
 
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintStreamImplSupport;
 import ai.timefold.solver.core.impl.score.stream.common.uni.AbstractUniConstraintStreamNodeSharingTest;
 
 final class BavetUniConstraintStreamNodeSharingTest extends AbstractUniConstraintStreamNodeSharingTest {
 
-    public BavetUniConstraintStreamNodeSharingTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    public BavetUniConstraintStreamNodeSharingTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetUniConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetUniConstraintStreamTest.java
@@ -1,12 +1,13 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.uni;
 
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.bavet.BavetConstraintStreamImplSupport;
 import ai.timefold.solver.core.impl.score.stream.common.uni.AbstractUniConstraintStreamTest;
 
 final class BavetUniConstraintStreamTest extends AbstractUniConstraintStreamTest {
 
-    public BavetUniConstraintStreamTest(boolean constraintMatchEnabled) {
-        super(new BavetConstraintStreamImplSupport(constraintMatchEnabled));
+    public BavetUniConstraintStreamTest(ConstraintMatchPolicy constraintMatchPolicy) {
+        super(new BavetConstraintStreamImplSupport(constraintMatchPolicy));
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractConstraintStreamTest {
         int scoreTotal = Arrays.stream(assertableMatches)
                 .mapToInt(assertableMatch -> assertableMatch.score)
                 .sum();
-        if (implSupport.isConstreamMatchEnabled()) {
+        if (implSupport.constraintMatchPolicy().isEnabled()) {
             for (AssertableMatch assertableMatch : assertableMatches) {
                 String constraintPackage = assertableMatch.constraintPackage == null
                         ? scoreDirector.getSolutionDescriptor().getSolutionClass().getPackage().getName()

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
@@ -64,19 +63,19 @@ public abstract class AbstractConstraintStreamTest {
     protected <Solution_> void assertScore(InnerScoreDirector<Solution_, SimpleScore> scoreDirector,
             AssertableMatch... assertableMatches) {
         scoreDirector.triggerVariableListeners();
-        SimpleScore score = scoreDirector.calculateScore();
-        int scoreTotal = Arrays.stream(assertableMatches)
+        var score = scoreDirector.calculateScore();
+        var scoreTotal = Arrays.stream(assertableMatches)
                 .mapToInt(assertableMatch -> assertableMatch.score)
                 .sum();
         if (implSupport.constraintMatchPolicy().isJustificationEnabled()) {
-            for (AssertableMatch assertableMatch : assertableMatches) {
-                String constraintPackage = assertableMatch.constraintPackage == null
+            for (var assertableMatch : assertableMatches) {
+                var constraintPackage = assertableMatch.constraintPackage == null
                         ? scoreDirector.getSolutionDescriptor().getSolutionClass().getPackage().getName()
                         : assertableMatch.constraintPackage;
-                Map<String, ConstraintMatchTotal<SimpleScore>> constraintMatchTotals =
+                var constraintMatchTotals =
                         scoreDirector.getConstraintMatchTotalMap();
-                String constraintId = ConstraintRef.composeConstraintId(constraintPackage, assertableMatch.constraintName);
-                ConstraintMatchTotal<SimpleScore> constraintMatchTotal = constraintMatchTotals.get(constraintId);
+                var constraintId = ConstraintRef.composeConstraintId(constraintPackage, assertableMatch.constraintName);
+                var constraintMatchTotal = constraintMatchTotals.get(constraintId);
                 if (constraintMatchTotal == null) {
                     throw new IllegalStateException("Requested constraint matches for unknown constraint (" +
                             constraintId + ").");
@@ -87,10 +86,9 @@ public abstract class AbstractConstraintStreamTest {
                             + constraintMatchTotal.getConstraintMatchSet() + ").");
                 }
             }
-            Map<String, ConstraintMatchTotal<SimpleScore>> constraintMatchTotalMap =
-                    scoreDirector.getConstraintMatchTotalMap();
-            for (ConstraintMatchTotal<SimpleScore> constraintMatchTotal : constraintMatchTotalMap.values()) {
-                for (ConstraintMatch<SimpleScore> constraintMatch : constraintMatchTotal.getConstraintMatchSet()) {
+            var constraintMatchTotalMap = scoreDirector.getConstraintMatchTotalMap();
+            for (var constraintMatchTotal : constraintMatchTotalMap.values()) {
+                for (var constraintMatch : constraintMatchTotal.getConstraintMatchSet()) {
                     if (Arrays.stream(assertableMatches)
                             .filter(assertableMatch -> assertableMatch.constraintName
                                     .equals(constraintMatch.getConstraintRef().constraintName()))
@@ -100,6 +98,13 @@ public abstract class AbstractConstraintStreamTest {
                     }
                 }
             }
+        } else if (implSupport.constraintMatchPolicy().isEnabled()) {
+            var matchCount = scoreDirector.getConstraintMatchTotalMap().values().stream()
+                    .mapToInt(ConstraintMatchTotal::getConstraintMatchCount)
+                    .sum();
+            assertThat(assertableMatches.length)
+                    .as("The expected number of constraint matches is different from actual.")
+                    .isEqualTo(matchCount);
         }
         assertThat(score.score()).isEqualTo(scoreTotal);
     }
@@ -157,9 +162,9 @@ public abstract class AbstractConstraintStreamTest {
             if (!constraintName.equals(constraintMatch.getConstraintRef().constraintName())) {
                 return false;
             }
-            ConstraintJustification justification = constraintMatch.getJustification();
+            var justification = constraintMatch.getJustification();
             if (justification instanceof DefaultConstraintJustification constraintJustification) {
-                List<?> actualJustificationList = constraintJustification.getFacts();
+                var actualJustificationList = constraintJustification.getFacts();
                 if (actualJustificationList.size() != justificationList.size()) {
                     return false;
                 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractConstraintStreamTest {
         int scoreTotal = Arrays.stream(assertableMatches)
                 .mapToInt(assertableMatch -> assertableMatch.score)
                 .sum();
-        if (implSupport.constraintMatchPolicy().isEnabled()) {
+        if (implSupport.constraintMatchPolicy().isJustificationEnabled()) {
             for (AssertableMatch assertableMatch : assertableMatches) {
                 String constraintPackage = assertableMatch.constraintPackage == null
                         ? scoreDirector.getSolutionDescriptor().getSolutionClass().getPackage().getName()

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/AbstractConstraintStreamTest.java
@@ -102,9 +102,9 @@ public abstract class AbstractConstraintStreamTest {
             var matchCount = scoreDirector.getConstraintMatchTotalMap().values().stream()
                     .mapToInt(ConstraintMatchTotal::getConstraintMatchCount)
                     .sum();
-            assertThat(assertableMatches.length)
+            assertThat(assertableMatches)
                     .as("The expected number of constraint matches is different from actual.")
-                    .isEqualTo(matchCount);
+                    .hasSize(matchCount);
         }
         assertThat(score.score()).isEqualTo(scoreTotal);
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/ConstraintStreamImplSupport.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/ConstraintStreamImplSupport.java
@@ -4,11 +4,12 @@ import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 
 public interface ConstraintStreamImplSupport {
 
-    boolean isConstreamMatchEnabled();
+    ConstraintMatchPolicy constraintMatchPolicy();
 
     <Score_ extends Score<Score_>, Solution_> InnerScoreDirector<Solution_, Score_> buildScoreDirector(
             SolutionDescriptor<Solution_> solutionDescriptorSupplier, ConstraintProvider constraintProvider);

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/ConstraintStreamTestExtension.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/ConstraintStreamTestExtension.java
@@ -5,6 +5,7 @@ import java.util.stream.Stream;
 
 import ai.timefold.solver.core.api.score.stream.ConstraintStream;
 import ai.timefold.solver.core.api.score.stream.ConstraintStreamImplType;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -17,7 +18,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 /**
  * This extension helps implement parameterized {@link ConstraintStream} tests. It provides invocation contexts
  * representing the cartesian product of {true, false} ⨯ {BAVET} for a test matrix with
- * {@code constraintMatchEnabled} and {@link ConstraintStreamImplType} axes.
+ * {@link ConstraintMatchPolicy} and {@link ConstraintStreamImplType} axes.
  * <p>
  * Each invocation context includes two additional extensions being {@link ParameterResolver parameter resolvers} that
  * populate the test class constructor with the test data. Since each CS test class has dozens of test methods
@@ -33,21 +34,23 @@ public class ConstraintStreamTestExtension implements TestTemplateInvocationCont
 
     @Override
     public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
-        return Stream.of(true, false)
+        return Stream
+                .of(ConstraintMatchPolicy.ENABLED, ConstraintMatchPolicy.ENABLED_WITHOUT_JUSTIFICATIONS,
+                        ConstraintMatchPolicy.DISABLED)
                 .map(ConstraintStreamTestExtension::invocationContext);
     }
 
-    private static TestTemplateInvocationContext invocationContext(Boolean constraintMatchEnabled) {
+    private static TestTemplateInvocationContext invocationContext(ConstraintMatchPolicy constraintMatchPolicy) {
         return new TestTemplateInvocationContext() {
 
             @Override
             public String getDisplayName(int invocationIndex) {
-                return "constraintMatchEnabled=" + constraintMatchEnabled;
+                return "constraintMatchPolicy=" + constraintMatchPolicy;
             }
 
             @Override
             public List<Extension> getAdditionalExtensions() {
-                return List.of(parameterResolver(boolean.class, constraintMatchEnabled));
+                return List.of(parameterResolver(ConstraintMatchPolicy.class, constraintMatchPolicy));
             }
         };
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/bi/AbstractBiConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/bi/AbstractBiConstraintStreamTest.java
@@ -2399,7 +2399,7 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
 
     private <Score_ extends Score<Score_>, Solution_, Entity_> void assertDefaultJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList) {
-        if (!implSupport.isConstreamMatchEnabled())
+        if (!implSupport.constraintMatchPolicy().isJustificationEnabled())
             return;
 
         assertThat(scoreDirector.getIndictmentMap())
@@ -2703,7 +2703,7 @@ public abstract class AbstractBiConstraintStreamTest extends AbstractConstraintS
 
     private <Score_ extends Score<Score_>, Solution_, Entity_> void assertCustomJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList) {
-        if (!implSupport.isConstreamMatchEnabled())
+        if (!implSupport.constraintMatchPolicy().isJustificationEnabled())
             return;
 
         assertThat(scoreDirector.getIndictmentMap())

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/AbstractScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/AbstractScoreInlinerTest.java
@@ -6,13 +6,14 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 import ai.timefold.solver.core.impl.testdata.TestConstraint;
 import ai.timefold.solver.core.impl.testdata.TestConstraintFactory;
 
 public abstract class AbstractScoreInlinerTest<Solution_, Score_ extends Score<Score_>> {
 
-    protected final boolean constraintMatchEnabled = true;
+    protected final ConstraintMatchPolicy constraintMatchPolicy = ConstraintMatchPolicy.ENABLED;
     private final TestConstraintFactory<Solution_, Score_> constraintFactory =
             new TestConstraintFactory<>(buildSolutionDescriptor());
 
@@ -25,11 +26,11 @@ public abstract class AbstractScoreInlinerTest<Solution_, Score_ extends Score<S
     protected WeightedScoreImpacter<Score_, ?> buildScoreImpacter(Score_ constraintWeight) {
         AbstractConstraint<?, ?, ?> constraint = buildConstraint(constraintWeight);
         Map<Constraint, Score_> constraintWeightMap = Collections.singletonMap(constraint, constraintWeight);
-        AbstractScoreInliner<Score_> scoreInliner = buildScoreInliner(constraintWeightMap, constraintMatchEnabled);
+        AbstractScoreInliner<Score_> scoreInliner = buildScoreInliner(constraintWeightMap, constraintMatchPolicy);
         return scoreInliner.buildWeightedScoreImpacter(constraint);
     }
 
     abstract protected AbstractScoreInliner<Score_> buildScoreInliner(Map<Constraint, Score_> constraintWeightMap,
-            boolean constraintMatchEnabled);
+            ConstraintMatchPolicy constraintMatchPolicy);
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreInlinerTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataBendableBigDecimalScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ class BendableBigDecimalScoreInlinerTest
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(buildScore(0, 0, 0));
     }
 
@@ -117,8 +118,9 @@ class BendableBigDecimalScoreInlinerTest
 
     @Override
     protected AbstractScoreInliner<BendableBigDecimalScore>
-            buildScoreInliner(Map<Constraint, BendableBigDecimalScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        return new BendableBigDecimalScoreInliner(constraintWeightMap, constraintMatchEnabled, 1, 2);
+            buildScoreInliner(Map<Constraint, BendableBigDecimalScore> constraintWeightMap,
+                    ConstraintMatchPolicy constraintMatchPolicy) {
+        return new BendableBigDecimalScoreInliner(constraintWeightMap, constraintMatchPolicy, 1, 2);
     }
 
     private BendableBigDecimalScore buildScore(long hard, long soft1, long soft2) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreInlinerTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.bendablelong.BendableLongScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataBendableLongScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class BendableLongScoreInlinerTest extends AbstractScoreInlinerTest<TestdataBend
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(buildScore(0, 0, 0));
     }
 
@@ -119,8 +120,8 @@ class BendableLongScoreInlinerTest extends AbstractScoreInlinerTest<TestdataBend
 
     @Override
     protected AbstractScoreInliner<BendableLongScore> buildScoreInliner(Map<Constraint, BendableLongScore> constraintWeightMap,
-            boolean constraintMatchEnabled) {
-        return new BendableLongScoreInliner(constraintWeightMap, constraintMatchEnabled, 1, 2);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        return new BendableLongScoreInliner(constraintWeightMap, constraintMatchPolicy, 1, 2);
     }
 
     private BendableLongScore buildScore(long hard, long soft1, long soft2) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreInlinerTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.bendable.BendableScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataBendableScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class BendableScoreInlinerTest extends AbstractScoreInlinerTest<TestdataBendable
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(buildScore(0, 0, 0));
     }
 
@@ -119,8 +120,8 @@ class BendableScoreInlinerTest extends AbstractScoreInlinerTest<TestdataBendable
 
     @Override
     protected AbstractScoreInliner<BendableScore> buildScoreInliner(Map<Constraint, BendableScore> constraintWeightMap,
-            boolean constraintMatchEnabled) {
-        return new BendableScoreInliner(constraintWeightMap, constraintMatchEnabled, 1, 2);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        return new BendableScoreInliner(constraintWeightMap, constraintMatchPolicy, 1, 2);
     }
 
     private BendableScore buildScore(int hard, int soft1, int soft2) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftBigDecimalScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftBigDecimalScoreInlinerTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataHardMediumSoftBigDecimalScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ class HardMediumSoftBigDecimalScoreInlinerTest
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(HardMediumSoftBigDecimalScore.ZERO);
     }
 
@@ -125,7 +126,7 @@ class HardMediumSoftBigDecimalScoreInlinerTest
 
     @Override
     protected AbstractScoreInliner<HardMediumSoftBigDecimalScore> buildScoreInliner(
-            Map<Constraint, HardMediumSoftBigDecimalScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        return new HardMediumSoftBigDecimalScoreInliner(constraintWeightMap, constraintMatchEnabled);
+            Map<Constraint, HardMediumSoftBigDecimalScore> constraintWeightMap, ConstraintMatchPolicy constraintMatchPolicy) {
+        return new HardMediumSoftBigDecimalScoreInliner(constraintWeightMap, constraintMatchPolicy);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreInlinerTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataHardMediumSoftLongScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ class HardMediumSoftLongScoreInlinerTest
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(HardMediumSoftLongScore.ZERO);
     }
 
@@ -120,7 +121,8 @@ class HardMediumSoftLongScoreInlinerTest
 
     @Override
     protected AbstractScoreInliner<HardMediumSoftLongScore>
-            buildScoreInliner(Map<Constraint, HardMediumSoftLongScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        return new HardMediumSoftLongScoreInliner(constraintWeightMap, constraintMatchEnabled);
+            buildScoreInliner(Map<Constraint, HardMediumSoftLongScore> constraintWeightMap,
+                    ConstraintMatchPolicy constraintMatchPolicy) {
+        return new HardMediumSoftLongScoreInliner(constraintWeightMap, constraintMatchPolicy);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreInlinerTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataHardMediumSoftScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ class HardMediumSoftScoreInlinerTest
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(HardMediumSoftScore.ZERO);
     }
 
@@ -120,7 +121,8 @@ class HardMediumSoftScoreInlinerTest
 
     @Override
     protected AbstractScoreInliner<HardMediumSoftScore>
-            buildScoreInliner(Map<Constraint, HardMediumSoftScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        return new HardMediumSoftScoreInliner(constraintWeightMap, constraintMatchEnabled);
+            buildScoreInliner(Map<Constraint, HardMediumSoftScore> constraintWeightMap,
+                    ConstraintMatchPolicy constraintMatchPolicy) {
+        return new HardMediumSoftScoreInliner(constraintWeightMap, constraintMatchPolicy);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreInlinerTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataHardSoftBigDecimalScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ class HardSoftBigDecimalScoreInlinerTest
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(HardSoftBigDecimalScore.ZERO);
     }
 
@@ -98,7 +99,8 @@ class HardSoftBigDecimalScoreInlinerTest
 
     @Override
     protected AbstractScoreInliner<HardSoftBigDecimalScore>
-            buildScoreInliner(Map<Constraint, HardSoftBigDecimalScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        return new HardSoftBigDecimalScoreInliner(constraintWeightMap, constraintMatchEnabled);
+            buildScoreInliner(Map<Constraint, HardSoftBigDecimalScore> constraintWeightMap,
+                    ConstraintMatchPolicy constraintMatchPolicy) {
+        return new HardSoftBigDecimalScoreInliner(constraintWeightMap, constraintMatchPolicy);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreInlinerTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataHardSoftLongScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class HardSoftLongScoreInlinerTest extends AbstractScoreInlinerTest<TestdataHard
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(HardSoftLongScore.ZERO);
     }
 
@@ -96,7 +97,7 @@ class HardSoftLongScoreInlinerTest extends AbstractScoreInlinerTest<TestdataHard
 
     @Override
     protected AbstractScoreInliner<HardSoftLongScore> buildScoreInliner(Map<Constraint, HardSoftLongScore> constraintWeightMap,
-            boolean constraintMatchEnabled) {
-        return new HardSoftLongScoreInliner(constraintWeightMap, constraintMatchEnabled);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        return new HardSoftLongScoreInliner(constraintWeightMap, constraintMatchPolicy);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreInlinerTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataHardSoftScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class HardSoftScoreInlinerTest extends AbstractScoreInlinerTest<TestdataHardSoft
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(HardSoftScore.ZERO);
     }
 
@@ -96,7 +97,7 @@ class HardSoftScoreInlinerTest extends AbstractScoreInlinerTest<TestdataHardSoft
 
     @Override
     protected AbstractScoreInliner<HardSoftScore> buildScoreInliner(Map<Constraint, HardSoftScore> constraintWeightMap,
-            boolean constraintMatchEnabled) {
-        return new HardSoftScoreInliner(constraintWeightMap, constraintMatchEnabled);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        return new HardSoftScoreInliner(constraintWeightMap, constraintMatchPolicy);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleBigDecimalScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleBigDecimalScoreInlinerTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataSimpleBigDecimalScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ class SimpleBigDecimalScoreInlinerTest
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(SimpleBigDecimalScore.ZERO);
     }
 
@@ -52,7 +53,8 @@ class SimpleBigDecimalScoreInlinerTest
 
     @Override
     protected AbstractScoreInliner<SimpleBigDecimalScore>
-            buildScoreInliner(Map<Constraint, SimpleBigDecimalScore> constraintWeightMap, boolean constraintMatchEnabled) {
-        return new SimpleBigDecimalScoreInliner(constraintWeightMap, constraintMatchEnabled);
+            buildScoreInliner(Map<Constraint, SimpleBigDecimalScore> constraintWeightMap,
+                    ConstraintMatchPolicy constraintMatchPolicy) {
+        return new SimpleBigDecimalScoreInliner(constraintWeightMap, constraintMatchPolicy);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreInlinerTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.simplelong.SimpleLongScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.score.TestdataSimpleLongScoreSolution;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class SimpleLongScoreInlinerTest extends AbstractScoreInlinerTest<TestdataSimple
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(SimpleLongScore.ZERO);
     }
 
@@ -50,7 +51,7 @@ class SimpleLongScoreInlinerTest extends AbstractScoreInlinerTest<TestdataSimple
 
     @Override
     protected AbstractScoreInliner<SimpleLongScore> buildScoreInliner(Map<Constraint, SimpleLongScore> constraintWeightMap,
-            boolean constraintMatchEnabled) {
-        return new SimpleLongScoreInliner(constraintWeightMap, constraintMatchEnabled);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        return new SimpleLongScoreInliner(constraintWeightMap, constraintMatchPolicy);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreInlinerTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class SimpleScoreInlinerTest extends AbstractScoreInlinerTest<TestdataSolution, 
 
     @Test
     void defaultScore() {
-        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchEnabled);
+        var scoreInliner = buildScoreInliner(Collections.emptyMap(), constraintMatchPolicy);
         assertThat(scoreInliner.extractScore(0)).isEqualTo(SimpleScore.ZERO);
     }
 
@@ -50,8 +51,8 @@ class SimpleScoreInlinerTest extends AbstractScoreInlinerTest<TestdataSolution, 
 
     @Override
     protected AbstractScoreInliner<SimpleScore> buildScoreInliner(Map<Constraint, SimpleScore> constraintWeightMap,
-            boolean constraintMatchEnabled) {
-        return new SimpleScoreInliner(constraintWeightMap, constraintMatchEnabled);
+            ConstraintMatchPolicy constraintMatchPolicy) {
+        return new SimpleScoreInliner(constraintWeightMap, constraintMatchPolicy);
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/quad/AbstractQuadConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/quad/AbstractQuadConstraintStreamTest.java
@@ -2098,7 +2098,7 @@ public abstract class AbstractQuadConstraintStreamTest
 
     private <Score_ extends Score<Score_>, Solution_, Entity_, Value_> void assertDefaultJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList, List<Value_> valueList) {
-        if (!implSupport.isConstreamMatchEnabled())
+        if (!implSupport.constraintMatchPolicy().isJustificationEnabled())
             return;
 
         assertThat(scoreDirector.getIndictmentMap())
@@ -2437,7 +2437,7 @@ public abstract class AbstractQuadConstraintStreamTest
 
     private <Score_ extends Score<Score_>, Solution_, Entity_, Value_> void assertCustomJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList, List<Value_> valueList) {
-        if (!implSupport.isConstreamMatchEnabled())
+        if (!implSupport.constraintMatchPolicy().isJustificationEnabled())
             return;
 
         assertThat(scoreDirector.getIndictmentMap())

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/tri/AbstractTriConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/tri/AbstractTriConstraintStreamTest.java
@@ -2385,7 +2385,7 @@ public abstract class AbstractTriConstraintStreamTest
 
     private <Score_ extends Score<Score_>, Solution_, Entity_, Value_> void assertDefaultJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList, List<Value_> valueList) {
-        if (!implSupport.isConstreamMatchEnabled())
+        if (!implSupport.constraintMatchPolicy().isJustificationEnabled())
             return;
 
         assertThat(scoreDirector.getIndictmentMap())
@@ -2709,7 +2709,7 @@ public abstract class AbstractTriConstraintStreamTest
 
     private <Score_ extends Score<Score_>, Solution_, Entity_, Value_> void assertCustomJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList, List<Value_> valueList) {
-        if (!implSupport.isConstreamMatchEnabled())
+        if (!implSupport.constraintMatchPolicy().isJustificationEnabled())
             return;
 
         assertThat(scoreDirector.getIndictmentMap())

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/uni/AbstractUniConstraintStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/uni/AbstractUniConstraintStreamTest.java
@@ -2974,7 +2974,7 @@ public abstract class AbstractUniConstraintStreamTest
 
     private <Score_ extends Score<Score_>, Solution_, Entity_> void assertDefaultJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList) {
-        if (!implSupport.isConstreamMatchEnabled())
+        if (!implSupport.constraintMatchPolicy().isJustificationEnabled())
             return;
 
         assertThat(scoreDirector.getIndictmentMap())
@@ -3275,7 +3275,7 @@ public abstract class AbstractUniConstraintStreamTest
 
     private <Score_ extends Score<Score_>, Solution_, Entity_> void assertCustomJustifications(
             InnerScoreDirector<Solution_, Score_> scoreDirector, List<Entity_> entityList) {
-        if (!implSupport.isConstreamMatchEnabled())
+        if (!implSupport.constraintMatchPolicy().isJustificationEnabled())
             return;
 
         assertThat(scoreDirector.getIndictmentMap())

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/util/PlannerTestUtils.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/util/PlannerTestUtils.java
@@ -31,6 +31,7 @@ import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescripto
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.score.DummySimpleScoreEasyScoreCalculator;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.easy.EasyScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.trend.InitializingScoreTrend;
@@ -117,7 +118,7 @@ public final class PlannerTestUtils {
         scoreDirectorFactory.setInitializingScoreTrend(
                 InitializingScoreTrend.buildUniformTrend(InitializingScoreTrendLevel.ONLY_DOWN, 1));
         return mock(InnerScoreDirector.class,
-                AdditionalAnswers.delegatesTo(scoreDirectorFactory.buildScoreDirector(false, false)));
+                AdditionalAnswers.delegatesTo(scoreDirectorFactory.buildScoreDirector(false, ConstraintMatchPolicy.DISABLED)));
     }
 
     public static <Solution_, Score_ extends Score<Score_>> InnerScoreDirector<Solution_, Score_>

--- a/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
@@ -108,6 +108,15 @@ Using score analysis, you can find out:
 * Which constraints are broken, and how many times.
 * Which planning entities and problem facts are responsible for breaking which constraints.
 
+[NOTE]
+====
+For performance reasons and especially with large datasets that you'll later need to serialize,
+you may choose to use `ScoreAnalysis` without justifications,
+while still maintaining the count of constraint matches.
+In that case, use `ScoreAnalysisFetchPolicy.FETCH_MATCH_COUNT` instead of
+the default `ScoreAnalysisFetchPolicy.FETCH_ALL` when calling `SolutionManager.analyze(...)`.
+====
+
 It is also possible to print the score summary:
 
 [tabs]
@@ -213,7 +222,6 @@ Each match is accompanied by the score difference it caused, and a justification
 Typically, the scoring engine creates justification objects automatically
 by using the results of xref:constraints-and-score/score-calculation.adoc#constraintStreamsCustomizingJustificationsAndIndictments[Constraint Streams' `justifyWith(...)` call].
 
-
 [#scoreAnalysisDiff]
 === Identifying changes between two solutions
 
@@ -303,6 +311,12 @@ This is because we have no way of knowing which `Score` or `ConstraintJustificat
 However, deserialization is easy to implement yourself by extending `AbstractScoreAnalysisJacksonDeserializer`
 and registering it with Jackson's `ObjectMapper`.
 ====
+
+With large datasets,
+you may choose to use `ScoreAnalysis` without justifications,
+while still maintaining the count of constraint matches.
+In that case, use `ScoreAnalysisFetchPolicy.FETCH_MATCH_COUNT` instead of
+the default `ScoreAnalysisFetchPolicy.FETCH_ALL` when calling `SolutionManager.analyze(...)`.
 
 
 [#indictmentHeatMap]

--- a/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-to-latest-version.adoc
+++ b/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-to-latest-version.adoc
@@ -101,6 +101,27 @@ Methods in the `Move` interface that deal with undo moves have been deprecated
 and will be removed in a future major version of Timefold Solver.
 ====
 
+'''
+
+.icon:info-circle[role=yellow] `ConstraintAnalysis.matchCount()` no longer throws an exception
+[%collapsible%open]
+====
+Previously in xref:constraints-and-score/understanding-the-score.adoc[score analysis],
+when there were no matches for a constraint,
+`ConstraintAnalysis.matchCount()` would throw an exception instead of returning a number.
+The behavior has been changed to depend on selected `ScoreAnalysisFetchPolicy`:
+
+- With `FETCH_ALL`, constraint match analysis will be performed, constraint matches will be available,
+and the method will return their precise count.
+- With `FETCH_MATCH_COUNT`, constraint match analysis will still be performed
+and the method will return the precise count of constraint matches.
+The constraint matches themselves will not be available.
+This is useful for situations
+where the score analysis with a full list of matches can be expected to be too large to transmit over the wire.
+- With `FETCH_SHALLOW`, constraint match analysis will not run, constraint matches will not be available
+and the method will return `-1`.
+
+====
 
 === Upgrade from 1.14.0 to 1.15.0
 

--- a/persistence/jackson/src/main/java/ai/timefold/solver/jackson/api/score/analysis/AbstractScoreAnalysisJacksonDeserializer.java
+++ b/persistence/jackson/src/main/java/ai/timefold/solver/jackson/api/score/analysis/AbstractScoreAnalysisJacksonDeserializer.java
@@ -39,9 +39,11 @@ public abstract class AbstractScoreAnalysisJacksonDeserializer<Score_ extends Sc
             var constraintScore = parseScore(constraintNode.get("score").asText());
             var matchScoreList = new ArrayList<MatchAnalysis<Score_>>();
             var matchesNode = constraintNode.get("matches");
+            var matchCountNode = constraintNode.get("matchCount");
             if (matchesNode == null) {
                 constraintAnalysisList.put(constraintRef,
-                        new ConstraintAnalysis<>(constraintRef, constraintWeight, constraintScore, null));
+                        new ConstraintAnalysis<>(constraintRef, constraintWeight, constraintScore, null,
+                                matchCountNode == null ? -1 : Integer.parseInt(matchCountNode.asText())));
             } else {
                 for (var matchNode : constraintNode.get("matches")) {
                     var matchScore = parseScore(matchNode.get("score").asText());

--- a/persistence/jackson/src/main/java/ai/timefold/solver/jackson/api/score/analysis/AbstractScoreAnalysisJacksonDeserializer.java
+++ b/persistence/jackson/src/main/java/ai/timefold/solver/jackson/api/score/analysis/AbstractScoreAnalysisJacksonDeserializer.java
@@ -48,6 +48,11 @@ public abstract class AbstractScoreAnalysisJacksonDeserializer<Score_ extends Sc
                 for (var matchNode : constraintNode.get("matches")) {
                     var matchScore = parseScore(matchNode.get("score").asText());
                     var justificationNode = matchNode.get("justification");
+                    if (justificationNode == null) {
+                        // Not allowed; if matches are present, they must have justifications.
+                        throw new IllegalStateException("The match justification of constraint (%s)'s match is missing."
+                                .formatted(constraintRef));
+                    }
                     var justificationString = justificationNode.toString();
                     if (getConstraintJustificationClass(constraintRef) == null) { // String-based fallback.
                         var parsedJustification = parseConstraintJustification(constraintRef, justificationString, matchScore);

--- a/persistence/jackson/src/main/java/ai/timefold/solver/jackson/api/score/analysis/ScoreAnalysisJacksonSerializer.java
+++ b/persistence/jackson/src/main/java/ai/timefold/solver/jackson/api/score/analysis/ScoreAnalysisJacksonSerializer.java
@@ -41,6 +41,9 @@ public final class ScoreAnalysisJacksonSerializer<Score_ extends Score<Score_>> 
                 });
                 constraintAnalysisMap.put("matches", matchAnalysis);
             }
+            if (constraintAnalysis.matchCount() != -1) {
+                constraintAnalysisMap.put("matchCount", constraintAnalysis.matchCount());
+            }
             result.add(constraintAnalysisMap);
         });
         gen.writeObjectField("constraints", result);

--- a/persistence/jackson/src/test/java/ai/timefold/solver/jackson/api/TimefoldJacksonModuleTest.java
+++ b/persistence/jackson/src/test/java/ai/timefold/solver/jackson/api/TimefoldJacksonModuleTest.java
@@ -77,7 +77,7 @@ class TimefoldJacksonModuleTest extends AbstractJacksonRoundTripTest {
         var constraintAnalysis1 =
                 new ConstraintAnalysis<>(constraintRef1, HardSoftScore.ofSoft(1), HardSoftScore.ofSoft(2), null);
         var constraintAnalysis2 =
-                new ConstraintAnalysis<>(constraintRef2, HardSoftScore.ofHard(1), HardSoftScore.ofHard(1), null);
+                new ConstraintAnalysis<>(constraintRef2, HardSoftScore.ofHard(1), HardSoftScore.ofHard(1), null, 2);
         var originalScoreAnalysis = new ScoreAnalysis<>(HardSoftScore.of(1, 2),
                 Map.of(constraintRef1, constraintAnalysis1,
                         constraintRef2, constraintAnalysis2));
@@ -92,7 +92,8 @@ class TimefoldJacksonModuleTest extends AbstractJacksonRoundTripTest {
                              "package" : "packageA",
                              "name" : "constraint2",
                              "weight" : "1hard/0soft",
-                             "score" : "1hard/0soft"
+                             "score" : "1hard/0soft",
+                             "matchCount" : 2
                            }, {
                              "package" : "packageB",
                              "name" : "constraint1",
@@ -154,24 +155,27 @@ class TimefoldJacksonModuleTest extends AbstractJacksonRoundTripTest {
                     "weight" : "1hard/0soft",
                     "score" : "2hard/0soft",
                     "matches" : [ {
-                      "score" : "1hard/0soft",
-                      "justification" : [ "A", "B" ]
-                    }, {
-                      "score" : "1hard/0soft",
-                      "justification" : [ "B", "C", "D" ]
-                    } ]
+                            "score" : "1hard/0soft",
+                            "justification" : [ "A", "B" ]
+                        }, {
+                            "score" : "1hard/0soft",
+                            "justification" : [ "B", "C", "D" ]
+                        }
+                     ],
+                    "matchCount" : 2
                   }, {
                     "package" : "package2",
                     "name" : "constraint2",
                     "weight" : "0hard/1soft",
                     "score" : "0hard/4soft",
                     "matches" : [ {
-                      "score" : "0hard/1soft",
-                      "justification" : [ "D" ]
-                    }, {
-                      "score" : "0hard/3soft",
-                      "justification" : [ "A", "C" ]
-                    } ]
+                            "score" : "0hard/1soft",
+                            "justification" : [ "D" ]
+                        }, {
+                            "score" : "0hard/3soft",
+                            "justification" : [ "A", "C" ]
+                    } ],
+                    "matchCount" : 2
                   } ]
                 }""";
     }

--- a/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultMultiConstraintVerification.java
+++ b/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultMultiConstraintVerification.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.test.api.score.stream.MultiConstraintVerification;
 
@@ -27,7 +28,7 @@ public final class DefaultMultiConstraintVerification<Solution_, Score_ extends 
 
     @Override
     public DefaultMultiConstraintAssertion<Score_> givenSolution(Solution_ solution) {
-        try (var scoreDirector = scoreDirectorFactory.buildDerivedScoreDirector(true, true)) {
+        try (var scoreDirector = scoreDirectorFactory.buildDerivedScoreDirector(true, ConstraintMatchPolicy.ENABLED)) {
             scoreDirector.setWorkingSolution(Objects.requireNonNull(solution));
             return new DefaultMultiConstraintAssertion<>(constraintProvider, scoreDirector.calculateScore(),
                     scoreDirector.getConstraintMatchTotalMap(), scoreDirector.getIndictmentMap());

--- a/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintVerification.java
+++ b/test/src/main/java/ai/timefold/solver/test/impl/score/stream/DefaultSingleConstraintVerification.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.test.impl.score.stream;
 import java.util.Objects;
 
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.test.api.score.stream.SingleConstraintVerification;
 
@@ -22,7 +23,7 @@ public final class DefaultSingleConstraintVerification<Solution_, Score_ extends
 
     @Override
     public DefaultSingleConstraintAssertion<Solution_, Score_> givenSolution(Solution_ solution) {
-        try (var scoreDirector = scoreDirectorFactory.buildDerivedScoreDirector(true, true)) {
+        try (var scoreDirector = scoreDirectorFactory.buildDerivedScoreDirector(true, ConstraintMatchPolicy.ENABLED)) {
             scoreDirector.setWorkingSolution(Objects.requireNonNull(solution));
             return new DefaultSingleConstraintAssertion<>(scoreDirectorFactory, scoreDirector.calculateScore(),
                     scoreDirector.getConstraintMatchTotalMap(), scoreDirector.getIndictmentMap());


### PR DESCRIPTION
Introduces an option to disable constraint match justifications,
while still keeping constraint matching enabled.
In some cases, the dataset is so large that justifications are pointless, 
and impractical to send over the wire as well.
In this case, score analysis only provides constraint match count, and not the full match analysis.
