### PR TITLE
fix: do not enumerate constraint matches which do not differ

### DIFF
--- a/core/src/test/java/ai/timefold/solver/core/api/score/analysis/ScoreAnalysisTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/analysis/ScoreAnalysisTest.java
@@ -165,7 +165,7 @@ class ScoreAnalysisTest {
     }
 
     @Test
-    void compareWithConstraintMatchesWithoutMatchAnalysis() {
+    void diffWithConstraintMatchesWithoutMatchAnalysis() {
         var constraintPackage = "constraintPackage";
         var constraintName1 = "constraint1";
         var constraintName2 = "constraint2";
@@ -208,53 +208,53 @@ class ScoreAnalysisTest {
                 constraintMatchTotal4.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal4, FETCH_SHALLOW));
         var scoreAnalysis2 = new ScoreAnalysis<>(SimpleScore.of(42), constraintAnalysisMap2);
 
-        var comparison = scoreAnalysis1.diff(scoreAnalysis2);
+        var diff = scoreAnalysis1.diff(scoreAnalysis2);
         assertSoftly(softly -> {
-            softly.assertThat(comparison.score()).isEqualTo(SimpleScore.of(8));
-            softly.assertThat(comparison.constraintMap())
+            softly.assertThat(diff.score()).isEqualTo(SimpleScore.of(8));
+            softly.assertThat(diff.constraintMap())
                     .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal2.getConstraintRef(),
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 not present.
-        var constraintAnalysis1 = comparison.getConstraintAnalysis(constraintName1);
+        var constraintAnalysis1 = diff.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis1.score()).isEqualTo(SimpleScore.of(20));
             softly.assertThat(constraintAnalysis1.matches()).isNull();
         });
         // Matches for constraint2 still not present.
-        var constraintAnalysis2 = comparison.getConstraintAnalysis(constraintName2);
+        var constraintAnalysis2 = diff.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis2.score()).isEqualTo(SimpleScore.of(18));
             softly.assertThat(constraintAnalysis2.matches()).isNull();
         });
         // Matches for constraint3 not present.
-        var constraintAnalysis3 = comparison.getConstraintAnalysis(constraintName3);
+        var constraintAnalysis3 = diff.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis3.score()).isEqualTo(SimpleScore.of(-30));
             softly.assertThat(constraintAnalysis3.matches()).isNull();
         });
 
-        var reverseComparison = scoreAnalysis2.diff(scoreAnalysis1);
+        var reverseDiff = scoreAnalysis2.diff(scoreAnalysis1);
         assertSoftly(softly -> {
-            softly.assertThat(reverseComparison.score()).isEqualTo(SimpleScore.of(-8));
-            softly.assertThat(reverseComparison.constraintMap())
+            softly.assertThat(reverseDiff.score()).isEqualTo(SimpleScore.of(-8));
+            softly.assertThat(reverseDiff.constraintMap())
                     .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal3.getConstraintRef(),
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 not present.
-        var reverseConstraintAnalysis1 = reverseComparison.getConstraintAnalysis(constraintName1);
+        var reverseConstraintAnalysis1 = reverseDiff.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis1.score()).isEqualTo(SimpleScore.of(-20));
             softly.assertThat(reverseConstraintAnalysis1.matches()).isNull();
         });
         // Matches for constraint2 still not present.
-        var reverseConstraintAnalysis2 = reverseComparison.getConstraintAnalysis(constraintName2);
+        var reverseConstraintAnalysis2 = reverseDiff.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis2.score()).isEqualTo(SimpleScore.of(-18));
             softly.assertThat(reverseConstraintAnalysis2.matches()).isNull();
         });
         // Matches for constraint3 not present in reverse.
-        var reverseConstraintAnalysis3 = reverseComparison.getConstraintAnalysis(constraintName3);
+        var reverseConstraintAnalysis3 = reverseDiff.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis3.score()).isEqualTo(SimpleScore.of(30));
             softly.assertThat(reverseConstraintAnalysis3.matches()).isNull();
@@ -262,7 +262,7 @@ class ScoreAnalysisTest {
     }
 
     @Test
-    void compareWithConstraintMatchesWithMatchCountOnly() {
+    void diffWithConstraintMatchesWithMatchCountOnly() {
         var constraintPackage = "constraintPackage";
         var constraintName1 = "constraint1";
         var constraintName2 = "constraint2";
@@ -306,58 +306,58 @@ class ScoreAnalysisTest {
                 constraintMatchTotal4.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal4, FETCH_MATCH_COUNT));
         var scoreAnalysis2 = new ScoreAnalysis<>(SimpleScore.of(42), constraintAnalysisMap2);
 
-        var comparison = scoreAnalysis1.diff(scoreAnalysis2);
+        var diff = scoreAnalysis1.diff(scoreAnalysis2);
         assertSoftly(softly -> {
-            softly.assertThat(comparison.score()).isEqualTo(SimpleScore.of(8));
-            softly.assertThat(comparison.constraintMap())
+            softly.assertThat(diff.score()).isEqualTo(SimpleScore.of(8));
+            softly.assertThat(diff.constraintMap())
                     .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal2.getConstraintRef(),
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 not present.
-        var constraintAnalysis1 = comparison.getConstraintAnalysis(constraintName1);
+        var constraintAnalysis1 = diff.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis1.score()).isEqualTo(SimpleScore.of(20));
             softly.assertThat(constraintAnalysis1.matches()).isNull();
             softly.assertThat(constraintAnalysis1.matchCount()).isGreaterThan(0);
         });
         // Matches for constraint2 still not present.
-        var constraintAnalysis2 = comparison.getConstraintAnalysis(constraintName2);
+        var constraintAnalysis2 = diff.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis2.score()).isEqualTo(SimpleScore.of(18));
             softly.assertThat(constraintAnalysis2.matches()).isNull();
             softly.assertThat(constraintAnalysis2.matchCount()).isGreaterThan(0);
         });
         // Matches for constraint3 not present.
-        var constraintAnalysis3 = comparison.getConstraintAnalysis(constraintName3);
+        var constraintAnalysis3 = diff.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis3.score()).isEqualTo(SimpleScore.of(-30));
             softly.assertThat(constraintAnalysis3.matches()).isNull();
             softly.assertThat(constraintAnalysis3.matchCount()).isLessThan(0);
         });
 
-        var reverseComparison = scoreAnalysis2.diff(scoreAnalysis1);
+        var reverseDiff = scoreAnalysis2.diff(scoreAnalysis1);
         assertSoftly(softly -> {
-            softly.assertThat(reverseComparison.score()).isEqualTo(SimpleScore.of(-8));
-            softly.assertThat(reverseComparison.constraintMap())
+            softly.assertThat(reverseDiff.score()).isEqualTo(SimpleScore.of(-8));
+            softly.assertThat(reverseDiff.constraintMap())
                     .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal3.getConstraintRef(),
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 not present.
-        var reverseConstraintAnalysis1 = reverseComparison.getConstraintAnalysis(constraintName1);
+        var reverseConstraintAnalysis1 = reverseDiff.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis1.score()).isEqualTo(SimpleScore.of(-20));
             softly.assertThat(reverseConstraintAnalysis1.matches()).isNull();
             softly.assertThat(reverseConstraintAnalysis1.matchCount()).isLessThan(0);
         });
         // Matches for constraint2 still not present.
-        var reverseConstraintAnalysis2 = reverseComparison.getConstraintAnalysis(constraintName2);
+        var reverseConstraintAnalysis2 = reverseDiff.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis2.score()).isEqualTo(SimpleScore.of(-18));
             softly.assertThat(reverseConstraintAnalysis2.matches()).isNull();
             softly.assertThat(reverseConstraintAnalysis2.matchCount()).isLessThan(0);
         });
         // Matches for constraint3 not present in reverse.
-        var reverseConstraintAnalysis3 = reverseComparison.getConstraintAnalysis(constraintName3);
+        var reverseConstraintAnalysis3 = reverseDiff.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis3.score()).isEqualTo(SimpleScore.of(30));
             softly.assertThat(reverseConstraintAnalysis3.matches()).isNull();
@@ -366,7 +366,7 @@ class ScoreAnalysisTest {
     }
 
     @Test
-    void compareWithConstraintMatchesAndMatchAnalysis() {
+    void diffWithConstraintMatchesAndMatchAnalysis() {
         var constraintPackage = "constraintPackage";
         var constraintName1 = "constraint1";
         var constraintName2 = "constraint2";
@@ -408,15 +408,15 @@ class ScoreAnalysisTest {
                 constraintMatchTotal4.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal4, FETCH_ALL));
         var scoreAnalysis2 = new ScoreAnalysis<>(SimpleScore.of(42), constraintAnalysisMap2);
 
-        var comparison = scoreAnalysis1.diff(scoreAnalysis2);
+        var diff = scoreAnalysis1.diff(scoreAnalysis2);
         assertSoftly(softly -> {
-            softly.assertThat(comparison.score()).isEqualTo(SimpleScore.of(8));
-            softly.assertThat(comparison.constraintMap())
+            softly.assertThat(diff.score()).isEqualTo(SimpleScore.of(8));
+            softly.assertThat(diff.constraintMap())
                     .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal2.getConstraintRef(),
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 present.
-        var constraintAnalysis1 = comparison.getConstraintAnalysis(constraintName1);
+        var constraintAnalysis1 = diff.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis1.score()).isEqualTo(SimpleScore.of(20));
             var matchAnalyses = constraintAnalysis1.matches();
@@ -428,7 +428,7 @@ class ScoreAnalysisTest {
                             matchAnalysisOf(constraintAnalysis1.constraintRef(), 8));
         });
         // Matches for constraint2 present in both.
-        var constraintAnalysis2 = comparison.getConstraintAnalysis(constraintName2);
+        var constraintAnalysis2 = diff.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis2.score()).isEqualTo(SimpleScore.of(18));
             var matchAnalyses = constraintAnalysis2.matches();
@@ -442,7 +442,7 @@ class ScoreAnalysisTest {
                             matchAnalysisOf(constraintAnalysis2.constraintRef(), -6, "A", "B"));
         });
         // Matches for constraint3 not present.
-        var constraintAnalysis3 = comparison.getConstraintAnalysis(constraintName3);
+        var constraintAnalysis3 = diff.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(constraintAnalysis3.score()).isEqualTo(SimpleScore.of(-30));
             var matchAnalyses = constraintAnalysis3.matches();
@@ -454,15 +454,15 @@ class ScoreAnalysisTest {
                             matchAnalysisOf(constraintAnalysis3.constraintRef(), -12));
         });
 
-        var reverseComparison = scoreAnalysis2.diff(scoreAnalysis1);
+        var reverseDiff = scoreAnalysis2.diff(scoreAnalysis1);
         assertSoftly(softly -> {
-            softly.assertThat(reverseComparison.score()).isEqualTo(SimpleScore.of(-8));
-            softly.assertThat(reverseComparison.constraintMap())
+            softly.assertThat(reverseDiff.score()).isEqualTo(SimpleScore.of(-8));
+            softly.assertThat(reverseDiff.constraintMap())
                     .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal3.getConstraintRef(),
                             constraintMatchTotal4.getConstraintRef());
         });
         // Matches for constraint1 not present.
-        var reverseConstraintAnalysis1 = reverseComparison.getConstraintAnalysis(constraintName1);
+        var reverseConstraintAnalysis1 = reverseDiff.getConstraintAnalysis(constraintName1);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis1.score()).isEqualTo(SimpleScore.of(-20));
             var matchAnalyses = reverseConstraintAnalysis1.matches();
@@ -474,7 +474,7 @@ class ScoreAnalysisTest {
                             matchAnalysisOf(reverseConstraintAnalysis1.constraintRef(), -8));
         });
         // Matches for constraint2 present in both.
-        var reverseConstraintAnalysis2 = reverseComparison.getConstraintAnalysis(constraintName2);
+        var reverseConstraintAnalysis2 = reverseDiff.getConstraintAnalysis(constraintName2);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis2.score()).isEqualTo(SimpleScore.of(-18));
             var matchAnalyses = reverseConstraintAnalysis2.matches();
@@ -488,7 +488,116 @@ class ScoreAnalysisTest {
                             matchAnalysisOf(reverseConstraintAnalysis2.constraintRef(), 6, "A", "B"));
         });
         // Matches for constraint3 present in reverse.
-        var reverseConstraintAnalysis3 = reverseComparison.getConstraintAnalysis(constraintName3);
+        var reverseConstraintAnalysis3 = reverseDiff.getConstraintAnalysis(constraintName3);
+        assertSoftly(softly -> {
+            softly.assertThat(reverseConstraintAnalysis3.score()).isEqualTo(SimpleScore.of(30));
+            var matchAnalyses = reverseConstraintAnalysis3.matches();
+            softly.assertThat(matchAnalyses)
+                    .containsOnly(matchAnalysisOf(reverseConstraintAnalysis3.constraintRef(), 3, "B", "C", "D"),
+                            matchAnalysisOf(reverseConstraintAnalysis3.constraintRef(), 6, "B", "C"),
+                            matchAnalysisOf(reverseConstraintAnalysis3.constraintRef(), 9, "C", "D"),
+                            matchAnalysisOf(reverseConstraintAnalysis3.constraintRef(), 12));
+        });
+    }
+
+    @Test
+    void diffWithConstraintMatchesAndMatchAnalysisWithSomeIdenticalMatches() {
+        var constraintPackage = "constraintPackage";
+        var constraintName1 = "constraint1";
+        var constraintName2 = "constraint2";
+        var constraintName3 = "constraint3";
+        var constraintId1 = ConstraintRef.of(constraintPackage, constraintName1);
+        var constraintId2 = ConstraintRef.of(constraintPackage, constraintName2);
+        var constraintId3 = ConstraintRef.of(constraintPackage, constraintName3);
+
+        var constraintMatchTotal1 = new DefaultConstraintMatchTotal<>(constraintId1, SimpleScore.of(1));
+        addConstraintMatch(constraintMatchTotal1, SimpleScore.of(2), "A", "B", "C");
+        addConstraintMatch(constraintMatchTotal1, SimpleScore.of(4), "A", "B");
+        addConstraintMatch(constraintMatchTotal1, SimpleScore.of(6), "B", "C");
+        addConstraintMatch(constraintMatchTotal1, SimpleScore.of(8));
+        var constraintMatchTotal2 = new DefaultConstraintMatchTotal<>(constraintId2, SimpleScore.of(3));
+        addConstraintMatch(constraintMatchTotal2, SimpleScore.of(3), "B", "C", "D");
+        addConstraintMatch(constraintMatchTotal2, SimpleScore.of(6), "B", "C");
+        addConstraintMatch(constraintMatchTotal2, SimpleScore.of(9), "C", "D");
+        addConstraintMatch(constraintMatchTotal2, SimpleScore.of(12));
+        var emptyConstraintMatchTotal1 = new DefaultConstraintMatchTotal<>(constraintId3, SimpleScore.of(0));
+        var constraintAnalysisMap1 = Map.of(
+                constraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal1, FETCH_ALL),
+                constraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal2, FETCH_ALL),
+                emptyConstraintMatchTotal1.getConstraintRef(), getConstraintAnalysis(emptyConstraintMatchTotal1, FETCH_ALL));
+        var scoreAnalysis1 = new ScoreAnalysis<>(SimpleScore.of(50), constraintAnalysisMap1);
+
+        var constraintMatchTotal3 = new DefaultConstraintMatchTotal<>(constraintId1, SimpleScore.of(2));
+        addConstraintMatch(constraintMatchTotal3, SimpleScore.of(2), "A", "B", "C");
+        addConstraintMatch(constraintMatchTotal3, SimpleScore.of(4), "B", "C");
+        addConstraintMatch(constraintMatchTotal3, SimpleScore.of(6), "A", "B");
+        var constraintMatchTotal4 = new DefaultConstraintMatchTotal<>(constraintId3, SimpleScore.of(3));
+        addConstraintMatch(constraintMatchTotal4, SimpleScore.of(3), "B", "C", "D");
+        addConstraintMatch(constraintMatchTotal4, SimpleScore.of(6), "B", "C");
+        addConstraintMatch(constraintMatchTotal4, SimpleScore.of(9), "C", "D");
+        addConstraintMatch(constraintMatchTotal4, SimpleScore.of(12));
+        var constraintAnalysisMap2 = Map.of(
+                constraintMatchTotal2.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal2, FETCH_ALL),
+                constraintMatchTotal3.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal3, FETCH_ALL),
+                constraintMatchTotal4.getConstraintRef(), getConstraintAnalysis(constraintMatchTotal4, FETCH_ALL));
+        var scoreAnalysis2 = new ScoreAnalysis<>(SimpleScore.of(42), constraintAnalysisMap2);
+
+        var diff = scoreAnalysis1.diff(scoreAnalysis2);
+        assertSoftly(softly -> {
+            softly.assertThat(diff.score()).isEqualTo(SimpleScore.of(8));
+            softly.assertThat(diff.constraintMap())
+                    .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal4.getConstraintRef());
+        });
+        // Matches for constraint1 present.
+        var constraintAnalysis1 = diff.getConstraintAnalysis(constraintName1);
+        assertSoftly(softly -> {
+            softly.assertThat(constraintAnalysis1.score()).isEqualTo(SimpleScore.of(8));
+            var matchAnalyses = constraintAnalysis1.matches();
+            softly.assertThat(matchAnalyses)
+                    .containsOnly(
+                            matchAnalysisOf(constraintAnalysis1.constraintRef(), -2, "A", "B"),
+                            matchAnalysisOf(constraintAnalysis1.constraintRef(), 2, "B", "C"),
+                            matchAnalysisOf(constraintAnalysis1.constraintRef(), 8));
+        });
+        // Identical matches for constraint2 present in both
+        var constraintAnalysis2 = diff.getConstraintAnalysis(constraintName2);
+        assertThat(constraintAnalysis2).isNull();
+
+        // Matches for constraint3 not present.
+        var constraintAnalysis3 = diff.getConstraintAnalysis(constraintName3);
+        assertSoftly(softly -> {
+            softly.assertThat(constraintAnalysis3.score()).isEqualTo(SimpleScore.of(-30));
+            var matchAnalyses = constraintAnalysis3.matches();
+            softly.assertThat(matchAnalyses)
+                    .containsOnly(
+                            matchAnalysisOf(constraintAnalysis3.constraintRef(), -3, "B", "C", "D"),
+                            matchAnalysisOf(constraintAnalysis3.constraintRef(), -6, "B", "C"),
+                            matchAnalysisOf(constraintAnalysis3.constraintRef(), -9, "C", "D"),
+                            matchAnalysisOf(constraintAnalysis3.constraintRef(), -12));
+        });
+
+        var reverseDiff = scoreAnalysis2.diff(scoreAnalysis1);
+        assertSoftly(softly -> {
+            softly.assertThat(reverseDiff.score()).isEqualTo(SimpleScore.of(-8));
+            softly.assertThat(reverseDiff.constraintMap())
+                    .containsOnlyKeys(constraintMatchTotal1.getConstraintRef(), constraintMatchTotal4.getConstraintRef());
+        });
+        // Matches for constraint1 not present.
+        var reverseConstraintAnalysis1 = reverseDiff.getConstraintAnalysis(constraintName1);
+        assertSoftly(softly -> {
+            softly.assertThat(reverseConstraintAnalysis1.score()).isEqualTo(SimpleScore.of(-8));
+            var matchAnalyses = reverseConstraintAnalysis1.matches();
+            softly.assertThat(matchAnalyses)
+                    .containsOnly(
+                            matchAnalysisOf(reverseConstraintAnalysis1.constraintRef(), 2, "A", "B"),
+                            matchAnalysisOf(reverseConstraintAnalysis1.constraintRef(), -2, "B", "C"),
+                            matchAnalysisOf(reverseConstraintAnalysis1.constraintRef(), -8));
+        });
+        // Identical matches for constraint2 present in both
+        var reverseConstraintAnalysis2 = reverseDiff.getConstraintAnalysis(constraintName2);
+        assertThat(reverseConstraintAnalysis2).isNull();
+        // Matches for constraint3 present in reverse.
+        var reverseConstraintAnalysis3 = reverseDiff.getConstraintAnalysis(constraintName3);
         assertSoftly(softly -> {
             softly.assertThat(reverseConstraintAnalysis3.score()).isEqualTo(SimpleScore.of(30));
             var matchAnalyses = reverseConstraintAnalysis3.matches();

--- a/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-to-latest-version.adoc
+++ b/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-to-latest-version.adoc
@@ -80,6 +80,24 @@ can refer to the initialization event on the `SolverManager`,
 or to `BestSolutionChangedEvent.isNewBestSolutionInitialized()` method.
 ====
 
+'''
+
+icon:info-circle[role=yellow] Score analysis diff correctly omitting certain matches
+[%collapsible%open]
+====
+We fixed a bug in `ScoreAnalysis.diff(...)` which would list constraint matches as different,
+even in cases where there were no differences between two sets of constraint matches.
+In this case, the diff would contain an otherwise empty entry for each such constraint,
+leading to confusion as to its meaning.
+
+In the new version, `ScoreAnalysis` no longer returns such constraints.
+User queries for such constraints will now result in `null`,
+as they should.
+We expect this change will only affect a tiny number of users,
+and we encourage users of `ScoreAnalysis` to check the heavily expanded and clarified Javadoc of the class
+to discover the exact behavior of the functionality.
+====
+
 
 === Upgrade from 1.19.0 to 1.20.0
 


### PR DESCRIPTION
In some use cases, we've seen this reduce the size of diffs by as much as 90 %.