### PR TITLE
docs: Lesson constructor for tests

### DIFF
--- a/docs/src/modules/ROOT/pages/quickstart/shared/school-timetabling/school-timetabling-model.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/shared/school-timetabling/school-timetabling-model.adoc
@@ -269,6 +269,12 @@ public class Lesson {
         this.studentGroup = studentGroup;
     }
 
+    public Lesson(String id, String subject, String teacher, String studentGroup, Timeslot timeslot, Room room) {
+        this(id, subject, teacher, studentGroup);
+        this.timeslot = timeslot;
+        this.room = room;
+    }
+
     public String getId() {
         return id;
     }

--- a/docs/src/modules/ROOT/pages/quickstart/shared/school-timetabling/school-timetabling-model.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/shared/school-timetabling/school-timetabling-model.adoc
@@ -269,7 +269,8 @@ public class Lesson {
         this.studentGroup = studentGroup;
     }
 
-    public Lesson(String id, String subject, String teacher, String studentGroup, Timeslot timeslot, Room room) {
+    // This constructor is only for tests
+    Lesson(String id, String subject, String teacher, String studentGroup, Timeslot timeslot, Room room) {
         this(id, subject, teacher, studentGroup);
         this.timeslot = timeslot;
         this.room = room;


### PR DESCRIPTION
My tests were failing because of this error:

```
/src/test/java/org/acme/schooltimetabling/solver/TimetableConstraintProviderTest.java:[28,30] no suitable constructor found for Lesson(java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.acme.schooltimetabling.domain.Timeslot,org.acme.schooltimetabling.domain.Room)
```

So i borrowed a second constructor from some of the OptaPlanner docs.