### PR TITLE
docs: add rest-assured dependency

### DIFF
--- a/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -237,6 +237,11 @@ Add a `timefold-solver-test` dependency in your `pom.xml`:
 [source,xml]
 ----
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
         <scope>test</scope>

--- a/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -237,9 +237,9 @@ Add a `timefold-solver-test` dependency in your `pom.xml`:
 [source,xml]
 ----
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
-      <scope>test</scope>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>rest-assured</artifactId>
+        <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ai.timefold.solver</groupId>


### PR DESCRIPTION
The docs are missing a dependency record for rest-assured.

This clears that up.