### PR TITLE
fix: Use FIELD_OR_READ_METHOD member accessor type for declarative shadow variable calculator

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/MemberAccessorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/MemberAccessorFactory.java
@@ -49,7 +49,7 @@ public final class MemberAccessorFactory {
             Class<? extends Annotation> annotationClass, DomainAccessType domainAccessType, ClassLoader classLoader) {
         return switch (domainAccessType) {
             case GIZMO -> GizmoMemberAccessorFactory.buildGizmoMemberAccessor(member, annotationClass,
-                    memberAccessorType != MemberAccessorType.REGULAR_METHOD,
+                    memberAccessorType != MemberAccessorType.VOID_METHOD,
                     (GizmoClassLoader) Objects.requireNonNull(classLoader));
             case REFLECTION -> buildReflectiveMemberAccessor(member, memberAccessorType, annotationClass);
         };
@@ -83,7 +83,7 @@ public final class MemberAccessorFactory {
                     }
                     memberAccessor = new ReflectionBeanPropertyMemberAccessor(method, getterOnly);
                     break;
-                case REGULAR_METHOD:
+                case VOID_METHOD:
                     memberAccessor = new ReflectionMethodMemberAccessor(method, false);
                     break;
                 default:
@@ -168,6 +168,6 @@ public final class MemberAccessorFactory {
         FIELD_OR_READ_METHOD,
         FIELD_OR_GETTER_METHOD,
         FIELD_OR_GETTER_METHOD_WITH_SETTER,
-        REGULAR_METHOD
+        VOID_METHOD
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/cascade/CascadingUpdateShadowVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/cascade/CascadingUpdateShadowVariableDescriptor.java
@@ -131,7 +131,7 @@ public final class CascadingUpdateShadowVariableDescriptor<Solution_> extends Sh
                                     targetMethodName));
         }
         targetMethod = descriptorPolicy.getMemberAccessorFactory().buildAndCacheMemberAccessor(allSourceMethodMembers.get(0),
-                MemberAccessorFactory.MemberAccessorType.REGULAR_METHOD, null, descriptorPolicy.getDomainAccessType());
+                MemberAccessorFactory.MemberAccessorType.VOID_METHOD, null, descriptorPolicy.getDomainAccessType());
         firstTargetVariableDescriptor = targetVariableDescriptorList.get(0);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
@@ -67,7 +67,7 @@ public class DeclarativeShadowVariableDescriptor<Solution_> extends ShadowVariab
         }
         this.calculator =
                 entityDescriptor.getSolutionDescriptor().getMemberAccessorFactory().buildAndCacheMemberAccessor(method,
-                        MemberAccessorFactory.MemberAccessorType.REGULAR_METHOD, ShadowSources.class,
+                        MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD, ShadowSources.class,
                         descriptorPolicy.getDomainAccessType());
 
         sourcePaths = shadowVariableUpdater.value();

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
@@ -25,8 +25,8 @@ public record RootVariableSource<Entity_, Value_>(
         BiConsumer<Object, Consumer<Value_>> valueEntityFunction,
         List<VariableSourceReference> variableSourceReferences) {
 
-    private static final String COLLECTION_REFERENCE_SUFFIX = "[]";
-    private static final String MEMBER_SEPERATOR_REGEX = "\\.";
+    public static final String COLLECTION_REFERENCE_SUFFIX = "[]";
+    public static final String MEMBER_SEPERATOR_REGEX = "\\.";
 
     private record VariablePath(Class<?> variableEntityClass,
             String variableName,

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/common/accessor/MemberAccessorFactoryTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/common/accessor/MemberAccessorFactoryTest.java
@@ -100,7 +100,7 @@ class MemberAccessorFactoryTest {
     @Test
     void methodReturnVoid() throws NoSuchMethodException {
         MemberAccessor memberAccessor = MemberAccessorFactory.buildMemberAccessor(TestdataEntity.class.getMethod("updateValue"),
-                MemberAccessorFactory.MemberAccessorType.REGULAR_METHOD, null, DomainAccessType.REFLECTION, null);
+                MemberAccessorFactory.MemberAccessorType.VOID_METHOD, null, DomainAccessType.REFLECTION, null);
         assertThat(memberAccessor).isInstanceOf(ReflectionMethodMemberAccessor.class);
         assertThat(memberAccessor.getName()).isEqualTo("updateValue");
         assertThat(memberAccessor.getType()).isEqualTo(void.class);

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/DotNames.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/DotNames.java
@@ -39,6 +39,7 @@ import ai.timefold.solver.core.api.solver.SolverFactory;
 import ai.timefold.solver.core.api.solver.SolverManager;
 import ai.timefold.solver.core.config.solver.SolverConfig;
 import ai.timefold.solver.core.config.solver.SolverManagerConfig;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
 
 import org.jboss.jandex.DotName;
 
@@ -84,6 +85,7 @@ public final class DotNames {
     static final DotName SHADOW_VARIABLE = DotName.createSimple(ShadowVariable.class.getName());
     static final DotName CASCADING_UPDATE_SHADOW_VARIABLE =
             DotName.createSimple(CascadingUpdateShadowVariable.class.getName());
+    static final DotName SHADOW_SOURCES = DotName.createSimple(ShadowSources.class.getName());
 
     static final DotName SOLVER_CONFIG = DotName.createSimple(SolverConfig.class.getName());
     static final DotName SOLVER_MANAGER_CONFIG = DotName.createSimple(SolverManagerConfig.class.getName());

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/SolverBuildTimeConfig.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/config/SolverBuildTimeConfig.java
@@ -1,9 +1,11 @@
 package ai.timefold.solver.quarkus.deployment.config;
 
 import java.util.Optional;
+import java.util.Set;
 
 import ai.timefold.solver.core.api.domain.common.DomainAccessType;
 import ai.timefold.solver.core.api.score.stream.ConstraintStreamImplType;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
 import ai.timefold.solver.core.config.solver.SolverConfig;
 import ai.timefold.solver.quarkus.config.SolverRuntimeConfig;
 
@@ -40,6 +42,13 @@ public interface SolverBuildTimeConfig {
     // Build time - visited by SolverConfig.visitReferencedClasses
     // which generates the constructor used by Quarkus
     Optional<Class<?>> nearbyDistanceMeterClass();
+
+    /**
+     * What preview features to enable.
+     * The list of available preview features should not
+     * be considered stable and may change between releases.
+     */
+    Optional<Set<PreviewFeature>> enabledPreviewFeatures();
 
     /**
      * What constraint stream implementation to use. Defaults to {@link ConstraintStreamImplType#BAVET}.

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSupplierShadowSolutionSolveTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorSupplierShadowSolutionSolveTest.java
@@ -1,0 +1,52 @@
+package ai.timefold.solver.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import jakarta.inject.Inject;
+
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.quarkus.testdata.suppliervariable.constraints.TestdataQuarkusSupplierVariableConstraintProvider;
+import ai.timefold.solver.quarkus.testdata.suppliervariable.domain.TestdataQuarkusSupplierVariableEntity;
+import ai.timefold.solver.quarkus.testdata.suppliervariable.domain.TestdataQuarkusSupplierVariableSolution;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldProcessorSupplierShadowSolutionSolveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.solver.enabled-preview-features", "DECLARATIVE_SHADOW_VARIABLES")
+            .overrideConfigKey("quarkus.timefold.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusSupplierVariableSolution.class,
+                            TestdataQuarkusSupplierVariableEntity.class,
+                            TestdataQuarkusSupplierVariableConstraintProvider.class));
+    @Inject
+    SolverManager<TestdataQuarkusSupplierVariableSolution, Long> solverManager;
+
+    @Test
+    void solve() throws ExecutionException, InterruptedException {
+        var shadowEntity =
+                new TestdataQuarkusSupplierVariableEntity();
+        var problem = new TestdataQuarkusSupplierVariableSolution();
+        problem.setEntityList(List.of(shadowEntity));
+        problem.setValueList(List.of("a", "b"));
+        var solverJob = solverManager.solve(1L, problem);
+        var solution = solverJob.getFinalBestSolution();
+        assertNotNull(solution);
+        assertNotSame(solution, problem);
+        assertEquals(0, solution.getScore().score());
+        assertNotSame(solution.getEntityList().get(0), problem.getEntityList().get(0));
+    }
+
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/suppliervariable/constraints/TestdataQuarkusSupplierVariableConstraintProvider.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/suppliervariable/constraints/TestdataQuarkusSupplierVariableConstraintProvider.java
@@ -1,0 +1,32 @@
+package ai.timefold.solver.quarkus.testdata.suppliervariable.constraints;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.api.score.stream.Joiners;
+import ai.timefold.solver.quarkus.testdata.suppliervariable.domain.TestdataQuarkusSupplierVariableEntity;
+
+import org.jspecify.annotations.NonNull;
+
+public class TestdataQuarkusSupplierVariableConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.forEach(TestdataQuarkusSupplierVariableEntity.class)
+                        .join(TestdataQuarkusSupplierVariableEntity.class,
+                                Joiners.equal(TestdataQuarkusSupplierVariableEntity::getValue1,
+                                        TestdataQuarkusSupplierVariableEntity::getValue2))
+                        .filter((a, b) -> {
+                            if (a.getValue1AndValue2() == null || b.getValue1AndValue2() == null) {
+                                throw new IllegalStateException();
+                            }
+                            return a.getValue1AndValue2().equals(b.getValue1AndValue2());
+                        })
+                        .penalize(SimpleScore.ONE)
+                        .asConstraint("Don't assign 2 entities the same value.")
+        };
+    }
+
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/suppliervariable/domain/TestdataQuarkusSupplierVariableEntity.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/suppliervariable/domain/TestdataQuarkusSupplierVariableEntity.java
@@ -1,0 +1,50 @@
+package ai.timefold.solver.quarkus.testdata.suppliervariable.domain;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+
+@PlanningEntity
+public class TestdataQuarkusSupplierVariableEntity {
+
+    private String value1;
+    private String value2;
+    private String value1AndValue2;
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue1() {
+        return value1;
+    }
+
+    public void setValue1(String value1) {
+        this.value1 = value1;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue2() {
+        return value2;
+    }
+
+    public void setValue2(String value2) {
+        this.value2 = value2;
+    }
+
+    @ShadowVariable(supplierName = "value1AndValue2Supplier")
+    public String getValue1AndValue2() {
+        return value1AndValue2;
+    }
+
+    public void setValue1AndValue2(String value1AndValue2) {
+        this.value1AndValue2 = value1AndValue2;
+    }
+
+    @ShadowSources({ "value1", "value2" })
+    public String value1AndValue2Supplier() {
+        if (value1 == null || value2 == null) {
+            return null;
+        }
+        return value1 + value2;
+    }
+
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/suppliervariable/domain/TestdataQuarkusSupplierVariableSolution.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdata/suppliervariable/domain/TestdataQuarkusSupplierVariableSolution.java
@@ -1,0 +1,48 @@
+package ai.timefold.solver.quarkus.testdata.suppliervariable.domain;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataQuarkusSupplierVariableSolution {
+
+    private List<String> valueList;
+    private List<TestdataQuarkusSupplierVariableEntity> entityList;
+
+    private SimpleScore score;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataQuarkusSupplierVariableEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataQuarkusSupplierVariableEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverAutoConfiguration.java
@@ -1,12 +1,13 @@
 package ai.timefold.solver.spring.boot.autoconfigure;
 
-import static ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptorValidator.*;
+import static ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptorValidator.assertValidPlanningVariables;
 import static java.util.stream.Collectors.joining;
 
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -270,6 +271,9 @@ public class TimefoldSolverAutoConfiguration
         }
         if (solverProperties.getDomainAccessType() != null) {
             solverConfig.setDomainAccessType(solverProperties.getDomainAccessType());
+        }
+        if (solverProperties.getEnabledPreviewFeatures() != null) {
+            solverConfig.setEnablePreviewFeatureSet(new HashSet<>(solverProperties.getEnabledPreviewFeatures()));
         }
         if (solverProperties.getNearbyDistanceMeterClass() != null) {
             solverConfig.setNearbyDistanceMeterClass(solverProperties.getNearbyDistanceMeterClass());

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperties.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperties.java
@@ -1,11 +1,13 @@
 package ai.timefold.solver.spring.boot.autoconfigure.config;
 
+import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
 import ai.timefold.solver.core.api.domain.common.DomainAccessType;
 import ai.timefold.solver.core.api.score.stream.ConstraintStreamImplType;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -48,6 +50,8 @@ public class SolverProperties {
      * and all planning annotations must be on public members.
      */
     private DomainAccessType domainAccessType;
+
+    private List<PreviewFeature> enabledPreviewFeatures;
 
     /**
      * Enable the Nearby Selection quick configuration.
@@ -119,6 +123,14 @@ public class SolverProperties {
 
     public void setDomainAccessType(DomainAccessType domainAccessType) {
         this.domainAccessType = domainAccessType;
+    }
+
+    public List<PreviewFeature> getEnabledPreviewFeatures() {
+        return enabledPreviewFeatures;
+    }
+
+    public void setEnabledPreviewFeatures(List<PreviewFeature> enabledPreviewFeatures) {
+        this.enabledPreviewFeatures = enabledPreviewFeatures;
     }
 
     public Class<? extends NearbyDistanceMeter<?, ?>> getNearbyDistanceMeterClass() {

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperty.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperty.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.spring.boot.autoconfigure.config;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -12,6 +13,7 @@ import java.util.stream.Stream;
 import ai.timefold.solver.core.api.domain.common.DomainAccessType;
 import ai.timefold.solver.core.api.score.stream.ConstraintStreamImplType;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 
 public enum SolverProperty {
@@ -22,6 +24,8 @@ public enum SolverProperty {
     MOVE_THREAD_COUNT("move-thread-count", SolverProperties::setMoveThreadCount, Object::toString),
     DOMAIN_ACCESS_TYPE("domain-access-type", SolverProperties::setDomainAccessType,
             value -> DomainAccessType.valueOf(value.toString())),
+    ENABLED_PREVIEW_FEATURES("enabled-preview-features", SolverProperties::setEnabledPreviewFeatures,
+            value -> Arrays.stream(value.toString().split(",")).map(PreviewFeature::valueOf).toList()),
     NEARBY_DISTANCE_METER_CLASS("nearby-distance-meter-class", SolverProperties::setNearbyDistanceMeterClass,
             value -> {
                 try {

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/suppliervariable/SupplierVariableSpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/suppliervariable/SupplierVariableSpringTestConfiguration.java
@@ -1,0 +1,16 @@
+package ai.timefold.solver.spring.boot.autoconfigure.suppliervariable;
+
+import ai.timefold.solver.spring.boot.autoconfigure.suppliervariable.constraints.TestdataSpringSupplierVariableConstraintProvider;
+import ai.timefold.solver.spring.boot.autoconfigure.suppliervariable.domain.TestdataSpringSupplierVariableSolution;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan(basePackageClasses = { TestdataSpringSupplierVariableSolution.class,
+        TestdataSpringSupplierVariableConstraintProvider.class })
+@AutoConfigurationPackage
+public class SupplierVariableSpringTestConfiguration {
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/suppliervariable/constraints/TestdataSpringSupplierVariableConstraintProvider.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/suppliervariable/constraints/TestdataSpringSupplierVariableConstraintProvider.java
@@ -1,0 +1,32 @@
+package ai.timefold.solver.spring.boot.autoconfigure.suppliervariable.constraints;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.api.score.stream.Joiners;
+import ai.timefold.solver.spring.boot.autoconfigure.suppliervariable.domain.TestdataSpringSupplierVariableEntity;
+
+import org.jspecify.annotations.NonNull;
+
+public class TestdataSpringSupplierVariableConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.forEach(TestdataSpringSupplierVariableEntity.class)
+                        .join(TestdataSpringSupplierVariableEntity.class,
+                                Joiners.equal(TestdataSpringSupplierVariableEntity::getValue1,
+                                        TestdataSpringSupplierVariableEntity::getValue2))
+                        .filter((a, b) -> {
+                            if (a.getValue1AndValue2() == null || b.getValue1AndValue2() == null) {
+                                throw new IllegalStateException();
+                            }
+                            return a.getValue1AndValue2().equals(b.getValue1AndValue2());
+                        })
+                        .penalize(SimpleScore.ONE)
+                        .asConstraint("Don't assign 2 entities the same value.")
+        };
+    }
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/suppliervariable/domain/TestdataSpringSupplierVariableEntity.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/suppliervariable/domain/TestdataSpringSupplierVariableEntity.java
@@ -1,0 +1,50 @@
+package ai.timefold.solver.spring.boot.autoconfigure.suppliervariable.domain;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+
+@PlanningEntity
+public class TestdataSpringSupplierVariableEntity {
+
+    private String value1;
+    private String value2;
+    private String value1AndValue2;
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue1() {
+        return value1;
+    }
+
+    public void setValue1(String value1) {
+        this.value1 = value1;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue2() {
+        return value2;
+    }
+
+    public void setValue2(String value2) {
+        this.value2 = value2;
+    }
+
+    @ShadowVariable(supplierName = "value1AndValue2Supplier")
+    public String getValue1AndValue2() {
+        return value1AndValue2;
+    }
+
+    public void setValue1AndValue2(String value1AndValue2) {
+        this.value1AndValue2 = value1AndValue2;
+    }
+
+    @ShadowSources({ "value1", "value2" })
+    public String value1AndValue2Supplier() {
+        if (value1 == null || value2 == null) {
+            return null;
+        }
+        return value1 + value2;
+    }
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/suppliervariable/domain/TestdataSpringSupplierVariableSolution.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/suppliervariable/domain/TestdataSpringSupplierVariableSolution.java
@@ -1,0 +1,48 @@
+package ai.timefold.solver.spring.boot.autoconfigure.suppliervariable.domain;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataSpringSupplierVariableSolution {
+
+    private List<String> valueList;
+    private List<TestdataSpringSupplierVariableEntity> entityList;
+
+    private SimpleScore score;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataSpringSupplierVariableEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataSpringSupplierVariableEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}


### PR DESCRIPTION
- Rename member accessor type REGULAR_METHOD to VOID_METHOD to prevent future confusion since that member accessor type can only be used on void methods.

Fixes #1542 