### PR TITLE
fix: Recurse through @DeepPlanningCloned classes to discover all @DeepPlanningCloned classes

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtils.java
@@ -47,11 +47,10 @@ public final class GizmoCloningUtils {
                     }
                 }
                 if (DeepCloningUtils.isFieldDeepCloned(solutionDescriptor, field, clazz)
-                        && !PlanningCloneable.class.isAssignableFrom(field.getType())) {
-                    if (!deepClonedClassSet.contains(field.getType())) {
-                        classesToProcess.add(field.getType());
-                        deepClonedClassSet.add(field.getType());
-                    }
+                        && !PlanningCloneable.class.isAssignableFrom(field.getType())
+                        && !deepClonedClassSet.contains(field.getType())) {
+                    classesToProcess.add(field.getType());
+                    deepClonedClassSet.add(field.getType());
                 }
             }
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtils.java
@@ -24,13 +24,34 @@ public final class GizmoCloningUtils {
         Set<Class<?>> classesToProcess = new LinkedHashSet<>(solutionDescriptor.getEntityClassSet());
         classesToProcess.add(solutionDescriptor.getSolutionClass());
         classesToProcess.addAll(entitySubclasses);
-        for (Class<?> clazz : classesToProcess) {
+
+        // deepClonedClassSet contains all processed classes so far,
+        // so we can use it to determine if we need to add a class
+        // to the classesToProcess set.
+        //
+        // This is important, since SolverConfig does not contain
+        // info on @DeepPlanningCloned classes, so we need to discover
+        // them from the domain classes, possibly recursively
+        // (when a @DeepPlanningCloned class reference another @DeepPlanningCloned
+        //  that is not referenced by any entity).
+        while (!classesToProcess.isEmpty()) {
+            var clazz = classesToProcess.iterator().next();
+            classesToProcess.remove(clazz);
             deepClonedClassSet.add(clazz);
             for (Field field : getAllFields(clazz)) {
-                deepClonedClassSet.addAll(getDeepClonedTypeArguments(solutionDescriptor, field.getGenericType()));
+                var deepClonedTypeArguments = getDeepClonedTypeArguments(solutionDescriptor, field.getGenericType());
+                for (var deepClonedTypeArgument : deepClonedTypeArguments) {
+                    if (!deepClonedClassSet.contains(deepClonedTypeArgument)) {
+                        classesToProcess.add(deepClonedTypeArgument);
+                        deepClonedClassSet.add(deepClonedTypeArgument);
+                    }
+                }
                 if (DeepCloningUtils.isFieldDeepCloned(solutionDescriptor, field, clazz)
                         && !PlanningCloneable.class.isAssignableFrom(field.getType())) {
-                    deepClonedClassSet.add(field.getType());
+                    if (!deepClonedClassSet.contains(field.getType())) {
+                        classesToProcess.add(field.getType());
+                        deepClonedClassSet.add(field.getType());
+                    }
                 }
             }
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -121,6 +122,10 @@ public class GizmoSolutionClonerImplementor {
                 memoizedSolutionOrEntityDescriptorMap, deepClonedClassSet);
     }
 
+    public static boolean isCloneableClass(Class<?> clazz) {
+        return !clazz.isInterface() && !Modifier.isAbstract(clazz.getModifiers());
+    }
+
     /**
      * Generates the constructor and implementations of SolutionCloner
      * methods for the given SolutionDescriptor using the given ClassCreator
@@ -139,7 +144,7 @@ public class GizmoSolutionClonerImplementor {
         Set<Class<?>> deepCloneClassesThatAreNotSolutionSet =
                 deepClonedClassSet.stream()
                         .filter(clazz -> !solutionClassSet.contains(clazz) && !clazz.isArray())
-                        .filter(clazz -> !clazz.isInterface() && !Modifier.isAbstract(clazz.getModifiers()))
+                        .filter(GizmoSolutionClonerImplementor::isCloneableClass)
                         .collect(Collectors.toSet());
 
         Comparator<Class<?>> instanceOfComparator = getInstanceOfComparator(deepClonedClassSet);
@@ -163,7 +168,7 @@ public class GizmoSolutionClonerImplementor {
         Set<Class<?>> abstractDeepCloneClassSet =
                 deepClonedClassSet.stream()
                         .filter(clazz -> !solutionClassSet.contains(clazz) && !clazz.isArray())
-                        .filter(clazz -> clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers()))
+                        .filter(Predicate.not(GizmoSolutionClonerImplementor::isCloneableClass))
                         .collect(Collectors.toSet());
 
         for (Class<?> abstractDeepClonedClass : abstractDeepCloneClassSet) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -902,6 +902,8 @@ public abstract class AbstractSolutionClonerTest {
             softly.assertThat(cloned.deepClonedListRef)
                     .first()
                     .isSameAs(original.deepClonedListRef.get(0));
+            softly.assertThat(cloned.extraDeepClonedObject).isNotSameAs(original.extraDeepClonedObject);
+            softly.assertThat(cloned.extraDeepClonedObject.id).isSameAs(original.extraDeepClonedObject.id);
         });
         assertSoftly(softly -> {
             softly.assertThat(cloned.shallowClonedListRef).isSameAs(original.shallowClonedListRef);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtilsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtilsTest.java
@@ -1,0 +1,34 @@
+package ai.timefold.solver.core.impl.domain.solution.cloner.gizmo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.AnnotatedTestdataVariousTypes;
+import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.ExtraDeepClonedObject;
+import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.TestdataDeepCloningEntity;
+import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.TestdataVariousTypes;
+import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.field.TestdataFieldAnnotatedDeepCloningEntity;
+import ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning.field.TestdataFieldAnnotatedDeepCloningSolution;
+
+import org.junit.jupiter.api.Test;
+
+class GizmoCloningUtilsTest {
+
+    @Test
+    void getDeepClonedClasses() {
+        assertThat(GizmoCloningUtils.getDeepClonedClasses(
+                TestdataFieldAnnotatedDeepCloningSolution.buildSolutionDescriptor(),
+                List.of(TestdataDeepCloningEntity.class)))
+                .containsExactlyInAnyOrder(
+                        TestdataDeepCloningEntity.class,
+                        ExtraDeepClonedObject.class,
+                        TestdataFieldAnnotatedDeepCloningEntity.class,
+                        AnnotatedTestdataVariousTypes.class,
+                        TestdataFieldAnnotatedDeepCloningSolution.class,
+                        TestdataVariousTypes.class,
+                        List.class,
+                        Map.class);
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/ExtraDeepClonedObject.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/ExtraDeepClonedObject.java
@@ -1,0 +1,15 @@
+package ai.timefold.solver.core.impl.testdata.domain.clone.deepcloning;
+
+import ai.timefold.solver.core.api.domain.solution.cloner.DeepPlanningClone;
+
+@DeepPlanningClone
+public class ExtraDeepClonedObject {
+    public String id;
+
+    public ExtraDeepClonedObject() {
+    }
+
+    public ExtraDeepClonedObject(String id) {
+        this.id = id;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/TestdataVariousTypes.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/testdata/domain/clone/deepcloning/TestdataVariousTypes.java
@@ -42,6 +42,9 @@ public class TestdataVariousTypes {
     @DeepPlanningClone
     public List<String> deepClonedListRef = Collections.singletonList(stringRef);
 
+    // And a DeepPlanningCloned object
+    public ExtraDeepClonedObject extraDeepClonedObject = new ExtraDeepClonedObject("extra");
+
     public record NonClonedRecord(int a, String b) {
     }
 

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/DotNames.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/DotNames.java
@@ -7,6 +7,7 @@ import ai.timefold.solver.core.api.domain.constraintweight.ConstraintConfigurati
 import ai.timefold.solver.core.api.domain.constraintweight.ConstraintWeight;
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.entity.PlanningPinToIndex;
 import ai.timefold.solver.core.api.domain.lookup.PlanningId;
 import ai.timefold.solver.core.api.domain.solution.ConstraintWeightOverrides;
 import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -55,6 +56,7 @@ public final class DotNames {
 
     static final DotName PLANNING_ENTITY = DotName.createSimple(PlanningEntity.class.getName());
     static final DotName PLANNING_PIN = DotName.createSimple(PlanningPin.class.getName());
+    static final DotName PLANNING_PIN_TO_INDEX = DotName.createSimple(PlanningPinToIndex.class.getName());
     static final DotName PLANNING_ID = DotName.createSimple(PlanningId.class.getName());
 
     static final DotName PLANNING_VARIABLE = DotName.createSimple(PlanningVariable.class.getName());
@@ -79,6 +81,7 @@ public final class DotNames {
 
     static final DotName[] PLANNING_ENTITY_FIELD_ANNOTATIONS = {
             PLANNING_PIN,
+            PLANNING_PIN_TO_INDEX,
             PLANNING_VARIABLE,
             PLANNING_LIST_VARIABLE,
             ANCHOR_SHADOW_VARIABLE,
@@ -101,6 +104,7 @@ public final class DotNames {
             CONSTRAINT_CONFIGURATION_PROVIDER,
             CONSTRAINT_WEIGHT,
             PLANNING_PIN,
+            PLANNING_PIN_TO_INDEX,
             PLANNING_ID,
             PLANNING_VARIABLE,
             PLANNING_LIST_VARIABLE,


### PR DESCRIPTION
The `GizmoSolutionClonerImplementor` requires a set of all
`@DeepPlanningCloned` classes so it can create cloners for all of them.
`GizmoCloningUtils.getDeepClonedClasses` incorrectly assume all
`@DeepPlanningCloned classes` are directly accessible from either
the `@PlanningSolution` class or an `@PlanningEntity` class. However,
a `@DeepPlanningCloned` class might be referenced from another
`@DeepPlanningCloned` class, which would not be detected.

In order to detect all `@DeepPlanningCloned` classes, when
a class that is `@DeepPlanningCloned` is found and was not
processed yet, it is added to the to process queue.

Fixes #1208.