### PR TITLE
fix: fail-fast on @PlanningEntity being used in a @ProblemFactCollectionProperty

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -591,7 +591,8 @@ public class SolutionDescriptor<Solution_> {
             if (type.isArray()) {
                 problemFactType = type.getComponentType();
             } else {
-                problemFactType = ConfigUtils.extractGenericTypeParameterOrFail("", memberAccessor.getDeclaringClass(),
+                problemFactType = ConfigUtils.extractGenericTypeParameterOrFail(PlanningSolution.class.getSimpleName(),
+                        memberAccessor.getDeclaringClass(),
                         type, memberAccessor.getGenericType(), annotationClass, memberAccessor.getName());
             }
         } else {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -587,7 +587,13 @@ public class SolutionDescriptor<Solution_> {
                                         Collection.class.getSimpleName()));
             }
             problemFactCollectionMemberAccessorMap.put(memberAccessor.getName(), memberAccessor);
-            problemFactType = type;
+
+            if (type.isArray()) {
+                problemFactType = type.getComponentType();
+            } else {
+                problemFactType = ConfigUtils.extractGenericTypeParameterOrFail("", memberAccessor.getDeclaringClass(),
+                        type, memberAccessor.getGenericType(), annotationClass, memberAccessor.getName());
+            }
         } else {
             throw new IllegalStateException("Impossible situation with annotationClass (" + annotationClass + ").");
         }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -33,6 +33,7 @@ import ai.timefold.solver.core.testdomain.invalid.badfactcollection.TestdataBadF
 import ai.timefold.solver.core.testdomain.invalid.constraintconfiguration.TestdataInvalidConfigurationSolution;
 import ai.timefold.solver.core.testdomain.invalid.constraintweightoverrides.TestdataInvalidConstraintWeightOverridesSolution;
 import ai.timefold.solver.core.testdomain.invalid.duplicateweightoverrides.TestdataDuplicateWeightConfigurationSolution;
+import ai.timefold.solver.core.testdomain.invalid.entityannotatedasproblemfact.TestdataEntityAnnotatedAsProblemFactArraySolution;
 import ai.timefold.solver.core.testdomain.invalid.entityannotatedasproblemfact.TestdataEntityAnnotatedAsProblemFactCollectionSolution;
 import ai.timefold.solver.core.testdomain.invalid.entityannotatedasproblemfact.TestdataEntityAnnotatedAsProblemFactSolution;
 import ai.timefold.solver.core.testdomain.invalid.multivar.TestdataInvalidMultiVarSolution;
@@ -137,6 +138,12 @@ class SolutionDescriptorTest {
     void planningEntityIsProblemFactCollectionProperty() {
         assertThatIllegalStateException()
                 .isThrownBy(TestdataEntityAnnotatedAsProblemFactCollectionSolution::buildSolutionDescriptor);
+    }
+
+    @Test
+    void planningEntityIsProblemFactArrayProperty() {
+        assertThatIllegalStateException()
+                .isThrownBy(TestdataEntityAnnotatedAsProblemFactArraySolution::buildSolutionDescriptor);
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -33,6 +33,7 @@ import ai.timefold.solver.core.testdomain.invalid.badfactcollection.TestdataBadF
 import ai.timefold.solver.core.testdomain.invalid.constraintconfiguration.TestdataInvalidConfigurationSolution;
 import ai.timefold.solver.core.testdomain.invalid.constraintweightoverrides.TestdataInvalidConstraintWeightOverridesSolution;
 import ai.timefold.solver.core.testdomain.invalid.duplicateweightoverrides.TestdataDuplicateWeightConfigurationSolution;
+import ai.timefold.solver.core.testdomain.invalid.entityannotatedasproblemfact.TestdataEntityAnnotatedAsProblemFactCollectionSolution;
 import ai.timefold.solver.core.testdomain.invalid.entityannotatedasproblemfact.TestdataEntityAnnotatedAsProblemFactSolution;
 import ai.timefold.solver.core.testdomain.invalid.multivar.TestdataInvalidMultiVarSolution;
 import ai.timefold.solver.core.testdomain.invalid.nosolution.TestdataNoSolution;
@@ -134,7 +135,8 @@ class SolutionDescriptorTest {
 
     @Test
     void planningEntityIsProblemFactCollectionProperty() {
-        assertThatIllegalStateException().isThrownBy(TestdataEntityAnnotatedAsProblemFactSolution::buildSolutionDescriptor);
+        assertThatIllegalStateException()
+                .isThrownBy(TestdataEntityAnnotatedAsProblemFactCollectionSolution::buildSolutionDescriptor);
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/invalid/entityannotatedasproblemfact/TestdataEntityAnnotatedAsProblemFactArraySolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/invalid/entityannotatedasproblemfact/TestdataEntityAnnotatedAsProblemFactArraySolution.java
@@ -1,0 +1,58 @@
+package ai.timefold.solver.core.testdomain.invalid.entityannotatedasproblemfact;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.testdomain.TestdataEntity;
+import ai.timefold.solver.core.testdomain.TestdataValue;
+
+@PlanningSolution
+public class TestdataEntityAnnotatedAsProblemFactArraySolution {
+    TestdataEntity[] entities;
+    TestdataValue[] values;
+    SimpleScore score;
+
+    public static SolutionDescriptor<TestdataEntityAnnotatedAsProblemFactArraySolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataEntityAnnotatedAsProblemFactArraySolution.class,
+                TestdataEntity.class);
+    }
+
+    public TestdataEntityAnnotatedAsProblemFactArraySolution() {
+    }
+
+    @ProblemFactCollectionProperty
+    public TestdataEntity[] getEntitiesAsFacts() {
+        return entities;
+    }
+
+    @PlanningEntityCollectionProperty
+    public TestdataEntity[] getEntities() {
+        return entities;
+    }
+
+    public void setEntities(TestdataEntity[] entities) {
+        this.entities = entities;
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    public TestdataValue[] getValues() {
+        return values;
+    }
+
+    public void setValues(TestdataValue[] values) {
+        this.values = values;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/invalid/entityannotatedasproblemfact/TestdataEntityAnnotatedAsProblemFactCollectionSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/invalid/entityannotatedasproblemfact/TestdataEntityAnnotatedAsProblemFactCollectionSolution.java
@@ -2,6 +2,8 @@ package ai.timefold.solver.core.testdomain.invalid.entityannotatedasproblemfact;
 
 import java.util.List;
 
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
@@ -25,6 +27,11 @@ public class TestdataEntityAnnotatedAsProblemFactCollectionSolution {
     }
 
     @ProblemFactCollectionProperty
+    public List<TestdataEntity> getEntitiesAsFacts() {
+        return entities;
+    }
+
+    @PlanningEntityCollectionProperty
     public List<TestdataEntity> getEntities() {
         return entities;
     }
@@ -42,6 +49,7 @@ public class TestdataEntityAnnotatedAsProblemFactCollectionSolution {
         this.values = values;
     }
 
+    @PlanningScore
     public SimpleScore getScore() {
         return score;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/invalid/entityannotatedasproblemfact/TestdataEntityAnnotatedAsProblemFactSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/invalid/entityannotatedasproblemfact/TestdataEntityAnnotatedAsProblemFactSolution.java
@@ -2,6 +2,8 @@ package ai.timefold.solver.core.testdomain.invalid.entityannotatedasproblemfact;
 
 import java.util.List;
 
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.solution.ProblemFactProperty;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
@@ -24,8 +26,13 @@ public class TestdataEntityAnnotatedAsProblemFactSolution {
     public TestdataEntityAnnotatedAsProblemFactSolution() {
     }
 
-    @ProblemFactProperty
+    @PlanningEntityProperty
     public TestdataEntity getEntity() {
+        return entity;
+    }
+
+    @ProblemFactProperty
+    public TestdataEntity getEntityAsFact() {
         return entity;
     }
 
@@ -42,6 +49,7 @@ public class TestdataEntityAnnotatedAsProblemFactSolution {
         this.values = values;
     }
 
+    @PlanningScore
     public SimpleScore getScore() {
         return score;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/inverserelation/TestdataInverseRelationSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/inverserelation/TestdataInverseRelationSolution.java
@@ -5,7 +5,6 @@ import java.util.List;
 import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
 import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
-import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
@@ -32,7 +31,7 @@ public class TestdataInverseRelationSolution extends TestdataObject {
     }
 
     @ValueRangeProvider(id = "valueRange")
-    @ProblemFactCollectionProperty
+    @PlanningEntityCollectionProperty
     public List<TestdataInverseRelationValue> getValueList() {
         return valueList;
     }

--- a/quarkus-integration/quarkus-benchmark/integration-test/src/main/java/ai/timefold/solver/quarkus/benchmark/it/domain/TestdataStringLengthShadowSolution.java
+++ b/quarkus-integration/quarkus-benchmark/integration-test/src/main/java/ai/timefold/solver/quarkus/benchmark/it/domain/TestdataStringLengthShadowSolution.java
@@ -5,14 +5,13 @@ import java.util.List;
 import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
 import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
-import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 
 @PlanningSolution
 public class TestdataStringLengthShadowSolution {
 
-    @ProblemFactCollectionProperty
+    @PlanningEntityCollectionProperty
     @ValueRangeProvider
     private List<TestdataListValueShadowEntity> valueList;
 


### PR DESCRIPTION
The old test classes had different issues that caused a different fail-fast; those issues are now removed.