### PR TITLE
chore: prevent asciidoctor warnings when building documentation

### DIFF
--- a/docs/src/modules/ROOT/pages/integration/config-properties.adoc
+++ b/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@@ -1,18 +1,18 @@
 ////
 Quarkus and Spring Boot support the same configuration properties.
 All the properties are in this file, which can then be included multiple times.
-The {property_prefix} attribute is used for Quarkus properties.
-The {solver_name_prefix} attribute is the solver name for multiple managers.
+The \{property_prefix\} attribute is used for Quarkus properties.
+The \{solver_name_prefix\} attribute is the solver name for multiple managers.
 ////
 
-ifeval::["{solver_name_prefix}" == ""]
-{property_prefix}timefold.solver-manager.parallel-solver-count::
+ifeval::["\{solver_name_prefix\}" == ""]
+\{property_prefix\}timefold.solver-manager.parallel-solver-count::
 The number of solvers that run in parallel.
 This directly influences CPU consumption.
 Defaults to `AUTO`.
 endif::[]
 
-{property_prefix}timefold.solver.{solver_name_prefix}solver-config-xml::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}solver-config-xml::
 A classpath resource to read the xref:using-timefold-solver/configuration.adoc#solverConfiguration[solver configuration XML].
 Defaults to `solverConfig.xml`.
 If a resource is specified, it must be located in the classpath, or the configuration will fail.
@@ -21,65 +21,65 @@ configuration continues without using any configuration file.
 The specified resources take precedence over the default file `solverConfig.xml`, even if both files' resources are
 located in the classpath.
 
-{property_prefix}timefold.solver.{solver_name_prefix}environment-mode::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}environment-mode::
 Enable xref:using-timefold-solver/running-the-solver.adoc#environmentMode[runtime assertions] to detect common bugs in your
 implementation during development.
 
-{property_prefix}timefold.solver.{solver_name_prefix}daemon::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}daemon::
 Enable xref:responding-to-change/responding-to-change.adoc#daemon[daemon mode].
 In daemon mode, non-early termination pauses the solver instead of stopping it, until the next problem fact change arrives.
 This is often useful for xref:responding-to-change/responding-to-change.adoc#realTimePlanning[real-time planning].
 Defaults to `false`.
 
-{property_prefix}timefold.solver.{solver_name_prefix}move-thread-count::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}move-thread-count::
 Enable multi-threaded solving for a single problem, which increases CPU consumption.
 Defaults to `NONE`.
 Note that this is a feature of the xref:enterprise-edition/enterprise-edition.adoc[Enterprise edition],
 which is Timefold's commercial offering.
 See xref:enterprise-edition/enterprise-edition.adoc#multithreadedIncrementalSolving[multithreaded incremental solving].
 
-{property_prefix}timefold.solver.{solver_name_prefix}domain-access-type::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}domain-access-type::
 How Timefold Solver should access the domain model.
 See xref:using-timefold-solver/configuration.adoc#domainAccess[the domain access section] for more details.
-ifeval::["{property_prefix}" == "quarkus."]
+ifeval::["\{property_prefix\}" == "quarkus."]
 Defaults to `GIZMO`.
 The other possible value is `REFLECTION`.
 endif::[]
-ifeval::["{property_prefix}" == ""]
+ifeval::["\{property_prefix\}" == ""]
 Defaults to `REFLECTION`.
 The other possible value is `GIZMO`.
 endif::[]
 
-{property_prefix}timefold.solver.{solver_name_prefix}nearby-distance-meter-class::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}nearby-distance-meter-class::
 Enable the xref:enterprise-edition/enterprise-edition.adoc#nearbySelection[Nearby Selection] quick configuration.
 If the Nearby Selection distance meter class is specified,
 the solver evaluates the available move selectors
 and automatically enables Nearby Selection for the compatible move selectors.
 
-{property_prefix}timefold.solver.{solver_name_prefix}termination.spent-limit::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}termination.spent-limit::
 How long the solver can run.
 For example: `30s` is 30 seconds. `5m` is 5 minutes. `2h` is 2 hours. `1d` is 1 day.
 The https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm[ISO8601 format]
 is also supported, e.g., `PT30S` is 30 seconds. `PT5M` is 5 minutes. `PT2H` is 2 hours. `P1D` is 1 day.
 
-{property_prefix}timefold.solver.{solver_name_prefix}termination.unimproved-spent-limit::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}termination.unimproved-spent-limit::
 How long the solver can run without finding a new best solution after finding a new best solution.
 For example: `30s` is 30 seconds. `5m` is 5 minutes. `2h` is 2 hours. `1d` is 1 day.
 The https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm[ISO8601 format]
 is also supported, e.g., `PT30S` is 30 seconds. `PT5M` is 5 minutes. `PT2H` is 2 hours. `P1D` is 1 day.
 
-{property_prefix}timefold.solver.{solver_name_prefix}termination.best-score-limit::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}termination.best-score-limit::
 Terminates the solver when a specific score (or better) has been reached.
 For example: `0hard/-1000soft` terminates when the best score changes from `0hard/-1200soft` to `0hard/-900soft`.
 Wildcards are supported to replace numbers.
 For example: `0hard/*soft` to terminate when any feasible score is reached.
 
-{property_prefix}timefold.solver.{solver_name_prefix}termination.diminished-returns.enabled::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}termination.diminished-returns.enabled::
 If set to true, adds a termination to the local search phase that records the initial improvement after a duration, and terminates when the ratio new improvement/initial improvement is below a specified ratio.
 If left unspecified, it is enabled only if any
-{property_prefix}timefold.solver.{solver_name_prefix}termination.diminished-returns properties are defined.
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}termination.diminished-returns properties are defined.
 
-{property_prefix}timefold.solver.{solver_name_prefix}termination.diminished-returns.sliding-window-duration::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}termination.diminished-returns.sliding-window-duration::
 Specify the best score from how long ago should the current best score be compared to.
 For `30s`, the current best score is compared against the best score from 30 seconds ago to calculate the improvement.
 `5m` is 5 minutes.
@@ -93,25 +93,25 @@ is also supported, e.g., `PT30S` is 30 seconds.
 +
 Default to `30s`.
 
-{property_prefix}timefold.solver.{solver_name_prefix}termination.diminished-returns.minimum-improvement-ratio::
+\{property_prefix\}timefold.solver.\{solver_name_prefix\}termination.diminished-returns.minimum-improvement-ratio::
 Specify the minimum ratio between the current improvement and the initial improvement.
 Must be positive.
 +
-For example, if the {property_prefix}timefold.solver.{solver_name_prefix}termination.diminished-returns.sliding-window-duration is "30s", the {property_prefix}timefold.solver.{solver_name_prefix}termination.diminished-returns.minimum-improvement-ratio is 0.25, and the score improves by 100soft during the first 30 seconds of local search, then the local search phase will terminate when the difference between the current best score and the best score from 30 seconds ago is less than 25soft (= 0.25 100soft).
+For example, if the \{property_prefix\}timefold.solver.\{solver_name_prefix\}termination.diminished-returns.sliding-window-duration is "30s", the \{property_prefix\}timefold.solver.\{solver_name_prefix\}termination.diminished-returns.minimum-improvement-ratio is 0.25, and the score improves by 100soft during the first 30 seconds of local search, then the local search phase will terminate when the difference between the current best score and the best score from 30 seconds ago is less than 25soft (= 0.25 100soft).
 +
 Defaults to 0.0001.
 
-ifeval::["{solver_name_prefix}" == ""]
-{property_prefix}timefold.benchmark.solver-benchmark-config-xml::
+ifeval::["\{solver_name_prefix\}" == ""]
+\{property_prefix\}timefold.benchmark.solver-benchmark-config-xml::
 A classpath resource to read the benchmark configuration XML.
 Defaults to solverBenchmarkConfig.xml.
 If this property isn't specified, that solverBenchmarkConfig.xml is optional.
 
-{property_prefix}timefold.benchmark.result-directory::
+\{property_prefix\}timefold.benchmark.result-directory::
 Where the benchmark results are written to. Defaults to
 target/benchmarks.
 
-{property_prefix}timefold.benchmark.solver.termination.spent-limit::
+\{property_prefix\}timefold.benchmark.solver.termination.spent-limit::
 How long solver should be run in a benchmark run.
 For example: `30s` is 30 seconds. `5m` is 5 minutes. `2h` is 2 hours. `1d` is 1 day.
 Also supports ISO-8601 format, see https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration].

--- a/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -217,11 +217,11 @@ repositories {
 }
 
 dependencies {
-    implementation platform("ai.timefold.solver:timefold-solver-bom:${timefoldSolverVersion}")
+    implementation platform("ai.timefold.solver:timefold-solver-bom:$\{timefoldSolverVersion\}")
     implementation "ai.timefold.solver:timefold-solver-core"
     testImplementation "ai.timefold.solver:timefold-solver-test"
 
-    runtimeOnly "ch.qos.logback:logback-classic:${logbackVersion}"
+    runtimeOnly "ch.qos.logback:logback-classic:$\{logbackVersion\}"
 }
 
 java {
@@ -903,13 +903,11 @@ Java::
 +
 --
 include::../shared/java-logback-config.adoc[]
-----
 --
 Kotlin::
 +
 --
 include::../shared/java-logback-config.adoc[]
-----
 --
 
 Python::

--- a/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
@@ -14,9 +14,9 @@ package org.acme.schooltimetabling.solver;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
-import {wiringannotationfq};
+import \{wiringannotationfq\};
 
-import {testannotationfq};
+import \{testannotationfq\};
 import org.acme.schooltimetabling.domain.Lesson;
 import org.acme.schooltimetabling.domain.Room;
 import org.acme.schooltimetabling.domain.Timetable;
@@ -24,14 +24,14 @@ import org.acme.schooltimetabling.domain.Timeslot;
 import org.junit.jupiter.api.Test;
 import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
 
-{testannotation}
+\{testannotation\}
 class TimetableConstraintProviderTest {
 
     private static final Room ROOM1 = new Room("Room1");
     private static final Timeslot TIMESLOT1 = new Timeslot(DayOfWeek.MONDAY, LocalTime.of(9,0), LocalTime.NOON);
     private static final Timeslot TIMESLOT2 = new Timeslot(DayOfWeek.TUESDAY, LocalTime.of(9,0), LocalTime.NOON);
 
-    {wiringannotation}
+    \{wiringannotation\}
     ConstraintVerifier<TimetableConstraintProvider, Timetable> constraintVerifier;
 
     @Test
@@ -57,8 +57,8 @@ Create the `src/test/kotlin/org/acme/schooltimetabling/solver/TimetableConstrain
 package org.acme.schooltimetabling.solver
 
 import ai.timefold.solver.test.api.score.stream.ConstraintVerifier
-import {testannotationfq}
-import {wiringannotationfq}
+import \{testannotationfq\}
+import \{wiringannotationfq\}
 import org.acme.schooltimetabling.domain.Lesson
 import org.acme.schooltimetabling.domain.Room
 import org.acme.schooltimetabling.domain.Timeslot
@@ -67,14 +67,14 @@ import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
 import java.time.LocalTime
 
-{testannotation}
+\{testannotation\}
 class TimetableConstraintProviderTest {
 
     val ROOM1: Room = Room(1, "Room1")
     private val TIMESLOT1: Timeslot = Timeslot(1, DayOfWeek.MONDAY, LocalTime.NOON)
     private val TIMESLOT2: Timeslot = Timeslot(2, DayOfWeek.TUESDAY, LocalTime.NOON)
 
-    {wiringannotation}
+    \{wiringannotation\}
     lateinit var constraintVerifier: ConstraintVerifier<TimeTableConstraintProvider, Timetable>
 
     @Test

--- a/docs/src/modules/ROOT/pages/quickstart/shared/java-logback-config.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/shared/java-logback-config.adoc
@@ -18,3 +18,4 @@ Create the `src/main/resource/logback.xml` file:
   </root>
 
 </configuration>
+----

--- a/docs/src/modules/ROOT/pages/quickstart/shared/solutionsourcecode.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/shared/solutionsourcecode.adoc
@@ -8,10 +8,10 @@ Alternatively, you can also skip right to the completed example:
 +
 [source,shell,subs=attributes+]
 ----
-$ git clone {quickstarts-clone-url}
+$ git clone \{quickstarts-clone-url\}
 ----
 +
-or download an {quickstarts-archive-url}[archive].
+or download an \{quickstarts-archive-url\}[archive].
 
-. Find the solution in {framework-quickstart-url}[the `java` directory]
+. Find the solution in \{framework-quickstart-url\}[the `java` directory]
 and run it (see its README file).


### PR DESCRIPTION
When building the docs for this repository, asciidoctor gives a couple of warnings. This PR fixes those warnings.

Most of them are forgotten escaping for `{variables}` and then a couple of places where blocks weren't ended properly.

Before:

```
@timefoldai/docs:dev: [17:11:01.614] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.615] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.615] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.615] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.616] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.616] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.616] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.616] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.617] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.617] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.618] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.618] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.618] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.618] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.618] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.618] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.618] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.619] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.619] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.619] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.619] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.619] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.619] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.619] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.619] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.620] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.620] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.620] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.620] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.620] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.620] WARN (asciidoctor): skipping reference to missing attribute: solver_name_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.620] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.620] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:01.621] WARN (asciidoctor): skipping reference to missing attribute: property_prefix
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/integration/config-properties.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.091] WARN (asciidoctor): skipping reference to missing attribute: timefoldsolverversion
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.091] WARN (asciidoctor): skipping reference to missing attribute: logbackversion
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.208] WARN (asciidoctor): skipping reference to missing attribute: wiringannotationfq
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.208] WARN (asciidoctor): skipping reference to missing attribute: testannotationfq
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.208] WARN (asciidoctor): skipping reference to missing attribute: testannotation
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.208] WARN (asciidoctor): skipping reference to missing attribute: wiringannotation
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.209] WARN (asciidoctor): skipping reference to missing attribute: testannotationfq
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.209] WARN (asciidoctor): skipping reference to missing attribute: wiringannotationfq
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.209] WARN (asciidoctor): skipping reference to missing attribute: testannotation
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.209] WARN (asciidoctor): skipping reference to missing attribute: wiringannotation
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/constrainttests.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.210] WARN (asciidoctor): unterminated listing block
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/java-logback-config.adoc:4
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.215] WARN (asciidoctor): skipping reference to missing attribute: quickstarts-clone-url
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/solutionsourcecode.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.215] WARN (asciidoctor): skipping reference to missing attribute: quickstarts-archive-url
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/solutionsourcecode.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
@timefoldai/docs:dev: [17:11:02.215] WARN (asciidoctor): skipping reference to missing attribute: framework-quickstart-url
@timefoldai/docs:dev:     file: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver/docs/src/modules/ROOT/pages/quickstart/shared/solutionsourcecode.adoc
@timefoldai/docs:dev:     source: /Users/jurriaanpersyn/Documents/GitHub/timefold-solver (branch: main <worktree> | start path: docs/src)
```

After:

🪄 