### PR TITLE
fix: Make solver and phase terminations check if the solver was terminated early

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
@@ -66,6 +66,10 @@ public abstract class AbstractPhaseScope<Solution_> {
         return phaseIndex;
     }
 
+    public boolean isTerminateEarly() {
+        return solverScope.isTerminateEarly();
+    }
+
     public boolean isPhaseSendingBestSolutionEvents() {
         return phaseSendingBestSolutionEvents;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
@@ -319,6 +319,7 @@ public class SolverScope<Solution_> {
 
     public SolverScope<Solution_> createChildThreadSolverScope(ChildThreadType childThreadType) {
         SolverScope<Solution_> childThreadSolverScope = new SolverScope<>();
+        childThreadSolverScope.solver = solver;
         childThreadSolverScope.bestSolution.set(null);
         childThreadSolverScope.bestScore.set(null);
         childThreadSolverScope.monitoringTags = monitoringTags;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
@@ -245,6 +245,10 @@ public class SolverScope<Solution_> {
     // Calculated methods
     // ************************************************************************
 
+    public boolean isTerminateEarly() {
+        return solver.isTerminateEarly();
+    }
+
     public boolean isMetricEnabled(SolverMetric solverMetric) {
         return solverMetricSet.contains(solverMetric);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractPhaseTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractPhaseTermination.java
@@ -32,4 +32,10 @@ abstract sealed class AbstractPhaseTermination<Solution_>
         // Override if needed.
     }
 
+    @Override
+    public final boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+        return phaseScope.isTerminateEarly() || isPhaseTerminateConditionMet(phaseScope);
+    }
+
+    abstract protected boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope);
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractPhaseTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractPhaseTermination.java
@@ -37,5 +37,5 @@ abstract sealed class AbstractPhaseTermination<Solution_>
         return phaseScope.isTerminateEarly() || isPhaseTerminateConditionMet(phaseScope);
     }
 
-    abstract protected boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope);
+    protected abstract boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope);
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractSolverTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractSolverTermination.java
@@ -24,5 +24,5 @@ abstract sealed class AbstractSolverTermination<Solution_>
         return solverScope.isTerminateEarly() || isSolverTerminateConditionMet(solverScope);
     }
 
-    abstract protected boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope);
+    protected abstract boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope);
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractSolverTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractSolverTermination.java
@@ -19,4 +19,10 @@ abstract sealed class AbstractSolverTermination<Solution_>
         // Override if needed.
     }
 
+    @Override
+    public final boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+        return solverScope.isTerminateEarly() || isSolverTerminateConditionMet(solverScope);
+    }
+
+    abstract protected boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope);
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractUniversalTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractUniversalTermination.java
@@ -44,4 +44,17 @@ abstract sealed class AbstractUniversalTermination<Solution_>
         // Override if needed.
     }
 
+    @Override
+    public final boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+        return solverScope.isTerminateEarly() || isSolverTerminateConditionMet(solverScope);
+    }
+
+    @Override
+    public final boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+        return phaseScope.isTerminateEarly() || isPhaseTerminateConditionMet(phaseScope);
+    }
+
+    abstract protected boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope);
+
+    abstract protected boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope);
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractUniversalTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AbstractUniversalTermination.java
@@ -54,7 +54,7 @@ abstract sealed class AbstractUniversalTermination<Solution_>
         return phaseScope.isTerminateEarly() || isPhaseTerminateConditionMet(phaseScope);
     }
 
-    abstract protected boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope);
+    protected abstract boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope);
 
-    abstract protected boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope);
+    protected abstract boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope);
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AndCompositeTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/AndCompositeTermination.java
@@ -26,7 +26,7 @@ final class AndCompositeTermination<Solution_>
      * @return true if all terminations are terminated.
      */
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         for (var termination : solverTerminationList) {
             if (!termination.isSolverTerminated(solverScope)) {
                 return false;
@@ -39,7 +39,7 @@ final class AndCompositeTermination<Solution_>
      * @return true if all supported terminations are terminated.
      */
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         for (var termination : phaseTerminationList) {
             if (termination.isApplicableTo(phaseScope.getClass()) && !termination.isPhaseTerminated(phaseScope)) {
                 return false;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BasicPlumbingTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BasicPlumbingTermination.java
@@ -107,7 +107,7 @@ public final class BasicPlumbingTermination<Solution_>
     }
 
     @Override
-    public synchronized boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public synchronized boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         // Destroying a thread pool with solver threads will only cause it to interrupt those solver threads,
         // it won't call Solver.terminateEarly()
         if (Thread.currentThread().isInterrupted() // Does not clear the interrupted flag

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
@@ -29,12 +29,12 @@ final class BestScoreFeasibleTermination<Solution_>
     }
 
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         return isTerminated(solverScope.getBestScore());
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         return isTerminated(phaseScope.getBestScore());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreTermination.java
@@ -32,12 +32,12 @@ final class BestScoreTermination<Solution_>
     }
 
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         return isTerminated(solverScope.isBestSolutionInitialized(), solverScope.getBestScore());
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         return isTerminated(phaseScope.isBestSolutionInitialized(), phaseScope.getBestScore());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ChildThreadPlumbingTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ChildThreadPlumbingTermination.java
@@ -24,7 +24,7 @@ public final class ChildThreadPlumbingTermination<Solution_>
     }
 
     @Override
-    public synchronized boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public synchronized boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         // Destroying a thread pool with solver threads will only cause it to interrupt those child solver threads
         if (Thread.currentThread().isInterrupted()) { // Does not clear the interrupted flag
             logger.info("A child solver thread got interrupted, so these child solvers are terminating early.");

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/DiminishedReturnsTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/DiminishedReturnsTermination.java
@@ -140,7 +140,7 @@ final class DiminishedReturnsTermination<Solution_, Score_ extends Score<Score_>
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         return isTerminated(System.nanoTime(), phaseScope.getBestScore());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/MoveCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/MoveCountTermination.java
@@ -21,12 +21,12 @@ final class MoveCountTermination<Solution_>
     }
 
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         return isTerminated(solverScope);
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         return isTerminated(phaseScope.getSolverScope());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/OrCompositeTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/OrCompositeTermination.java
@@ -27,7 +27,7 @@ final class OrCompositeTermination<Solution_>
      * @return true if any one of the terminations is terminated.
      */
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         for (var termination : solverTerminationList) {
             if (termination.isSolverTerminated(solverScope)) {
                 return true;
@@ -40,7 +40,7 @@ final class OrCompositeTermination<Solution_>
      * @return true if any one of the supported terminations is terminated.
      */
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         for (var termination : phaseTerminationList) {
             if (termination.isApplicableTo(phaseScope.getClass()) && termination.isPhaseTerminated(phaseScope)) {
                 return true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ScoreCalculationCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/ScoreCalculationCountTermination.java
@@ -24,12 +24,12 @@ final class ScoreCalculationCountTermination<Solution_>
     }
 
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         return isTerminated(solverScope.getScoreDirector());
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         return isTerminated(phaseScope.getScoreDirector());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/SolverBridgePhaseTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/SolverBridgePhaseTermination.java
@@ -20,7 +20,7 @@ final class SolverBridgePhaseTermination<Solution_>
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         return solverTermination.isSolverTerminated(phaseScope.getSolverScope());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/SolverToUniversalBridgeTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/SolverToUniversalBridgeTermination.java
@@ -20,7 +20,7 @@ final class SolverToUniversalBridgeTermination<Solution_>
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         return false;
     }
 
@@ -30,7 +30,7 @@ final class SolverToUniversalBridgeTermination<Solution_>
     }
 
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         return solverTermination.isSolverTerminated(solverScope);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/StepCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/StepCountTermination.java
@@ -26,7 +26,7 @@ final class StepCountTermination<Solution_>
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         int nextStepIndex = phaseScope.getNextStepIndex();
         return nextStepIndex >= stepCountLimit;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTermination.java
@@ -26,13 +26,13 @@ final class TimeMillisSpentTermination<Solution_>
     }
 
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         var solverTimeMillisSpent = solverScope.calculateTimeMillisSpentUpToNow();
         return isTerminated(solverTimeMillisSpent);
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         var phaseTimeMillisSpent = phaseScope.calculatePhaseTimeMillisSpentUpToNow();
         return isTerminated(phaseTimeMillisSpent);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedStepCountTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedStepCountTermination.java
@@ -24,7 +24,7 @@ final class UnimprovedStepCountTermination<Solution_>
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         var unimprovedStepCount = calculateUnimprovedStepCount(phaseScope);
         return unimprovedStepCount >= unimprovedStepCountLimit;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
@@ -113,12 +113,12 @@ final class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<Solutio
     }
 
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         return isTerminated(solverSafeTimeMillis);
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         return isTerminated(phaseSafeTimeMillis);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -54,13 +54,13 @@ final class UnimprovedTimeMillisSpentTermination<Solution_>
     }
 
     @Override
-    public boolean isSolverTerminated(SolverScope<Solution_> solverScope) {
+    public boolean isSolverTerminateConditionMet(SolverScope<Solution_> solverScope) {
         long bestSolutionTimeMillis = solverScope.getBestSolutionTimeMillis();
         return isTerminated(bestSolutionTimeMillis);
     }
 
     @Override
-    public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+    public boolean isPhaseTerminateConditionMet(AbstractPhaseScope<Solution_> phaseScope) {
         var bestSolutionTimeMillis = phaseScope.getPhaseBestSolutionTimeMillis();
         return isTerminated(bestSolutionTimeMillis);
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
@@ -404,5 +404,4 @@ class DefaultLocalSearchPhaseTest extends AbstractMeterTest {
                 .hasMessageContaining("planning list variable")
                 .hasMessageContaining("unexpected unassigned values");
     }
-
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.withPrecision;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 
@@ -14,6 +15,7 @@ import ai.timefold.solver.core.impl.constructionheuristic.scope.ConstructionHeur
 import ai.timefold.solver.core.impl.constructionheuristic.scope.ConstructionHeuristicStepScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
+import ai.timefold.solver.core.impl.solver.AbstractSolver;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
@@ -37,6 +39,9 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         var solverScope = spy(new SolverScope<TestdataSolution>());
         var phaseScope = spy(new LocalSearchPhaseScope<>(solverScope, 0));
         var stepScope = spy(new LocalSearchStepScope<>(phaseScope));
+        var solver = mock(AbstractSolver.class);
+        when(solver.isTerminateEarly()).thenReturn(false);
+        solverScope.setSolver(solver);
         var clock = mock(Clock.class);
 
         var termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<TestdataSolution>(1000L,
@@ -85,6 +90,10 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         var solverScope = spy(new SolverScope<TestdataSolution>());
         var phaseScope = spy(new LocalSearchPhaseScope<>(solverScope, 0));
         var stepScope = spy(new LocalSearchStepScope<>(phaseScope));
+        var solver = mock(AbstractSolver.class);
+        when(solver.isTerminateEarly()).thenReturn(false);
+        solverScope.setSolver(solver);
+
         var clock = mock(Clock.class);
 
         var termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<TestdataSolution>(1000L,
@@ -137,6 +146,9 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         var solverScope = spy(new SolverScope<TestdataSolution>());
         var phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope, 0));
         var stepScope = spy(new ConstructionHeuristicStepScope<>(phaseScope));
+        var solver = mock(AbstractSolver.class);
+        when(solver.isTerminateEarly()).thenReturn(false);
+        solverScope.setSolver(solver);
         var clock = mock(Clock.class);
 
         var termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<TestdataSolution>(1000L,
@@ -175,6 +187,9 @@ class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         var solverScope = spy(new SolverScope<TestdataSolution>());
         var phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope, 0));
         var stepScope = spy(new ConstructionHeuristicStepScope<>(phaseScope));
+        var solver = mock(AbstractSolver.class);
+        when(solver.isTerminateEarly()).thenReturn(false);
+        solverScope.setSolver(solver);
         var clock = mock(Clock.class);
 
         var termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination<TestdataSolution>(1000L,

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
@@ -6,12 +6,14 @@ import static org.assertj.core.api.Assertions.withPrecision;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 
 import ai.timefold.solver.core.impl.constructionheuristic.scope.ConstructionHeuristicPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
+import ai.timefold.solver.core.impl.solver.AbstractSolver;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 
@@ -30,6 +32,9 @@ class UnimprovedTimeMillisSpentTerminationTest {
     void solverTermination() {
         SolverScope<TestdataSolution> solverScope = spy(new SolverScope<>());
         AbstractPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        var solver = mock(AbstractSolver.class);
+        when(solver.isTerminateEarly()).thenReturn(false);
+        solverScope.setSolver(solver);
         Clock clock = mock(Clock.class);
 
         UniversalTermination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
@@ -51,6 +56,9 @@ class UnimprovedTimeMillisSpentTerminationTest {
     void phaseTermination() {
         SolverScope<TestdataSolution> solverScope = new SolverScope<>();
         AbstractPhaseScope<TestdataSolution> phaseScope = spy(new LocalSearchPhaseScope<>(solverScope, 0));
+        var solver = mock(AbstractSolver.class);
+        when(solver.isTerminateEarly()).thenReturn(false);
+        solverScope.setSolver(solver);
         Clock clock = mock(Clock.class);
 
         UniversalTermination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
@@ -71,6 +79,9 @@ class UnimprovedTimeMillisSpentTerminationTest {
     @Test
     void solverTerminationWithConstructionHeuristic() { // CH ignores unimproved time spent termination.
         SolverScope<TestdataSolution> solverScope = spy(new SolverScope<>());
+        var solver = mock(AbstractSolver.class);
+        when(solver.isTerminateEarly()).thenReturn(false);
+        solverScope.setSolver(solver);
         Clock clock = mock(Clock.class);
 
         UniversalTermination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
@@ -115,6 +126,9 @@ class UnimprovedTimeMillisSpentTerminationTest {
     void phaseTerminationWithConstructionHeuristic() { // CH ignores unimproved time spent termination.
         SolverScope<TestdataSolution> solverScope = new SolverScope<>();
         AbstractPhaseScope<TestdataSolution> phaseScope = spy(new ConstructionHeuristicPhaseScope<>(solverScope, 0));
+        var solver = mock(AbstractSolver.class);
+        when(solver.isTerminateEarly()).thenReturn(false);
+        solverScope.setSolver(solver);
         Clock clock = mock(Clock.class);
 
         UniversalTermination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);


### PR DESCRIPTION
Fixes a regression where terminateEarly was not checked until the end of a phase. Previously, the top level termination was always BasicPlumbingTermination, which checks for/sets the terminateEarly flag. However, with the refactor to terminations, phases use different termination instances (that are not instances of BasicPlumbingTermination). None of these terminations check terminateEarly before, since that was the job of the BasicPlumbingTermination.

The abstract base classes of the terminations was changed:

- A new abstract method isPhaseTerminateConditionMet/isSolverTerminateConditionMet
- A final implementation of isPhaseTerminated/isSolverTerminated that checks if the solver is terminated, and then call the subclass method.

The reason our tests did not catch this is that termination is also checked at the end/between phases, and that check works. The old terminate early tests used a custom phase command that unblocks a runner that terminates the solver. The issue is the solver is terminated before LS (i.e. either between custom & CH, or during CH), and thus the between check terminates the solver. To correctly test for this, a custom easy score calculator that throws once all entities are assigned is used for CH, and an event listener that count LS steps is used for LS.