### PR TITLE
fix: Benchmarker best score graph no longer empty

### DIFF
--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/result/SubSingleBenchmarkResult.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/result/SubSingleBenchmarkResult.java
@@ -304,6 +304,7 @@ public class SubSingleBenchmarkResult implements BenchmarkResult {
         // Skip oldResult.usedMemoryAfterInputSolution
         newResult.succeeded = oldResult.succeeded;
         newResult.score = oldResult.score;
+        newResult.initialized = oldResult.initialized;
         newResult.timeMillisSpent = oldResult.timeMillisSpent;
         newResult.scoreCalculationCount = oldResult.scoreCalculationCount;
         newResult.moveEvaluationCount = oldResult.moveEvaluationCount;

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/StatisticRegistry.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/StatisticRegistry.java
@@ -12,13 +12,14 @@ import java.util.function.Function;
 import java.util.function.ObjLongConsumer;
 import java.util.stream.Collectors;
 
-import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.constraint.ConstraintRef;
 import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListener;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverMetricUtil;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 
 import io.micrometer.core.instrument.Meter;
@@ -88,21 +89,17 @@ public class StatisticRegistry<Solution_> extends SimpleMeterRegistry
                 .collect(Collectors.toSet());
     }
 
-    public void extractScoreFromMeters(SolverMetric metric, Tags runId, Consumer<Score<?>> scoreConsumer) {
-        var labelNames = scoreDefinition.getLevelLabels();
-        for (var i = 0; i < labelNames.length; i++) {
-            labelNames[i] = labelNames[i].replace(' ', '.');
-        }
-        var levelNumbers = new Number[labelNames.length];
-        for (var i = 0; i < labelNames.length; i++) {
-            var scoreLevelGauge = this.find(metric.getMeterId() + "." + labelNames[i]).tags(runId).gauge();
+    public void extractScoreFromMeters(SolverMetric metric, Tags runId, Consumer<InnerScore<?>> scoreConsumer) {
+        var score = SolverMetricUtil.extractScore(metric, scoreDefinition, id -> {
+            var gaugeId = metric.getMeterId() + "." + id;
+            var scoreLevelGauge = this.find(gaugeId).tags(runId).gauge();
             if (scoreLevelGauge != null && Double.isFinite(scoreLevelGauge.value())) {
-                levelNumbers[i] = scoreLevelNumberConverter.apply(scoreLevelGauge.value());
+                return scoreLevelNumberConverter.apply(scoreLevelGauge.value());
             } else {
-                return;
+                return scoreLevelNumberConverter.apply(0.0);
             }
-        }
-        scoreConsumer.accept(scoreDefinition.fromLevelNumbers(levelNumbers));
+        });
+        scoreConsumer.accept(score);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -121,7 +118,7 @@ public class StatisticRegistry<Solution_> extends SimpleMeterRegistry
                             // Get the count gauge (add constraint package and constraint name to the run tags)
                             score -> getGaugeValue(metric.getMeterId() + ".count", constraintMatchTotalRunId,
                                     count -> constraintMatchTotalConsumer
-                                            .accept(new ConstraintSummary(constraintRef, score, count.intValue()))));
+                                            .accept(new ConstraintSummary(constraintRef, score.raw(), count.intValue()))));
                 });
     }
 

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/StatisticRegistry.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/StatisticRegistry.java
@@ -117,21 +117,15 @@ public class StatisticRegistry<Solution_> extends SimpleMeterRegistry
                     // Get the score from the corresponding constraint package and constraint name meters
                     extractScoreFromMeters(metric, constraintMatchTotalRunId,
                             // Get the count gauge (add constraint package and constraint name to the run tags)
-                            score -> getGaugeValue(SolverMetricUtil.getGaugeName(metric, "count"), constraintMatchTotalRunId,
-                                    count -> constraintMatchTotalConsumer
-                                            .accept(new ConstraintSummary(constraintRef, score.raw(), count.intValue()))));
+                            score -> {
+                                var count = SolverMetricUtil.getGaugeValue(this, SolverMetricUtil.getGaugeName(metric, "count"),
+                                        constraintMatchTotalRunId);
+                                if (count != null) {
+                                    constraintMatchTotalConsumer
+                                            .accept(new ConstraintSummary(constraintRef, score.raw(), count.intValue()));
+                                }
+                            });
                 });
-    }
-
-    public void getGaugeValue(SolverMetric metric, Tags runId, Consumer<Number> gaugeConsumer) {
-        getGaugeValue(metric.getMeterId(), runId, gaugeConsumer);
-    }
-
-    public void getGaugeValue(String meterId, Tags runId, Consumer<Number> gaugeConsumer) {
-        var gauge = this.find(meterId).tags(runId).gauge();
-        if (gauge != null && Double.isFinite(gauge.value())) {
-            gaugeConsumer.accept(gauge.value());
-        }
     }
 
     public void extractMoveCountPerType(SolverScope<Solution_> solverScope, ObjLongConsumer<String> gaugeConsumer) {

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/bestscore/BestScoreSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/bestscore/BestScoreSubSingleStatistic.java
@@ -32,7 +32,7 @@ public class BestScoreSubSingleStatistic<Solution_>
         registry.addListener(SolverMetric.BEST_SCORE,
                 timestamp -> registry.extractScoreFromMeters(SolverMetric.BEST_SCORE, runTag,
                         score -> pointList
-                                .add(new BestScoreStatisticPoint(timestamp, score.raw(), score.fullyAssigned()))));
+                                .add(new BestScoreStatisticPoint(timestamp, score.raw(), score.isFullyAssigned()))));
     }
 
     // ************************************************************************

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/bestscore/BestScoreSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/bestscore/BestScoreSubSingleStatistic.java
@@ -32,7 +32,7 @@ public class BestScoreSubSingleStatistic<Solution_>
         registry.addListener(SolverMetric.BEST_SCORE,
                 timestamp -> registry.extractScoreFromMeters(SolverMetric.BEST_SCORE, runTag,
                         score -> pointList
-                                .add(new BestScoreStatisticPoint(timestamp, score, subSingleBenchmarkResult.isInitialized()))));
+                                .add(new BestScoreStatisticPoint(timestamp, score.raw(), score.fullyAssigned()))));
     }
 
     // ************************************************************************

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/bestsolutionmutation/BestSolutionMutationSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/bestsolutionmutation/BestSolutionMutationSubSingleStatistic.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.benchmark.impl.statistic.StatisticPoint;
 import ai.timefold.solver.benchmark.impl.statistic.StatisticRegistry;
 import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverMetricUtil;
 
 import io.micrometer.core.instrument.Tags;
 
@@ -30,9 +31,12 @@ public class BestSolutionMutationSubSingleStatistic<Solution_>
     @Override
     public void open(StatisticRegistry<Solution_> registry, Tags runTag) {
         registry.addListener(SolverMetric.BEST_SOLUTION_MUTATION,
-                timestamp -> registry.getGaugeValue(SolverMetric.BEST_SOLUTION_MUTATION, runTag,
-                        mutationCount -> pointList
-                                .add(new BestSolutionMutationStatisticPoint(timestamp, mutationCount.intValue()))));
+                timestamp -> {
+                    var mutationCount = SolverMetricUtil.getGaugeValue(registry, SolverMetric.BEST_SOLUTION_MUTATION, runTag);
+                    if (mutationCount != null) {
+                        pointList.add(new BestSolutionMutationStatisticPoint(timestamp, mutationCount.intValue()));
+                    }
+                });
     }
 
     // ************************************************************************

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/common/AbstractCalculationSpeedSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/common/AbstractCalculationSpeedSubSingleStatistic.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.benchmark.impl.statistic.ProblemBasedSubSingleStatisti
 import ai.timefold.solver.benchmark.impl.statistic.StatisticRegistry;
 import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverMetricUtil;
 
 import io.micrometer.core.instrument.Tags;
 
@@ -44,7 +45,8 @@ public abstract class AbstractCalculationSpeedSubSingleStatistic<Solution_>
             @Override
             public void accept(Long timeMillisSpent) {
                 if (timeMillisSpent >= nextTimeMillisThreshold) {
-                    registry.getGaugeValue(solverMetric, runTag, countNumber -> {
+                    var countNumber = SolverMetricUtil.getGaugeValue(registry, solverMetric, runTag);
+                    if (countNumber != null) {
                         var moveEvaluationCount = countNumber.longValue();
                         var countInterval = moveEvaluationCount - lastCalculationCount.get();
                         var timeMillisSpentInterval = timeMillisSpent - lastTimeMillisSpent;
@@ -55,7 +57,7 @@ public abstract class AbstractCalculationSpeedSubSingleStatistic<Solution_>
                         var speed = countInterval * 1000L / timeMillisSpentInterval;
                         pointList.add(new LongStatisticPoint(timeMillisSpent, speed));
                         lastCalculationCount.set(moveEvaluationCount);
-                    });
+                    }
                     lastTimeMillisSpent = timeMillisSpent;
                     nextTimeMillisThreshold += timeMillisThresholdInterval;
                     if (nextTimeMillisThreshold < timeMillisSpent) {

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/memoryuse/MemoryUseSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/memoryuse/MemoryUseSubSingleStatistic.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.benchmark.impl.statistic.StatisticPoint;
 import ai.timefold.solver.benchmark.impl.statistic.StatisticRegistry;
 import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverMetricUtil;
 
 import io.micrometer.core.instrument.Tags;
 
@@ -58,10 +59,11 @@ public class MemoryUseSubSingleStatistic<Solution_>
         @Override
         public void accept(Long timeMillisSpent) {
             if (timeMillisSpent >= nextTimeMillisThreshold) {
-                registry.getGaugeValue(SolverMetric.MEMORY_USE, tags,
-                        memoryUse -> pointList.add(
-                                new MemoryUseStatisticPoint(timeMillisSpent, memoryUse.longValue(),
-                                        (long) registry.find("jvm.memory.max").tags(tags).gauge().value())));
+                var memoryUse = SolverMetricUtil.getGaugeValue(registry, SolverMetric.MEMORY_USE, tags);
+                if (memoryUse != null) {
+                    var max = SolverMetricUtil.getGaugeValue(registry, "jvm.memory.max", tags);
+                    pointList.add(new MemoryUseStatisticPoint(timeMillisSpent, memoryUse.longValue(), max.longValue()));
+                }
 
                 nextTimeMillisThreshold += timeMillisThresholdInterval;
                 if (nextTimeMillisThreshold < timeMillisSpent) {

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/movecountperstep/MoveCountPerStepSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/movecountperstep/MoveCountPerStepSubSingleStatistic.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.benchmark.impl.statistic.StatisticPoint;
 import ai.timefold.solver.benchmark.impl.statistic.StatisticRegistry;
 import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverMetricUtil;
 
 import io.micrometer.core.instrument.Tags;
 
@@ -30,10 +31,18 @@ public class MoveCountPerStepSubSingleStatistic<Solution_>
     @Override
     public void open(StatisticRegistry<Solution_> registry, Tags runTag) {
         registry.addListener(SolverMetric.MOVE_COUNT_PER_STEP,
-                timeMillisSpent -> registry.getGaugeValue(SolverMetric.MOVE_COUNT_PER_STEP.getMeterId() + ".accepted", runTag,
-                        accepted -> registry.getGaugeValue(SolverMetric.MOVE_COUNT_PER_STEP.getMeterId() + ".selected", runTag,
-                                selected -> pointList.add(new MoveCountPerStepStatisticPoint(timeMillisSpent,
-                                        accepted.longValue(), selected.longValue())))));
+                timeMillisSpent -> {
+                    var accepted = SolverMetricUtil.getGaugeValue(registry,
+                            SolverMetric.MOVE_COUNT_PER_STEP.getMeterId() + ".accepted", runTag);
+                    if (accepted != null) {
+                        var selected = SolverMetricUtil.getGaugeValue(registry,
+                                SolverMetric.MOVE_COUNT_PER_STEP.getMeterId() + ".selected", runTag);
+                        if (selected != null) {
+                            pointList.add(new MoveCountPerStepStatisticPoint(timeMillisSpent, accepted.longValue(),
+                                    selected.longValue()));
+                        }
+                    }
+                });
     }
 
     // ************************************************************************

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/stepscore/StepScoreSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/stepscore/StepScoreSubSingleStatistic.java
@@ -31,8 +31,8 @@ public class StepScoreSubSingleStatistic<Solution_>
     public void open(StatisticRegistry<Solution_> registry, Tags runTag) {
         registry.addListener(SolverMetric.STEP_SCORE,
                 timeMillisSpent -> registry.extractScoreFromMeters(SolverMetric.STEP_SCORE, runTag,
-                        score -> pointList.add(new StepScoreStatisticPoint(timeMillisSpent, score,
-                                subSingleBenchmarkResult.isInitialized()))));
+                        score -> pointList
+                                .add(new StepScoreStatisticPoint(timeMillisSpent, score.raw(), score.fullyAssigned()))));
     }
 
     // ************************************************************************

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/stepscore/StepScoreSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/stepscore/StepScoreSubSingleStatistic.java
@@ -32,7 +32,7 @@ public class StepScoreSubSingleStatistic<Solution_>
         registry.addListener(SolverMetric.STEP_SCORE,
                 timeMillisSpent -> registry.extractScoreFromMeters(SolverMetric.STEP_SCORE, runTag,
                         score -> pointList
-                                .add(new StepScoreStatisticPoint(timeMillisSpent, score.raw(), score.fullyAssigned()))));
+                                .add(new StepScoreStatisticPoint(timeMillisSpent, score.raw(), score.isFullyAssigned()))));
     }
 
     // ************************************************************************

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/pickedmovetypebestscore/PickedMoveTypeBestScoreDiffSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/pickedmovetypebestscore/PickedMoveTypeBestScoreDiffSubSingleStatistic.java
@@ -35,7 +35,7 @@ public class PickedMoveTypeBestScoreDiffSubSingleStatistic<Solution_>
                 registry.extractScoreFromMeters(SolverMetric.PICKED_MOVE_TYPE_BEST_SCORE_DIFF,
                         runTag.and(Tag.of("move.type", moveType)),
                         score -> pointList.add(new PickedMoveTypeBestScoreDiffStatisticPoint(
-                                timeMillisSpent, moveType, score)));
+                                timeMillisSpent, moveType, score.raw())));
             }
         });
     }

--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/pickedmovetypestepscore/PickedMoveTypeStepScoreDiffSubSingleStatistic.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/statistic/subsingle/pickedmovetypestepscore/PickedMoveTypeStepScoreDiffSubSingleStatistic.java
@@ -35,7 +35,7 @@ public class PickedMoveTypeStepScoreDiffSubSingleStatistic<Solution_>
                 registry.extractScoreFromMeters(SolverMetric.PICKED_MOVE_TYPE_STEP_SCORE_DIFF,
                         runTag.and(Tag.of("move.type", moveType)),
                         score -> pointList.add(new PickedMoveTypeStepScoreDiffStatisticPoint(
-                                timeMillisSpent, moveType, score)));
+                                timeMillisSpent, moveType, score.raw())));
             }
         });
     }

--- a/benchmark/src/test/java/ai/timefold/solver/benchmark/api/PlannerBenchmarkFactoryTest.java
+++ b/benchmark/src/test/java/ai/timefold/solver/benchmark/api/PlannerBenchmarkFactoryTest.java
@@ -3,9 +3,10 @@ package ai.timefold.solver.benchmark.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,51 +27,63 @@ import ai.timefold.solver.core.testutil.NoChangeCustomPhaseCommand;
 import ai.timefold.solver.core.testutil.PlannerTestUtils;
 
 import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 class PlannerBenchmarkFactoryTest {
+
+    private static File benchmarkTestDir;
+    private static File benchmarkOutputTestDir;
+
+    @BeforeAll
+    static void setup() throws IOException {
+        benchmarkTestDir = new File("target/test/benchmarkTest/");
+        benchmarkTestDir.mkdirs();
+        new File(benchmarkTestDir, "input.xml").createNewFile();
+        benchmarkOutputTestDir = new File(benchmarkTestDir, "output/");
+        benchmarkOutputTestDir.mkdir();
+    }
 
     // ************************************************************************
     // Static creation methods: SolverConfig XML
     // ************************************************************************
 
     @Test
-    void createFromSolverConfigXmlResource(@TempDir Path benchmarkTestDir) {
-        var benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfigXmlResource(
+    void createFromSolverConfigXmlResource() {
+        PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfigXmlResource(
                 "ai/timefold/solver/core/config/solver/testdataSolverConfig.xml");
-        var solution = new TestdataSolution("s1");
+        TestdataSolution solution = new TestdataSolution("s1");
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3")));
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
         assertThat(benchmarkFactory.buildPlannerBenchmark(solution)).isNotNull();
 
         benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfigXmlResource(
-                "ai/timefold/solver/core/config/solver/testdataSolverConfig.xml", benchmarkTestDir.toFile());
+                "ai/timefold/solver/core/config/solver/testdataSolverConfig.xml", benchmarkOutputTestDir);
         assertThat(benchmarkFactory.buildPlannerBenchmark(solution)).isNotNull();
     }
 
     @Test
-    void createFromSolverConfigXmlResource_classLoader(@TempDir Path benchmarkTestDir) {
+    void createFromSolverConfigXmlResource_classLoader() {
         // Mocking loadClass doesn't work well enough, because the className still differs from class.getName()
         ClassLoader classLoader = new DivertingClassLoader(getClass().getClassLoader());
-        var benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfigXmlResource(
+        PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfigXmlResource(
                 "divertThroughClassLoader/ai/timefold/solver/core/api/solver/classloaderTestdataSolverConfig.xml", classLoader);
-        var solution = new TestdataSolution("s1");
+        TestdataSolution solution = new TestdataSolution("s1");
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3")));
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
         assertThat(benchmarkFactory.buildPlannerBenchmark(solution)).isNotNull();
 
         benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfigXmlResource(
                 "divertThroughClassLoader/ai/timefold/solver/core/api/solver/classloaderTestdataSolverConfig.xml",
-                benchmarkTestDir.toFile(), classLoader);
+                benchmarkOutputTestDir, classLoader);
         assertThat(benchmarkFactory.buildPlannerBenchmark(solution)).isNotNull();
     }
 
     @Test
     void problemIsNotASolutionInstance() {
-        var solverConfig = PlannerTestUtils.buildSolverConfig(
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataSolution.class, TestdataEntity.class);
-        var benchmarkFactory = PlannerBenchmarkFactory.create(
+        PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.create(
                 PlannerBenchmarkConfig.createFromSolverConfig(solverConfig));
         assertThatIllegalArgumentException().isThrownBy(
                 () -> benchmarkFactory.buildPlannerBenchmark("This is not a solution instance."));
@@ -78,11 +91,11 @@ class PlannerBenchmarkFactoryTest {
 
     @Test
     void problemIsNull() {
-        var solverConfig = PlannerTestUtils.buildSolverConfig(
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataSolution.class, TestdataEntity.class);
-        var benchmarkFactory = PlannerBenchmarkFactory.create(
+        PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.create(
                 PlannerBenchmarkConfig.createFromSolverConfig(solverConfig));
-        var solution = new TestdataSolution("s1");
+        TestdataSolution solution = new TestdataSolution("s1");
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3")));
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
         assertThatIllegalArgumentException().isThrownBy(() -> benchmarkFactory.buildPlannerBenchmark(solution, null));
@@ -94,9 +107,9 @@ class PlannerBenchmarkFactoryTest {
 
     @Test
     void createFromXmlResource() {
-        var plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromXmlResource(
+        PlannerBenchmarkFactory plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromXmlResource(
                 "ai/timefold/solver/benchmark/api/testdataBenchmarkConfig.xml");
-        var plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
+        PlannerBenchmark plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
@@ -105,17 +118,17 @@ class PlannerBenchmarkFactoryTest {
     void createFromXmlResource_classLoader() {
         // Mocking loadClass doesn't work well enough, because the className still differs from class.getName()
         ClassLoader classLoader = new DivertingClassLoader(getClass().getClassLoader());
-        var plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromXmlResource(
+        PlannerBenchmarkFactory plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromXmlResource(
                 "divertThroughClassLoader/ai/timefold/solver/benchmark/api/classloaderTestdataBenchmarkConfig.xml",
                 classLoader);
-        var plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
+        PlannerBenchmark plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
 
     @Test
     void createFromXmlResource_nonExisting() {
-        final var nonExistingBenchmarkConfigResource = "ai/timefold/solver/benchmark/api/nonExistingBenchmarkConfig.xml";
+        final String nonExistingBenchmarkConfigResource = "ai/timefold/solver/benchmark/api/nonExistingBenchmarkConfig.xml";
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> PlannerBenchmarkFactory.createFromXmlResource(nonExistingBenchmarkConfigResource))
                 .withMessageContaining(nonExistingBenchmarkConfigResource);
@@ -123,7 +136,7 @@ class PlannerBenchmarkFactoryTest {
 
     @Test
     void createFromInvalidXmlResource_failsShowingBothResourceAndReason() {
-        final var invalidXmlBenchmarkConfigResource = "ai/timefold/solver/benchmark/api/invalidBenchmarkConfig.xml";
+        final String invalidXmlBenchmarkConfigResource = "ai/timefold/solver/benchmark/api/invalidBenchmarkConfig.xml";
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> PlannerBenchmarkFactory.createFromXmlResource(invalidXmlBenchmarkConfigResource))
                 .withMessageContaining(invalidXmlBenchmarkConfigResource)
@@ -131,66 +144,66 @@ class PlannerBenchmarkFactoryTest {
     }
 
     @Test
-    void createFromInvalidXmlFile_failsShowingBothPathAndReason(@TempDir Path benchmarkTestDir) throws IOException {
-        var invalidXmlBenchmarkConfigResource = "ai/timefold/solver/benchmark/api/invalidBenchmarkConfig.xml";
-        var path = benchmarkTestDir.resolve("invalidBenchmarkConfig.xml");
-        try (var in = getClass().getClassLoader().getResourceAsStream(invalidXmlBenchmarkConfigResource)) {
-            Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
+    void createFromInvalidXmlFile_failsShowingBothPathAndReason() throws IOException {
+        final String invalidXmlBenchmarkConfigResource = "ai/timefold/solver/benchmark/api/invalidBenchmarkConfig.xml";
+        File file = new File(benchmarkTestDir, "invalidBenchmarkConfig.xml");
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(invalidXmlBenchmarkConfigResource)) {
+            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> PlannerBenchmarkFactory.createFromXmlFile(path.toFile()))
-                .withMessageContaining(path.toString())
+                .isThrownBy(() -> PlannerBenchmarkFactory.createFromXmlFile(file))
+                .withMessageContaining(file.toString())
                 .withStackTraceContaining("invalidElementThatShouldNotBeHere");
     }
 
     @Test
     void createFromXmlResource_uninitializedBestSolution() {
-        var benchmarkConfig = PlannerBenchmarkConfig.createFromXmlResource(
+        PlannerBenchmarkConfig benchmarkConfig = PlannerBenchmarkConfig.createFromXmlResource(
                 "ai/timefold/solver/benchmark/api/testdataBenchmarkConfig.xml");
-        var solverBenchmarkConfig = benchmarkConfig.getSolverBenchmarkConfigList().get(0);
-        var phaseConfig = new CustomPhaseConfig();
+        SolverBenchmarkConfig solverBenchmarkConfig = benchmarkConfig.getSolverBenchmarkConfigList().get(0);
+        CustomPhaseConfig phaseConfig = new CustomPhaseConfig();
         phaseConfig.setCustomPhaseCommandClassList(Collections.singletonList(NoChangeCustomPhaseCommand.class));
         solverBenchmarkConfig.getSolverConfig().setPhaseConfigList(Collections.singletonList(phaseConfig));
-        var plannerBenchmark = PlannerBenchmarkFactory.create(benchmarkConfig).buildPlannerBenchmark();
+        PlannerBenchmark plannerBenchmark = PlannerBenchmarkFactory.create(benchmarkConfig).buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
 
     @Test
     void createFromXmlResource_subSingleCount() {
-        var benchmarkConfig = PlannerBenchmarkConfig.createFromXmlResource(
+        PlannerBenchmarkConfig benchmarkConfig = PlannerBenchmarkConfig.createFromXmlResource(
                 "ai/timefold/solver/benchmark/api/testdataBenchmarkConfig.xml");
-        var solverBenchmarkConfig = benchmarkConfig.getSolverBenchmarkConfigList().get(0);
+        SolverBenchmarkConfig solverBenchmarkConfig = benchmarkConfig.getSolverBenchmarkConfigList().get(0);
         solverBenchmarkConfig.setSubSingleCount(3);
-        var plannerBenchmark = PlannerBenchmarkFactory.create(benchmarkConfig).buildPlannerBenchmark();
+        PlannerBenchmark plannerBenchmark = PlannerBenchmarkFactory.create(benchmarkConfig).buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
 
     @Test
-    void createFromXmlFile(@TempDir Path benchmarkTestDir) throws IOException {
-        var path = benchmarkTestDir.resolve("testdataBenchmarkConfig.xml");
-        try (var in = getClass().getClassLoader().getResourceAsStream(
+    void createFromXmlFile() throws IOException {
+        File file = new File(benchmarkTestDir, "testdataBenchmarkConfig.xml");
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(
                 "ai/timefold/solver/benchmark/api/testdataBenchmarkConfig.xml")) {
-            Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
-        var plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromXmlFile(path.toFile());
-        var plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
+        PlannerBenchmarkFactory plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromXmlFile(file);
+        PlannerBenchmark plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
 
     @Test
-    void createFromXmlFile_classLoader(@TempDir Path benchmarkTestDir) throws IOException {
+    void createFromXmlFile_classLoader() throws IOException {
         // Mocking loadClass doesn't work well enough, because the className still differs from class.getName()
         ClassLoader classLoader = new DivertingClassLoader(getClass().getClassLoader());
-        var path = benchmarkTestDir.resolve("classloaderTestdataBenchmarkConfig.xml");
-        try (var in = getClass().getClassLoader().getResourceAsStream(
+        File file = new File(benchmarkTestDir, "classloaderTestdataBenchmarkConfig.xml");
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(
                 "ai/timefold/solver/benchmark/api/classloaderTestdataBenchmarkConfig.xml")) {
-            Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
-        var plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromXmlFile(path.toFile(), classLoader);
-        var plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
+        PlannerBenchmarkFactory plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromXmlFile(file, classLoader);
+        PlannerBenchmark plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
@@ -201,9 +214,9 @@ class PlannerBenchmarkFactoryTest {
 
     @Test
     void createFromFreemarkerXmlResource() {
-        var plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromFreemarkerXmlResource(
+        PlannerBenchmarkFactory plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromFreemarkerXmlResource(
                 "ai/timefold/solver/benchmark/api/testdataBenchmarkConfigTemplate.xml.ftl");
-        var plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
+        PlannerBenchmark plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
@@ -212,10 +225,10 @@ class PlannerBenchmarkFactoryTest {
     void createFromFreemarkerXmlResource_classLoader() {
         // Mocking loadClass doesn't work well enough, because the className still differs from class.getName()
         ClassLoader classLoader = new DivertingClassLoader(getClass().getClassLoader());
-        var plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromFreemarkerXmlResource(
+        PlannerBenchmarkFactory plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromFreemarkerXmlResource(
                 "divertThroughClassLoader/ai/timefold/solver/benchmark/api/classloaderTestdataBenchmarkConfigTemplate.xml.ftl",
                 classLoader);
-        var plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
+        PlannerBenchmark plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
@@ -227,29 +240,30 @@ class PlannerBenchmarkFactoryTest {
     }
 
     @Test
-    void createFromFreemarkerXmlFile(@TempDir Path benchmarkTestDir) throws IOException {
-        var path = benchmarkTestDir.resolve("testdataBenchmarkConfigTemplate.xml.ftl");
-        try (var in = getClass().getClassLoader().getResourceAsStream(
+    void createFromFreemarkerXmlFile() throws IOException {
+        File file = new File(benchmarkTestDir, "testdataBenchmarkConfigTemplate.xml.ftl");
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(
                 "ai/timefold/solver/benchmark/api/testdataBenchmarkConfigTemplate.xml.ftl")) {
-            Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
-        var plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromFreemarkerXmlFile(path.toFile());
-        var plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
+        PlannerBenchmarkFactory plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromFreemarkerXmlFile(file);
+        PlannerBenchmark plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
 
     @Test
-    void createFromFreemarkerXmlFile_classLoader(@TempDir Path benchmarkTestDir) throws IOException {
+    void createFromFreemarkerXmlFile_classLoader() throws IOException {
         // Mocking loadClass doesn't work well enough, because the className still differs from class.getName()
         ClassLoader classLoader = new DivertingClassLoader(getClass().getClassLoader());
-        var path = benchmarkTestDir.resolve("classloaderTestdataBenchmarkConfigTemplate.xml.ftl");
-        try (var in = getClass().getClassLoader().getResourceAsStream(
+        File file = new File(benchmarkTestDir, "classloaderTestdataBenchmarkConfigTemplate.xml.ftl");
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(
                 "ai/timefold/solver/benchmark/api/classloaderTestdataBenchmarkConfigTemplate.xml.ftl")) {
-            Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
-        var plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromFreemarkerXmlFile(path.toFile(), classLoader);
-        var plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
+        PlannerBenchmarkFactory plannerBenchmarkFactory = PlannerBenchmarkFactory.createFromFreemarkerXmlFile(file,
+                classLoader);
+        PlannerBenchmark plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.benchmark()).exists();
     }
@@ -259,17 +273,17 @@ class PlannerBenchmarkFactoryTest {
     // ************************************************************************
 
     @Test
-    void createFromSolverConfig(@TempDir Path benchmarkTestDir) {
-        var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
+    void createFromSolverConfig() {
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
 
-        var solution = new TestdataSolution("s1");
+        TestdataSolution solution = new TestdataSolution("s1");
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3")));
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
 
-        var benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfig(solverConfig);
+        PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfig(solverConfig);
         assertThat(benchmarkFactory.buildPlannerBenchmark(solution)).isNotNull();
 
-        benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfig(solverConfig, benchmarkTestDir.toFile());
+        benchmarkFactory = PlannerBenchmarkFactory.createFromSolverConfig(solverConfig, benchmarkOutputTestDir);
         assertThat(benchmarkFactory.buildPlannerBenchmark(solution)).isNotNull();
     }
 
@@ -279,8 +293,8 @@ class PlannerBenchmarkFactoryTest {
 
     @Test
     void buildPlannerBenchmark() {
-        var benchmarkConfig = new PlannerBenchmarkConfig();
-        var inheritedSolverConfig = new SolverBenchmarkConfig();
+        PlannerBenchmarkConfig benchmarkConfig = new PlannerBenchmarkConfig();
+        SolverBenchmarkConfig inheritedSolverConfig = new SolverBenchmarkConfig();
         inheritedSolverConfig.setSolverConfig(new SolverConfig()
                 .withSolutionClass(TestdataSolution.class)
                 .withEntityClasses(TestdataEntity.class)
@@ -290,16 +304,16 @@ class PlannerBenchmarkFactoryTest {
         benchmarkConfig.setSolverBenchmarkConfigList(Arrays.asList(
                 new SolverBenchmarkConfig(), new SolverBenchmarkConfig(), new SolverBenchmarkConfig()));
 
-        var benchmarkFactory = PlannerBenchmarkFactory.create(benchmarkConfig);
+        PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.create(benchmarkConfig);
 
-        var solution1 = new TestdataSolution("s1");
+        TestdataSolution solution1 = new TestdataSolution("s1");
         solution1.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3")));
         solution1.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
-        var solution2 = new TestdataSolution("s2");
+        TestdataSolution solution2 = new TestdataSolution("s2");
         solution2.setEntityList(Arrays.asList(new TestdataEntity("e11"), new TestdataEntity("e12"), new TestdataEntity("e13")));
         solution2.setValueList(Arrays.asList(new TestdataValue("v11"), new TestdataValue("v12")));
 
-        var plannerBenchmark =
+        DefaultPlannerBenchmark plannerBenchmark =
                 (DefaultPlannerBenchmark) benchmarkFactory.buildPlannerBenchmark(solution1, solution2);
         assertThat(plannerBenchmark).isNotNull();
         assertThat(plannerBenchmark.getPlannerBenchmarkResult().getSolverBenchmarkResultList()).hasSize(3);

--- a/benchmark/src/test/java/ai/timefold/solver/benchmark/api/PlannerBenchmarkTest.java
+++ b/benchmark/src/test/java/ai/timefold/solver/benchmark/api/PlannerBenchmarkTest.java
@@ -61,8 +61,8 @@ class PlannerBenchmarkTest {
                 softly.assertThat(lineList)
                         .first()
                         .isEqualTo("""
-                            "timeMillisSpent","score","initialized"
-                            """.trim());
+                                "timeMillisSpent","score","initialized"
+                                """.trim());
                 // Checks that best score was recorded at least once.
                 // Requires LS to have started, as CH does not store best score.
                 // We only check score+initialized, as "timeMillisSpent" can be anything.
@@ -70,8 +70,8 @@ class PlannerBenchmarkTest {
                         .last()
                         .asString()
                         .endsWith("""
-                            "0","true"
-                            """.trim());
+                                "0","true"
+                                """.trim());
             });
         } catch (IOException e) {
             fail(e);

--- a/benchmark/src/test/java/ai/timefold/solver/benchmark/api/PlannerBenchmarkTest.java
+++ b/benchmark/src/test/java/ai/timefold/solver/benchmark/api/PlannerBenchmarkTest.java
@@ -1,0 +1,81 @@
+package ai.timefold.solver.benchmark.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import ai.timefold.solver.benchmark.config.PlannerBenchmarkConfig;
+import ai.timefold.solver.benchmark.config.SolverBenchmarkConfig;
+import ai.timefold.solver.benchmark.impl.DefaultPlannerBenchmark;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
+import ai.timefold.solver.core.testdomain.TestdataConstraintProvider;
+import ai.timefold.solver.core.testdomain.TestdataEntity;
+import ai.timefold.solver.core.testdomain.TestdataSolution;
+import ai.timefold.solver.core.testdomain.TestdataValue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PlannerBenchmarkTest {
+
+    @Test
+    void runPlannerBenchmark(@TempDir Path benchmarkTestDir) {
+        var benchmarkConfig = new PlannerBenchmarkConfig();
+        benchmarkConfig.setBenchmarkDirectory(benchmarkTestDir.toFile());
+        benchmarkConfig.setWarmUpMillisecondsSpentLimit(1L); // Minimize warmup.
+        var inheritedSolverConfig = new SolverBenchmarkConfig();
+        inheritedSolverConfig.setSolverConfig(new SolverConfig()
+                .withSolutionClass(TestdataSolution.class)
+                .withEntityClasses(TestdataEntity.class)
+                .withConstraintProviderClass(TestdataConstraintProvider.class)
+                // Only run for a short amount of time.
+                .withTerminationConfig(new TerminationConfig().withUnimprovedMillisecondsSpentLimit(100L)));
+        benchmarkConfig.setInheritedSolverBenchmarkConfig(inheritedSolverConfig);
+        benchmarkConfig.setSolverBenchmarkConfigList(List.of(new SolverBenchmarkConfig()));
+        var benchmarkFactory = PlannerBenchmarkFactory.create(benchmarkConfig);
+
+        var solution1 = new TestdataSolution("s1");
+        solution1.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3")));
+        solution1.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
+
+        var plannerBenchmark = (DefaultPlannerBenchmark) benchmarkFactory.buildPlannerBenchmark(solution1);
+        plannerBenchmark.benchmark(); // Run the benchmark.
+        var folder = plannerBenchmark.getBenchmarkReport().getHtmlOverviewFile()
+                .toPath()
+                .getParent();
+        var csv = folder.resolve(Path.of("Problem_0", "Config_0", "sub0", "BEST_SCORE.csv"));
+        assertThat(csv).exists();
+
+        try (var lines = Files.lines(csv)) {
+            var lineList = lines.toList();
+            assertThat(lineList).isNotEmpty();
+            assertSoftly(softly -> {
+                // Proper header.
+                softly.assertThat(lineList)
+                        .first()
+                        .isEqualTo("""
+                            "timeMillisSpent","score","initialized"
+                            """.trim());
+                // Checks that best score was recorded at least once.
+                // Requires LS to have started, as CH does not store best score.
+                // We only check score+initialized, as "timeMillisSpent" can be anything.
+                softly.assertThat(lineList)
+                        .last()
+                        .asString()
+                        .endsWith("""
+                            "0","true"
+                            """.trim());
+            });
+        } catch (IOException e) {
+            fail(e);
+        }
+    }
+
+}

--- a/benchmark/src/test/java/ai/timefold/solver/benchmark/api/PlannerBenchmarkTest.java
+++ b/benchmark/src/test/java/ai/timefold/solver/benchmark/api/PlannerBenchmarkTest.java
@@ -55,7 +55,7 @@ class PlannerBenchmarkTest {
 
         try (var lines = Files.lines(csv)) {
             var lineList = lines.toList();
-            assertThat(lineList).isNotEmpty();
+            assertThat(lineList).hasSizeGreaterThan(1);
             assertSoftly(softly -> {
                 // Proper header.
                 softly.assertThat(lineList)
@@ -70,7 +70,7 @@ class PlannerBenchmarkTest {
                         .last()
                         .asString()
                         .endsWith("""
-                                "0","true"
+                                "-3","true"
                                 """.trim());
             });
         } catch (IOException e) {

--- a/core/src/main/java/ai/timefold/solver/core/api/solver/event/BestSolutionChangedEvent.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/event/BestSolutionChangedEvent.java
@@ -15,6 +15,7 @@ import org.jspecify.annotations.NonNull;
  *
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
+// TODO In Solver 2.0, maybe convert this to an interface.
 public class BestSolutionChangedEvent<Solution_> extends EventObject {
 
     private final Solver<Solution_> solver;

--- a/core/src/main/java/ai/timefold/solver/core/api/solver/event/BestSolutionChangedEvent.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/event/BestSolutionChangedEvent.java
@@ -25,7 +25,7 @@ public class BestSolutionChangedEvent<Solution_> extends EventObject {
 
     /**
      * @param timeMillisSpent {@code >= 0L}
-     * @deprecated Use {@link #BestSolutionChangedEvent(Solver, long, Object, Score, boolean)} instead.
+     * @deprecated Users should not manually construct instances of this event.
      */
     @Deprecated(forRemoval = true, since = "1.22.0")
     public BestSolutionChangedEvent(@NonNull Solver<Solution_> solver, long timeMillisSpent,
@@ -35,7 +35,9 @@ public class BestSolutionChangedEvent<Solution_> extends EventObject {
 
     /**
      * @param timeMillisSpent {@code >= 0L}
+     * @deprecated Users should not manually construct instances of this event.
      */
+    @Deprecated(forRemoval = true, since = "1.23.0")
     public BestSolutionChangedEvent(@NonNull Solver<Solution_> solver, long timeMillisSpent,
             @NonNull Solution_ newBestSolution, @NonNull Score newBestScore,
             boolean isNewBestSolutionInitialized) {

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/monitoring/SolverMetric.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/monitoring/SolverMetric.java
@@ -1,35 +1,26 @@
 package ai.timefold.solver.core.config.solver.monitoring;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.ToDoubleFunction;
 
 import jakarta.xml.bind.annotation.XmlEnum;
 
-import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.solver.Solver;
-import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
+import ai.timefold.solver.core.impl.solver.monitoring.statistic.BestScoreStatistic;
+import ai.timefold.solver.core.impl.solver.monitoring.statistic.BestSolutionMutationCountStatistic;
+import ai.timefold.solver.core.impl.solver.monitoring.statistic.MemoryUseStatistic;
+import ai.timefold.solver.core.impl.solver.monitoring.statistic.MoveCountPerTypeStatistic;
+import ai.timefold.solver.core.impl.solver.monitoring.statistic.PickedMoveBestScoreDiffStatistic;
+import ai.timefold.solver.core.impl.solver.monitoring.statistic.PickedMoveStepScoreDiffStatistic;
+import ai.timefold.solver.core.impl.solver.monitoring.statistic.SolverScopeStatistic;
+import ai.timefold.solver.core.impl.solver.monitoring.statistic.SolverStatistic;
+import ai.timefold.solver.core.impl.solver.monitoring.statistic.StatelessSolverStatistic;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
-import ai.timefold.solver.core.impl.statistic.BestScoreStatistic;
-import ai.timefold.solver.core.impl.statistic.BestSolutionMutationCountStatistic;
-import ai.timefold.solver.core.impl.statistic.MemoryUseStatistic;
-import ai.timefold.solver.core.impl.statistic.MoveCountPerTypeStatistic;
-import ai.timefold.solver.core.impl.statistic.PickedMoveBestScoreDiffStatistic;
-import ai.timefold.solver.core.impl.statistic.PickedMoveStepScoreDiffStatistic;
-import ai.timefold.solver.core.impl.statistic.SolverScopeStatistic;
-import ai.timefold.solver.core.impl.statistic.SolverStatistic;
-import ai.timefold.solver.core.impl.statistic.StatelessSolverStatistic;
 
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.NullMarked;
-
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Tags;
 
 @XmlEnum
 public enum SolverMetric {
+
     SOLVE_DURATION("timefold.solver.solve.duration", false),
     ERROR_COUNT("timefold.solver.errors", false),
     SCORE_CALCULATION_COUNT("timefold.solver.score.calculation.count",
@@ -62,6 +53,9 @@ public enum SolverMetric {
             true),
     PICKED_MOVE_TYPE_STEP_SCORE_DIFF("timefold.solver.move.type.step.score.diff", new PickedMoveStepScoreDiffStatistic<>(),
             false);
+
+    // Necessary for benchmarker, but otherwise undocumented and not considered public.
+    public static final String UNASSIGNED_COUNT = "unassigned.count";
 
     private final String meterId;
     @SuppressWarnings("rawtypes")
@@ -97,30 +91,6 @@ public enum SolverMetric {
         return meterId;
     }
 
-    @NullMarked
-    public static void registerScoreMetrics(SolverMetric metric, Tags tags, ScoreDefinition<?> scoreDefinition,
-            Map<Tags, List<AtomicReference<Number>>> tagToScoreLevels, Score<?> innerScore) {
-        Number[] levelValues = innerScore.toLevelNumbers();
-        if (tagToScoreLevels.containsKey(tags)) {
-            List<AtomicReference<Number>> scoreLevels = tagToScoreLevels.get(tags);
-            for (int i = 0; i < levelValues.length; i++) {
-                scoreLevels.get(i).set(levelValues[i]);
-            }
-        } else {
-            String[] levelLabels = scoreDefinition.getLevelLabels();
-            for (int i = 0; i < levelLabels.length; i++) {
-                levelLabels[i] = levelLabels[i].replace(' ', '.');
-            }
-            List<AtomicReference<Number>> scoreLevels = new ArrayList<>(levelValues.length);
-            for (int i = 0; i < levelValues.length; i++) {
-                scoreLevels.add(Metrics.gauge(metric.getMeterId() + "." + levelLabels[i],
-                        tags, new AtomicReference<>(levelValues[i]),
-                        ar -> ar.get().doubleValue()));
-            }
-            tagToScoreLevels.put(tags, scoreLevels);
-        }
-    }
-
     public boolean isMetricBestSolutionBased() {
         return isBestSolutionBased;
     }
@@ -130,7 +100,6 @@ public enum SolverMetric {
     }
 
     @SuppressWarnings("unchecked")
-    // TODO: clarify @NonNull ok here
     public void register(@NonNull Solver<?> solver) {
         registerFunction.register(solver);
     }
@@ -139,4 +108,5 @@ public enum SolverMetric {
     public void unregister(@NonNull Solver<?> solver) {
         registerFunction.unregister(solver);
     }
+
 }

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/monitoring/SolverMetric.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/monitoring/SolverMetric.java
@@ -54,9 +54,6 @@ public enum SolverMetric {
     PICKED_MOVE_TYPE_STEP_SCORE_DIFF("timefold.solver.move.type.step.score.diff", new PickedMoveStepScoreDiffStatistic<>(),
             false);
 
-    // Necessary for benchmarker, but otherwise undocumented and not considered public.
-    public static final String UNASSIGNED_COUNT = "unassigned.count";
-
     private final String meterId;
     @SuppressWarnings("rawtypes")
     private final SolverStatistic registerFunction;

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -196,7 +196,7 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
                 Metrics.gauge(metric.getMeterId() + ".count",
                         tags, count);
             }
-            SolverMetricUtil.registerScoreMetrics(metric, tags, scoreDefinition, scoreMap,
+            SolverMetricUtil.registerScore(metric, tags, scoreDefinition, scoreMap,
                     InnerScore.fullyAssigned(constraintMatchTotal.getScore()));
         }
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -1,12 +1,11 @@
 package ai.timefold.solver.core.impl.localsearch;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.constraint.ConstraintMatchTotal;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
@@ -16,6 +15,9 @@ import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.phase.AbstractPhase;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
+import ai.timefold.solver.core.impl.solver.monitoring.ScoreLevels;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverMetricUtil;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.PhaseTermination;
 
@@ -35,8 +37,8 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
     protected final AtomicLong selectedMoveCountPerStep = new AtomicLong(0);
     protected final Map<Tags, AtomicLong> constraintMatchTotalTagsToStepCount = new ConcurrentHashMap<>();
     protected final Map<Tags, AtomicLong> constraintMatchTotalTagsToBestCount = new ConcurrentHashMap<>();
-    protected final Map<Tags, List<AtomicReference<Number>>> constraintMatchTotalStepScoreMap = new ConcurrentHashMap<>();
-    protected final Map<Tags, List<AtomicReference<Number>>> constraintMatchTotalBestScoreMap = new ConcurrentHashMap<>();
+    protected final Map<Tags, ScoreLevels> constraintMatchTotalStepScoreMap = new ConcurrentHashMap<>();
+    protected final Map<Tags, ScoreLevels> constraintMatchTotalBestScoreMap = new ConcurrentHashMap<>();
 
     private DefaultLocalSearchPhase(Builder<Solution_> builder) {
         super(builder);
@@ -181,9 +183,10 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
         }
     }
 
-    private void collectConstraintMatchTotalMetrics(SolverMetric metric, Tags tags, Map<Tags, AtomicLong> countMap,
-            Map<Tags, List<AtomicReference<Number>>> scoreMap, ConstraintMatchTotal<?> constraintMatchTotal,
-            ScoreDefinition<?> scoreDefinition, SolverScope<Solution_> solverScope) {
+    private <Score_ extends Score<Score_>> void collectConstraintMatchTotalMetrics(SolverMetric metric, Tags tags,
+            Map<Tags, AtomicLong> countMap, Map<Tags, ScoreLevels> scoreMap,
+            ConstraintMatchTotal<Score_> constraintMatchTotal, ScoreDefinition<Score_> scoreDefinition,
+            SolverScope<Solution_> solverScope) {
         if (solverScope.isMetricEnabled(metric)) {
             if (countMap.containsKey(tags)) {
                 countMap.get(tags).set(constraintMatchTotal.getConstraintMatchCount());
@@ -193,7 +196,8 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
                 Metrics.gauge(metric.getMeterId() + ".count",
                         tags, count);
             }
-            SolverMetric.registerScoreMetrics(metric, tags, scoreDefinition, scoreMap, constraintMatchTotal.getScore());
+            SolverMetricUtil.registerScoreMetrics(metric, tags, scoreDefinition, scoreMap,
+                    InnerScore.fullyAssigned(constraintMatchTotal.getScore()));
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/AbstractPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/AbstractPhase.java
@@ -199,7 +199,7 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
 
     private static <Solution_> void collectMetrics(AbstractStepScope<Solution_> stepScope) {
         var solverScope = stepScope.getPhaseScope().getSolverScope();
-        if (solverScope.isMetricEnabled(SolverMetric.STEP_SCORE) && stepScope.getScore().fullyAssigned()) {
+        if (solverScope.isMetricEnabled(SolverMetric.STEP_SCORE) && stepScope.getScore().isFullyAssigned()) {
             Tags tags = solverScope.getMonitoringTags();
             ScoreDefinition<?> scoreDefinition = solverScope.getScoreDefinition();
             Map<Tags, ScoreLevels> tagToScoreLevels = solverScope.getStepScoreMap();
@@ -223,7 +223,7 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
     // ************************************************************************
 
     protected void assertWorkingSolutionInitialized(AbstractPhaseScope<Solution_> phaseScope) {
-        if (!phaseScope.getStartingScore().fullyAssigned()) {
+        if (!phaseScope.getStartingScore().isFullyAssigned()) {
             var scoreDirector = phaseScope.getScoreDirector();
             var solutionDescriptor = scoreDirector.getSolutionDescriptor();
             var workingSolution = scoreDirector.getWorkingSolution();

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/AbstractPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/AbstractPhase.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.phase;
 
+import java.util.Map;
+
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -9,14 +11,19 @@ import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListener;
 import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleSupport;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
+import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.solver.exception.ScoreCorruptionException;
 import ai.timefold.solver.core.impl.solver.exception.VariableCorruptionException;
+import ai.timefold.solver.core.impl.solver.monitoring.ScoreLevels;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverMetricUtil;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.PhaseTermination;
 import ai.timefold.solver.core.impl.solver.termination.Termination;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.micrometer.core.instrument.Tags;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
@@ -193,11 +200,11 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
     private static <Solution_> void collectMetrics(AbstractStepScope<Solution_> stepScope) {
         var solverScope = stepScope.getPhaseScope().getSolverScope();
         if (solverScope.isMetricEnabled(SolverMetric.STEP_SCORE) && stepScope.getScore().fullyAssigned()) {
-            SolverMetric.registerScoreMetrics(SolverMetric.STEP_SCORE,
-                    solverScope.getMonitoringTags(),
-                    solverScope.getScoreDefinition(),
-                    solverScope.getStepScoreMap(),
-                    stepScope.getScore().raw());
+            Tags tags = solverScope.getMonitoringTags();
+            ScoreDefinition<?> scoreDefinition = solverScope.getScoreDefinition();
+            Map<Tags, ScoreLevels> tagToScoreLevels = solverScope.getStepScoreMap();
+            SolverMetricUtil.registerScoreMetrics(SolverMetric.STEP_SCORE, tags, scoreDefinition, tagToScoreLevels,
+                    stepScope.getScore());
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/AbstractPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/AbstractPhase.java
@@ -203,7 +203,7 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
             Tags tags = solverScope.getMonitoringTags();
             ScoreDefinition<?> scoreDefinition = solverScope.getScoreDefinition();
             Map<Tags, ScoreLevels> tagToScoreLevels = solverScope.getStepScoreMap();
-            SolverMetricUtil.registerScoreMetrics(SolverMetric.STEP_SCORE, tags, scoreDefinition, tagToScoreLevels,
+            SolverMetricUtil.registerScore(SolverMetric.STEP_SCORE, tags, scoreDefinition, tagToScoreLevels,
                     stepScope.getScore());
         }
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/DefaultScoreExplanation.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/DefaultScoreExplanation.java
@@ -49,7 +49,7 @@ public final class DefaultScoreExplanation<Solution_, Score_ extends Score<Score
         scoreExplanation.append("""
                 Explanation of score (%s)%s:
                     Constraint matches:
-                """.formatted(workingScore, workingScore.fullyAssigned() ? "" : " for an uninitialized solution"));
+                """.formatted(workingScore, workingScore.isFullyAssigned() ? "" : " for an uninitialized solution"));
 
         Comparator<ConstraintMatchTotal<Score_>> constraintMatchTotalComparator = comparing(ConstraintMatchTotal::getScore);
         Comparator<ConstraintMatch<Score_>> constraintMatchComparator = comparing(ConstraintMatch::getScore);
@@ -163,7 +163,7 @@ public final class DefaultScoreExplanation<Solution_, Score_ extends Score<Score
 
     @Override
     public boolean isInitialized() {
-        return innerScore.fullyAssigned();
+        return innerScore.isFullyAssigned();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScore.java
@@ -7,6 +7,8 @@ import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 import ai.timefold.solver.core.api.score.Score;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Carries information on if the {@link PlanningSolution} of this score was fully initialized when it was calculated.
  * This only works for solutions where:
@@ -19,6 +21,7 @@ import ai.timefold.solver.core.api.score.Score;
  *
  * For solutions which do allow unassigning values, {@link #unassignedCount} is always zero.
  */
+@NullMarked
 public record InnerScore<Score_ extends Score<Score_>>(Score_ raw, int unassignedCount)
         implements
             Comparable<InnerScore<Score_>> {
@@ -39,7 +42,7 @@ public record InnerScore<Score_ extends Score<Score_>>(Score_ raw, int unassigne
         }
     }
 
-    public boolean fullyAssigned() {
+    public boolean isFullyAssigned() {
         return unassignedCount == 0;
     }
 
@@ -55,6 +58,6 @@ public record InnerScore<Score_ extends Score<Score_>>(Score_ raw, int unassigne
 
     @Override
     public String toString() {
-        return fullyAssigned() ? raw.toString() : "-%dinit/%s".formatted(unassignedCount, raw);
+        return isFullyAssigned() ? raw.toString() : "-%dinit/%s".formatted(unassignedCount, raw);
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -367,7 +367,7 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
             var constraintAnalysis = getConstraintAnalysis(constraintMatchTotal, scoreAnalysisFetchPolicy);
             constraintAnalysisMap.put(constraintMatchTotal.getConstraintRef(), constraintAnalysis);
         }
-        return new ScoreAnalysis<>(state.raw(), constraintAnalysisMap, state.fullyAssigned());
+        return new ScoreAnalysis<>(state.raw(), constraintAnalysisMap, state.isFullyAssigned());
     }
 
     /*

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/event/DefaultBestSolutionChangedEvent.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/event/DefaultBestSolutionChangedEvent.java
@@ -12,7 +12,7 @@ public final class DefaultBestSolutionChangedEvent<Solution_> extends BestSoluti
 
     public DefaultBestSolutionChangedEvent(@NonNull Solver<Solution_> solver, long timeMillisSpent,
             @NonNull Solution_ newBestSolution, @NonNull InnerScore newBestScore) {
-        super(solver, timeMillisSpent, newBestSolution, newBestScore.raw(), newBestScore.fullyAssigned());
+        super(solver, timeMillisSpent, newBestSolution, newBestScore.raw(), newBestScore.isFullyAssigned());
         this.unassignedCount = newBestScore.unassignedCount();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/event/DefaultBestSolutionChangedEvent.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/event/DefaultBestSolutionChangedEvent.java
@@ -1,0 +1,22 @@
+package ai.timefold.solver.core.impl.solver.event;
+
+import ai.timefold.solver.core.api.solver.Solver;
+import ai.timefold.solver.core.api.solver.event.BestSolutionChangedEvent;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
+
+import org.jspecify.annotations.NonNull;
+
+public final class DefaultBestSolutionChangedEvent<Solution_> extends BestSolutionChangedEvent<Solution_> {
+
+    private final int unassignedCount;
+
+    public DefaultBestSolutionChangedEvent(@NonNull Solver<Solution_> solver, long timeMillisSpent, @NonNull Solution_ newBestSolution, @NonNull InnerScore newBestScore) {
+        super(solver, timeMillisSpent, newBestSolution, newBestScore.raw(), newBestScore.fullyAssigned());
+        this.unassignedCount = newBestScore.unassignedCount();
+    }
+
+    public int getUnassignedCount() {
+        return unassignedCount;
+    }
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/event/DefaultBestSolutionChangedEvent.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/event/DefaultBestSolutionChangedEvent.java
@@ -10,7 +10,8 @@ public final class DefaultBestSolutionChangedEvent<Solution_> extends BestSoluti
 
     private final int unassignedCount;
 
-    public DefaultBestSolutionChangedEvent(@NonNull Solver<Solution_> solver, long timeMillisSpent, @NonNull Solution_ newBestSolution, @NonNull InnerScore newBestScore) {
+    public DefaultBestSolutionChangedEvent(@NonNull Solver<Solution_> solver, long timeMillisSpent,
+            @NonNull Solution_ newBestSolution, @NonNull InnerScore newBestScore) {
         super(solver, timeMillisSpent, newBestSolution, newBestScore.raw(), newBestScore.fullyAssigned());
         this.unassignedCount = newBestScore.unassignedCount();
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/event/SolverEventSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/event/SolverEventSupport.java
@@ -2,7 +2,6 @@ package ai.timefold.solver.core.impl.solver.event;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.solver.Solver;
-import ai.timefold.solver.core.api.solver.event.BestSolutionChangedEvent;
 import ai.timefold.solver.core.api.solver.event.SolverEventListener;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 
@@ -27,8 +26,7 @@ public class SolverEventSupport<Solution_> extends AbstractEventSupport<SolverEv
             // We need to clone the new best solution, or we may share the same instance with user consumers.
             // Reusing the instance can lead to inconsistent states if intermediary consumers change the solution.
             var newBestSolutionCloned = solverScope.getScoreDirector().cloneSolution(newBestSolution);
-            var event = new BestSolutionChangedEvent<>(solver, timeMillisSpent, newBestSolutionCloned, bestScore.raw(),
-                    bestScore.fullyAssigned());
+            var event = new DefaultBestSolutionChangedEvent<>(solver, timeMillisSpent, newBestSolutionCloned, bestScore);
             do {
                 it.next().bestSolutionChanged(event);
             } while (it.hasNext());

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/ScoreLevels.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/ScoreLevels.java
@@ -1,0 +1,33 @@
+package ai.timefold.solver.core.impl.solver.monitoring;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class ScoreLevels {
+
+    final AtomicReference<Number>[] levelValues;
+    final AtomicInteger unnassignedCount;
+
+    @SuppressWarnings("unchecked")
+    ScoreLevels(int unnassignedCount, Number[] levelValues) {
+        // We store the values inside a constant reference,
+        // so that the metric can always load the latest value.
+        // If we stored the value directly and just overwrote it,
+        // the metric would always hold a reference to the old value,
+        // effectively ignoring the update.
+        this.unnassignedCount = new AtomicInteger(unnassignedCount);
+        this.levelValues = Arrays.stream(levelValues)
+                .map(AtomicReference::new)
+                .toArray(AtomicReference[]::new);
+    }
+
+    void setLevelValue(int level, Number value) {
+        levelValues[level].set(value);
+    }
+
+    void setUnnassignedCount(int unnassignedCount) {
+        this.unnassignedCount.set(unnassignedCount);
+    }
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/ScoreLevels.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/ScoreLevels.java
@@ -7,16 +7,16 @@ import java.util.concurrent.atomic.AtomicReference;
 public final class ScoreLevels {
 
     final AtomicReference<Number>[] levelValues;
-    final AtomicInteger unnassignedCount;
+    final AtomicInteger unassignedCount;
 
     @SuppressWarnings("unchecked")
-    ScoreLevels(int unnassignedCount, Number[] levelValues) {
+    ScoreLevels(int unassignedCount, Number[] levelValues) {
         // We store the values inside a constant reference,
         // so that the metric can always load the latest value.
         // If we stored the value directly and just overwrote it,
         // the metric would always hold a reference to the old value,
         // effectively ignoring the update.
-        this.unnassignedCount = new AtomicInteger(unnassignedCount);
+        this.unassignedCount = new AtomicInteger(unassignedCount);
         this.levelValues = Arrays.stream(levelValues)
                 .map(AtomicReference::new)
                 .toArray(AtomicReference[]::new);
@@ -26,8 +26,8 @@ public final class ScoreLevels {
         levelValues[level].set(value);
     }
 
-    void setUnnassignedCount(int unnassignedCount) {
-        this.unnassignedCount.set(unnassignedCount);
+    void setUnassignedCount(int unassignedCount) {
+        this.unassignedCount.set(unassignedCount);
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/SolverMetricUtil.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/SolverMetricUtil.java
@@ -1,0 +1,49 @@
+package ai.timefold.solver.core.impl.solver.monitoring;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
+import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
+
+import org.jspecify.annotations.NullMarked;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tags;
+
+@NullMarked
+public final class SolverMetricUtil {
+
+    public static void registerScoreMetrics(SolverMetric metric, Tags tags, ScoreDefinition<?> scoreDefinition,
+            Map<Tags, ScoreLevels> tagToScoreLevels, InnerScore<?> innerScore) {
+        var levelValues = innerScore.raw().toLevelNumbers();
+        if (tagToScoreLevels.containsKey(tags)) {
+            var scoreLevels = tagToScoreLevels.get(tags);
+            scoreLevels.setUnnassignedCount(innerScore.unassignedCount());
+            for (var i = 0; i < levelValues.length; i++) {
+                scoreLevels.setLevelValue(i, levelValues[i]);
+            }
+        } else {
+            var levelLabels = scoreDefinition.getLevelLabels();
+            for (var i = 0; i < levelLabels.length; i++) {
+                levelLabels[i] = levelLabels[i].replace(' ', '.');
+            }
+            var scoreLevels = new Number[levelLabels.length];
+            System.arraycopy(levelValues, 0, scoreLevels, 0, levelValues.length);
+            var result = new ScoreLevels(innerScore.unassignedCount(), scoreLevels);
+            tagToScoreLevels.put(tags, result);
+            Metrics.gauge(metric.getMeterId() + "." + SolverMetric.UNASSIGNED_COUNT, tags, result.unnassignedCount,
+                    AtomicInteger::doubleValue);
+            for (var i = 0; i < levelValues.length; i++) {
+                Metrics.gauge(metric.getMeterId() + "." + levelLabels[i], tags, result.levelValues[i],
+                        ref -> ref.get().doubleValue());
+            }
+        }
+    }
+
+    private SolverMetricUtil() {
+        // No external instances.
+    }
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/SolverMetricUtil.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/SolverMetricUtil.java
@@ -2,7 +2,9 @@ package ai.timefold.solver.core.impl.solver.monitoring;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
+import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.score.director.InnerScore;
@@ -15,8 +17,11 @@ import io.micrometer.core.instrument.Tags;
 @NullMarked
 public final class SolverMetricUtil {
 
-    public static void registerScoreMetrics(SolverMetric metric, Tags tags, ScoreDefinition<?> scoreDefinition,
-            Map<Tags, ScoreLevels> tagToScoreLevels, InnerScore<?> innerScore) {
+    // Necessary for benchmarker, but otherwise undocumented and not considered public.
+    private static final String UNASSIGNED_COUNT = "unassigned.count";
+
+    public static <Score_ extends Score<Score_>> void registerScore(SolverMetric metric, Tags tags,
+            ScoreDefinition<Score_> scoreDefinition, Map<Tags, ScoreLevels> tagToScoreLevels, InnerScore<Score_> innerScore) {
         var levelValues = innerScore.raw().toLevelNumbers();
         if (tagToScoreLevels.containsKey(tags)) {
             var scoreLevels = tagToScoreLevels.get(tags);
@@ -33,13 +38,28 @@ public final class SolverMetricUtil {
             System.arraycopy(levelValues, 0, scoreLevels, 0, levelValues.length);
             var result = new ScoreLevels(innerScore.unassignedCount(), scoreLevels);
             tagToScoreLevels.put(tags, result);
-            Metrics.gauge(metric.getMeterId() + "." + SolverMetric.UNASSIGNED_COUNT, tags, result.unnassignedCount,
+            Metrics.gauge(metric.getMeterId() + "." + UNASSIGNED_COUNT, tags, result.unnassignedCount,
                     AtomicInteger::doubleValue);
             for (var i = 0; i < levelValues.length; i++) {
                 Metrics.gauge(metric.getMeterId() + "." + levelLabels[i], tags, result.levelValues[i],
                         ref -> ref.get().doubleValue());
             }
         }
+    }
+
+    public static <Score_ extends Score<Score_>> InnerScore<Score_> extractScore(SolverMetric metric,
+            ScoreDefinition<Score_> scoreDefinition, Function<String, Number> scoreLevelFunction) {
+        var labelNames = scoreDefinition.getLevelLabels();
+        for (var i = 0; i < labelNames.length; i++) {
+            labelNames[i] = labelNames[i].replace(' ', '.');
+        }
+        var levelNumbers = new Number[labelNames.length];
+        for (var i = 0; i < labelNames.length; i++) {
+            levelNumbers[i] = scoreLevelFunction.apply(metric.getMeterId() + "." + labelNames[i]);
+        }
+        var score = scoreDefinition.fromLevelNumbers(levelNumbers);
+        var unassignedCount = scoreLevelFunction.apply(metric.getMeterId() + "." + UNASSIGNED_COUNT);
+        return InnerScore.withUnassignedCount(score, unassignedCount.intValue());
     }
 
     private SolverMetricUtil() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/BestScoreStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/BestScoreStatistic.java
@@ -42,7 +42,7 @@ public class BestScoreStatistic<Solution_> implements SolverStatistic<Solution_>
         SolverEventListener<Solution_> listener =
                 event -> {
                     var castEvent = (DefaultBestSolutionChangedEvent<Solution_>) event;
-                    SolverMetricUtil.registerScoreMetrics(SolverMetric.BEST_SCORE, tags, scoreDefinition, tagsToBestScoreMap,
+                    SolverMetricUtil.registerScore(SolverMetric.BEST_SCORE, tags, scoreDefinition, tagsToBestScoreMap,
                             InnerScore.withUnassignedCount(event.getNewBestScore(), castEvent.getUnassignedCount()));
                 };
         solverToEventListenerMap.put(defaultSolver, listener);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/BestSolutionMutationCountStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/BestSolutionMutationCountStatistic.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.core.impl.statistic;
+package ai.timefold.solver.core.impl.solver.monitoring.statistic;
 
 import java.util.Map;
 import java.util.WeakHashMap;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/MemoryUseStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/MemoryUseStatistic.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.core.impl.statistic;
+package ai.timefold.solver.core.impl.solver.monitoring.statistic;
 
 import ai.timefold.solver.core.api.solver.Solver;
 import ai.timefold.solver.core.impl.solver.DefaultSolver;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/MoveCountPerTypeStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/MoveCountPerTypeStatistic.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.core.impl.statistic;
+package ai.timefold.solver.core.impl.solver.monitoring.statistic;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveBestScoreDiffStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveBestScoreDiffStatistic.java
@@ -81,7 +81,7 @@ public class PickedMoveBestScoreDiffStatistic<Solution_, Score_ extends Score<Sc
                 var newBestScore = stepScope.<Score_> getScore().raw();
                 var bestScoreDiff = newBestScore.subtract(oldBestScore);
                 oldBestScore = newBestScore;
-                Tags tags = stepScope.getPhaseScope().getSolverScope().getMonitoringTags()
+                var tags = stepScope.getPhaseScope().getSolverScope().getMonitoringTags()
                         .and("move.type", moveType);
                 SolverMetricUtil.registerScore(SolverMetric.PICKED_MOVE_TYPE_BEST_SCORE_DIFF, tags, scoreDefinition,
                         tagsToMoveScoreMap, InnerScore.fullyAssigned(bestScoreDiff));

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveBestScoreDiffStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveBestScoreDiffStatistic.java
@@ -83,7 +83,7 @@ public class PickedMoveBestScoreDiffStatistic<Solution_, Score_ extends Score<Sc
                 oldBestScore = newBestScore;
                 Tags tags = stepScope.getPhaseScope().getSolverScope().getMonitoringTags()
                         .and("move.type", moveType);
-                SolverMetricUtil.registerScoreMetrics(SolverMetric.PICKED_MOVE_TYPE_BEST_SCORE_DIFF, tags, scoreDefinition,
+                SolverMetricUtil.registerScore(SolverMetric.PICKED_MOVE_TYPE_BEST_SCORE_DIFF, tags, scoreDefinition,
                         tagsToMoveScoreMap, InnerScore.fullyAssigned(bestScoreDiff));
             }
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveStepScoreDiffStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveStepScoreDiffStatistic.java
@@ -83,7 +83,7 @@ public class PickedMoveStepScoreDiffStatistic<Solution_> implements SolverStatis
             var stepScoreDiff = newStepScore.subtract(oldStepScore);
             oldStepScore = newStepScore;
 
-            Tags tags = stepScope.getPhaseScope().getSolverScope().getMonitoringTags()
+            var tags = stepScope.getPhaseScope().getSolverScope().getMonitoringTags()
                     .and("move.type", moveType);
             SolverMetricUtil.registerScore(SolverMetric.PICKED_MOVE_TYPE_STEP_SCORE_DIFF, tags, scoreDefinition,
                     tagsToMoveScoreMap, InnerScore.fullyAssigned(stepScoreDiff));

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveStepScoreDiffStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveStepScoreDiffStatistic.java
@@ -85,7 +85,7 @@ public class PickedMoveStepScoreDiffStatistic<Solution_> implements SolverStatis
 
             Tags tags = stepScope.getPhaseScope().getSolverScope().getMonitoringTags()
                     .and("move.type", moveType);
-            SolverMetricUtil.registerScoreMetrics(SolverMetric.PICKED_MOVE_TYPE_STEP_SCORE_DIFF, tags, scoreDefinition,
+            SolverMetricUtil.registerScore(SolverMetric.PICKED_MOVE_TYPE_STEP_SCORE_DIFF, tags, scoreDefinition,
                     tagsToMoveScoreMap, InnerScore.fullyAssigned(stepScoreDiff));
         }
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveStepScoreDiffStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/PickedMoveStepScoreDiffStatistic.java
@@ -1,10 +1,8 @@
-package ai.timefold.solver.core.impl.statistic;
+package ai.timefold.solver.core.impl.solver.monitoring.statistic;
 
-import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
 
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.solver.Solver;
@@ -15,11 +13,14 @@ import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListenerAdapter;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.solver.DefaultSolver;
+import ai.timefold.solver.core.impl.solver.monitoring.ScoreLevels;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverMetricUtil;
 
 import io.micrometer.core.instrument.Tags;
 
-public class PickedMoveBestScoreDiffStatistic<Solution_, Score_ extends Score<Score_>> implements SolverStatistic<Solution_> {
+public class PickedMoveStepScoreDiffStatistic<Solution_> implements SolverStatistic<Solution_> {
 
     private final Map<Solver<Solution_>, PhaseLifecycleListenerAdapter<Solution_>> solverToPhaseLifecycleListenerMap =
             new WeakHashMap<>();
@@ -32,38 +33,40 @@ public class PickedMoveBestScoreDiffStatistic<Solution_, Score_ extends Score<Sc
         }
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public void register(Solver<Solution_> solver) {
         var defaultSolver = (DefaultSolver<Solution_>) solver;
         var scoreDirectorFactory = defaultSolver.getScoreDirectorFactory();
         var solutionDescriptor = scoreDirectorFactory.getSolutionDescriptor();
-        var listener = new PickedMoveBestScoreDiffStatisticListener<Solution_, Score_>(solutionDescriptor.getScoreDefinition());
+        var listener = new PickedMoveStepScoreDiffStatisticListener(solutionDescriptor.getScoreDefinition());
         solverToPhaseLifecycleListenerMap.put(solver, listener);
         defaultSolver.addPhaseLifecycleListener(listener);
     }
 
-    private static class PickedMoveBestScoreDiffStatisticListener<Solution_, Score_ extends Score<Score_>>
+    private static class PickedMoveStepScoreDiffStatisticListener<Solution_, Score_ extends Score<Score_>>
             extends PhaseLifecycleListenerAdapter<Solution_> {
 
-        private Score_ oldBestScore = null; // Guaranteed local search; no need for InnerScore.
+        private Score_ oldStepScore = null; // Guaranteed local search; no need for InnerScore.
         private final ScoreDefinition<Score_> scoreDefinition;
-        private final Map<Tags, List<AtomicReference<Number>>> tagsToMoveScoreMap = new ConcurrentHashMap<>();
+        private final Map<Tags, ScoreLevels> tagsToMoveScoreMap = new ConcurrentHashMap<>();
 
-        public PickedMoveBestScoreDiffStatisticListener(ScoreDefinition<Score_> scoreDefinition) {
+        public PickedMoveStepScoreDiffStatisticListener(ScoreDefinition<Score_> scoreDefinition) {
             this.scoreDefinition = scoreDefinition;
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
             if (phaseScope instanceof LocalSearchPhaseScope) {
-                oldBestScore = phaseScope.<Score_> getBestScore().raw();
+                oldStepScore = (Score_) phaseScope.getStartingScore().raw();
             }
         }
 
         @Override
         public void phaseEnded(AbstractPhaseScope<Solution_> phaseScope) {
             if (phaseScope instanceof LocalSearchPhaseScope) {
-                oldBestScore = null;
+                oldStepScore = null;
             }
         }
 
@@ -75,18 +78,15 @@ public class PickedMoveBestScoreDiffStatistic<Solution_, Score_ extends Score<Sc
         }
 
         private void localSearchStepEnded(LocalSearchStepScope<Solution_> stepScope) {
-            if (stepScope.getBestScoreImproved()) {
-                var moveType = stepScope.getStep().describe();
-                var newBestScore = stepScope.<Score_> getScore().raw();
-                var bestScoreDiff = newBestScore.subtract(oldBestScore);
-                oldBestScore = newBestScore;
-                SolverMetric.registerScoreMetrics(SolverMetric.PICKED_MOVE_TYPE_BEST_SCORE_DIFF,
-                        stepScope.getPhaseScope().getSolverScope().getMonitoringTags()
-                                .and("move.type", moveType),
-                        scoreDefinition,
-                        tagsToMoveScoreMap,
-                        bestScoreDiff);
-            }
+            var moveType = stepScope.getStep().describe();
+            var newStepScore = stepScope.<Score_> getScore().raw();
+            var stepScoreDiff = newStepScore.subtract(oldStepScore);
+            oldStepScore = newStepScore;
+
+            Tags tags = stepScope.getPhaseScope().getSolverScope().getMonitoringTags()
+                    .and("move.type", moveType);
+            SolverMetricUtil.registerScoreMetrics(SolverMetric.PICKED_MOVE_TYPE_STEP_SCORE_DIFF, tags, scoreDefinition,
+                    tagsToMoveScoreMap, InnerScore.fullyAssigned(stepScoreDiff));
         }
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/SolverScopeStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/SolverScopeStatistic.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.core.impl.statistic;
+package ai.timefold.solver.core.impl.solver.monitoring.statistic;
 
 import java.util.function.ToDoubleFunction;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/SolverStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/SolverStatistic.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.core.impl.statistic;
+package ai.timefold.solver.core.impl.solver.monitoring.statistic;
 
 import ai.timefold.solver.core.api.solver.Solver;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/StatelessSolverStatistic.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/statistic/StatelessSolverStatistic.java
@@ -1,4 +1,4 @@
-package ai.timefold.solver.core.impl.statistic;
+package ai.timefold.solver.core.impl.solver.monitoring.statistic;
 
 import ai.timefold.solver.core.api.solver.Solver;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -54,7 +54,7 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
         solverScope.setBestSolutionTimeMillis(solverScope.getClock().millis());
         // The original bestSolution might be the final bestSolution and should have an accurate Score
         solverScope.getSolutionDescriptor().setScore(solverScope.getBestSolution(), score);
-        if (innerScore.fullyAssigned()) {
+        if (innerScore.isFullyAssigned()) {
             solverScope.setStartingInitializedScore(innerScore.raw());
         } else {
             solverScope.setStartingInitializedScore(null);
@@ -145,7 +145,7 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
 
     private void updateBestSolutionWithoutFiring(SolverScope<Solution_> solverScope, InnerScore<?> bestScore,
             Solution_ bestSolution) {
-        if (bestScore.fullyAssigned() && !solverScope.isBestSolutionInitialized()) {
+        if (bestScore.isFullyAssigned() && !solverScope.isBestSolutionInitialized()) {
             solverScope.setStartingInitializedScore(bestScore.raw());
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
@@ -5,7 +5,6 @@ import static ai.timefold.solver.core.impl.util.MathUtils.getSpeed;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
@@ -27,6 +26,7 @@ import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.AbstractSolver;
 import ai.timefold.solver.core.impl.solver.change.DefaultProblemChangeDirector;
+import ai.timefold.solver.core.impl.solver.monitoring.ScoreLevels;
 import ai.timefold.solver.core.impl.solver.termination.PhaseTermination;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
@@ -69,7 +69,7 @@ public class SolverScope<Solution_> {
     /**
      * Used for tracking step score
      */
-    private final Map<Tags, List<AtomicReference<Number>>> stepScoreMap = new ConcurrentHashMap<>();
+    private final Map<Tags, ScoreLevels> stepScoreMap = new ConcurrentHashMap<>();
 
     /**
      * Used for tracking move count per move type
@@ -122,7 +122,7 @@ public class SolverScope<Solution_> {
         this.monitoringTags = monitoringTags;
     }
 
-    public Map<Tags, List<AtomicReference<Number>>> getStepScoreMap() {
+    public Map<Tags, ScoreLevels> getStepScoreMap() {
         return stepScoreMap;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
@@ -290,7 +290,7 @@ public class SolverScope<Solution_> {
     }
 
     public boolean isBestSolutionInitialized() {
-        return getBestScore().fullyAssigned();
+        return getBestScore().isFullyAssigned();
     }
 
     public long calculateTimeMillisSpentUpToNow() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTermination.java
@@ -40,7 +40,7 @@ final class BestScoreFeasibleTermination<Solution_>
     }
 
     private static boolean isTerminated(InnerScore<?> innerScore) {
-        return innerScore.fullyAssigned() && innerScore.raw().isFeasible();
+        return innerScore.isFullyAssigned() && innerScore.raw().isFeasible();
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -57,7 +57,7 @@ final class BestScoreFeasibleTermination<Solution_>
 
     <Score_ extends Score<Score_>> double calculateFeasibilityTimeGradient(@Nullable InnerScore<Score_> innerStartScore,
             Score_ score) {
-        if (innerStartScore == null || !innerStartScore.fullyAssigned()) {
+        if (innerStartScore == null || !innerStartScore.isFullyAssigned()) {
             return 0.0;
         }
         var startScore = innerStartScore.raw();

--- a/core/src/test/java/ai/timefold/solver/core/config/solver/EnvironmentModeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/config/solver/EnvironmentModeTest.java
@@ -289,7 +289,7 @@ class EnvironmentModeTest {
                     (InnerScoreDirector<TestdataSolution, ?>) scoreDirector;
             var score = innerScoreDirector.calculateScore();
 
-            if (!score.fullyAssigned()) {
+            if (!score.isFullyAssigned()) {
                 throw new IllegalStateException("The solution (" + TestdataEntity.class.getSimpleName()
                         + ") was not fully initialized by CustomSolverPhase: ("
                         + this.getClass().getCanonicalName() + ")");

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorSemanticsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorSemanticsTest.java
@@ -145,7 +145,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
             scoreDirector.setWorkingSolution(solution);
             var score1 = scoreDirector.calculateScore();
             assertSoftly(softly -> {
-                softly.assertThat(score1.fullyAssigned()).isTrue();
+                softly.assertThat(score1.isFullyAssigned()).isTrue();
                 softly.assertThat(score1.raw().score()).isEqualTo(1);
                 softly.assertThat(scoreDirector.getConstraintMatchTotalMap())
                         .containsOnlyKeys("ai.timefold.solver.core.testdomain.constraintconfiguration/First weight");
@@ -158,7 +158,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
             scoreDirector.afterVariableChanged(entity, "value");
             var score2 = scoreDirector.calculateScore();
             assertSoftly(softly -> {
-                softly.assertThat(score2.fullyAssigned()).isFalse();
+                softly.assertThat(score2.isFullyAssigned()).isFalse();
                 softly.assertThat(score2.raw().score()).isZero();
                 softly.assertThat(scoreDirector.getConstraintMatchTotalMap())
                         .containsOnlyKeys("ai.timefold.solver.core.testdomain.constraintconfiguration/First weight");


### PR DESCRIPTION
During the init score removal (cf87aa7), we did not notice that this impacts metrics as well. Benchmarker reads its data from metrics, and therefore lost the information on what score is or is not initialized. As a result, the default value was always false, resulting in empty score graph.

This commit fixes that issue by registering a metric for the unassigned count, which will be reused by benchmarker to provide the correct initialization state.