### PR TITLE
fix: Use Named Solver fields and method parameters to determine list of solver names in Quarkus

### DIFF
--- a/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMultipleSolversConfigTest.java
+++ b/quarkus-integration/quarkus-benchmark/deployment/src/test/java/ai/timefold/solver/benchmark/quarkus/TimefoldBenchmarkProcessorMultipleSolversConfigTest.java
@@ -5,9 +5,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.ExecutionException;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
 import ai.timefold.solver.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import ai.timefold.solver.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
 import ai.timefold.solver.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+import ai.timefold.solver.core.api.solver.SolverManager;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -34,6 +38,14 @@ class TimefoldBenchmarkProcessorMultipleSolversConfigTest {
                             """
                                     When defining multiple solvers, the benchmark feature is not enabled.
                                     Consider using separate <solverBenchmark> instances for evaluating different solver configurations."""));
+
+    @Inject
+    @Named("solver1")
+    SolverManager<?, ?> solverManager1;
+
+    @Inject
+    @Named("solver2")
+    SolverManager<?, ?> solverManager2;
 
     @Test
     void benchmark() throws ExecutionException, InterruptedException {

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/DotNames.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/DotNames.java
@@ -2,6 +2,9 @@ package ai.timefold.solver.quarkus.deployment;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+
+import jakarta.inject.Named;
 
 import ai.timefold.solver.core.api.domain.constraintweight.ConstraintConfigurationProvider;
 import ai.timefold.solver.core.api.domain.constraintweight.ConstraintWeight;
@@ -32,11 +35,18 @@ import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
 import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
 import ai.timefold.solver.core.api.score.calculator.IncrementalScoreCalculator;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.api.solver.SolverFactory;
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.SolverManagerConfig;
 
 import org.jboss.jandex.DotName;
 
 public final class DotNames {
+    // Jakarta classes
+    static final DotName NAMED = DotName.createSimple(Named.class);
 
+    // Timefold classes
     static final DotName PLANNING_SOLUTION = DotName.createSimple(PlanningSolution.class.getName());
     static final DotName PLANNING_ENTITY_COLLECTION_PROPERTY =
             DotName.createSimple(PlanningEntityCollectionProperty.class.getName());
@@ -74,6 +84,11 @@ public final class DotNames {
     static final DotName SHADOW_VARIABLE = DotName.createSimple(ShadowVariable.class.getName());
     static final DotName CASCADING_UPDATE_SHADOW_VARIABLE =
             DotName.createSimple(CascadingUpdateShadowVariable.class.getName());
+
+    static final DotName SOLVER_CONFIG = DotName.createSimple(SolverConfig.class.getName());
+    static final DotName SOLVER_MANAGER_CONFIG = DotName.createSimple(SolverManagerConfig.class.getName());
+    static final DotName SOLVER_FACTORY = DotName.createSimple(SolverFactory.class.getName());
+    static final DotName SOLVER_MANAGER = DotName.createSimple(SolverManager.class.getName());
 
     // Need to use String since timefold-solver-test is not on the compile classpath
     static final DotName CONSTRAINT_VERIFIER =
@@ -120,6 +135,12 @@ public final class DotNames {
             SHADOW_VARIABLE,
             CASCADING_UPDATE_SHADOW_VARIABLE
     };
+
+    static final Set<DotName> SOLVER_INJECTABLE_TYPES = Set.of(
+            SOLVER_CONFIG,
+            SOLVER_MANAGER_CONFIG,
+            SOLVER_FACTORY,
+            SOLVER_MANAGER);
 
     public enum BeanDefiningAnnotations {
         PLANNING_SCORE(DotNames.PLANNING_SCORE, "scoreDefinitionClass"),

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/SolverConfigBuildItem.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/SolverConfigBuildItem.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.quarkus.deployment;
 import java.util.Map;
 
 import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.quarkus.deployment.config.TimefoldBuildTimeConfig;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
@@ -16,6 +17,10 @@ public final class SolverConfigBuildItem extends SimpleBuildItem {
     public SolverConfigBuildItem(Map<String, SolverConfig> solverConfig, GeneratedGizmoClasses generatedGizmoClasses) {
         this.solverConfigurations = solverConfig;
         this.generatedGizmoClasses = generatedGizmoClasses;
+    }
+
+    public boolean isDefaultSolverConfig(String solverName) {
+        return solverConfigurations.size() <= 1 || TimefoldBuildTimeConfig.DEFAULT_SOLVER_NAME.equals(solverName);
     }
 
     public Map<String, SolverConfig> getSolverConfigMap() {

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -183,12 +183,12 @@ class TimefoldProcessor {
     /**
      * Converts a method's camelCase name to the kabab-case name used in properties.
      */
-    private String toKebabCase(String camelCaseName) {
+    private static String toKebabCase(String camelCaseName) {
         var matcher = CAPITAL_LETTER_PATTERN.matcher(camelCaseName);
         return matcher.replaceAll(letter -> "-" + letter.group().toLowerCase());
     }
 
-    private void addAllConfigProperties(Class<?> config, String prefix, Set<String> result) {
+    private static void addAllConfigProperties(Class<?> config, String prefix, Set<String> result) {
         for (var method : config.getMethods()) {
             if (method.getReturnType().getAnnotation(ConfigGroup.class) != null) {
                 addAllConfigProperties(method.getReturnType(), prefix + "." + toKebabCase(method.getName()), result);

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -642,11 +642,10 @@ class TimefoldProcessor {
             TimefoldDevUIRecorder devUIRecorder,
             RecorderContext recorderContext,
             SolverConfigBuildItem solverConfigBuildItem,
-            TimefoldRuntimeConfig runtimeConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(DevUISolverConfig.class)
                 .scope(ApplicationScoped.class)
-                .supplier(devUIRecorder.solverConfigSupplier(solverConfigBuildItem.getSolverConfigMap(), runtimeConfig,
+                .supplier(devUIRecorder.solverConfigSupplier(solverConfigBuildItem.getSolverConfigMap(),
                         GizmoMemberAccessorEntityEnhancer.getGeneratedGizmoMemberAccessorMap(recorderContext,
                                 solverConfigBuildItem
                                         .getGeneratedGizmoClasses().generatedGizmoMemberAccessorClassSet),
@@ -721,10 +720,6 @@ class TimefoldProcessor {
         applyScoreDirectorFactoryProperties(indexView, solverConfig);
 
         // Override the current configuration with values from the solver properties
-        timefoldBuildTimeConfig.getSolverConfig(solverName).flatMap(SolverBuildTimeConfig::environmentMode)
-                .ifPresent(solverConfig::setEnvironmentMode);
-        timefoldBuildTimeConfig.getSolverConfig(solverName).flatMap(SolverBuildTimeConfig::daemon)
-                .ifPresent(solverConfig::setDaemon);
         timefoldBuildTimeConfig.getSolverConfig(solverName).flatMap(SolverBuildTimeConfig::domainAccessType)
                 .ifPresent(solverConfig::setDomainAccessType);
 

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -200,7 +200,6 @@ class TimefoldProcessor {
                 solverNames.add(namedItem.value().asString());
             }
         }
-        solverNames.addAll(timefoldBuildTimeConfig.solver().keySet());
 
         // Only skip this extension if everything is missing. Otherwise, if some parts are missing, fail fast later.
         if (indexView.getAnnotations(DotNames.PLANNING_SOLUTION).isEmpty()

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/SolverBuildTimeConfig.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/SolverBuildTimeConfig.java
@@ -6,9 +6,7 @@ import ai.timefold.solver.core.api.domain.common.DomainAccessType;
 import ai.timefold.solver.core.api.score.stream.ConstraintStreamImplType;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.config.solver.SolverConfig;
-import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 import ai.timefold.solver.quarkus.config.SolverRuntimeConfig;
-import ai.timefold.solver.quarkus.config.TerminationRuntimeConfig;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 
@@ -19,7 +17,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
  * @see SolverRuntimeConfig
  */
 @ConfigGroup
-public interface SolverBuildTimeConfig {
+public interface SolverBuildTimeConfig extends SolverRuntimeConfig {
 
     /**
      * A classpath resource to read the specific solver configuration XML.
@@ -46,22 +44,6 @@ public interface SolverBuildTimeConfig {
      * Defaults to {@link DomainAccessType#GIZMO}.
      */
     Optional<DomainAccessType> domainAccessType();
-
-    /**
-     * Note: this setting is only available
-     * for <a href="https://timefold.ai/docs/timefold-solver/latest/enterprise-edition/enterprise-edition">Timefold Solver
-     * Enterprise Edition</a>.
-     * Enable multithreaded solving for a single problem, which increases CPU consumption.
-     * Defaults to {@value SolverConfig#MOVE_THREAD_COUNT_NONE}.
-     * Other options include {@value SolverConfig#MOVE_THREAD_COUNT_AUTO}, a number
-     * or formula based on the available processor count.
-     */
-    Optional<String> moveThreadCount();
-
-    /**
-     * Configuration properties regarding {@link TerminationConfig}.
-     */
-    TerminationRuntimeConfig termination();
 
     /**
      * Enable the Nearby Selection quick configuration.

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/SolverBuildTimeConfig.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/SolverBuildTimeConfig.java
@@ -17,7 +17,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
  * @see SolverRuntimeConfig
  */
 @ConfigGroup
-public interface SolverBuildTimeConfig extends SolverRuntimeConfig {
+public interface SolverBuildTimeConfig {
 
     /**
      * A classpath resource to read the specific solver configuration XML.

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/SolverBuildTimeConfig.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/SolverBuildTimeConfig.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import ai.timefold.solver.core.api.domain.common.DomainAccessType;
 import ai.timefold.solver.core.api.score.stream.ConstraintStreamImplType;
-import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.config.solver.SolverConfig;
 import ai.timefold.solver.quarkus.config.SolverRuntimeConfig;
 
@@ -23,31 +22,23 @@ public interface SolverBuildTimeConfig {
      * A classpath resource to read the specific solver configuration XML.
      * If this property isn't specified, that solverConfig.xml is optional.
      */
+    // Build time - classes in the SolverConfig are visited by SolverConfig.visitReferencedClasses
+    // which generates the constructor of classes used by Quarkus
     Optional<String> solverConfigXml();
-
-    /**
-     * Enable runtime assertions to detect common bugs in your implementation during development.
-     * Defaults to {@link EnvironmentMode#REPRODUCIBLE}.
-     */
-    Optional<EnvironmentMode> environmentMode();
-
-    /**
-     * Enable daemon mode. In daemon mode, non-early termination pauses the solver instead of stopping it,
-     * until the next problem fact change arrives.
-     * This is often useful for real-time planning.
-     * Defaults to "false".
-     */
-    Optional<Boolean> daemon();
 
     /**
      * Determines how to access the fields and methods of domain classes.
      * Defaults to {@link DomainAccessType#GIZMO}.
      */
+    // Build time - GIZMO classes are only generated if at least one solver
+    // has domain access type GIZMO
     Optional<DomainAccessType> domainAccessType();
 
     /**
      * Enable the Nearby Selection quick configuration.
      */
+    // Build time - visited by SolverConfig.visitReferencedClasses
+    // which generates the constructor used by Quarkus
     Optional<Class<?>> nearbyDistanceMeterClass();
 
     /**
@@ -68,5 +59,6 @@ public interface SolverBuildTimeConfig {
      * will no longer be triggered.
      * Defaults to "false".
      */
+    // Build time - modifies the ConstraintProvider class if set
     Optional<Boolean> constraintStreamAutomaticNodeSharing();
 }

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/TimefoldBuildTimeConfig.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/TimefoldBuildTimeConfig.java
@@ -34,12 +34,6 @@ public interface TimefoldBuildTimeConfig {
     @WithUnnamedKey(DEFAULT_SOLVER_NAME)
     Map<String, SolverBuildTimeConfig> solver();
 
-    default boolean isDefaultSolverConfig(String solverName) {
-        // 1 - No solver configuration, which means we will use a default empty SolverConfig and default Solver name
-        // 2 - Only one solve config. It will be the default one.
-        return solver().isEmpty() || solver().size() == 1 && getSolverConfig(solverName).isPresent();
-    }
-
     default Optional<SolverBuildTimeConfig> getSolverConfig(String solverName) {
         return Optional.ofNullable(solver().get(solverName));
     }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidConstraintClassTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidConstraintClassTest.java
@@ -4,6 +4,10 @@ package ai.timefold.solver.quarkus;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import ai.timefold.solver.core.api.solver.SolverManager;
 import ai.timefold.solver.quarkus.testdata.dummy.DummyTestdataQuarkusEasyScoreCalculator;
 import ai.timefold.solver.quarkus.testdata.dummy.DummyTestdataQuarkusIncrementalScoreCalculator;
 import ai.timefold.solver.quarkus.testdata.dummy.DummyTestdataQuarkusShadowVariableEasyScoreCalculator;
@@ -225,6 +229,14 @@ class TimefoldProcessorMultipleSolversInvalidConstraintClassTest {
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining(
                             "Unused classes ([ai.timefold.solver.quarkus.testdata.dummy.DummyTestdataQuarkusShadowVariableIncrementalScoreCalculator]) that implements IncrementalScoreCalculator were found."));
+
+    @Inject
+    @Named("solver1")
+    SolverManager<?, ?> solverManager1;
+
+    @Inject
+    @Named("solver2")
+    SolverManager<?, ?> solverManager2;
 
     @Test
     void test() {

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidEntityClassTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidEntityClassTest.java
@@ -4,6 +4,10 @@ package ai.timefold.solver.quarkus;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import ai.timefold.solver.core.api.solver.SolverManager;
 import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -25,6 +29,14 @@ class TimefoldProcessorMultipleSolversInvalidEntityClassTest {
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining(
                             "No classes were found with a @PlanningEntity annotation."));
+
+    @Inject
+    @Named("solver1")
+    SolverManager<?, ?> solverManager1;
+
+    @Inject
+    @Named("solver2")
+    SolverManager<?, ?> solverManager2;
 
     @Test
     void test() {

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidSolutionClassTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversInvalidSolutionClassTest.java
@@ -4,6 +4,10 @@ package ai.timefold.solver.quarkus;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import ai.timefold.solver.core.api.solver.SolverManager;
 import ai.timefold.solver.quarkus.testdata.chained.domain.TestdataChainedQuarkusSolution;
 import ai.timefold.solver.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
@@ -77,6 +81,14 @@ class TimefoldProcessorMultipleSolversInvalidSolutionClassTest {
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining(
                             "Unused classes ([ai.timefold.solver.quarkus.testdata.chained.domain.TestdataChainedQuarkusSolution]) found with a @PlanningSolution annotation."));
+
+    @Inject
+    @Named("solver1")
+    SolverManager<?, ?> solverManager1;
+
+    @Inject
+    @Named("solver2")
+    SolverManager<?, ?> solverManager2;
 
     @Test
     void test() {

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversPropertiesTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversPropertiesTest.java
@@ -2,6 +2,10 @@ package ai.timefold.solver.quarkus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import ai.timefold.solver.core.api.solver.SolverManager;
 import ai.timefold.solver.quarkus.rest.TestdataQuarkusSolutionConfigResource;
 import ai.timefold.solver.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
@@ -24,6 +28,14 @@ class TimefoldProcessorMultipleSolversPropertiesTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
                             TestdataQuarkusConstraintProvider.class, TestdataQuarkusSolutionConfigResource.class));
+
+    @Inject
+    @Named("solver1")
+    SolverManager<?, ?> solverManager1;
+
+    @Inject
+    @Named("solver2")
+    SolverManager<?, ?> solverManager2;
 
     @Test
     void solverProperties() {

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversYamlTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMultipleSolversYamlTest.java
@@ -2,6 +2,10 @@ package ai.timefold.solver.quarkus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import ai.timefold.solver.core.api.solver.SolverManager;
 import ai.timefold.solver.quarkus.rest.TestdataQuarkusSolutionConfigResource;
 import ai.timefold.solver.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
@@ -23,6 +27,14 @@ class TimefoldProcessorMultipleSolversYamlTest {
                     .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
                             TestdataQuarkusConstraintProvider.class, TestdataQuarkusSolutionConfigResource.class)
                     .addAsResource("ai/timefold/solver/quarkus/multiple-solvers/application.yaml", "application.yaml"));
+
+    @Inject
+    @Named("solver1")
+    SolverManager<?, ?> solverManager1;
+
+    @Inject
+    @Named("solver2")
+    SolverManager<?, ?> solverManager2;
 
     @Test
     void solverProperties() {

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSolverResourcesTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSolverResourcesTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import ai.timefold.solver.core.api.domain.common.DomainAccessType;
 import ai.timefold.solver.core.api.score.ScoreManager;
@@ -50,6 +51,10 @@ class TimefoldProcessorSolverResourcesTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
                             TestdataQuarkusConstraintProvider.class));
+
+    @Inject
+    @Named("solver1")
+    SolverManager<?, ?> solverManager1;
 
     @Inject
     ConstraintMetaModel constraintMetaModel;

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSolverUnusedPropertiesTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSolverUnusedPropertiesTest.java
@@ -1,0 +1,86 @@
+package ai.timefold.solver.quarkus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.quarkus.testdata.dummy.DummyDistanceMeter;
+import ai.timefold.solver.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldProcessorSolverUnusedPropertiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config1 = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.solver.environment-mode", "FULL_ASSERT")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver1\".daemon", "true")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver1\".nearby-distance-meter-class",
+                    "ai.timefold.solver.quarkus.testdata.dummy.DummyDistanceMeter")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver2\".move-thread-count", "2")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver2\".domain-access-type", "REFLECTION")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver2\".termination.spent-limit", "4h")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver3\".termination.unimproved-spent-limit", "5h")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver3\".termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
+                            TestdataQuarkusConstraintProvider.class, DummyDistanceMeter.class))
+            .assertException(throwable -> {
+                // This failure happens at build time and does not have access to solver3, which
+                // is only defined at runtime
+                assertThat(throwable)
+                        .hasMessageContaining("Some names defined in properties")
+                        .hasMessageContaining("solver2")
+                        .hasMessageContaining("do not have a corresponding @" + Named.class.getSimpleName()
+                                + " injection point")
+                        .hasMessageContaining("solver1");
+            });
+
+    @RegisterExtension
+    static final QuarkusUnitTest config2 = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.solver.environment-mode", "FULL_ASSERT")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver1\".daemon", "true")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver1\".nearby-distance-meter-class",
+                    "ai.timefold.solver.quarkus.testdata.dummy.DummyDistanceMeter")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver2\".termination.unimproved-spent-limit", "5h")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver2\".termination.best-score-limit", "0")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver3\".termination.unimproved-spent-limit", "5h")
+            .overrideConfigKey("quarkus.timefold.solver.\"solver3\".termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
+                            TestdataQuarkusConstraintProvider.class, DummyDistanceMeter.class))
+            .assertException(throwable -> {
+                // The build succeeds, but runtime fails at startup due to runtime properties referencing
+                // missing Named annotations
+                assertThat(throwable)
+                        .hasMessageContaining("Some names defined in properties")
+                        .hasMessageContaining("solver2")
+                        .hasMessageContaining("solver3")
+                        .hasMessageContaining("do not have a corresponding @" + Named.class.getSimpleName()
+                                + " injection point")
+                        .hasMessageContaining("solver1");
+            });
+
+    @Inject
+    SolverConfig solverConfig;
+
+    @Inject
+    @Named("solver1")
+    SolverManager<TestdataQuarkusSolution, ?> solverManager;
+
+    @Test
+    void solve() {
+        fail("Build should fail");
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorWarningBuildTimePropertyChangedTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorWarningBuildTimePropertyChangedTest.java
@@ -25,14 +25,13 @@ class TimefoldProcessorWarningBuildTimePropertyChangedTest {
                     .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
                             TestdataQuarkusConstraintProvider.class))
             // Make sure Quarkus does not produce a warning for overwriting a build time value at runtime
-            .setLogRecordPredicate(record -> record.getLoggerName().startsWith("io.quarkus")
-                    && record.getLevel().intValue() >= Level.WARNING.intValue())
-            .assertLogRecords(logRecords -> {
-                assertEquals(1, logRecords.size(), "expected warning to be generated");
-            });
+            .setLogRecordPredicate(logRecord -> logRecord.getLoggerName().startsWith("io.quarkus")
+                    && logRecord.getLevel().intValue() >= Level.WARNING.intValue());
 
     @Test
     void solverProperties() {
-        // Test is done by assertLogRecords
+        config.assertLogRecords(logRecords -> {
+            assertEquals(1, logRecords.size(), "expected warning to be generated");
+        });
     }
 }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorWarningBuildTimePropertyChangedTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorWarningBuildTimePropertyChangedTest.java
@@ -1,0 +1,38 @@
+package ai.timefold.solver.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.logging.Level;
+
+import ai.timefold.solver.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldProcessorWarningBuildTimePropertyChangedTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.solver.daemon", "true")
+            // We overwrite the value at runtime
+            .overrideRuntimeConfigKey("quarkus.timefold.solver.daemon", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
+                            TestdataQuarkusConstraintProvider.class))
+            // Make sure Quarkus does not produce a warning for overwriting a build time value at runtime
+            .setLogRecordPredicate(record -> record.getLoggerName().startsWith("io.quarkus")
+                    && record.getLevel().intValue() >= Level.WARNING.intValue())
+            .assertLogRecords(logRecords -> {
+                assertEquals(1, logRecords.size(), "expected warning to be generated");
+            });
+
+    @Test
+    void solverProperties() {
+        // Test is done by assertLogRecords
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorWarningRuntimePropertyChangedTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorWarningRuntimePropertyChangedTest.java
@@ -1,0 +1,40 @@
+package ai.timefold.solver.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.logging.Level;
+
+import ai.timefold.solver.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import ai.timefold.solver.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldProcessorWarningRuntimePropertyChangedTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.solver.move-thread-count", "1")
+            .overrideConfigKey("quarkus.timefold.solver.termination.spent-limit", "1s")
+            // We overwrite the value at runtime
+            .overrideRuntimeConfigKey("quarkus.timefold.solver.move-thread-count", "2")
+            .overrideRuntimeConfigKey("quarkus.timefold.solver.termination.spent-limit", "2s")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
+                            TestdataQuarkusConstraintProvider.class))
+            // Make sure Quarkus does not produce a warning for overwriting a build time value at runtime
+            .setLogRecordPredicate(record -> record.getLoggerName().startsWith("io.quarkus")
+                    && record.getLevel().intValue() >= Level.WARNING.intValue())
+            .assertLogRecords(logRecords -> {
+                assertEquals(0, logRecords.size(), "expected no warnings to be generated");
+            });
+
+    @Test
+    void solverProperties() {
+        // Test is done by assertLogRecords
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorWarningRuntimePropertyChangedTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorWarningRuntimePropertyChangedTest.java
@@ -27,14 +27,13 @@ class TimefoldProcessorWarningRuntimePropertyChangedTest {
                     .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
                             TestdataQuarkusConstraintProvider.class))
             // Make sure Quarkus does not produce a warning for overwriting a build time value at runtime
-            .setLogRecordPredicate(record -> record.getLoggerName().startsWith("io.quarkus")
-                    && record.getLevel().intValue() >= Level.WARNING.intValue())
-            .assertLogRecords(logRecords -> {
-                assertEquals(0, logRecords.size(), "expected no warnings to be generated");
-            });
+            .setLogRecordPredicate(logRecord -> logRecord.getLoggerName().startsWith("io.quarkus")
+                    && logRecord.getLevel().intValue() >= Level.WARNING.intValue());
 
     @Test
     void solverProperties() {
-        // Test is done by assertLogRecords
+        config.assertLogRecords(logRecords -> {
+            assertEquals(0, logRecords.size(), "expected no warnings to be generated");
+        });
     }
 }

--- a/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/config/SolverRuntimeConfig.java
+++ b/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/config/SolverRuntimeConfig.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.quarkus.config;
 
 import java.util.Optional;
 
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.config.solver.SolverConfig;
 import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 
@@ -13,6 +14,20 @@ import io.quarkus.runtime.annotations.ConfigGroup;
  */
 @ConfigGroup
 public interface SolverRuntimeConfig {
+    /**
+     * Enable runtime assertions to detect common bugs in your implementation during development.
+     * Defaults to {@link EnvironmentMode#REPRODUCIBLE}.
+     */
+    Optional<EnvironmentMode> environmentMode();
+
+    /**
+     * Enable daemon mode. In daemon mode, non-early termination pauses the solver instead of stopping it,
+     * until the next problem fact change arrives.
+     * This is often useful for real-time planning.
+     * Defaults to "false".
+     */
+    Optional<Boolean> daemon();
+
     /**
      * Note: this setting is only available
      * for <a href="https://timefold.ai/docs/timefold-solver/latest/enterprise-edition/enterprise-edition">Timefold Solver

--- a/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/config/SolverRuntimeConfig.java
+++ b/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/config/SolverRuntimeConfig.java
@@ -14,6 +14,9 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 @ConfigGroup
 public interface SolverRuntimeConfig {
     /**
+     * Note: this setting is only available
+     * for <a href="https://timefold.ai/docs/timefold-solver/latest/enterprise-edition/enterprise-edition">Timefold Solver
+     * Enterprise Edition</a>.
      * Enable multithreaded solving for a single problem, which increases CPU consumption.
      * Defaults to {@value SolverConfig#MOVE_THREAD_COUNT_NONE}.
      * Other options include {@value SolverConfig#MOVE_THREAD_COUNT_AUTO}, a number

--- a/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/devui/TimefoldDevUIRecorder.java
+++ b/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/devui/TimefoldDevUIRecorder.java
@@ -8,10 +8,9 @@ import java.util.function.Supplier;
 import ai.timefold.solver.core.api.domain.solution.cloner.SolutionCloner;
 import ai.timefold.solver.core.api.solver.SolverFactory;
 import ai.timefold.solver.core.config.solver.SolverConfig;
-import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 import ai.timefold.solver.core.impl.domain.common.accessor.MemberAccessor;
 import ai.timefold.solver.core.impl.io.jaxb.SolverConfigIO;
-import ai.timefold.solver.quarkus.config.SolverRuntimeConfig;
+import ai.timefold.solver.quarkus.TimefoldRecorder;
 import ai.timefold.solver.quarkus.config.TimefoldRuntimeConfig;
 
 import io.quarkus.runtime.RuntimeValue;
@@ -19,15 +18,19 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class TimefoldDevUIRecorder {
+    final TimefoldRuntimeConfig timefoldRuntimeConfig;
+
+    public TimefoldDevUIRecorder(final TimefoldRuntimeConfig timefoldRuntimeConfig) {
+        this.timefoldRuntimeConfig = timefoldRuntimeConfig;
+    }
 
     public Supplier<DevUISolverConfig> solverConfigSupplier(Map<String, SolverConfig> allSolverConfig,
-            TimefoldRuntimeConfig timefoldRuntimeConfig,
             Map<String, RuntimeValue<MemberAccessor>> generatedGizmoMemberAccessorMap,
             Map<String, RuntimeValue<SolutionCloner>> generatedGizmoSolutionClonerMap) {
         return () -> {
             DevUISolverConfig uiSolverConfig = new DevUISolverConfig();
             allSolverConfig.forEach((solverName, solverConfig) -> {
-                updateSolverConfigWithRuntimeProperties(solverName, solverConfig, timefoldRuntimeConfig);
+                updateSolverConfigWithRuntimeProperties(solverName, solverConfig);
                 Map<String, MemberAccessor> memberAccessorMap = new HashMap<>();
                 Map<String, SolutionCloner> solutionClonerMap = new HashMap<>();
                 generatedGizmoMemberAccessorMap
@@ -50,20 +53,8 @@ public class TimefoldDevUIRecorder {
 
     }
 
-    private void updateSolverConfigWithRuntimeProperties(String solverName, SolverConfig solverConfig,
-            TimefoldRuntimeConfig timefoldRunTimeConfig) {
-        TerminationConfig terminationConfig = solverConfig.getTerminationConfig();
-        if (terminationConfig == null) {
-            terminationConfig = new TerminationConfig();
-            solverConfig.setTerminationConfig(terminationConfig);
-        }
-        timefoldRunTimeConfig.getSolverRuntimeConfig(solverName).flatMap(config -> config.termination().spentLimit())
-                .ifPresent(terminationConfig::setSpentLimit);
-        timefoldRunTimeConfig.getSolverRuntimeConfig(solverName).flatMap(config -> config.termination().unimprovedSpentLimit())
-                .ifPresent(terminationConfig::setUnimprovedSpentLimit);
-        timefoldRunTimeConfig.getSolverRuntimeConfig(solverName).flatMap(config -> config.termination().bestScoreLimit())
-                .ifPresent(terminationConfig::setBestScoreLimit);
-        timefoldRunTimeConfig.getSolverRuntimeConfig(solverName).flatMap(SolverRuntimeConfig::moveThreadCount)
-                .ifPresent(solverConfig::setMoveThreadCount);
+    private void updateSolverConfigWithRuntimeProperties(String solverName, SolverConfig solverConfig) {
+        TimefoldRecorder.updateSolverConfigWithRuntimeProperties(solverConfig,
+                timefoldRuntimeConfig.getSolverRuntimeConfig(solverName).orElse(null));
     }
 }


### PR DESCRIPTION
In order to know the names of Solver beans to generate, the SolverBuildTimeConfig must extend the SolverRuntimeConfig, since all build time properties of SolverBuildTimeConfig are optional (so a named Solver might only be defined by termination, which is a runtime property).

Quarkus does not provide a mechanism for defining additional produces/instances of a bean at runtime (it goes against doing all possible work at build time), and thus, all names of Solver beans MUST be known at build time.

You cannot read a RuntimeConfig object inside a processor; all its methods will return null. Thus, it is impossible to get a list of runtime properties that were defined at build time.

Having SolverBuildTimeConfig extend SolverRuntimeConfig causes an issue. Namely, Quarkus, will generate a warning if a SolverRuntimeConfig property changes at runtime, since, by definition, it is also a SolverBuildTimeConfig property.

Quarkus provides a handy build item for surpressing the warning (although its intended use is to hide sensitive data): SuppressNonRuntimeConfigChangedWarningBuildItem.
Unfortunately, we need the EXACT name of the property to hide (there was no programmatic method available for getting the name from a method or class). Thus, we use ConfigurationBuildItem to get all build time properties (which natuarally includes the SolverBuildTimeConfig properties), filter them to check only properties that start with TimefoldBuildTimeConfig prefix, and suppress warnings for any property that match the filter and ends with a runtime property suffix.