### PR TITLE
fix: do not double count move evaluations

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateConstructionHeuristicPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateConstructionHeuristicPhaseScope.java
@@ -11,11 +11,6 @@ final class RuinRecreateConstructionHeuristicPhaseScope<Solution_> extends Const
     }
 
     @Override
-    public void addChildThreadsMoveEvaluationCount(long addition) {
-        // Nested phase does not count moves.
-    }
-
-    @Override
     public void addMoveEvaluationCount(Move<Solution_> move, long count) {
         // Nested phase does not count moves.
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
@@ -32,7 +32,6 @@ public abstract class AbstractPhaseScope<Solution_> {
     protected Long endingScoreCalculationCount;
     protected Long endingMoveEvaluationCount;
     protected long childThreadsScoreCalculationCount = 0L;
-    protected long childThreadsMoveEvaluationCount = 0L;
 
     protected int bestSolutionStepIndex;
 
@@ -140,11 +139,6 @@ public abstract class AbstractPhaseScope<Solution_> {
         childThreadsScoreCalculationCount += addition;
     }
 
-    public void addChildThreadsMoveEvaluationCount(long addition) {
-        solverScope.addChildThreadsMoveEvaluationCount(addition);
-        childThreadsMoveEvaluationCount += addition;
-    }
-
     public void addMoveEvaluationCount(Move<Solution_> move, long count) {
         solverScope.addMoveEvaluationCount(1);
         addMoveEvaluationCountPerType(move, count);
@@ -153,12 +147,6 @@ public abstract class AbstractPhaseScope<Solution_> {
     public void addMoveEvaluationCountPerType(Move<Solution_> move, long count) {
         if (solverScope.isMetricEnabled(SolverMetric.MOVE_COUNT_PER_TYPE)) {
             solverScope.addMoveEvaluationCountPerType(move.describe(), count);
-        }
-    }
-
-    public void addMoveEvaluationCountPerType(String moveDescription, long count) {
-        if (solverScope.isMetricEnabled(SolverMetric.MOVE_COUNT_PER_TYPE)) {
-            solverScope.addMoveEvaluationCountPerType(moveDescription, count);
         }
     }
 
@@ -171,7 +159,7 @@ public abstract class AbstractPhaseScope<Solution_> {
         if (endingMoveEvaluationCount == null) {
             currentMoveEvaluationCount = getSolverScope().getMoveEvaluationCount();
         }
-        return currentMoveEvaluationCount - startingMoveEvaluationCount + childThreadsMoveEvaluationCount;
+        return currentMoveEvaluationCount - startingMoveEvaluationCount;
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
@@ -55,7 +55,6 @@ public class SolverScope<Solution_> {
     private long childThreadsScoreCalculationCount = 0L;
 
     private long moveEvaluationCount = 0L;
-    private long childThreadsMoveEvaluationCount = 0L;
 
     private Score<?> startingInitializedScore;
 
@@ -200,12 +199,8 @@ public class SolverScope<Solution_> {
         moveEvaluationCount += addition;
     }
 
-    public void addChildThreadsMoveEvaluationCount(long addition) {
-        childThreadsMoveEvaluationCount += addition;
-    }
-
     public long getMoveEvaluationCount() {
-        return moveEvaluationCount + childThreadsMoveEvaluationCount;
+        return moveEvaluationCount;
     }
 
     public Solution_ getBestSolution() {


### PR DESCRIPTION
Since move evaluations are already counted by the foragers, and the same foragers are used in multithreaded solving, Having a seperate field for multithreaded move evaluations leads to a double count.