### PR TITLE
docs: specified timefold-solver-test dependency version

### DIFF
--- a/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -244,6 +244,7 @@ Add a `timefold-solver-test` dependency in your `pom.xml`:
     <dependency>
       <groupId>ai.timefold.solver</groupId>
       <artifactId>timefold-solver-test</artifactId>
+      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
 ----


### PR DESCRIPTION
To address this during compilation:

```
[ERROR] 'dependencies.dependency.version' for ai.timefold.solver:timefold-solver-test:jar is missing.
```