### PR TITLE
fix: support MoveCountPerTypeProblemStatistic in JAXB mapping

### DIFF
--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/result/ProblemBenchmarkResult.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/result/ProblemBenchmarkResult.java
@@ -33,6 +33,7 @@ import ai.timefold.solver.benchmark.impl.statistic.bestscore.BestScoreProblemSta
 import ai.timefold.solver.benchmark.impl.statistic.bestsolutionmutation.BestSolutionMutationProblemStatistic;
 import ai.timefold.solver.benchmark.impl.statistic.memoryuse.MemoryUseProblemStatistic;
 import ai.timefold.solver.benchmark.impl.statistic.movecountperstep.MoveCountPerStepProblemStatistic;
+import ai.timefold.solver.benchmark.impl.statistic.movecountpertype.MoveCountPerTypeProblemStatistic;
 import ai.timefold.solver.benchmark.impl.statistic.moveevaluationspeed.MoveEvaluationSpeedProblemStatisticTime;
 import ai.timefold.solver.benchmark.impl.statistic.scorecalculationspeed.ScoreCalculationSpeedProblemStatistic;
 import ai.timefold.solver.benchmark.impl.statistic.stepscore.StepScoreProblemStatistic;
@@ -71,6 +72,7 @@ public class ProblemBenchmarkResult<Solution_> {
             @XmlElement(name = "moveEvaluationSpeedProblemStatistic", type = MoveEvaluationSpeedProblemStatisticTime.class),
             @XmlElement(name = "bestSolutionMutationProblemStatistic", type = BestSolutionMutationProblemStatistic.class),
             @XmlElement(name = "moveCountPerStepProblemStatistic", type = MoveCountPerStepProblemStatistic.class),
+            @XmlElement(name = "moveCountPerTypeProblemStatistic", type = MoveCountPerTypeProblemStatistic.class),
             @XmlElement(name = "memoryUseProblemStatistic", type = MemoryUseProblemStatistic.class),
     })
     private List<ProblemStatistic> problemStatisticList = null;

--- a/benchmark/src/test/resources/dummyPlannerBenchmarkResult.xml
+++ b/benchmark/src/test/resources/dummyPlannerBenchmarkResult.xml
@@ -52,9 +52,9 @@
     <moveCountPerStepProblemStatistic>
       <problemStatisticType>MOVE_COUNT_PER_STEP</problemStatisticType>
     </moveCountPerStepProblemStatistic>
-    <bestScoreProblemStatistic>
+    <moveCountPerTypeProblemStatistic>
       <problemStatisticType>MOVE_COUNT_PER_TYPE</problemStatisticType>
-    </bestScoreProblemStatistic>
+    </moveCountPerTypeProblemStatistic>
     <moveEvaluationSpeedProblemStatistic>
       <problemStatisticType>MOVE_EVALUATION_SPEED</problemStatisticType>
       <reportFileName>moveEvaluationSpeedProblemStatisticChart</reportFileName>


### PR DESCRIPTION
This is a copy of @Magnusrk's PR: https://github.com/TimefoldAI/timefold-solver/pull/1566

I needed to make automatic formatting changes and due to the fact that Magnus committed his changes directly to `main`, I decided not to try to push to his repo directly.

I kept the attribution of the commit to Magnus.