### PR TITLE
fix: Update looped status of entity even if no variables changed

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
@@ -118,13 +118,18 @@ final class AffectedEntitiesUpdater<Solution_>
         var entity = entityVariable.entity();
         var shadowVariableReference = entityVariable.variableReference();
         var oldValue = shadowVariableReference.memberAccessor().executeGetter(entity);
+        var loopDescriptor = shadowVariableReference.shadowVariableLoopedDescriptor();
+        if (loopDescriptor != null) {
+            var oldLooped = (boolean) loopDescriptor.getValue(entity);
+            if (oldLooped != isLooped) {
+                // Loop status change; add to affected entities
+                affectedEntities.add(entityVariable);
+            }
+        }
 
         if (isLooped) {
-            // null might be a valid value, and thus it could be the case
-            // that is was not looped and null, then turned to looped and null,
-            // which is still considered a change.
-            affectedEntities.add(entityVariable);
             if (oldValue != null) {
+                affectedEntities.add(entityVariable);
                 changeShadowVariableAndNotify(shadowVariableReference, entity, null);
             }
             return true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
@@ -2,12 +2,12 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.supply.Supply;
+import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class DefaultShadowVariableSession<Solution_> implements Supply {
-
+public final class DefaultShadowVariableSession<Solution_> implements Supply {
     final VariableReferenceGraph<Solution_> graph;
 
     public DefaultShadowVariableSession(VariableReferenceGraph<Solution_> graph) {
@@ -15,12 +15,22 @@ public class DefaultShadowVariableSession<Solution_> implements Supply {
     }
 
     public void beforeVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity) {
-        graph.beforeVariableChanged(variableDescriptor.getVariableMetaModel(),
+        beforeVariableChanged(variableDescriptor.getVariableMetaModel(),
                 entity);
     }
 
     public void afterVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity) {
-        graph.afterVariableChanged(variableDescriptor.getVariableMetaModel(),
+        afterVariableChanged(variableDescriptor.getVariableMetaModel(),
+                entity);
+    }
+
+    public void beforeVariableChanged(VariableMetaModel<Solution_, ?, ?> variableMetaModel, Object entity) {
+        graph.beforeVariableChanged(variableMetaModel,
+                entity);
+    }
+
+    public void afterVariableChanged(VariableMetaModel<Solution_, ?, ?> variableMetaModel, Object entity) {
+        graph.afterVariableChanged(variableMetaModel,
                 entity);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
@@ -354,6 +354,12 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
         }
         if (shadowVariableSession != null) {
             shadowVariableSession.updateVariables();
+            // Some internal variable listeners (such as those used
+            // to check for solution corruption) might have a declarative
+            // shadow variable as a source and need to be triggered here.
+            for (var notifiable : notifiableRegistry.getAll()) {
+                notifiable.triggerAllNotifications();
+            }
         }
         notificationQueuesAreEmpty = true;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/violation/SolutionTracker.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/violation/SolutionTracker.java
@@ -111,9 +111,15 @@ public final class SolutionTracker<Solution_> {
         return out;
     }
 
-    public String buildScoreCorruptionMessage() {
+    public record SolutionCorruptionResult(boolean isCorrupted, String message) {
+        public static SolutionCorruptionResult untracked() {
+            return new SolutionCorruptionResult(false, "");
+        }
+    }
+
+    public SolutionCorruptionResult buildSolutionCorruptionResult() {
         if (beforeMoveSolution == null) {
-            return "";
+            return new SolutionCorruptionResult(false, "");
         }
 
         StringBuilder out = new StringBuilder();
@@ -161,11 +167,17 @@ public final class SolutionTracker<Solution_> {
                     """.formatted(formatList(missingEventsBackward)));
         }
 
-        if (out.isEmpty()) {
-            return "Genuine and shadow variables agree with from scratch calculation after the undo move and match the state prior to the move.";
+        var isCorrupted = !out.isEmpty();
+        if (isCorrupted) {
+            return new SolutionCorruptionResult(isCorrupted, out.toString());
+        } else {
+            return new SolutionCorruptionResult(false,
+                    "Genuine and shadow variables agree with from scratch calculation after the undo move and match the state prior to the move.");
         }
+    }
 
-        return out.toString();
+    public String buildScoreCorruptionMessage() {
+        return buildSolutionCorruptionResult().message;
     }
 
     static <Solution_> List<String> getVariableChangedViolations(

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAssertScoreDirector.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAssertScoreDirector.java
@@ -1,0 +1,47 @@
+package ai.timefold.solver.core.impl.solver;
+
+import java.util.Map;
+
+import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.api.score.constraint.ConstraintMatchTotal;
+import ai.timefold.solver.core.api.score.constraint.Indictment;
+import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
+import ai.timefold.solver.core.impl.score.director.AbstractScoreDirector;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
+
+public class MoveAssertScoreDirector<Solution_, Score_ extends Score<Score_>>
+        extends AbstractScoreDirector<Solution_, Score_, MoveAssertScoreDirectorFactory<Solution_, Score_>> {
+
+    protected MoveAssertScoreDirector(MoveAssertScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory,
+            boolean lookUpEnabled,
+            ConstraintMatchPolicy constraintMatchPolicy,
+            boolean expectShadowVariablesInCorrectState) {
+        super(scoreDirectorFactory, lookUpEnabled, constraintMatchPolicy, expectShadowVariablesInCorrectState);
+    }
+
+    @Override
+    public void setWorkingSolution(Solution_ workingSolution) {
+        super.setWorkingSolution(workingSolution, ignored -> {
+        });
+    }
+
+    @Override
+    public InnerScore<Score_> calculateScore() {
+        return InnerScore.fullyAssigned(scoreDirectorFactory.getScoreDefinition().getZeroScore());
+    }
+
+    @Override
+    public Map<String, ConstraintMatchTotal<Score_>> getConstraintMatchTotalMap() {
+        return Map.of();
+    }
+
+    @Override
+    public Map<Object, Indictment<Score_>> getIndictmentMap() {
+        return Map.of();
+    }
+
+    @Override
+    public boolean requiresFlushing() {
+        return false;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAssertScoreDirectorFactory.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAssertScoreDirectorFactory.java
@@ -1,0 +1,38 @@
+package ai.timefold.solver.core.impl.solver;
+
+import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.director.AbstractScoreDirector;
+import ai.timefold.solver.core.impl.score.director.AbstractScoreDirectorFactory;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class MoveAssertScoreDirectorFactory<Solution_, Score_ extends Score<Score_>>
+        extends AbstractScoreDirectorFactory<Solution_, Score_, MoveAssertScoreDirectorFactory<Solution_, Score_>> {
+    public MoveAssertScoreDirectorFactory(
+            SolutionDescriptor<Solution_> solutionDescriptor) {
+        super(solutionDescriptor);
+    }
+
+    @Override
+    public AbstractScoreDirector.AbstractScoreDirectorBuilder<Solution_, Score_, ?, ?> createScoreDirectorBuilder() {
+        return new MoveAssertScoreDirectorBuilder(this);
+    }
+
+    public class MoveAssertScoreDirectorBuilder extends
+            AbstractScoreDirector.AbstractScoreDirectorBuilder<Solution_, Score_, MoveAssertScoreDirectorFactory<Solution_, Score_>, MoveAssertScoreDirectorBuilder> {
+
+        protected MoveAssertScoreDirectorBuilder(MoveAssertScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory) {
+            super(scoreDirectorFactory);
+        }
+
+        @Override
+        public MoveAssertScoreDirector<Solution_, Score_> build() {
+            return new MoveAssertScoreDirector<>(scoreDirectorFactory,
+                    lookUpEnabled,
+                    constraintMatchPolicy,
+                    expectShadowVariablesInCorrectState);
+        }
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAsserter.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAsserter.java
@@ -1,0 +1,37 @@
+package ai.timefold.solver.core.impl.solver;
+
+import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
+import ai.timefold.solver.core.preview.api.move.Move;
+
+public class MoveAsserter<Solution_> {
+    private final SolutionDescriptor<Solution_> solutionDescriptor;
+
+    private MoveAsserter(SolutionDescriptor<Solution_> solutionDescriptor) {
+        this.solutionDescriptor = solutionDescriptor;
+    }
+
+    public static <Solution_> MoveAsserter<Solution_> create(SolutionDescriptor<Solution_> solutionDescriptor) {
+        return new MoveAsserter<>(solutionDescriptor);
+    }
+
+    public void assertMove(Solution_ solution, Move<Solution_> move) {
+        var scoreDirectorFactory = new MoveAssertScoreDirectorFactory<>(solutionDescriptor);
+        scoreDirectorFactory.setTrackingWorkingSolution(true);
+        try (var scoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
+                .withLookUpEnabled(false)
+                .buildDerived()) {
+            var innerScore = InnerScore.fullyAssigned((Score) scoreDirector.getScoreDefinition().getZeroScore());
+            scoreDirector.setWorkingSolution(solution);
+            scoreDirector.executeTemporaryMove(move, true);
+            var corruptionResult = scoreDirector.getSolutionCorruptionAfterUndo(move, innerScore);
+            if (corruptionResult.isCorrupted()) {
+                throw new AssertionError("""
+                        Solution corruption caused by move (%s) or its undo.
+                        Analysis:
+                        %s""".formatted(move, corruptionResult.message()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
We previously only added a non-looped entity to affected entities if one of its declarative variables changed. However, if null is a valid value (such as for unassigned entities), then it might be the case the looped status of an entity changed from looped to non-looped. We now add an entity to the affected entities list if its loop status changed.