### PR TITLE
fix: Graph now notify updater when cycles are formed or broken

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/BaseTopologicalOrderGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/BaseTopologicalOrderGraph.java
@@ -29,7 +29,7 @@ public interface BaseTopologicalOrderGraph {
 
     /**
      * Returns a tuple containing node ID and a number corresponding to its topological order.
-     * In particular, after {@link TopologicalOrderGraph#commitChanges()} is called, the following
+     * In particular, after {@link TopologicalOrderGraph#commitChanges(java.util.BitSet)} is called, the following
      * must be true for any pair of nodes A, B where:
      * <ul>
      * <li>A is a predecessor of B</li>

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultTopologicalOrderGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultTopologicalOrderGraph.java
@@ -40,13 +40,13 @@ public class DefaultTopologicalOrderGraph implements TopologicalOrderGraph {
     }
 
     @Override
-    public void addEdge(int fromNode, int toNode, BitSet changed) {
+    public void addEdge(int fromNode, int toNode) {
         forwardEdges[fromNode].add(toNode);
         backEdges[toNode].add(fromNode);
     }
 
     @Override
-    public void removeEdge(int fromNode, int toNode, BitSet changed) {
+    public void removeEdge(int fromNode, int toNode) {
         forwardEdges[fromNode].remove(toNode);
         backEdges[toNode].remove(fromNode);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -94,7 +94,7 @@ final class DefaultVariableReferenceGraph<Solution_> implements VariableReferenc
 
         var count = edgeCount[fromNodeId].get(toNodeId);
         if (count == 0) {
-            graph.addEdge(fromNodeId, toNodeId, changed);
+            graph.addEdge(fromNodeId, toNodeId);
         }
         edgeCount[fromNodeId].set(toNodeId, count + 1);
         markChanged(to);
@@ -110,7 +110,7 @@ final class DefaultVariableReferenceGraph<Solution_> implements VariableReferenc
 
         var count = edgeCount[fromNodeId].get(toNodeId);
         if (count == 1) {
-            graph.removeEdge(fromNodeId, toNodeId, changed);
+            graph.removeEdge(fromNodeId, toNodeId);
         }
         edgeCount[fromNodeId].set(toNodeId, count - 1);
         markChanged(to);

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -94,7 +94,7 @@ final class DefaultVariableReferenceGraph<Solution_> implements VariableReferenc
 
         var count = edgeCount[fromNodeId].get(toNodeId);
         if (count == 0) {
-            graph.addEdge(fromNodeId, toNodeId);
+            graph.addEdge(fromNodeId, toNodeId, changed);
         }
         edgeCount[fromNodeId].set(toNodeId, count + 1);
         markChanged(to);
@@ -110,7 +110,7 @@ final class DefaultVariableReferenceGraph<Solution_> implements VariableReferenc
 
         var count = edgeCount[fromNodeId].get(toNodeId);
         if (count == 1) {
-            graph.removeEdge(fromNodeId, toNodeId);
+            graph.removeEdge(fromNodeId, toNodeId, changed);
         }
         edgeCount[fromNodeId].set(toNodeId, count - 1);
         markChanged(to);
@@ -126,7 +126,7 @@ final class DefaultVariableReferenceGraph<Solution_> implements VariableReferenc
         if (changed.isEmpty()) {
             return;
         }
-        graph.commitChanges();
+        graph.commitChanges(changed);
         affectedEntitiesUpdater.accept(changed);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalOrderGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalOrderGraph.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
+import java.util.BitSet;
 import java.util.List;
 
 public interface TopologicalOrderGraph extends BaseTopologicalOrderGraph {
@@ -9,7 +10,7 @@ public interface TopologicalOrderGraph extends BaseTopologicalOrderGraph {
      * After this method returns, {@link #getTopologicalOrder(int)}
      * must be accurate for every node in the graph.
      */
-    void commitChanges();
+    void commitChanges(BitSet changed);
 
     /**
      * Called on graph creation to supply metadata about the graph nodes.
@@ -22,21 +23,21 @@ public interface TopologicalOrderGraph extends BaseTopologicalOrderGraph {
 
     /**
      * Called when a graph edge is added.
-     * The operation is added to a batch and only executed when {@link #commitChanges()} is called.
+     * The operation is added to a batch and only executed when {@link #commitChanges(BitSet)} is called.
      * <p>
      * {@link #getTopologicalOrder(int)} is allowed to be invalid
      * when this method returns.
      */
-    void addEdge(int from, int to);
+    void addEdge(int from, int to, BitSet changed);
 
     /**
      * Called when a graph edge is removed.
-     * The operation is added to a batch and only executed when {@link #commitChanges()} is called.
+     * The operation is added to a batch and only executed when {@link #commitChanges(BitSet)} is called.
      * <p>
      * {@link #getTopologicalOrder(int)} is allowed to be invalid
      * when this method returns.
      */
-    void removeEdge(int from, int to);
+    void removeEdge(int from, int to, BitSet changed);
 
     void forEachEdge(EdgeConsumer edgeConsumer);
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalOrderGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalOrderGraph.java
@@ -28,7 +28,7 @@ public interface TopologicalOrderGraph extends BaseTopologicalOrderGraph {
      * {@link #getTopologicalOrder(int)} is allowed to be invalid
      * when this method returns.
      */
-    void addEdge(int from, int to, BitSet changed);
+    void addEdge(int from, int to);
 
     /**
      * Called when a graph edge is removed.
@@ -37,7 +37,7 @@ public interface TopologicalOrderGraph extends BaseTopologicalOrderGraph {
      * {@link #getTopologicalOrder(int)} is allowed to be invalid
      * when this method returns.
      */
-    void removeEdge(int from, int to, BitSet changed);
+    void removeEdge(int from, int to);
 
     void forEachEdge(EdgeConsumer edgeConsumer);
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractTopologicalGraphTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractTopologicalGraphTest.java
@@ -1,0 +1,401 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.function.ToIntFunction;
+
+import ai.timefold.solver.core.api.function.TriConsumer;
+
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractTopologicalGraphTest<Graph_ extends TopologicalOrderGraph> {
+    /**
+     * Create a topological graph of the given size
+     * 
+     * @param graphSize The size of the graph
+     * @return a new {@link Graph_}
+     */
+    protected abstract Graph_ createTopologicalGraph(int graphSize);
+
+    /**
+     * Verify the graph datastructures are consistent
+     * 
+     * @param graph The graph being verified
+     */
+    protected abstract void verifyConsistent(Graph_ graph);
+
+    /**
+     * Get the component members as a list.
+     *
+     * @param graph the graph
+     * @param node The node to get the component members of.
+     * @return The list of nodes in that component.
+     */
+    protected abstract List<Integer> getComponentMembers(Graph_ graph, int graphSize, int node);
+
+    @SafeVarargs
+    private static void assertTopologicalOrder(TopologicalOrderGraph graph, List<Integer>... expectedTopologicalNodeOrder) {
+        for (var i = 0; i < expectedTopologicalNodeOrder.length; i++) {
+            var members = expectedTopologicalNodeOrder[i];
+            for (var j = 0; j < i; j++) {
+                var lowerMembers = expectedTopologicalNodeOrder[j];
+                for (var a : members) {
+                    for (var b : lowerMembers) {
+                        var aOrder = graph.getTopologicalOrder(a).order();
+                        var bOrder = graph.getTopologicalOrder(b).order();
+                        assertThat(aOrder)
+                                .withFailMessage(
+                                        () -> "Expected topological order of %d (%d) to be greater than %d (%d) in graph %s"
+                                                .formatted(
+                                                        a, aOrder, b, bOrder, graph))
+                                .isGreaterThan(bOrder);
+                    }
+                }
+            }
+        }
+    }
+
+    private static <T> List<List<T>> permutations(List<T> source) {
+        var out = new ArrayList<List<T>>();
+        if (source.isEmpty()) {
+            out.add(new ArrayList<>());
+            return out;
+        }
+        var head = source.get(0);
+        var tailPermutations = permutations(source.subList(1, source.size()));
+        for (var tailPermutation : tailPermutations) {
+            for (var i = 0; i <= tailPermutation.size(); i++) {
+                var permutationWithHead = new ArrayList<>(tailPermutation);
+                permutationWithHead.add(i, head);
+                out.add(permutationWithHead);
+            }
+        }
+        return out;
+    }
+
+    private static <T> List<List<T>> permutations(List<T> source, int limit) {
+        var out = new ArrayList<List<T>>();
+        if (source.isEmpty()) {
+            out.add(new ArrayList<>());
+            return out;
+        }
+        if (limit <= 1) {
+            out.add(new ArrayList<>(source));
+            return out;
+        }
+        var head = source.get(0);
+        var tailPermutations = permutations(source.subList(1, source.size()), limit / source.size());
+        for (var tailPermutation : tailPermutations) {
+            for (var i = 0; i <= tailPermutation.size(); i++) {
+                var permutationWithHead = new ArrayList<>(tailPermutation);
+                permutationWithHead.add(i, head);
+                out.add(permutationWithHead);
+            }
+        }
+        return out;
+    }
+
+    void assertAllPermutations(int size, List<List<Integer>> graphEdges,
+            TriConsumer<Graph_, ToIntFunction<Integer>, BitSet> asserter) {
+        var nodes = new ArrayList<Integer>();
+        for (var i = 0; i < size; i++) {
+            nodes.add(i);
+        }
+
+        for (var renamedNodes : permutations(nodes)) {
+            var changed = new BitSet();
+            var renamedEdges = new ArrayList<List<Integer>>();
+            for (var fromNode = 0; fromNode < size; fromNode++) {
+                var renamedFromNode = renamedNodes.get(fromNode);
+                for (var toNode : graphEdges.get(fromNode)) {
+                    var renamedToNode = renamedNodes.get(toNode);
+                    renamedEdges.add(List.of(renamedFromNode, renamedToNode));
+                }
+            }
+            for (var edgesPermutation : permutations(renamedEdges)) {
+                var graph = createTopologicalGraph(size);
+                for (var edge : edgesPermutation) {
+                    graph.addEdge(edge.get(0), edge.get(1), changed);
+                }
+                graph.commitChanges(changed);
+                asserter.accept(graph, renamedNodes::get, changed);
+            }
+        }
+    }
+
+    // Used for tests where there are simply too many permutations to test
+    void assertSomePermutations(int size, List<List<Integer>> graphEdges,
+            TriConsumer<Graph_, ToIntFunction<Integer>, BitSet> asserter) {
+        var count = 0;
+        var nodes = new ArrayList<Integer>();
+
+        for (var i = 0; i < size; i++) {
+            nodes.add(i);
+        }
+
+        for (var renamedNodes : permutations(nodes)) {
+            var renamedEdges = new ArrayList<List<Integer>>();
+            for (var fromNode = 0; fromNode < size; fromNode++) {
+                var renamedFromNode = renamedNodes.get(fromNode);
+                for (var toNode : graphEdges.get(fromNode)) {
+                    var renamedToNode = renamedNodes.get(toNode);
+                    renamedEdges.add(List.of(renamedFromNode, renamedToNode));
+                }
+            }
+            Collections.shuffle(renamedEdges, new Random(count));
+            var edgePermutations = permutations(renamedEdges, 1_000);
+
+            for (var edgesPermutation : edgePermutations) {
+                var changed = new BitSet();
+                var graph = createTopologicalGraph(size);
+                for (var edge : edgesPermutation) {
+                    graph.addEdge(edge.get(0), edge.get(1), changed);
+                }
+                graph.commitChanges(changed);
+                asserter.accept(graph, renamedNodes::get, changed);
+                count++;
+            }
+        }
+    }
+
+    @Test
+    void testNoLoops() {
+        final var GRAPH_SIZE = 5;
+        assertAllPermutations(GRAPH_SIZE, List.of(
+                List.of(1, 2),
+                List.of(3),
+                List.of(3),
+                List.of(4),
+                List.of()), (graph, mapper, changed) -> {
+                    verifyConsistent(graph);
+                    assertTopologicalOrder(graph, List.of(mapper.applyAsInt(0)),
+                            List.of(mapper.applyAsInt(1), mapper.applyAsInt(2)),
+                            List.of(mapper.applyAsInt(3)),
+                            List.of(mapper.applyAsInt(4)));
+
+                    assertThat(changed.cardinality()).isZero();
+                });
+    }
+
+    @Test
+    void testNoLoopsRemoveEdge() {
+        final var GRAPH_SIZE = 5;
+        assertAllPermutations(GRAPH_SIZE, List.of(
+                List.of(1, 2),
+                List.of(3),
+                List.of(3),
+                List.of(4),
+                List.of()), (graph, mapper, changed) -> {
+                    verifyConsistent(graph);
+
+                    graph.removeEdge(mapper.applyAsInt(2), mapper.applyAsInt(3), changed);
+                    graph.commitChanges(changed);
+
+                    assertTopologicalOrder(graph, List.of(mapper.applyAsInt(0)),
+                            List.of(mapper.applyAsInt(1)),
+                            List.of(mapper.applyAsInt(3)),
+                            List.of(mapper.applyAsInt(4)));
+
+                    // it is okay for 2 to be at the same level as 1, 3 or 4; the only requirement for
+                    // it is to be after 0.
+                    assertTopologicalOrder(graph, List.of(mapper.applyAsInt(0)), List.of(mapper.applyAsInt(2)));
+
+                    assertThat(changed.cardinality()).isZero();
+                });
+    }
+
+    @Test
+    void testLoops() {
+        final var GRAPH_SIZE = 5;
+        assertAllPermutations(GRAPH_SIZE, List.of(
+                List.of(1, 2),
+                List.of(3),
+                List.of(3),
+                List.of(4, 1),
+                List.of()), (graph, mapper, changed) -> {
+                    verifyConsistent(graph);
+                    assertTopologicalOrder(graph, List.of(mapper.applyAsInt(0)),
+                            List.of(mapper.applyAsInt(1), mapper.applyAsInt(2), mapper.applyAsInt(3)),
+                            List.of(mapper.applyAsInt(4)));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(0)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(0));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(1))).containsExactlyInAnyOrder(
+                            mapper.applyAsInt(1),
+                            mapper.applyAsInt(3));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(2)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(2));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(3))).containsExactlyInAnyOrder(
+                            mapper.applyAsInt(1),
+                            mapper.applyAsInt(3));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(4)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(4));
+                    assertThat(changed.cardinality()).isEqualTo(2);
+                    assertThat(changed.get(mapper.applyAsInt(1))).isTrue();
+                    assertThat(changed.get(mapper.applyAsInt(3))).isTrue();
+                });
+    }
+
+    @Test
+    void testLoopRemoveEdgeInLoop() {
+        final var GRAPH_SIZE = 5;
+        assertAllPermutations(GRAPH_SIZE, List.of(
+                List.of(1, 2),
+                List.of(3),
+                List.of(3),
+                List.of(4, 1),
+                List.of()), (graph, mapper, changed) -> {
+                    changed.clear();
+                    graph.removeEdge(mapper.applyAsInt(3), mapper.applyAsInt(1), changed);
+                    graph.commitChanges(changed);
+
+                    verifyConsistent(graph);
+                    assertTopologicalOrder(graph, List.of(mapper.applyAsInt(0)),
+                            List.of(mapper.applyAsInt(1), mapper.applyAsInt(2)),
+                            List.of(mapper.applyAsInt(3)),
+                            List.of(mapper.applyAsInt(4)));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(0)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(0));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(1)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(1));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(2)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(2));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(3)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(3));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(4)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(4));
+                    assertThat(changed.cardinality()).isEqualTo(2);
+                    assertThat(changed.get(mapper.applyAsInt(1))).isTrue();
+                    assertThat(changed.get(mapper.applyAsInt(3))).isTrue();
+                });
+    }
+
+    @Test
+    void testConnectingTwoLoops() {
+        final var GRAPH_SIZE = 6;
+        assertSomePermutations(6, List.of(
+                List.of(1, 2),
+                List.of(3, 2),
+                List.of(4),
+                List.of(5, 1),
+                List.of(5, 2, 3),
+                List.of()), (graph, mapper, changed) -> {
+                    verifyConsistent(graph);
+                    assertTopologicalOrder(graph, List.of(mapper.applyAsInt(0)),
+                            List.of(mapper.applyAsInt(1), mapper.applyAsInt(2), mapper.applyAsInt(3), mapper.applyAsInt(4)),
+                            List.of(mapper.applyAsInt(5)));
+                    var cycle = new Integer[] { mapper.applyAsInt(1),
+                            mapper.applyAsInt(2),
+                            mapper.applyAsInt(3),
+                            mapper.applyAsInt(4)
+                    };
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(0)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(0));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(1))).containsExactlyInAnyOrder(cycle);
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(2))).containsExactlyInAnyOrder(cycle);
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(3))).containsExactlyInAnyOrder(cycle);
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(4))).containsExactlyInAnyOrder(cycle);
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(5)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(5));
+                    assertThat(changed.cardinality()).isEqualTo(4);
+                    for (var node : cycle) {
+                        assertThat(changed.get(node)).isTrue();
+                    }
+                });
+    }
+
+    @Test
+    void testConnectingTwoLoopsRemoveJoiningEdge() {
+        final var GRAPH_SIZE = 6;
+        assertSomePermutations(GRAPH_SIZE, List.of(
+                List.of(1, 2),
+                List.of(3, 2),
+                List.of(4),
+                List.of(5, 1),
+                List.of(5, 2, 3),
+                List.of()), (graph, mapper, changed) -> {
+                    changed.clear();
+                    graph.removeEdge(mapper.applyAsInt(4), mapper.applyAsInt(3), changed);
+                    graph.commitChanges(changed);
+
+                    verifyConsistent(graph);
+                    assertThat(graph.getTopologicalOrder(mapper.applyAsInt(0)))
+                            .isLessThan(graph.getTopologicalOrder(mapper.applyAsInt(1)));
+                    assertThat(graph.getTopologicalOrder(mapper.applyAsInt(0)))
+                            .isLessThan(graph.getTopologicalOrder(mapper.applyAsInt(2)));
+                    assertThat(graph.getTopologicalOrder(mapper.applyAsInt(0)))
+                            .isLessThan(graph.getTopologicalOrder(mapper.applyAsInt(3)));
+                    assertThat(graph.getTopologicalOrder(mapper.applyAsInt(0)))
+                            .isLessThan(graph.getTopologicalOrder(mapper.applyAsInt(4)));
+                    assertThat(graph.getTopologicalOrder(mapper.applyAsInt(0)))
+                            .isLessThan(graph.getTopologicalOrder(mapper.applyAsInt(5)));
+
+                    assertThat(graph.getTopologicalOrder(mapper.applyAsInt(1)))
+                            .isLessThan(graph.getTopologicalOrder(mapper.applyAsInt(5)));
+                    assertThat(graph.getTopologicalOrder(mapper.applyAsInt(2)))
+                            .isLessThan(graph.getTopologicalOrder(mapper.applyAsInt(5)));
+                    assertThat(graph.getTopologicalOrder(mapper.applyAsInt(3)))
+                            .isLessThan(graph.getTopologicalOrder(mapper.applyAsInt(5)));
+                    assertThat(graph.getTopologicalOrder(mapper.applyAsInt(4)))
+                            .isLessThan(graph.getTopologicalOrder(mapper.applyAsInt(5)));
+
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(0)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(0));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(1))).containsExactlyInAnyOrder(
+                            mapper.applyAsInt(1),
+                            mapper.applyAsInt(3));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(2))).containsExactlyInAnyOrder(
+                            mapper.applyAsInt(2),
+                            mapper.applyAsInt(4));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(3))).containsExactlyInAnyOrder(
+                            mapper.applyAsInt(1),
+                            mapper.applyAsInt(3));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(4))).containsExactlyInAnyOrder(
+                            mapper.applyAsInt(2),
+                            mapper.applyAsInt(4));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(5)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(5));
+
+                    assertThat(changed.cardinality()).isZero();
+                });
+    }
+
+    @Test
+    void testConnectingTwoLoopsRemoveNonJoiningEdge() {
+        final var GRAPH_SIZE = 6;
+        assertSomePermutations(GRAPH_SIZE, List.of(
+                List.of(1, 2),
+                List.of(2),
+                List.of(4, 3),
+                List.of(4, 5),
+                List.of(5, 1),
+                List.of()), (graph, mapper, changed) -> {
+                    changed.clear();
+                    graph.removeEdge(mapper.applyAsInt(2), mapper.applyAsInt(4), changed);
+                    graph.commitChanges(changed);
+
+                    verifyConsistent(graph);
+                    assertTopologicalOrder(graph,
+                            List.of(mapper.applyAsInt(0)),
+                            List.of(mapper.applyAsInt(1), mapper.applyAsInt(2), mapper.applyAsInt(3), mapper.applyAsInt(4)),
+                            List.of(mapper.applyAsInt(5)));
+
+                    var loop = new Integer[] { mapper.applyAsInt(1), mapper.applyAsInt(2), mapper.applyAsInt(3),
+                            mapper.applyAsInt(4) };
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(0)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(0));
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(1))).containsExactlyInAnyOrder(loop);
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(2))).containsExactlyInAnyOrder(loop);
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(3))).containsExactlyInAnyOrder(loop);
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(4))).containsExactlyInAnyOrder(loop);
+                    assertThat(getComponentMembers(graph, GRAPH_SIZE, mapper.applyAsInt(5)))
+                            .containsExactlyInAnyOrder(mapper.applyAsInt(5));
+
+                    assertThat(changed.cardinality()).isZero();
+                });
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractTopologicalGraphTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractTopologicalGraphTest.java
@@ -120,7 +120,7 @@ public abstract class AbstractTopologicalGraphTest<Graph_ extends TopologicalOrd
             for (var edgesPermutation : permutations(renamedEdges)) {
                 var graph = createTopologicalGraph(size);
                 for (var edge : edgesPermutation) {
-                    graph.addEdge(edge.get(0), edge.get(1), changed);
+                    graph.addEdge(edge.get(0), edge.get(1));
                 }
                 graph.commitChanges(changed);
                 asserter.accept(graph, renamedNodes::get, changed);
@@ -154,7 +154,7 @@ public abstract class AbstractTopologicalGraphTest<Graph_ extends TopologicalOrd
                 var changed = new BitSet();
                 var graph = createTopologicalGraph(size);
                 for (var edge : edgesPermutation) {
-                    graph.addEdge(edge.get(0), edge.get(1), changed);
+                    graph.addEdge(edge.get(0), edge.get(1));
                 }
                 graph.commitChanges(changed);
                 asserter.accept(graph, renamedNodes::get, changed);
@@ -193,7 +193,7 @@ public abstract class AbstractTopologicalGraphTest<Graph_ extends TopologicalOrd
                 List.of()), (graph, mapper, changed) -> {
                     verifyConsistent(graph);
 
-                    graph.removeEdge(mapper.applyAsInt(2), mapper.applyAsInt(3), changed);
+                    graph.removeEdge(mapper.applyAsInt(2), mapper.applyAsInt(3));
                     graph.commitChanges(changed);
 
                     assertTopologicalOrder(graph, List.of(mapper.applyAsInt(0)),
@@ -250,7 +250,7 @@ public abstract class AbstractTopologicalGraphTest<Graph_ extends TopologicalOrd
                 List.of(4, 1),
                 List.of()), (graph, mapper, changed) -> {
                     changed.clear();
-                    graph.removeEdge(mapper.applyAsInt(3), mapper.applyAsInt(1), changed);
+                    graph.removeEdge(mapper.applyAsInt(3), mapper.applyAsInt(1));
                     graph.commitChanges(changed);
 
                     verifyConsistent(graph);
@@ -319,7 +319,7 @@ public abstract class AbstractTopologicalGraphTest<Graph_ extends TopologicalOrd
                 List.of(5, 2, 3),
                 List.of()), (graph, mapper, changed) -> {
                     changed.clear();
-                    graph.removeEdge(mapper.applyAsInt(4), mapper.applyAsInt(3), changed);
+                    graph.removeEdge(mapper.applyAsInt(4), mapper.applyAsInt(3));
                     graph.commitChanges(changed);
 
                     verifyConsistent(graph);
@@ -375,7 +375,7 @@ public abstract class AbstractTopologicalGraphTest<Graph_ extends TopologicalOrd
                 List.of(5, 1),
                 List.of()), (graph, mapper, changed) -> {
                     changed.clear();
-                    graph.removeEdge(mapper.applyAsInt(2), mapper.applyAsInt(4), changed);
+                    graph.removeEdge(mapper.applyAsInt(2), mapper.applyAsInt(4));
                     graph.commitChanges(changed);
 
                     verifyConsistent(graph);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultTopologicalGraphTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultTopologicalGraphTest.java
@@ -1,0 +1,30 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import java.util.List;
+
+public class DefaultTopologicalGraphTest extends AbstractTopologicalGraphTest<DefaultTopologicalOrderGraph> {
+
+    @Override
+    protected DefaultTopologicalOrderGraph createTopologicalGraph(int graphSize) {
+        return new DefaultTopologicalOrderGraph(graphSize);
+    }
+
+    @Override
+    protected void verifyConsistent(DefaultTopologicalOrderGraph graph) {
+        // DefaultTopologicalOrderGraph is not incremental
+        // and has no datastructures to keep consistent
+    }
+
+    /**
+     * Get the component members as a list.
+     *
+     * @param graph the graph
+     * @param node The node to get the component members of.
+     * @return The list of nodes in that component.
+     */
+    @Override
+    protected List<Integer> getComponentMembers(DefaultTopologicalOrderGraph graph, int graphSize, int node) {
+        return graph.getComponent(node);
+    }
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -191,15 +192,15 @@ class VariableListenerSupportTest {
         }
 
         @Override
-        public void addEdge(int fromNode, int toNode) {
-            super.addEdge(fromNode, toNode);
+        public void addEdge(int fromNode, int toNode, BitSet changed) {
+            super.addEdge(fromNode, toNode, changed);
             addEdge(nodeToVariableMetamodel[fromNode], nodeToEntities[fromNode], nodeToVariableMetamodel[toNode],
                     nodeToEntities[toNode]);
         }
 
         @Override
-        public void removeEdge(int fromNode, int toNode) {
-            super.removeEdge(fromNode, toNode);
+        public void removeEdge(int fromNode, int toNode, BitSet changed) {
+            super.removeEdge(fromNode, toNode, changed);
             removeEdge(nodeToVariableMetamodel[fromNode], nodeToEntities[fromNode], nodeToVariableMetamodel[toNode],
                     nodeToEntities[toNode]);
         }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -192,15 +191,15 @@ class VariableListenerSupportTest {
         }
 
         @Override
-        public void addEdge(int fromNode, int toNode, BitSet changed) {
-            super.addEdge(fromNode, toNode, changed);
+        public void addEdge(int fromNode, int toNode) {
+            super.addEdge(fromNode, toNode);
             addEdge(nodeToVariableMetamodel[fromNode], nodeToEntities[fromNode], nodeToVariableMetamodel[toNode],
                     nodeToEntities[toNode]);
         }
 
         @Override
-        public void removeEdge(int fromNode, int toNode, BitSet changed) {
-            super.removeEdge(fromNode, toNode, changed);
+        public void removeEdge(int fromNode, int toNode) {
+            super.removeEdge(fromNode, toNode);
             removeEdge(nodeToVariableMetamodel[fromNode], nodeToEntities[fromNode], nodeToVariableMetamodel[toNode],
                     nodeToEntities[toNode]);
         }


### PR DESCRIPTION
Previously, the updater only considered nodes that were changed from an edge insertion or deletion. However, an edge insertion/deletion can also change the looped status of a disconnected node. For example, if we have a -> b and b -> a, and we
remove a -> b, only b is marked as changed. This is incorrect, since a changed indirectly, since it is no longer looped. Thus, the graph implementations now mark any nodes whose SCC change from singleton to multinode (looped) and vice-versa.