### PR TITLE
 docs: hotfix a minor error in the python quickstarts tutorial. 

### DIFF
--- a/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -710,7 +710,7 @@ def generate_demo_data() -> Timetable:
     lessons.append(Lesson(next(ids), "English", "P. Cruz", "10th grade"))
     lessons.append(Lesson(next(ids), "Spanish", "P. Cruz", "10th grade"))
 
-    return Timetable(demo_data.name, timeslots, rooms, lessons)
+    return Timetable("DEMO_DATA", timeslots, rooms, lessons)
 
 
 def print_timetable(time_table: Timetable) -> None:


### PR DESCRIPTION
In section **8. Create the application**, there is a line: 
```python
    return Timetable(demo_data.name, timeslots, rooms, lessons)
```
This will cause `NameError: name 'demo_data' is not defined` because `demo_data` is not defined anywhere in the `generate_demo_data()` function.  A possible hotfix is to just directly assign a name:
```python
    return Timetable("DEMO_DATA", timeslots, rooms, lessons)
```