### PR TITLE
Fix equals and hash code variable

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/violation/VariableId.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/violation/VariableId.java
@@ -9,7 +9,7 @@ import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescripto
  * <p>
  * Note: The entity is compared using {@link Object#equals(Object)} and {@link Object#hashCode()},
  * so it's important that the planning entity class properly overrides both methods,
- * typically based on a unique identifier (e.g. a database ID or business key).
+ * typically based on a unique identifier (e.g. a UId).
  * <p>
  * @param variableDescriptor The variable this {@link VariableId} refers to.
  * @param entity The entity this {@link VariableId} refers to.

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/violation/VariableId.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/violation/VariableId.java
@@ -6,7 +6,11 @@ import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescripto
  * A {@link VariableId} is an entity/variable of a given solution.
  * {@link VariableId} cannot be compared across different solution instances,
  * since variableDescriptor and entity are compared by reference equality.
- *
+ * <p>
+ * Note: The entity is compared using {@link Object#equals(Object)} and {@link Object#hashCode()},
+ * so it's important that the planning entity class properly overrides both methods,
+ * typically based on a unique identifier (e.g. a database ID or business key).
+ * <p>
  * @param variableDescriptor The variable this {@link VariableId} refers to.
  * @param entity The entity this {@link VariableId} refers to.
  */
@@ -14,8 +18,8 @@ public record VariableId<Solution_>(VariableDescriptor<Solution_> variableDescri
     @Override
     public boolean equals(Object other) {
         if (other instanceof VariableId<?> variableId) {
-            return variableDescriptor == variableId.variableDescriptor &&
-                    entity == variableId.entity;
+            return variableDescriptor.equals(variableId.variableDescriptor) &&
+                    entity.equals(variableId.entity);
         }
         return false;
     }


### PR DESCRIPTION
I encountered an issue where VariableId was used as a key in the HashMap inside VariableSnapshotTotal, but the key couldn't be found — even though, in the debugger, the objects inside the VariableId record looked exactly the same (also memory location). The hash also appeared correct in the debugger.

My solution was to change the equals() method in VariableId to use .equals() on both fields instead of ==. If the user doesn't override equals() for their entity, it still behaves the same as before. However, this change enables users to define logical equality themselves.

I believe part of the issue came from the default hashCode() behavior. Since Java's default hash is based on memory addresses, it can lead to bad hash distributions — especially when two logically identical objects (like two copies of an entity with the same ID) are placed into different buckets. I also had to implement proper equals() and hashCode() in my planning entity, which I noted in a comment in the code. After doing that, Timefold started working correctly again.

My guess is that the entity is cloned or copied at some point and for some reason my debugger wasn't showing me the correct memorylocation, and that's why some VariableId instances couldn't be found

I was implementing moveSelectors when this became an issue.

If the original design was intended to enforce identity equality for specific reasons, or if you have an idea what happened for me to have this issue let me know it works now following my approach overwriting hash and equals in entity using a better value for hashing (like id) :)