### PR TITLE
chore: Remove GraalVM for Java 17 from Quarkus test, fix some warnings

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -98,6 +98,13 @@ jobs:
         os: [ ubuntu-latest ] # Windows doesn't work, Mac is not a deploy OS.
         module: ["spring-integration", "quarkus-integration"]
         java-version: [ 17, 21, 23 ] # LTS + latest.
+        exclude:
+          # Quarkus 3.17.2 has weird issues with Java 17 GraalVM,
+          # with Java 21+ GraalVM being recommended even for
+          # Java 17 projects.
+          # https://github.com/quarkusio/quarkus/issues/44877
+          - module: "quarkus-integration"
+            java-version: 17
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4

--- a/quarkus-integration/quarkus/devui-integration-test/pom.xml
+++ b/quarkus-integration/quarkus/devui-integration-test/pom.xml
@@ -123,7 +123,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
   </profiles>

--- a/quarkus-integration/quarkus/integration-test/pom.xml
+++ b/quarkus-integration/quarkus/integration-test/pom.xml
@@ -111,7 +111,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
   </profiles>

--- a/quarkus-integration/quarkus/reflection-integration-test/pom.xml
+++ b/quarkus-integration/quarkus/reflection-integration-test/pom.xml
@@ -111,7 +111,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
   </profiles>

--- a/quarkus-integration/quarkus/runtime/pom.xml
+++ b/quarkus-integration/quarkus/runtime/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
-      <artifactId>graal-sdk</artifactId>
+      <artifactId>nativeimage</artifactId>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
- Per https://github.com/quarkusio/quarkus/issues/44877, GraalVM for Java 21 is recommended even for Java 17 projects, since GraalVM for Java 17 has weird issues with Quarkus

- Use quarkus.native.enabled since quarkus.package.type is deprecated

- Use org.graalvm.sdk:nativeimage instead of org.graalvm.sdk:graalvm-sdk per the recommendation in the logs