### PR TITLE
fix: do not crash dev mode on empty app

### DIFF
--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -669,6 +670,18 @@ class TimefoldProcessor {
             RecorderContext recorderContext,
             SolverConfigBuildItem solverConfigBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+        if (solverConfigBuildItem.getGeneratedGizmoClasses() == null) {
+            // Extension was skipped, so no solver configs
+            syntheticBeans.produce(SyntheticBeanBuildItem.configure(DevUISolverConfig.class)
+                    .scope(ApplicationScoped.class)
+                    .supplier(devUIRecorder.solverConfigSupplier(Collections.emptyMap(),
+                            Collections.emptyMap(),
+                            Collections.emptyMap()))
+                    .defaultBean()
+                    .setRuntimeInit()
+                    .done());
+            return;
+        }
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(DevUISolverConfig.class)
                 .scope(ApplicationScoped.class)
                 .supplier(devUIRecorder.solverConfigSupplier(solverConfigBuildItem.getSolverConfigMap(),

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorDevModeEmptyAppTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorDevModeEmptyAppTest.java
@@ -1,0 +1,22 @@
+package ai.timefold.solver.quarkus;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class TimefoldProcessorDevModeEmptyAppTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses());
+
+    @Test
+    void emptyAppDoesNotCrash() {
+        // Success if it didn't crash during bootstrap
+    }
+
+}


### PR DESCRIPTION
If the app is empty, generated gizmo classes will be null, and that cause an NPE to be thrown in the Dev UI supplier which did not have a null check. It now builds an empty Dev UI item.

Fixes #1365 