### PR TITLE
docs: clarify migration limitations

### DIFF
--- a/docs/src/modules/ROOT/pages/integration/integration.adoc
+++ b/docs/src/modules/ROOT/pages/integration/integration.adoc
@@ -769,6 +769,11 @@ class Resource {
 To use Timefold Solver on Spring Boot, add the `timefold-solver-spring-boot-starter` dependency
 and read the xref:quickstart/spring-boot/spring-boot-quickstart.adoc#springBootQuickStart[Spring Boot Java quick start].
 
+[NOTE]
+====
+Timefold Solver Spring Boot Starter only supports Spring Boot version 3.2.x and up.
+====
+
 [#integrationWithSpringBootProperties]
 === Available configuration properties
 

--- a/docs/src/modules/ROOT/pages/upgrading-timefold-solver/framework-version-warning.adoc
+++ b/docs/src/modules/ROOT/pages/upgrading-timefold-solver/framework-version-warning.adoc
@@ -1,0 +1,5 @@
+[NOTE]
+====
+Our automatic migrations will not change the version of your frameworks.
+If you run into compatibility issues, please consult the integration guides for xref:../integration/integration.adoc#integrationWithSpringBoot[Spring] or xref:../integration/integration.adoc#integrationWithQuarkus[Quarkus].
+====

--- a/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-from-optaplanner.adoc
+++ b/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-from-optaplanner.adoc
@@ -32,6 +32,8 @@ curl https://raw.githubusercontent.com/TimefoldAI/timefold-solver/refs/tags/v{ti
 --
 ====
 
+include::framework-version-warning.adoc[leveloffset=+1]
+
 Having done that, do a test run of the solver and commit the changes.
 If it doesn't work, just revert it instead and
 https://github.com/timefoldai/timefold-solver/issues[submit an issue].

--- a/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-to-latest-version.adoc
+++ b/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-to-latest-version.adoc
@@ -38,6 +38,8 @@ curl https://raw.githubusercontent.com/TimefoldAI/timefold-solver/refs/tags/v{ti
 --
 ====
 
+include::framework-version-warning.adoc[leveloffset=+1]
+
 Having done that, you can check the local changes and commit them.
 Note that none of the upgrade steps could be automatically applied,
 and it may still be worth your while to read the rest the upgrade recipe below.


### PR DESCRIPTION
After interaction on Stack Overflow, noticed that we do not document our minimal Spring Boot Version. 
Fixing that in this PR: https://stackoverflow.com/questions/79488759/move-from-optaplanner-to-timefold-results-in-spring-error