### PR TITLE
docs: importing java.io objects for TimetableResourceTest

### DIFF
--- a/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -302,6 +302,9 @@ import io.quarkus.jackson.ObjectMapperCustomizer;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
+import java.io.IOException;
+import java.io.File;
+
 @QuarkusTest
 class TimetableResourceTest {
 


### PR DESCRIPTION
I might be running a different version of Java, but i had to explicitly import a couple of `java.io` objects.