### PR TITLE
docs: align api structure for quickstarts

### DIFF
--- a/docs/src/modules/ROOT/pages/quickstart/quarkus-vehicle-routing/quarkus-vehicle-routing-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/quarkus-vehicle-routing/quarkus-vehicle-routing-quickstart.adoc
@@ -367,7 +367,6 @@ public class VehicleRoutePlanResource {
     }
 
     @POST
-    @Path("solve")
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces(MediaType.APPLICATION_JSON)
     public VehicleRoutePlan solve(VehicleRoutePlan problem) {
@@ -425,7 +424,6 @@ class VehicleRoutePlanResource {
     }
 
     @POST
-    @Path("solve")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     fun solve(problem: VehicleRoutePlan): VehicleRoutePlan {
@@ -491,7 +489,7 @@ The following example uses the Linux command `curl` to send a POST request:
 
 [source,shell]
 ----
-$ curl -i -X POST http://localhost:8080/route-plans/solve -H "Content-Type:application/json" -d '{"name":"demo","vehicles":[{"id":"1","capacity":15,"homeLocation":[40.605994321126936,-75.68106859680056],"departureTime":"2024-02-10T07:30:00"},{"id":"2","capacity":25,"homeLocation":[40.32196770776356,-75.69785667307953],"departureTime":"2024-02-10T07:30:00"}],"visits":[{"id":"1","name":"Dan Green","location":[40.76104493121754,-75.16056341466826],"demand":1,"minStartTime":"2024-02-10T13:00:00","maxEndTime":"2024-02-10T18:00:00","serviceDuration":1200},{"id":"2","name":"Ivy King","location":[40.13754381024318,-75.492526629236],"demand":1,"minStartTime":"2024-02-10T13:00:00","maxEndTime":"2024-02-10T18:00:00","serviceDuration":1200.000000000},{"id":"3","name":"Flo Li","location":[39.87122455090297,-75.64520072015769],"demand":2,"minStartTime":"2024-02-10T08:00:00","maxEndTime":"2024-02-10T12:00:00","serviceDuration":600.000000000},{"id":"4","name":"Flo Cole","location":[40.46124744193433,-75.18250987609025],"demand":1,"minStartTime":"2024-02-10T13:00:00","maxEndTime":"2024-02-10T18:00:00","serviceDuration":2400.000000000},{"id":"5","name":"Carl Green","location":[40.61352381171549,-75.83301278355529],"demand":1,"minStartTime":"2024-02-10T08:00:00","maxEndTime":"2024-02-10T12:00:00","serviceDuration":1800.000000000}]}'
+$ curl -i -X POST http://localhost:8080/route-plans -H "Content-Type:application/json" -d '{"name":"demo","vehicles":[{"id":"1","capacity":15,"homeLocation":[40.605994321126936,-75.68106859680056],"departureTime":"2024-02-10T07:30:00"},{"id":"2","capacity":25,"homeLocation":[40.32196770776356,-75.69785667307953],"departureTime":"2024-02-10T07:30:00"}],"visits":[{"id":"1","name":"Dan Green","location":[40.76104493121754,-75.16056341466826],"demand":1,"minStartTime":"2024-02-10T13:00:00","maxEndTime":"2024-02-10T18:00:00","serviceDuration":1200},{"id":"2","name":"Ivy King","location":[40.13754381024318,-75.492526629236],"demand":1,"minStartTime":"2024-02-10T13:00:00","maxEndTime":"2024-02-10T18:00:00","serviceDuration":1200.000000000},{"id":"3","name":"Flo Li","location":[39.87122455090297,-75.64520072015769],"demand":2,"minStartTime":"2024-02-10T08:00:00","maxEndTime":"2024-02-10T12:00:00","serviceDuration":600.000000000},{"id":"4","name":"Flo Cole","location":[40.46124744193433,-75.18250987609025],"demand":1,"minStartTime":"2024-02-10T13:00:00","maxEndTime":"2024-02-10T18:00:00","serviceDuration":2400.000000000},{"id":"5","name":"Carl Green","location":[40.61352381171549,-75.83301278355529],"demand":1,"minStartTime":"2024-02-10T08:00:00","maxEndTime":"2024-02-10T12:00:00","serviceDuration":1800.000000000}]}'
 ----
 
 After about five seconds, according to the termination spent time defined in your `application.properties`,

--- a/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -10,7 +10,7 @@ include::../../_attributes.adoc[]
 :wiringannotationfq: jakarta.inject.Inject
 :testannotation: @QuarkusTest
 :testannotationfq: io.quarkus.test.junit.QuarkusTest
-:framework-quickstart-url: {quarkus-quickstart-url-quickstart-url}
+:framework-quickstart-url: {quarkus-quickstart-url}
 // disable python code examples for quarkus
 :python-disabled:
 
@@ -234,7 +234,7 @@ Maven::
 +
 --
 Add a `timefold-solver-test` dependency in your `pom.xml`:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -249,7 +249,7 @@ Add a `timefold-solver-test` dependency in your `pom.xml`:
     <dependency>
       <groupId>ai.timefold.solver</groupId>
       <artifactId>timefold-solver-test</artifactId>
-      <version>1.19.0</version>
+      <version>{timefold-solver-version}</version>
       <scope>test</scope>
     </dependency>
 ----
@@ -261,7 +261,7 @@ Add the subsequent dependencies to your `build.gradle`:
 [source,groovy,subs=attributes+]
 ----
     testImplementation "io.quarkus:quarkus-junit5"
-    testImplementation "ai.timefold.solver:timefold-solver-test"
+    testImplementation "ai.timefold.solver:timefold-solver-test:{timefold-solver-version}"
 ----
 --
 ====
@@ -456,4 +456,3 @@ Next Steps:
 
 - For a full implementation with a web UI and in-memory storage, check out {quarkus-quickstart-url}[the Quarkus quickstart source code].
 - Check out more information about Timefold's integration with Quarkus in our xref:../integration/integration.adoc#integrationWithQuarkus[Integration documentation].
-// TODO Link here - Create a native image using Spring Boot

--- a/docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
@@ -77,7 +77,7 @@ public class TimetableController {
     @Autowired
     private SolverManager<Timetable, UUID> solverManager;
 
-    @PostMapping("/solve")
+    @PostMapping
     public Timetable solve(@RequestBody Timetable problem) {
         UUID problemId = UUID.randomUUID();
         // Submit the problem to start solving
@@ -119,7 +119,7 @@ class TimetableController {
     @Autowired
     private val solverManager: SolverManager<Timetable, UUID>? = null
 
-    @PostMapping("/solve")
+    @PostMapping
     fun solve(@RequestBody problem: Timetable): Timetable {
         val problemId = UUID.randomUUID()
         // Submit the problem to start solving
@@ -223,7 +223,7 @@ The following example uses the Linux command `curl` to send a POST request:
 
 [source,shell]
 ----
-$ curl -i -X POST http://localhost:8080/timetable/solve -H "Content-Type:application/json" -d '{"timeslots":[{"dayOfWeek":"MONDAY","startTime":"08:30:00","endTime":"09:30:00"},{"dayOfWeek":"MONDAY","startTime":"09:30:00","endTime":"10:30:00"}],"rooms":[{"name":"Room A"},{"name":"Room B"}],"lessons":[{"id":1,"subject":"Math","teacher":"A. Turing","studentGroup":"9th grade"},{"id":2,"subject":"Chemistry","teacher":"M. Curie","studentGroup":"9th grade"},{"id":3,"subject":"French","teacher":"M. Curie","studentGroup":"10th grade"},{"id":4,"subject":"History","teacher":"I. Jones","studentGroup":"10th grade"}]}'
+$ curl -i -X POST http://localhost:8080/timetable -H "Content-Type:application/json" -d '{"timeslots":[{"dayOfWeek":"MONDAY","startTime":"08:30:00","endTime":"09:30:00"},{"dayOfWeek":"MONDAY","startTime":"09:30:00","endTime":"10:30:00"}],"rooms":[{"name":"Room A"},{"name":"Room B"}],"lessons":[{"id":1,"subject":"Math","teacher":"A. Turing","studentGroup":"9th grade"},{"id":2,"subject":"Chemistry","teacher":"M. Curie","studentGroup":"9th grade"},{"id":3,"subject":"French","teacher":"M. Curie","studentGroup":"10th grade"},{"id":4,"subject":"History","teacher":"I. Jones","studentGroup":"10th grade"}]}'
 ----
 
 After about five seconds, according to the termination spent time defined in your `application.properties`,
@@ -276,7 +276,7 @@ Maven::
 +
 --
 Add the folllowing dependencies to your `pom.xml`:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -286,6 +286,7 @@ Add the folllowing dependencies to your `pom.xml`:
     <dependency>
         <groupId>ai.timefold.solver</groupId>
         <artifactId>timefold-solver-test</artifactId>
+        <version>{timefold-solver-version}</version>
         <scope>test</scope>
     </dependency>
 ----
@@ -297,7 +298,7 @@ Add the subsequent dependencies to your `build.gradle`:
 [source,groovy,subs=attributes+]
 ----
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("ai.timefold.solver:timefold-solver-test")
+    testImplementation("ai.timefold.solver:timefold-solver-test:{timefold-solver-version}")
 ----
 --
 ====


### PR DESCRIPTION
Sending a problem to the APIs should now all be `POST /<problem>` not `POST /<problem>/solve`

Also fixed a variable substitution issue. 