### PR TITLE
chore: filtering move selector honoring the phase termination

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelector.java
@@ -100,6 +100,7 @@ public final class FilteringMoveSelector<Solution_> extends AbstractMoveSelector
 
     private class JustInTimeFilteringMoveIterator extends UpcomingSelectionIterator<Move<Solution_>> {
 
+        private final long TERMINATION_BAIL_OUT_SIZE = 1000L;
         private final Iterator<Move<Solution_>> childMoveIterator;
         private final long bailOutSize;
         private final AbstractPhaseScope<Solution_> phaseScope;
@@ -118,9 +119,8 @@ public final class FilteringMoveSelector<Solution_> extends AbstractMoveSelector
             Move<Solution_> next;
             long attemptsBeforeBailOut = bailOutSize;
             // To reduce the impact of checking for termination on each move,
-            // we only check for termination
-            // after filtering out a total number of moves equal to size(childMoveSelector).
-            long attemptsBeforeCheckTermination = bailOutSize / BAIL_OUT_MULTIPLIER;
+            // we only check for termination after filtering out 1000 moves.
+            long attemptsBeforeCheckTermination = TERMINATION_BAIL_OUT_SIZE;
             do {
                 if (!childMoveIterator.hasNext()) {
                     return noUpcomingSelection();
@@ -133,7 +133,7 @@ public final class FilteringMoveSelector<Solution_> extends AbstractMoveSelector
                         return noUpcomingSelection();
                     } else if (termination != null && attemptsBeforeCheckTermination <= 0L) {
                         // Reset the counter
-                        attemptsBeforeCheckTermination = bailOutSize / BAIL_OUT_MULTIPLIER;
+                        attemptsBeforeCheckTermination = TERMINATION_BAIL_OUT_SIZE;
                         if (termination.isPhaseTerminated(phaseScope)) {
                             logger.trace(
                                     "Bailing out of neverEnding selector ({}) because the termination setting has been triggered.",

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelector.java
@@ -87,7 +87,7 @@ public final class FilteringMoveSelector<Solution_> extends AbstractMoveSelector
             this.childMoveIterator = childMoveIterator;
             this.bailOutSize = bailOutSize;
             this.phaseScope = phaseScope;
-            this.termination = phaseScope.getTermination();
+            this.termination = phaseScope != null ? phaseScope.getTermination() : null;
         }
 
         @Override
@@ -141,12 +141,11 @@ public final class FilteringMoveSelector<Solution_> extends AbstractMoveSelector
     }
 
     private boolean accept(ScoreDirector<Solution_> scoreDirector, Move<Solution_> move) {
-        if (filter != null) {
-            if (!filter.accept(scoreDirector, move)) {
-                logger.trace("        Move ({}) filtered out by a selection filter ({}).", move, filter);
-                return false;
-            }
+        if (filter != null && !filter.accept(scoreDirector, move)) {
+            logger.trace("        Move ({}) filtered out by a selection filter ({}).", move, filter);
+            return false;
         }
+
         return true;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -125,6 +125,7 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
         super.phaseStarted(phaseScope);
         decider.phaseStarted(phaseScope);
         assertWorkingSolutionInitialized(phaseScope);
+        phaseScope.setTermination(phaseTermination);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -125,7 +125,6 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
         super.phaseStarted(phaseScope);
         decider.phaseStarted(phaseScope);
         assertWorkingSolutionInitialized(phaseScope);
-        phaseScope.setTermination(phaseTermination);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/AbstractPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/AbstractPhase.java
@@ -95,6 +95,7 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
             solver.phaseStarted(phaseScope);
         }
         phaseTermination.phaseStarted(phaseScope);
+        phaseScope.setTermination(phaseTermination);
         phaseLifecycleSupport.firePhaseStarted(phaseScope);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescripto
 import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.impl.solver.termination.PhaseTermination;
 import ai.timefold.solver.core.preview.api.move.Move;
 
 import org.slf4j.Logger;
@@ -35,6 +36,11 @@ public abstract class AbstractPhaseScope<Solution_> {
     protected long childThreadsScoreCalculationCount = 0L;
 
     protected int bestSolutionStepIndex;
+
+    /**
+     * The solver termination configuration
+     */
+    private PhaseTermination<Solution_> termination;
 
     /**
      * As defined by #AbstractPhaseScope(SolverScope, int, boolean)
@@ -186,6 +192,14 @@ public abstract class AbstractPhaseScope<Solution_> {
 
     public <Score_ extends Score<Score_>> InnerScoreDirector<Solution_, Score_> getScoreDirector() {
         return solverScope.getScoreDirector();
+    }
+
+    public void setTermination(PhaseTermination<Solution_> termination) {
+        this.termination = termination;
+    }
+
+    public PhaseTermination<Solution_> getTermination() {
+        return termination;
     }
 
     public Solution_ getWorkingSolution() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
@@ -38,7 +38,7 @@ public abstract class AbstractPhaseScope<Solution_> {
     protected int bestSolutionStepIndex;
 
     /**
-     * The solver termination configuration
+     * The phase termination configuration
      */
     private PhaseTermination<Solution_> termination;
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
@@ -52,7 +52,7 @@ class FilteringMoveSelectorTest {
         var moveSelector = mock(MoveSelector.class);
         var termination = mock(BasicPlumbingTermination.class);
         var iterator = mock(Iterator.class);
-        when(moveSelector.getSize()).thenReturn(100L);
+        when(moveSelector.getSize()).thenReturn(1000L);
         when(moveSelector.isNeverEnding()).thenReturn(true);
         when(moveSelector.iterator()).thenReturn(iterator);
         when(iterator.hasNext()).thenReturn(true);
@@ -61,8 +61,8 @@ class FilteringMoveSelectorTest {
         var filteredMoveSelector = FilteringMoveSelector.of(moveSelector, (scoreDirector, selection) -> false);
         filteredMoveSelector.phaseStarted(phaseScope);
         assertThat(filteredMoveSelector.iterator().hasNext()).isFalse();
-        // The termination returns true at the second call, and only (100 * 10) * 30% calls are executed per check
-        verify(iterator, times(200)).next();
+        // The termination returns true at the second call, and 2000 calls are executed in total
+        verify(iterator, times(2000)).next();
     }
 
     public void filter(SelectionCacheType cacheType, int timesCalled) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
@@ -52,18 +52,17 @@ class FilteringMoveSelectorTest {
         var moveSelector = mock(MoveSelector.class);
         var termination = mock(BasicPlumbingTermination.class);
         var iterator = mock(Iterator.class);
-        // We set the maximum value to force it to run many evaluations
-        when(moveSelector.getSize()).thenReturn(Long.MAX_VALUE / 11);
+        when(moveSelector.getSize()).thenReturn(100L);
         when(moveSelector.isNeverEnding()).thenReturn(true);
         when(moveSelector.iterator()).thenReturn(iterator);
         when(iterator.hasNext()).thenReturn(true);
         when(phaseScope.getTermination()).thenReturn(termination);
-        when(termination.isPhaseTerminated(any(AbstractPhaseScope.class))).thenReturn(false, false, true);
+        when(termination.isPhaseTerminated(any(AbstractPhaseScope.class))).thenReturn(false, true);
         var filteredMoveSelector = FilteringMoveSelector.of(moveSelector, (scoreDirector, selection) -> false);
         filteredMoveSelector.phaseStarted(phaseScope);
         assertThat(filteredMoveSelector.iterator().hasNext()).isFalse();
-        // The termination returns true at the third call
-        verify(iterator, times(2)).next();
+        // The termination returns true at the second call, and only (100 * 10) * 30% calls are executed per check
+        verify(iterator, times(200)).next();
     }
 
     public void filter(SelectionCacheType cacheType, int timesCalled) {


### PR DESCRIPTION
This PR ensures that the `FilteringMoveSelector` will honor the phase termination setting. There may be use cases where a move filtering filters out all moves, resulting in the iterator analyzing a large number of moves before returning no valid upcoming selection.

It is important to note that the proposed strategy may not work for every termination configuration, and the phase will only end after the move selector bails out. Termination not based on time can cause the process to stuck during the generation of the first valid move in the phase, which may result in no move being returned after bailing out.