### PR TITLE
chore: enable CI when updating only .adoc files

### DIFF
--- a/.github/workflows/pull_request_secure.yml
+++ b/.github/workflows/pull_request_secure.yml
@@ -21,7 +21,6 @@ on:
       - 'LICENSE*'
       - '.gitignore'
       - '**.md'
-      - '**.adoc'
       - '*.txt'
 
 jobs:


### PR DESCRIPTION
This PR removes the adoc files from the ignored paths because we have a deployment job that should trigger whenever an adoc file is updated.

We will still run some unnecessary jobs, but it is necessary to continue using the secured workflow.