### PR TITLE
fix: Use a stable recipe order for `NullableRecipe.getRecipeList()`

### DIFF
--- a/migration/src/main/java/ai/timefold/solver/migration/v8/NullableRecipe.java
+++ b/migration/src/main/java/ai/timefold/solver/migration/v8/NullableRecipe.java
@@ -25,7 +25,7 @@ public final class NullableRecipe extends AbstractRecipe {
     @Override
     public List<Recipe> getRecipeList() {
         var packageName = "ai.timefold.solver.core.api.score.stream";
-        var methodsToRename = Map.ofEntries(
+        var methodsToRename = List.of(
                 Map.entry("ConstraintFactory forEachIncludingNullVars(Class)",
                         "forEachIncludingUnassigned"),
                 Map.entry("uni.UniConstraintStream ifExistsIncludingNullVars(..)",
@@ -50,9 +50,9 @@ public final class NullableRecipe extends AbstractRecipe {
                         "ifNotExistsIncludingUnassigned"));
 
         var result = new ArrayList<Recipe>();
-        methodsToRename.forEach((oldPattern, newMethodName) -> {
-            var pattern = packageName + "." + oldPattern;
-            result.add(new ChangeMethodName(pattern, newMethodName, null, null));
+        methodsToRename.forEach(entry -> {
+            var pattern = packageName + "." + entry.getKey();
+            result.add(new ChangeMethodName(pattern, entry.getValue(), null, null));
         });
         result.add(new ChangeAnnotationAttributeName("ai.timefold.solver.core.api.domain.variable.PlanningVariable", "nullable",
                 "allowsUnassigned"));


### PR DESCRIPTION
Hi! Great to see the recipes here; I do have one request: can we make the order of the recipe list stable?

For context: we generate documentation for recipes, even when maintained externally. Before this change we would see a new recipe list order for every run. After this change the order should be fixed, such that we do not keep changing that documentation page every time.

Thanks in advance!