### PR TITLE
fix: Python custom justifications with Decimal scores

### DIFF
--- a/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonDecimal.java
+++ b/python/jpyinterpreter/src/main/java/ai/timefold/jpyinterpreter/types/numeric/PythonDecimal.java
@@ -119,6 +119,19 @@ public class PythonDecimal extends AbstractPythonLikeObject implements PythonNum
         return value.toPlainString();
     }
 
+    // Required since to_python_score expects a BigDecimal instance
+    // (which comes from the Java *BigDecimalScore)
+    // but the translator will automatically convert all BigDecimals
+    // into PythonDecimal instances.
+    // In particular, it expects a toPlainString method so it can
+    // create a Python decimal from a BigDecimal.
+    // The function can be called either untranslated (normally)
+    // or translated (when used in a justification function),
+    // hence why we define this method.
+    public PythonString $method$toPlainString() {
+        return PythonString.valueOf(value.toPlainString());
+    }
+
     public boolean equals(Object o) {
         if (o instanceof PythonNumber number) {
             return compareTo(number) == 0;


### PR DESCRIPTION
The translator automatically converts the result of Java method calls on Java objects into the corresponding Python types. This is normally wanted, since it allow users to use the result of ConstraintCollectors (which are Java objects).

However, `to_python_score` does not want this; it expects the normal Java result. It is typically called in an untranslated context and thus usually does not run into this issue. However, when a custom justification function is used, it is called in a translation context. For normal scores, it works, since we don't access any properties of the long when creating the corresponding Python score. For decimal scores, we call toPlainString() so we can create a Python Decimal instance from a Java BigDecimal. Python Decimal does not have a toPlainString method normally, so it causes an attribute lookup failure at runtime.

The fix is to add a toPlainString method to PythonDecimal, that just delegate to the toPlainString method of its value.