### PR TITLE
ci: add CodeQL JavaScript config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include:
         - language: java-kotlin
-          build-mode: none # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
+          build-mode: autobuild
         - language: python
           build-mode: none
         - language: javascript-typescript # Need to add this even though we don't want this; otherwise Github complains.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,9 +25,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: java-kotlin
+        - language: java
           build-mode: none # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
         - language: python
+          build-mode: none
+        - language: javascript # Need to add this even though we don't want this; otherwise Github complains.
           build-mode: none
     steps:
     - name: Checkout repository
@@ -45,12 +47,13 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        # JS is only used in Benchmarker, which runs locally and is irrelevant in terms of security.
+        # We do not want to analyze those.
+        config: |          
+          paths-ignore:
+            - 'benchmark/**/*.html'
+            - 'benchmark/**/*.ftl'
+            - 'benchmark/**/*.js'
 
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,11 +25,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: java
+        - language: java-kotlin
           build-mode: none # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
         - language: python
           build-mode: none
-        - language: javascript # Need to add this even though we don't want this; otherwise Github complains.
+        - language: javascript-typescript # Need to add this even though we don't want this; otherwise Github complains.
           build-mode: none
     steps:
     - name: Checkout repository


### PR DESCRIPTION
The analysis was complaining about missing configs.
With this PR, it no longer does.