### PR TITLE
docs: improve documentation on configuration of preview feature.

### DIFF
--- a/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
@@ -296,8 +296,8 @@ In that case, use `ScoreAnalysisFetchPolicy.FETCH_MATCH_COUNT` instead of the de
 
 [IMPORTANT]
 ====
-The solution diff is available as a xref:upgrading-timefold-solver/backwards-compatibility.adoc#previewFeatures[preview feature]
-and must be specifically enabled in the solver configuration.
+The solution diff is available as a xref:upgrading-timefold-solver/backwards-compatibility.adoc#previewFeatures[preview feature].
+It may be subject to change and must be enabled in the solver configuration by setting: `<enablePreviewFeature>PLANNING_SOLUTION_DIFF</enablePreviewFeature>`
 ====
 
 [NOTE]

--- a/docs/src/modules/ROOT/pages/optimization-algorithms/local-search.adoc
+++ b/docs/src/modules/ROOT/pages/optimization-algorithms/local-search.adoc
@@ -563,7 +563,7 @@ Advanced configuration:
 [IMPORTANT]
 ====
 The new acceptor is available as a xref:upgrading-timefold-solver/backwards-compatibility.adoc#previewFeatures[preview feature]
-and must be specifically enabled with `<enablePreviewFeature>`.
+It may be subject to change and must be enabled in the solver configuration by setting: `<enablePreviewFeature>DIVERSIFIED_LATE_ACCEPTANCE</enablePreviewFeature>`
 ====
 
 [#greatDeluge]

--- a/docs/src/modules/ROOT/pages/upgrading-timefold-solver/backwards-compatibility.adoc
+++ b/docs/src/modules/ROOT/pages/upgrading-timefold-solver/backwards-compatibility.adoc
@@ -32,11 +32,22 @@ However, their APIs and behavior are not yet considered stable, pending user fee
 Any class, method or field related to these features may change or be removed without prior notice,
 although we strive to avoid this as much as possible.
 
+Preview features need to be activated in the solverConfig.xml file.
+
+[source,xml,options="nowrap"]
+----
+<solver xmlns="https://timefold.ai/xsd/solver">
+  <enablePreviewFeature>DIVERSIFIED_LATE_ACCEPTANCE</enablePreviewFeature>
+  <enablePreviewFeature>DECLARATIVE_SHADOW_VARIABLES</enablePreviewFeature>
+  <enablePreviewFeature>PLANNING_SOLUTION_DIFF</enablePreviewFeature>
+</solver>
+----
+
 Preview features often live in the `preview.api` package, and they are:
 
 - xref:optimization-algorithms/local-search.adoc#diversifiedLateAcceptance[Diversified Late Acceptance] acceptor
-- xref:constraints-and-score/understanding-the-score.adoc#solutionDiff[Solution diff API]
 - xref:using-timefold-solver/modeling-planning-problems.adoc#declarativeShadowVariable[Declarative Shadow Variables]
+- xref:constraints-and-score/understanding-the-score.adoc#solutionDiff[Solution diff API]
 in the `ai.timefold.solver.core.preview.api.domain.solution.diff` package,
 and in the `SolutionManager`
 - _Timefold Solver for Python_, which is currently in beta

--- a/docs/src/modules/ROOT/pages/using-timefold-solver/modeling-planning-problems.adoc
+++ b/docs/src/modules/ROOT/pages/using-timefold-solver/modeling-planning-problems.adoc
@@ -986,9 +986,10 @@ capacity: Annotated[int, PiggybackShadowVariable(shadow_variable_name="transport
 Declarative shadow variables are the simplest way to calculate shadow variables.
 This approach allows access to all the fields and methods of the declaring class.
 
-[WARNING]
+[IMPORTANT]
 ====
-This feature is currently in xref:/upgrading-timefold-solver/backwards-compatibility.adoc#previewFeatures[preview] and may be subject to change.
+This feature is currently available as a xref:/upgrading-timefold-solver/backwards-compatibility.adoc#previewFeatures[preview feature].
+It may be subject to change and must be enabled in the solver configuration by setting: `<enablePreviewFeature>DECLARATIVE_SHADOW_VARIABLES</enablePreviewFeature>`
 ====
 [NOTE]
 ====


### PR DESCRIPTION
A community member gave feedback that our documentation doesn't clearly show how to enable preview features.
This PR addresses that.