### PR TITLE
perf: optimize the updater used for shadow variables in certain cases

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -1287,7 +1288,7 @@ public class SolutionDescriptor<Solution_> {
     }
 
     public List<DeclarativeShadowVariableDescriptor<Solution_>> getDeclarativeShadowVariableDescriptors() {
-        var out = new ArrayList<DeclarativeShadowVariableDescriptor<Solution_>>();
+        var out = new HashSet<DeclarativeShadowVariableDescriptor<Solution_>>();
         for (var entityDescriptor : entityDescriptorMap.values()) {
             entityDescriptor.getShadowVariableDescriptors();
             for (var shadowVariableDescriptor : entityDescriptor.getShadowVariableDescriptors()) {
@@ -1296,7 +1297,7 @@ public class SolutionDescriptor<Solution_> {
                 }
             }
         }
-        return out;
+        return new ArrayList<>(out);
     }
 
     public ProblemSizeStatistics getProblemSizeStatistics(Solution_ solution) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableUpdateHelper.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableUpdateHelper.java
@@ -133,7 +133,7 @@ public final class ShadowVariableUpdateHelper<Solution_> {
     }
 
     private record InternalShadowVariableSession<Solution_>(SolutionDescriptor<Solution_> solutionDescriptor,
-            VariableReferenceGraph<Solution_> graph) {
+            VariableReferenceGraph graph) {
 
         public static <Solution_> InternalShadowVariableSession<Solution_> build(
                 SolutionDescriptor<Solution_> solutionDescriptor, VariableReferenceGraphBuilder<Solution_> graph,

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
@@ -1,0 +1,167 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+
+import ai.timefold.solver.core.impl.util.DynamicIntArray;
+import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public sealed abstract class AbstractVariableReferenceGraph<Solution_, ChangeSet_> implements VariableReferenceGraph<Solution_>
+        permits DefaultVariableReferenceGraph, FixedVariableReferenceGraph {
+    // These structures are immutable.
+    protected final List<EntityVariablePair<Solution_>> instanceList;
+    protected final Map<VariableMetaModel<?, ?, ?>, Map<Object, EntityVariablePair<Solution_>>> variableReferenceToInstanceMap;
+    protected final Map<VariableMetaModel<?, ?, ?>, List<BiConsumer<VariableReferenceGraph<Solution_>, Object>>> variableReferenceToBeforeProcessor;
+    protected final Map<VariableMetaModel<?, ?, ?>, List<BiConsumer<VariableReferenceGraph<Solution_>, Object>>> variableReferenceToAfterProcessor;
+
+    // These structures are mutable.
+    protected final DynamicIntArray[] edgeCount;
+    protected final ChangeSet_ changeSet;
+    protected final TopologicalOrderGraph graph;
+
+    public AbstractVariableReferenceGraph(VariableReferenceGraphBuilder<Solution_> outerGraph,
+            IntFunction<TopologicalOrderGraph> graphCreator) {
+        instanceList = List.copyOf(outerGraph.instanceList);
+        var instanceCount = instanceList.size();
+        // Often the maps are a singleton; we improve performance by actually making it so.
+        variableReferenceToInstanceMap = mapOfMapsDeepCopyOf(outerGraph.variableReferenceToInstanceMap);
+        variableReferenceToBeforeProcessor = mapOfListsDeepCopyOf(outerGraph.variableReferenceToBeforeProcessor);
+        variableReferenceToAfterProcessor = mapOfListsDeepCopyOf(outerGraph.variableReferenceToAfterProcessor);
+        edgeCount = new DynamicIntArray[instanceCount];
+        for (int i = 0; i < instanceCount; i++) {
+            edgeCount[i] = new DynamicIntArray(instanceCount);
+        }
+        graph = graphCreator.apply(instanceCount);
+        graph.withNodeData(instanceList);
+
+        var visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        changeSet = createChangeSet(instanceCount);
+        for (var instance : instanceList) {
+            var entity = instance.entity();
+            if (visited.add(entity)) {
+                for (var variableId : outerGraph.variableReferenceToAfterProcessor.keySet()) {
+                    afterVariableChanged(variableId, entity);
+                }
+            }
+        }
+        for (var fixedEdgeEntry : outerGraph.fixedEdges.entrySet()) {
+            for (var toEdge : fixedEdgeEntry.getValue()) {
+                addEdge(fixedEdgeEntry.getKey(), toEdge);
+            }
+        }
+    }
+
+    abstract protected ChangeSet_ createChangeSet(int instanceCount);
+
+    @Override
+    public @Nullable EntityVariablePair<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity) {
+        var map = variableReferenceToInstanceMap.get(variableId);
+        if (map == null) {
+            return null;
+        }
+        return map.get(entity);
+    }
+
+    @Override
+    public void addEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to) {
+        var fromNodeId = from.graphNodeId();
+        var toNodeId = to.graphNodeId();
+        if (fromNodeId == toNodeId) {
+            return;
+        }
+
+        var count = edgeCount[fromNodeId].get(toNodeId);
+        if (count == 0) {
+            graph.addEdge(fromNodeId, toNodeId);
+        }
+        edgeCount[fromNodeId].set(toNodeId, count + 1);
+        markChanged(to);
+    }
+
+    @Override
+    public void removeEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to) {
+        var fromNodeId = from.graphNodeId();
+        var toNodeId = to.graphNodeId();
+        if (fromNodeId == toNodeId) {
+            return;
+        }
+
+        var count = edgeCount[fromNodeId].get(toNodeId);
+        if (count == 1) {
+            graph.removeEdge(fromNodeId, toNodeId);
+        }
+        edgeCount[fromNodeId].set(toNodeId, count - 1);
+        markChanged(to);
+    }
+
+    @Override
+    public void beforeVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
+        if (variableReference.entity().type().isInstance(entity)) {
+            processEntity(variableReferenceToBeforeProcessor.getOrDefault(variableReference, Collections.emptyList()), entity);
+        }
+    }
+
+    private void processEntity(List<BiConsumer<VariableReferenceGraph<Solution_>, Object>> processorList, Object entity) {
+        var processorCount = processorList.size();
+        // Avoid creation of iterators on the hot path.
+        // The short-lived instances were observed to cause considerable GC pressure.
+        for (int i = 0; i < processorCount; i++) {
+            processorList.get(i).accept(this, entity);
+        }
+    }
+
+    @Override
+    public void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
+        if (variableReference.entity().type().isInstance(entity)) {
+            var node = lookupOrNull(variableReference, entity);
+            if (node != null) {
+                markChanged(node);
+            }
+            processEntity(variableReferenceToAfterProcessor.getOrDefault(variableReference, Collections.emptyList()), entity);
+        }
+    }
+
+    @Override
+    public String toString() {
+        var edgeList = new LinkedHashMap<EntityVariablePair<Solution_>, List<EntityVariablePair<Solution_>>>();
+        graph.forEachEdge((from, to) -> edgeList.computeIfAbsent(instanceList.get(from), k -> new ArrayList<>())
+                .add(instanceList.get(to)));
+        return edgeList.entrySet()
+                .stream()
+                .map(e -> e.getKey() + "->" + e.getValue())
+                .collect(Collectors.joining(
+                        "," + System.lineSeparator() + " ",
+                        "{" + System.lineSeparator() + "  ",
+                        "}"));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K1, K2, V> Map<K1, Map<K2, V>> mapOfMapsDeepCopyOf(Map<K1, Map<K2, V>> map) {
+        var entryArray = map.entrySet()
+                .stream()
+                .map(e -> Map.entry(e.getKey(), Map.copyOf(e.getValue())))
+                .toArray(Map.Entry[]::new);
+        return Map.ofEntries(entryArray);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K1, V> Map<K1, List<V>> mapOfListsDeepCopyOf(Map<K1, List<V>> map) {
+        var entryArray = map.entrySet()
+                .stream()
+                .map(e -> Map.entry(e.getKey(), List.copyOf(e.getValue())))
+                .toArray(Map.Entry[]::new);
+        return Map.ofEntries(entryArray);
+    }
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
@@ -132,6 +132,11 @@ public sealed abstract class AbstractVariableReferenceGraph<Solution_, ChangeSet
     }
 
     @Override
+    public boolean shouldQueueAfterEvents() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         var edgeList = new LinkedHashMap<EntityVariablePair<Solution_>, List<EntityVariablePair<Solution_>>>();
         graph.forEachEdge((from, to) -> edgeList.computeIfAbsent(instanceList.get(from), k -> new ArrayList<>())

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
@@ -16,7 +16,7 @@ import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-public sealed abstract class AbstractVariableReferenceGraph<Solution_, ChangeSet_> implements VariableReferenceGraph<Solution_>
+public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet_> implements VariableReferenceGraph
         permits DefaultVariableReferenceGraph, FixedVariableReferenceGraph {
     // These structures are immutable.
     protected final List<EntityVariablePair<Solution_>> instanceList;
@@ -29,7 +29,7 @@ public sealed abstract class AbstractVariableReferenceGraph<Solution_, ChangeSet
     protected final ChangeSet_ changeSet;
     protected final TopologicalOrderGraph graph;
 
-    public AbstractVariableReferenceGraph(VariableReferenceGraphBuilder<Solution_> outerGraph,
+    AbstractVariableReferenceGraph(VariableReferenceGraphBuilder<Solution_> outerGraph,
             IntFunction<TopologicalOrderGraph> graphCreator) {
         instanceList = List.copyOf(outerGraph.instanceList);
         var instanceCount = instanceList.size();
@@ -61,7 +61,7 @@ public sealed abstract class AbstractVariableReferenceGraph<Solution_, ChangeSet
         }
     }
 
-    abstract protected ChangeSet_ createChangeSet(int instanceCount);
+    protected abstract ChangeSet_ createChangeSet(int instanceCount);
 
     public @Nullable EntityVariablePair<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity) {
         var map = variableReferenceToInstanceMap.get(variableId);
@@ -110,12 +110,12 @@ public sealed abstract class AbstractVariableReferenceGraph<Solution_, ChangeSet
         }
     }
 
+    @SuppressWarnings("ForLoopReplaceableByForEach")
     private void processEntity(List<BiConsumer<AbstractVariableReferenceGraph<Solution_, ?>, Object>> processorList,
             Object entity) {
         var processorCount = processorList.size();
         // Avoid creation of iterators on the hot path.
         // The short-lived instances were observed to cause considerable GC pressure.
-        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < processorCount; i++) {
             processorList.get(i).accept(this, entity);
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ChangedVariableNotifier.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ChangedVariableNotifier.java
@@ -2,15 +2,21 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.function.BiConsumer;
 
+import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 
+import org.jspecify.annotations.Nullable;
+
 public record ChangedVariableNotifier<Solution_>(BiConsumer<VariableDescriptor<Solution_>, Object> beforeVariableChanged,
-        BiConsumer<VariableDescriptor<Solution_>, Object> afterVariableChanged) {
+        BiConsumer<VariableDescriptor<Solution_>, Object> afterVariableChanged,
+        @Nullable ListVariableStateSupply<Solution_> listVariableStateSupply) {
+
     private static final ChangedVariableNotifier<?> EMPTY = new ChangedVariableNotifier<>((a, b) -> {
     },
             (a, b) -> {
-            });
+            },
+            null);
 
     @SuppressWarnings("unchecked")
     public static <Solution_> ChangedVariableNotifier<Solution_> empty() {
@@ -18,9 +24,18 @@ public record ChangedVariableNotifier<Solution_>(BiConsumer<VariableDescriptor<S
     }
 
     public static <Solution_> ChangedVariableNotifier<Solution_> of(InnerScoreDirector<Solution_, ?> scoreDirector) {
+        var listVariable = scoreDirector.getSolutionDescriptor().getListVariableDescriptor();
+        if (listVariable == null) {
+            return new ChangedVariableNotifier<>(
+                    scoreDirector::beforeVariableChanged,
+                    scoreDirector::afterVariableChanged,
+                    null);
+        }
+        var listVariableStateSupply = scoreDirector.getListVariableStateSupply(listVariable);
         return new ChangedVariableNotifier<>(
                 scoreDirector::beforeVariableChanged,
-                scoreDirector::afterVariableChanged);
+                scoreDirector::afterVariableChanged,
+                listVariableStateSupply);
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ChangedVariableNotifier.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ChangedVariableNotifier.java
@@ -2,7 +2,6 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.function.BiConsumer;
 
-import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 
@@ -10,7 +9,7 @@ import org.jspecify.annotations.Nullable;
 
 public record ChangedVariableNotifier<Solution_>(BiConsumer<VariableDescriptor<Solution_>, Object> beforeVariableChanged,
         BiConsumer<VariableDescriptor<Solution_>, Object> afterVariableChanged,
-        @Nullable ListVariableStateSupply<Solution_> listVariableStateSupply) {
+        @Nullable InnerScoreDirector<Solution_, ?> innerScoreDirector) {
 
     private static final ChangedVariableNotifier<?> EMPTY = new ChangedVariableNotifier<>((a, b) -> {
     },
@@ -24,18 +23,10 @@ public record ChangedVariableNotifier<Solution_>(BiConsumer<VariableDescriptor<S
     }
 
     public static <Solution_> ChangedVariableNotifier<Solution_> of(InnerScoreDirector<Solution_, ?> scoreDirector) {
-        var listVariable = scoreDirector.getSolutionDescriptor().getListVariableDescriptor();
-        if (listVariable == null) {
-            return new ChangedVariableNotifier<>(
-                    scoreDirector::beforeVariableChanged,
-                    scoreDirector::afterVariableChanged,
-                    null);
-        }
-        var listVariableStateSupply = scoreDirector.getListVariableStateSupply(listVariable);
         return new ChangedVariableNotifier<>(
                 scoreDirector::beforeVariableChanged,
                 scoreDirector::afterVariableChanged,
-                listVariableStateSupply);
+                scoreDirector);
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
@@ -1,38 +1,17 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.supply.Supply;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public final class DefaultShadowVariableSession<Solution_> implements Supply {
     final VariableReferenceGraph<Solution_> graph;
-    final boolean shouldQueueAfterEvents;
-
-    record VariableChangedEvent<Solution_>(VariableMetaModel<Solution_, ?, ?> variableMetaModel, Object entity) {
-    }
-
-    @Nullable
-    final List<VariableChangedEvent<Solution_>> variableChangedList;
-
-    boolean isUpdating;
 
     public DefaultShadowVariableSession(VariableReferenceGraph<Solution_> graph) {
         this.graph = graph;
-        this.isUpdating = false;
-        if (graph.shouldQueueAfterEvents()) {
-            this.shouldQueueAfterEvents = true;
-            this.variableChangedList = new ArrayList<>();
-        } else {
-            this.shouldQueueAfterEvents = false;
-            this.variableChangedList = null;
-        }
     }
 
     public void beforeVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity) {
@@ -51,23 +30,11 @@ public final class DefaultShadowVariableSession<Solution_> implements Supply {
     }
 
     public void afterVariableChanged(VariableMetaModel<Solution_, ?, ?> variableMetaModel, Object entity) {
-        if (shouldQueueAfterEvents && !isUpdating) {
-            variableChangedList.add(new VariableChangedEvent<>(variableMetaModel, entity));
-        } else {
-            graph.afterVariableChanged(variableMetaModel,
-                    entity);
-        }
+        graph.afterVariableChanged(variableMetaModel,
+                entity);
     }
 
     public void updateVariables() {
-        if (shouldQueueAfterEvents) {
-            isUpdating = true;
-            for (var variableChanged : variableChangedList) {
-                graph.afterVariableChanged(variableChanged.variableMetaModel, variableChanged.entity);
-            }
-            variableChangedList.clear();
-            isUpdating = false;
-        }
         graph.updateChanged();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
@@ -8,9 +8,9 @@ import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public final class DefaultShadowVariableSession<Solution_> implements Supply {
-    final VariableReferenceGraph<Solution_> graph;
+    final VariableReferenceGraph graph;
 
-    public DefaultShadowVariableSession(VariableReferenceGraph<Solution_> graph) {
+    public DefaultShadowVariableSession(VariableReferenceGraph graph) {
         this.graph = graph;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
@@ -1,17 +1,38 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.supply.Supply;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public final class DefaultShadowVariableSession<Solution_> implements Supply {
     final VariableReferenceGraph<Solution_> graph;
+    final boolean shouldQueueAfterEvents;
+
+    record VariableChangedEvent<Solution_>(VariableMetaModel<Solution_, ?, ?> variableMetaModel, Object entity) {
+    }
+
+    @Nullable
+    final List<VariableChangedEvent<Solution_>> variableChangedList;
+
+    boolean isUpdating;
 
     public DefaultShadowVariableSession(VariableReferenceGraph<Solution_> graph) {
         this.graph = graph;
+        this.isUpdating = false;
+        if (graph.shouldQueueAfterEvents()) {
+            this.shouldQueueAfterEvents = true;
+            this.variableChangedList = new ArrayList<>();
+        } else {
+            this.shouldQueueAfterEvents = false;
+            this.variableChangedList = null;
+        }
     }
 
     public void beforeVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity) {
@@ -30,11 +51,23 @@ public final class DefaultShadowVariableSession<Solution_> implements Supply {
     }
 
     public void afterVariableChanged(VariableMetaModel<Solution_, ?, ?> variableMetaModel, Object entity) {
-        graph.afterVariableChanged(variableMetaModel,
-                entity);
+        if (shouldQueueAfterEvents && !isUpdating) {
+            variableChangedList.add(new VariableChangedEvent<>(variableMetaModel, entity));
+        } else {
+            graph.afterVariableChanged(variableMetaModel,
+                    entity);
+        }
     }
 
     public void updateVariables() {
+        if (shouldQueueAfterEvents) {
+            isUpdating = true;
+            for (var variableChanged : variableChangedList) {
+                graph.afterVariableChanged(variableChanged.variableMetaModel, variableChanged.entity);
+            }
+            variableChangedList.clear();
+            isUpdating = false;
+        }
         graph.updateChanged();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -19,7 +19,6 @@ import java.util.function.IntFunction;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.inverserelation.InverseRelationShadowVariableDescriptor;
-import ai.timefold.solver.core.impl.domain.variable.inverserelation.SingletonInverseVariableDemand;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
@@ -129,13 +128,6 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
                 scoreDirector.getListVariableStateSupply(solutionDescriptor.getListVariableDescriptor())::getNextElement;
             case NEXT ->
                 scoreDirector.getListVariableStateSupply(solutionDescriptor.getListVariableDescriptor())::getPreviousElement;
-            case CHAINED_PREVIOUS -> {
-                var entityDescriptor = solutionDescriptor.getEntityDescriptorStrict(parentMetaModel.entity().type());
-                var variableDescriptor = entityDescriptor.getVariableDescriptor(parentMetaModel.name());
-                var inverseSupply =
-                        scoreDirector.getSupplyManager().demand(new SingletonInverseVariableDemand<>(variableDescriptor));
-                yield inverseSupply::getInverseSingleton;
-            }
             case CHAINED_NEXT -> {
                 var entityDescriptor = solutionDescriptor.getEntityDescriptorStrict(parentMetaModel.entity().type());
                 var inverseVariable = (InverseRelationShadowVariableDescriptor<?>) entityDescriptor

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -50,7 +50,7 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
             VariableReferenceGraphBuilder<Solution_> variableReferenceGraphBuilder, Object[] entities,
             IntFunction<TopologicalOrderGraph> graphCreator) {
         var graphStructureAndDirection = GraphStructure.determineGraphStructure(solutionDescriptor, entities);
-        LOGGER.trace("Graph structure: {}", graphStructureAndDirection);
+        LOGGER.trace("Shadow variable graph structure: {}", graphStructureAndDirection);
         return switch (graphStructureAndDirection.structure()) {
             case EMPTY -> EmptyVariableReferenceGraph.INSTANCE;
             case SINGLE_DIRECTIONAL_PARENT -> {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -10,7 +10,7 @@ import java.util.function.IntFunction;
 import org.jspecify.annotations.NonNull;
 
 final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableReferenceGraph<Solution_, BitSet>
-        implements VariableReferenceGraph<Solution_> {
+        implements VariableReferenceGraph {
     // These structures are mutable.
     private final Consumer<BitSet> affectedEntitiesUpdater;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -2,69 +2,27 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.Collections;
 import java.util.IdentityHashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
-import java.util.stream.Collectors;
-
-import ai.timefold.solver.core.impl.util.DynamicIntArray;
-import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 
-final class DefaultVariableReferenceGraph<Solution_> implements VariableReferenceGraph<Solution_> {
-
-    // These structures are immutable.
-    private final List<EntityVariablePair<Solution_>> instanceList;
-    private final Map<VariableMetaModel<?, ?, ?>, Map<Object, EntityVariablePair<Solution_>>> variableReferenceToInstanceMap;
-    private final Map<VariableMetaModel<?, ?, ?>, List<BiConsumer<VariableReferenceGraph<Solution_>, Object>>> variableReferenceToBeforeProcessor;
-    private final Map<VariableMetaModel<?, ?, ?>, List<BiConsumer<VariableReferenceGraph<Solution_>, Object>>> variableReferenceToAfterProcessor;
-
+final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableReferenceGraph<Solution_, BitSet>
+        implements VariableReferenceGraph<Solution_> {
     // These structures are mutable.
-    private final DynamicIntArray[] edgeCount;
-    private final TopologicalOrderGraph graph;
-    private final BitSet changed;
-
     private final Consumer<BitSet> affectedEntitiesUpdater;
 
     public DefaultVariableReferenceGraph(VariableReferenceGraphBuilder<Solution_> outerGraph,
             IntFunction<TopologicalOrderGraph> graphCreator) {
-        instanceList = List.copyOf(outerGraph.instanceList);
-        var instanceCount = instanceList.size();
-        // Often the maps are a singleton; we improve performance by actually making it so.
-        variableReferenceToInstanceMap = mapOfMapsDeepCopyOf(outerGraph.variableReferenceToInstanceMap);
-        variableReferenceToBeforeProcessor = mapOfListsDeepCopyOf(outerGraph.variableReferenceToBeforeProcessor);
-        variableReferenceToAfterProcessor = mapOfListsDeepCopyOf(outerGraph.variableReferenceToAfterProcessor);
-        edgeCount = new DynamicIntArray[instanceCount];
-        for (int i = 0; i < instanceCount; i++) {
-            edgeCount[i] = new DynamicIntArray(instanceCount);
-        }
-        graph = graphCreator.apply(instanceCount);
-        graph.withNodeData(instanceList);
-        changed = new BitSet(instanceCount);
+        super(outerGraph, graphCreator);
 
         var entityToVariableReferenceMap = new IdentityHashMap<Object, List<EntityVariablePair<Solution_>>>();
-        var visited = Collections.newSetFromMap(new IdentityHashMap<>());
         for (var instance : instanceList) {
             var entity = instance.entity();
-            if (visited.add(entity)) {
-                for (var variableId : outerGraph.variableReferenceToAfterProcessor.keySet()) {
-                    afterVariableChanged(variableId, entity);
-                }
-            }
             entityToVariableReferenceMap.computeIfAbsent(entity, ignored -> new ArrayList<>())
                     .add(instance);
-        }
-        for (var fixedEdgeEntry : outerGraph.fixedEdges.entrySet()) {
-            for (var toEdge : fixedEdgeEntry.getValue()) {
-                addEdge(fixedEdgeEntry.getKey(), toEdge);
-            }
         }
         // Immutable optimized version of the map, now that it won't be updated anymore.
         var immutableEntityToVariableReferenceMap = mapOfListsDeepCopyOf(entityToVariableReferenceMap);
@@ -76,118 +34,21 @@ final class DefaultVariableReferenceGraph<Solution_> implements VariableReferenc
     }
 
     @Override
-    public @Nullable EntityVariablePair<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity) {
-        var map = variableReferenceToInstanceMap.get(variableId);
-        if (map == null) {
-            return null;
-        }
-        return map.get(entity);
-    }
-
-    @Override
-    public void addEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to) {
-        var fromNodeId = from.graphNodeId();
-        var toNodeId = to.graphNodeId();
-        if (fromNodeId == toNodeId) {
-            return;
-        }
-
-        var count = edgeCount[fromNodeId].get(toNodeId);
-        if (count == 0) {
-            graph.addEdge(fromNodeId, toNodeId);
-        }
-        edgeCount[fromNodeId].set(toNodeId, count + 1);
-        markChanged(to);
-    }
-
-    @Override
-    public void removeEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to) {
-        var fromNodeId = from.graphNodeId();
-        var toNodeId = to.graphNodeId();
-        if (fromNodeId == toNodeId) {
-            return;
-        }
-
-        var count = edgeCount[fromNodeId].get(toNodeId);
-        if (count == 1) {
-            graph.removeEdge(fromNodeId, toNodeId);
-        }
-        edgeCount[fromNodeId].set(toNodeId, count - 1);
-        markChanged(to);
+    protected BitSet createChangeSet(int instanceCount) {
+        return new BitSet(instanceCount);
     }
 
     @Override
     public void markChanged(@NonNull EntityVariablePair<Solution_> node) {
-        changed.set(node.graphNodeId());
+        changeSet.set(node.graphNodeId());
     }
 
     @Override
     public void updateChanged() {
-        if (changed.isEmpty()) {
+        if (changeSet.isEmpty()) {
             return;
         }
-        graph.commitChanges(changed);
-        affectedEntitiesUpdater.accept(changed);
+        graph.commitChanges(changeSet);
+        affectedEntitiesUpdater.accept(changeSet);
     }
-
-    @Override
-    public void beforeVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
-        if (variableReference.entity().type().isInstance(entity)) {
-            processEntity(variableReferenceToBeforeProcessor.getOrDefault(variableReference, Collections.emptyList()), entity);
-        }
-    }
-
-    private void processEntity(List<BiConsumer<VariableReferenceGraph<Solution_>, Object>> processorList, Object entity) {
-        var processorCount = processorList.size();
-        // Avoid creation of iterators on the hot path.
-        // The short-lived instances were observed to cause considerable GC pressure.
-        for (int i = 0; i < processorCount; i++) {
-            processorList.get(i).accept(this, entity);
-        }
-    }
-
-    @Override
-    public void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
-        if (variableReference.entity().type().isInstance(entity)) {
-            var node = lookupOrNull(variableReference, entity);
-            if (node != null) {
-                markChanged(node);
-            }
-            processEntity(variableReferenceToAfterProcessor.getOrDefault(variableReference, Collections.emptyList()), entity);
-        }
-    }
-
-    @Override
-    public String toString() {
-        var edgeList = new LinkedHashMap<EntityVariablePair<Solution_>, List<EntityVariablePair<Solution_>>>();
-        graph.forEachEdge((from, to) -> edgeList.computeIfAbsent(instanceList.get(from), k -> new ArrayList<>())
-                .add(instanceList.get(to)));
-        return edgeList.entrySet()
-                .stream()
-                .map(e -> e.getKey() + "->" + e.getValue())
-                .collect(Collectors.joining(
-                        "," + System.lineSeparator() + " ",
-                        "{" + System.lineSeparator() + "  ",
-                        "}"));
-
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <K1, K2, V> Map<K1, Map<K2, V>> mapOfMapsDeepCopyOf(Map<K1, Map<K2, V>> map) {
-        var entryArray = map.entrySet()
-                .stream()
-                .map(e -> Map.entry(e.getKey(), Map.copyOf(e.getValue())))
-                .toArray(Map.Entry[]::new);
-        return Map.ofEntries(entryArray);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <K1, V> Map<K1, List<V>> mapOfListsDeepCopyOf(Map<K1, List<V>> map) {
-        var entryArray = map.entrySet()
-                .stream()
-                .map(e -> Map.entry(e.getKey(), List.copyOf(e.getValue())))
-                .toArray(Map.Entry[]::new);
-        return Map.ofEntries(entryArray);
-    }
-
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
-final class EmptyVariableReferenceGraph<Solution_> implements VariableReferenceGraph<Solution_> {
+final class EmptyVariableReferenceGraph<Solution_> implements VariableReferenceGraph {
 
     @SuppressWarnings("rawtypes")
     public static final EmptyVariableReferenceGraph INSTANCE = new EmptyVariableReferenceGraph<>();

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
@@ -46,6 +46,12 @@ final class EmptyVariableReferenceGraph<Solution_> implements VariableReferenceG
     }
 
     @Override
+    public boolean shouldQueueAfterEvents() {
+        // Queuing involves more work, so don't
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "{}";
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
@@ -2,33 +2,10 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-
 final class EmptyVariableReferenceGraph<Solution_> implements VariableReferenceGraph<Solution_> {
 
     @SuppressWarnings("rawtypes")
     public static final EmptyVariableReferenceGraph INSTANCE = new EmptyVariableReferenceGraph<>();
-
-    @Override
-    public @Nullable EntityVariablePair<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity) {
-        return null;
-    }
-
-    @Override
-    public void addEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to) {
-        throw new IllegalStateException("Impossible state: cannot modify an empty graph.");
-    }
-
-    @Override
-    public void removeEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to) {
-        throw new IllegalStateException("Impossible state: cannot modify an empty graph.");
-    }
-
-    @Override
-    public void markChanged(@NonNull EntityVariablePair<Solution_> node) {
-        throw new IllegalStateException("Impossible state: cannot modify an empty graph.");
-    }
 
     @Override
     public void updateChanged() {
@@ -43,12 +20,6 @@ final class EmptyVariableReferenceGraph<Solution_> implements VariableReferenceG
     @Override
     public void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
         // No need to do anything.
-    }
-
-    @Override
-    public boolean shouldQueueAfterEvents() {
-        // Queuing involves more work, so don't
-        return false;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
@@ -2,10 +2,9 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
-final class EmptyVariableReferenceGraph<Solution_> implements VariableReferenceGraph {
+final class EmptyVariableReferenceGraph implements VariableReferenceGraph {
 
-    @SuppressWarnings("rawtypes")
-    public static final EmptyVariableReferenceGraph INSTANCE = new EmptyVariableReferenceGraph<>();
+    public static final EmptyVariableReferenceGraph INSTANCE = new EmptyVariableReferenceGraph();
 
     @Override
     public void updateChanged() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.NonNull;
 
 public final class FixedVariableReferenceGraph<Solution_>
         extends AbstractVariableReferenceGraph<Solution_, PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder>>
-        implements VariableReferenceGraph<Solution_> {
+        implements VariableReferenceGraph {
     // These are immutable
     private final ChangedVariableNotifier<Solution_> changedVariableNotifier;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -1,0 +1,85 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import java.util.BitSet;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.function.IntFunction;
+
+import org.jspecify.annotations.NonNull;
+
+public final class FixedVariableReferenceGraph<Solution_>
+        extends AbstractVariableReferenceGraph<Solution_, PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder>>
+        implements VariableReferenceGraph<Solution_> {
+    // These are immutable
+    private final ChangedVariableNotifier<Solution_> changedVariableNotifier;
+
+    // These are mutable
+    private boolean isFinalized = false;
+
+    public FixedVariableReferenceGraph(VariableReferenceGraphBuilder<Solution_> outerGraph,
+            IntFunction<TopologicalOrderGraph> graphCreator) {
+        super(outerGraph, graphCreator);
+        // We don't use a bit set to store changes, so pass a one-use instance
+        graph.commitChanges(new BitSet(instanceList.size()));
+        isFinalized = true;
+
+        // Now that we know the topological order of nodes, add
+        // each node to changed.
+        for (var node = 0; node < instanceList.size(); node++) {
+            changeSet.add(graph.getTopologicalOrder(node));
+        }
+        changedVariableNotifier = outerGraph.changedVariableNotifier;
+    }
+
+    @Override
+    protected PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder> createChangeSet(int instanceCount) {
+        return new PriorityQueue<>(instanceCount);
+    }
+
+    @Override
+    public void markChanged(@NonNull EntityVariablePair<Solution_> node) {
+        // Before the graph is finalized, ignore changes, since
+        // we don't know the topological order yet
+        if (isFinalized) {
+            changeSet.add(graph.getTopologicalOrder(node.graphNodeId()));
+        }
+    }
+
+    @Override
+    public void updateChanged() {
+        BitSet visited;
+        if (!changeSet.isEmpty()) {
+            visited = new BitSet(instanceList.size());
+            visited.set(changeSet.peek().nodeId());
+        } else {
+            return;
+        }
+
+        // NOTE: This assumes the user did not add any fixed loops to
+        // their graph (i.e. have two variables ALWAYS depend on one-another).
+        while (!changeSet.isEmpty()) {
+            var changedNode = changeSet.poll();
+            var entityVariable = instanceList.get(changedNode.nodeId());
+            var entity = entityVariable.entity();
+            var shadowVariableReference = entityVariable.variableReference();
+            var oldValue = shadowVariableReference.memberAccessor().executeGetter(entity);
+            var newValue = shadowVariableReference.calculator().apply(entity);
+            var isVariableChanged = !Objects.equals(oldValue, newValue);
+            if (isVariableChanged) {
+                var variableDescriptor = shadowVariableReference.variableDescriptor();
+                changedVariableNotifier.beforeVariableChanged().accept(variableDescriptor, entity);
+                variableDescriptor.setValue(entity, newValue);
+                changedVariableNotifier.afterVariableChanged().accept(variableDescriptor, entity);
+
+                for (var iterator = graph.nodeForwardEdges(changedNode.nodeId()); iterator.hasNext();) {
+                    var nextNode = iterator.next();
+                    if (visited.get(nextNode)) {
+                        continue;
+                    }
+                    visited.set(nextNode);
+                    changeSet.add(graph.getTopologicalOrder(nextNode));
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphChangeType.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphChangeType.java
@@ -1,0 +1,17 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+public enum GraphChangeType {
+    NO_CHANGE(false),
+    ADD_EDGE(true),
+    REMOVE_EDGE(true);
+
+    private final boolean affectsGraph;
+
+    GraphChangeType(boolean affectsGraph) {
+        this.affectsGraph = affectsGraph;
+    }
+
+    public boolean affectsGraph() {
+        return affectsGraph;
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
@@ -1,0 +1,87 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import java.util.Arrays;
+
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum GraphStructure {
+    /**
+     * A graph structure that only accepts the empty graph.
+     */
+    EMPTY,
+
+    /**
+     * A graph structure without dynamic edges.
+     */
+    NO_DYNAMIC_EDGES,
+
+    /**
+     * A graph structure where there is at most
+     * one directional parent for each graph node.
+     */
+    SINGLE_DIRECTIONAL_PARENT,
+
+    /**
+     * A graph structure that accepts all graphs.
+     */
+    ARBITRARY;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GraphStructure.class);
+
+    public static <Solution_> GraphStructure determineGraphStructure(SolutionDescriptor<Solution_> solutionDescriptor) {
+        var declarativeShadowVariableDescriptors = solutionDescriptor.getDeclarativeShadowVariableDescriptors();
+        if (declarativeShadowVariableDescriptors.isEmpty()) {
+            return EMPTY;
+        }
+        var multipleDeclarativeEntityClasses = declarativeShadowVariableDescriptors.stream()
+                .map(variable -> variable.getEntityDescriptor().getEntityClass())
+                .distinct().count() > 1;
+
+        if (multipleDeclarativeEntityClasses) {
+            // Inverse might become directional if it has
+            // declarative variables; ARBITRARY does optimize
+            // the graph to NO_DYNAMIC_EDGES if there are no variable listeners that
+            // add/remove edges.
+            return ARBITRARY;
+        }
+
+        var rootVariableSources = declarativeShadowVariableDescriptors.stream()
+                .flatMap(descriptor -> Arrays.stream(descriptor.getSources()))
+                .toList();
+        ParentVariableType directionalType = null;
+        for (var variableSource : rootVariableSources) {
+            var parentVariableType = variableSource.parentVariableType();
+            LOGGER.debug("{} has parentVariableType {}", variableSource, parentVariableType);
+            switch (parentVariableType) {
+                case GROUP, INDIRECT_DIRECTIONAL, CHAINED_INVERSE -> {
+                    // CHAINED_INVERSE is arbitrary, since we don't have
+                    // the concept of "index" to help us identify topological
+                    // order without creating a graph.
+                    return GraphStructure.ARBITRARY;
+                }
+                case NEXT, PREVIOUS -> {
+                    if (directionalType == null) {
+                        directionalType = parentVariableType;
+                    } else if (directionalType != parentVariableType) {
+                        return GraphStructure.ARBITRARY;
+                    }
+                }
+                case UNDIRECTIONAL -> {
+                    // Do nothing
+                }
+                default -> {
+                    throw new IllegalStateException("Unhandled case %s".formatted(variableSource.parentVariableType()));
+                }
+            }
+        }
+
+        if (directionalType == null) {
+            return NO_DYNAMIC_EDGES;
+        } else {
+            return SINGLE_DIRECTIONAL_PARENT;
+        }
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
@@ -6,10 +6,12 @@ import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescripto
 import ai.timefold.solver.core.impl.util.MutableInt;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@NullMarked
 public enum GraphStructure {
     /**
      * A graph structure that only accepts the empty graph.
@@ -70,9 +72,7 @@ public enum GraphStructure {
                     var groupMemberCount = new MutableInt(0);
                     for (var entity : entities) {
                         if (variableSource.rootEntity().isInstance(entity)) {
-                            variableSource.valueEntityFunction().accept(entity, fromEntity -> {
-                                groupMemberCount.increment();
-                            });
+                            variableSource.valueEntityFunction().accept(entity, fromEntity -> groupMemberCount.increment());
                         }
                     }
                     if (groupMemberCount.intValue() != 0) {
@@ -80,10 +80,10 @@ public enum GraphStructure {
                     }
                     // The group variable is unused/always empty
                 }
-                case INDIRECT, INVERSE -> {
+                case INDIRECT, INVERSE, VARIABLE -> {
                     return new GraphStructureAndDirection(ARBITRARY, null, null);
                 }
-                case NEXT, PREVIOUS, CHAINED_NEXT, CHAINED_PREVIOUS -> {
+                case NEXT, PREVIOUS, CHAINED_NEXT -> {
                     if (parentMetaModel == null) {
                         parentMetaModel = variableSource.variableSourceReferences().get(0).variableMetaModel();
                         directionalType = parentVariableType;

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ParentVariableType.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ParentVariableType.java
@@ -7,30 +7,36 @@ public enum ParentVariableType {
     NO_PARENT(false, false),
 
     /**
-     * A variable accessed from the inverse.
+     * A variable accessed from another variable.
+     */
+    VARIABLE(false, false),
+
+    /**
+     * Variable on the inverse accessed from the root object.
      */
     INVERSE(false, false),
 
     /**
-     * Next element variable accessed from the root object.
+     * Variable on a next element variable accessed from the root object.
      */
     NEXT(true, false),
 
     /**
-     * Previous element variable accessed from the root object.
+     * Variable on a previous element variable accessed from the root object.
      */
     PREVIOUS(true, false),
 
-    /**
-     * PREVIOUS element variable accessed from the root object in a chained model.
-     * Note: it might be impossible, since a chained model uses separate classes
-     * for the anchor and values, and the anchor does not have a planning
-     * variable on it.
+    /*
+     * Previous element variable accessed from the root object in a chained model
+     * (i.e. PlanningVariable(graphType = PlanningVariableGraphType.CHAINED))
+     * is not included, since it would require a source path to accept properties
+     * that are only included on subclasses of the property's type (since the
+     * value of a chained value is either an entity (which has the property) or
+     * an anchor (which does not have the property)).
      */
-    CHAINED_PREVIOUS(true, false),
 
     /**
-     * Next element variable accessed from the root object in a chained model.
+     * Variable on a next element variable accessed from the root object in a chained model.
      */
     CHAINED_NEXT(true, false),
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ParentVariableType.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ParentVariableType.java
@@ -1,0 +1,35 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+public enum ParentVariableType {
+    /**
+     * Next element variable accessed from the root object.
+     */
+    NEXT,
+
+    /**
+     * Previous element variable accessed from the root object.
+     */
+    PREVIOUS,
+
+    /**
+     * Previous element variable accessed from the root object in a chained model.
+     */
+    CHAINED_INVERSE,
+
+    /**
+     * Next/previous element variable accessed
+     * from a fact.
+     */
+    INDIRECT_DIRECTIONAL,
+
+    /**
+     * Variables accessed from a group.
+     */
+    GROUP,
+
+    /**
+     * Declarative variables, inverse variables, and
+     * genuine variables.
+     */
+    UNDIRECTIONAL
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ParentVariableType.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ParentVariableType.java
@@ -2,34 +2,71 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 public enum ParentVariableType {
     /**
+     * A variable accessed from the root object.
+     */
+    NO_PARENT(false, false),
+
+    /**
+     * A variable accessed from the inverse.
+     */
+    INVERSE(false, false),
+
+    /**
      * Next element variable accessed from the root object.
      */
-    NEXT,
+    NEXT(true, false),
 
     /**
      * Previous element variable accessed from the root object.
      */
-    PREVIOUS,
+    PREVIOUS(true, false),
 
     /**
-     * Previous element variable accessed from the root object in a chained model.
+     * PREVIOUS element variable accessed from the root object in a chained model.
+     * Note: it might be impossible, since a chained model uses separate classes
+     * for the anchor and values, and the anchor does not have a planning
+     * variable on it.
      */
-    CHAINED_INVERSE,
+    CHAINED_PREVIOUS(true, false),
 
     /**
-     * Next/previous element variable accessed
-     * from a fact.
+     * Next element variable accessed from the root object in a chained model.
      */
-    INDIRECT_DIRECTIONAL,
+    CHAINED_NEXT(true, false),
+
+    /**
+     * A variable accessed indirectly from a fact or variable.
+     */
+    INDIRECT(false, true),
 
     /**
      * Variables accessed from a group.
      */
-    GROUP,
+    GROUP(false, true);
 
     /**
-     * Declarative variables, inverse variables, and
-     * genuine variables.
+     * True if the parent variable has a well-defined successor function.
+     * For instance, the successor of a variable with a previous variable
+     * is next.
      */
-    UNDIRECTIONAL
+    private final boolean isDirectional;
+
+    /**
+     * True if the variable is accessed indirectly from a fact or
+     * a group.
+     */
+    private final boolean isIndirect;
+
+    ParentVariableType(boolean isDirectional, boolean isIndirect) {
+        this.isDirectional = isDirectional;
+        this.isIndirect = isIndirect;
+    }
+
+    public boolean isDirectional() {
+        return isDirectional;
+    }
+
+    public boolean isIndirect() {
+        return isIndirect;
+    }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
@@ -374,11 +374,7 @@ public record RootVariableSource<Entity_, Value_>(
             }
         }
         if (getAnnotation(declaringClass, memberName, PlanningVariable.class) != null) {
-            PlanningVariable planningVariable =
-                    Objects.requireNonNull(getAnnotation(declaringClass, memberName, PlanningVariable.class));
-            if (planningVariable.graphType() == PlanningVariableGraphType.CHAINED) {
-                return ParentVariableType.CHAINED_PREVIOUS;
-            }
+            return ParentVariableType.VARIABLE;
         }
         return ParentVariableType.NO_PARENT;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
@@ -1,0 +1,149 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+
+import ai.timefold.solver.core.impl.util.CollectionUtils;
+import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public final class SingleDirectionalParentVariableReferenceGraph<Solution_> implements VariableReferenceGraph<Solution_> {
+    private final Map<VariableMetaModel<?, ?, ?>, Map<Object, EntityVariablePair<Solution_>>> variableReferenceToInstanceMap;
+    private final Set<VariableMetaModel<?, ?, ?>> monitoredSourceVariableSet;
+    private final List<VariableUpdaterInfo<Solution_>> sortedVariableUpdaterInfoList;
+    private final Set<Object> changedSet;
+    private final Function<Object, Object> successorFunction;
+    private final Comparator<Object> comparator;
+    private final ChangedVariableNotifier<Solution_> changedVariableNotifier;
+    private final ShadowVariableLoopedVariableDescriptor<Solution_> loopedDescriptor;
+
+    public SingleDirectionalParentVariableReferenceGraph(
+            List<DeclarativeShadowVariableDescriptor<Solution_>> sortedDeclarativeShadowVariableDescriptors,
+            Function<Object, Object> successorFunction, Comparator<Object> comparator,
+            ChangedVariableNotifier<Solution_> changedVariableNotifier,
+            Object[] entities) {
+        variableReferenceToInstanceMap = CollectionUtils.newHashMap(sortedDeclarativeShadowVariableDescriptors.size());
+        sortedVariableUpdaterInfoList = new ArrayList<>(sortedDeclarativeShadowVariableDescriptors.size());
+        monitoredSourceVariableSet = new HashSet<>();
+        changedSet = Collections.newSetFromMap(CollectionUtils.newIdentityHashMap(entities.length));
+
+        this.successorFunction = successorFunction;
+        this.comparator = comparator;
+        this.changedVariableNotifier = changedVariableNotifier;
+        this.loopedDescriptor =
+                sortedDeclarativeShadowVariableDescriptors.get(0).getEntityDescriptor().getShadowVariableLoopedDescriptor();
+
+        for (var variableDescriptor : sortedDeclarativeShadowVariableDescriptors) {
+            var variableMetaModel = variableDescriptor.getVariableMetaModel();
+            var objectMap = CollectionUtils.newIdentityHashMap(entities.length);
+            var variableUpdaterInfo = new VariableUpdaterInfo<>(
+                    variableMetaModel,
+                    variableDescriptor,
+                    loopedDescriptor,
+                    variableDescriptor.getMemberAccessor(),
+                    variableDescriptor.getCalculator()::executeGetter);
+            sortedVariableUpdaterInfoList.add(variableUpdaterInfo);
+            variableReferenceToInstanceMap.put(variableMetaModel, CollectionUtils.newIdentityHashMap(entities.length));
+
+            for (var source : variableDescriptor.getSources()) {
+                for (var sourceReference : source.variableSourceReferences()) {
+                    monitoredSourceVariableSet.add(sourceReference.variableMetaModel());
+                }
+            }
+
+            for (var entity : entities) {
+                // No graph, so no graph id
+                if (variableDescriptor.getEntityDescriptor().getEntityClass().isInstance(entity)) {
+                    objectMap.put(entity, new EntityVariablePair<>(entity, variableUpdaterInfo, -1));
+                    changedSet.add(entity);
+                }
+            }
+        }
+    }
+
+    @Override
+    public @Nullable EntityVariablePair<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity) {
+        return variableReferenceToInstanceMap.get(variableId).get(entity);
+    }
+
+    @Override
+    public void addEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to) {
+        markChanged(to);
+    }
+
+    @Override
+    public void removeEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to) {
+        markChanged(to);
+    }
+
+    @Override
+    public void markChanged(@NonNull EntityVariablePair<Solution_> node) {
+        changedSet.add(node.entity());
+    }
+
+    @Override
+    public void updateChanged() {
+        var changedSorted = new TreeSet<>(comparator);
+        var visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        changedSorted.addAll(changedSet);
+        for (var changed : changedSorted) {
+            if (visited.contains(changed)) {
+                continue;
+            }
+
+            var current = changed;
+            while (current != null) {
+                visited.add(current);
+                var anyChanged = false;
+                if (loopedDescriptor != null) {
+                    var oldValue = loopedDescriptor.getValue(current);
+                    if (!Objects.equals(oldValue, false)) {
+                        anyChanged = true;
+                        changedVariableNotifier.beforeVariableChanged().accept(loopedDescriptor, current);
+                        loopedDescriptor.setValue(current, false);
+                        changedVariableNotifier.afterVariableChanged().accept(loopedDescriptor, current);
+                    }
+                }
+                for (var updater : sortedVariableUpdaterInfoList) {
+                    var oldValue = updater.memberAccessor().executeGetter(current);
+                    var newValue = updater.calculator().apply(current);
+                    if (!Objects.equals(oldValue, newValue)) {
+                        anyChanged = true;
+                        changedVariableNotifier.beforeVariableChanged().accept(updater.variableDescriptor(), current);
+                        updater.memberAccessor().executeSetter(current, newValue);
+                        changedVariableNotifier.afterVariableChanged().accept(updater.variableDescriptor(), current);
+                    }
+                }
+                if (anyChanged) {
+                    current = successorFunction.apply(current);
+                } else {
+                    current = null;
+                }
+            }
+        }
+        changedSet.clear();
+    }
+
+    @Override
+    public void beforeVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
+        // Do nothing
+    }
+
+    @Override
+    public void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
+        if (monitoredSourceVariableSet.contains(variableReference)) {
+            changedSet.add(entity);
+        }
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
@@ -6,26 +6,26 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
-public final class SingleDirectionalParentVariableReferenceGraph<Solution_> implements VariableReferenceGraph<Solution_> {
+public final class SingleDirectionalParentVariableReferenceGraph<Solution_> implements VariableReferenceGraph {
     private final Set<VariableMetaModel<?, ?, ?>> monitoredSourceVariableSet;
     private final VariableUpdaterInfo<Solution_>[] sortedVariableUpdaterInfos;
-    private final Function<Object, Object> successorFunction;
+    private final UnaryOperator<Object> successorFunction;
     private final ChangedVariableNotifier<Solution_> changedVariableNotifier;
     private final List<Object> changedEntities;
     private final Class<?> monitoredEntityClass;
     private boolean isUpdating;
 
+    @SuppressWarnings("unchecked")
     public SingleDirectionalParentVariableReferenceGraph(
             List<DeclarativeShadowVariableDescriptor<Solution_>> sortedDeclarativeShadowVariableDescriptors,
-            Function<Object, Object> successorFunction,
+            UnaryOperator<Object> successorFunction,
             ChangedVariableNotifier<Solution_> changedVariableNotifier,
             Object[] entities) {
         monitoredEntityClass = sortedDeclarativeShadowVariableDescriptors.get(0).getEntityDescriptor().getEntityClass();
-        // noinspection unchecked
         sortedVariableUpdaterInfos = new VariableUpdaterInfo[sortedDeclarativeShadowVariableDescriptors.size()];
         monitoredSourceVariableSet = new HashSet<>();
         changedEntities = new ArrayList<>();

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -6,7 +6,8 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 public sealed interface VariableReferenceGraph<Solution_>
-        permits DefaultVariableReferenceGraph, EmptyVariableReferenceGraph {
+        permits AbstractVariableReferenceGraph, DefaultVariableReferenceGraph, EmptyVariableReferenceGraph,
+        FixedVariableReferenceGraph {
 
     @Nullable
     EntityVariablePair<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity);

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -2,35 +2,14 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-
 public sealed interface VariableReferenceGraph<Solution_>
         permits AbstractVariableReferenceGraph, DefaultVariableReferenceGraph, EmptyVariableReferenceGraph,
         FixedVariableReferenceGraph, SingleDirectionalParentVariableReferenceGraph {
-
-    @Nullable
-    EntityVariablePair<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity);
-
-    void addEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to);
-
-    void removeEdge(@NonNull EntityVariablePair<Solution_> from, @NonNull EntityVariablePair<Solution_> to);
-
-    void markChanged(@NonNull EntityVariablePair<Solution_> node);
 
     void updateChanged();
 
     void beforeVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity);
 
     void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity);
-
-    /**
-     * If afterVariableChanged events should be queued instead of executed immediately.
-     * Needed if variables are updated in afterVariableChanged instead of updateChanged
-     * to guarantee the input variables are consistent with one another.
-     * 
-     * @return true iff the afterVariableChanged events should be queued.
-     */
-    boolean shouldQueueAfterEvents();
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -7,7 +7,7 @@ import org.jspecify.annotations.Nullable;
 
 public sealed interface VariableReferenceGraph<Solution_>
         permits AbstractVariableReferenceGraph, DefaultVariableReferenceGraph, EmptyVariableReferenceGraph,
-        FixedVariableReferenceGraph {
+        FixedVariableReferenceGraph, SingleDirectionalParentVariableReferenceGraph {
 
     @Nullable
     EntityVariablePair<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity);

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
-public sealed interface VariableReferenceGraph<Solution_>
+public sealed interface VariableReferenceGraph
         permits AbstractVariableReferenceGraph, DefaultVariableReferenceGraph, EmptyVariableReferenceGraph,
         FixedVariableReferenceGraph, SingleDirectionalParentVariableReferenceGraph {
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -24,4 +24,13 @@ public sealed interface VariableReferenceGraph<Solution_>
 
     void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity);
 
+    /**
+     * If afterVariableChanged events should be queued instead of executed immediately.
+     * Needed if variables are updated in afterVariableChanged instead of updateChanged
+     * to guarantee the input variables are consistent with one another.
+     * 
+     * @return true iff the afterVariableChanged events should be queued.
+     */
+    boolean shouldQueueAfterEvents();
+
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
@@ -16,8 +16,8 @@ import org.jspecify.annotations.NonNull;
 public final class VariableReferenceGraphBuilder<Solution_> {
 
     final ChangedVariableNotifier<Solution_> changedVariableNotifier;
-    final Map<VariableMetaModel<?, ?, ?>, List<BiConsumer<VariableReferenceGraph<Solution_>, Object>>> variableReferenceToBeforeProcessor;
-    final Map<VariableMetaModel<?, ?, ?>, List<BiConsumer<VariableReferenceGraph<Solution_>, Object>>> variableReferenceToAfterProcessor;
+    final Map<VariableMetaModel<?, ?, ?>, List<BiConsumer<AbstractVariableReferenceGraph<Solution_, ?>, Object>>> variableReferenceToBeforeProcessor;
+    final Map<VariableMetaModel<?, ?, ?>, List<BiConsumer<AbstractVariableReferenceGraph<Solution_, ?>, Object>>> variableReferenceToAfterProcessor;
     final List<EntityVariablePair<Solution_>> instanceList;
     final Map<EntityVariablePair<Solution_>, List<EntityVariablePair<Solution_>>> fixedEdges;
     final Map<VariableMetaModel<?, ?, ?>, Map<Object, EntityVariablePair<Solution_>>> variableReferenceToInstanceMap;
@@ -57,14 +57,14 @@ public final class VariableReferenceGraphBuilder<Solution_> {
     }
 
     public void addBeforeProcessor(GraphChangeType graphChangeType, VariableMetaModel<?, ?, ?> variableId,
-            BiConsumer<VariableReferenceGraph<Solution_>, Object> consumer) {
+            BiConsumer<AbstractVariableReferenceGraph<Solution_, ?>, Object> consumer) {
         isGraphFixed &= !graphChangeType.affectsGraph();
         variableReferenceToBeforeProcessor.computeIfAbsent(variableId, k -> new ArrayList<>())
                 .add(consumer);
     }
 
     public void addAfterProcessor(GraphChangeType graphChangeType, VariableMetaModel<?, ?, ?> variableId,
-            BiConsumer<VariableReferenceGraph<Solution_>, Object> consumer) {
+            BiConsumer<AbstractVariableReferenceGraph<Solution_, ?>, Object> consumer) {
         isGraphFixed &= !graphChangeType.affectsGraph();
         variableReferenceToAfterProcessor.computeIfAbsent(variableId, k -> new ArrayList<>())
                 .add(consumer);

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
@@ -71,7 +71,7 @@ public final class VariableReferenceGraphBuilder<Solution_> {
     }
 
     @SuppressWarnings("unchecked")
-    public VariableReferenceGraph<Solution_> build(IntFunction<TopologicalOrderGraph> graphCreator) {
+    public VariableReferenceGraph build(IntFunction<TopologicalOrderGraph> graphCreator) {
         // TODO empty shows up in VRP example when using it as CVRP, not CVRPTW
         //  In that case, TimeWindowedCustomer does not exist
         //  and therefore Customer has no shadow variable.

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
@@ -1,0 +1,48 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.timefold.solver.core.testdomain.TestdataSolution;
+import ai.timefold.solver.core.testdomain.declarative.concurrent.TestdataConcurrentSolution;
+import ai.timefold.solver.core.testdomain.declarative.extended.TestdataDeclarativeExtendedSolution;
+import ai.timefold.solver.core.testdomain.declarative.follower.TestdataFollowerSolution;
+import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclarativeSimpleListSolution;
+
+import org.junit.jupiter.api.Test;
+
+public class GraphStructureTest {
+    @Test
+    public void simpleListStructure() {
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataDeclarativeSimpleListSolution.buildSolutionDescriptor()))
+                .isEqualTo(GraphStructure.SINGLE_DIRECTIONAL_PARENT);
+    }
+
+    @Test
+    public void extendedSimpleListStructure() {
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataDeclarativeExtendedSolution.buildSolutionDescriptor()))
+                .isEqualTo(GraphStructure.SINGLE_DIRECTIONAL_PARENT);
+    }
+
+    @Test
+    public void concurrentValuesStructure() {
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataConcurrentSolution.buildSolutionDescriptor()))
+                .isEqualTo(GraphStructure.ARBITRARY);
+    }
+
+    @Test
+    public void followerStructure() {
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataFollowerSolution.buildSolutionDescriptor()))
+                .isEqualTo(GraphStructure.NO_DYNAMIC_EDGES);
+    }
+
+    @Test
+    public void emptyStructure() {
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataSolution.buildSolutionDescriptor()))
+                .isEqualTo(GraphStructure.EMPTY);
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
@@ -19,9 +19,9 @@ import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclar
 
 import org.junit.jupiter.api.Test;
 
-public class GraphStructureTest {
+class GraphStructureTest {
     @Test
-    public void simpleListStructure() {
+    void simpleListStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataDeclarativeSimpleListSolution.buildSolutionDescriptor()))
                 .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
@@ -29,7 +29,7 @@ public class GraphStructureTest {
     }
 
     @Test
-    public void simpleChainedStructure() {
+    void simpleChainedStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataChainedSimpleVarSolution.buildSolutionDescriptor()))
                 .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
@@ -37,7 +37,7 @@ public class GraphStructureTest {
     }
 
     @Test
-    public void extendedSimpleListStructure() {
+    void extendedSimpleListStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataDeclarativeExtendedSolution.buildSolutionDescriptor()))
                 .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
@@ -45,7 +45,7 @@ public class GraphStructureTest {
     }
 
     @Test
-    public void concurrentValuesStructureWithoutGroups() {
+    void concurrentValuesStructureWithoutGroups() {
         var value1 = new TestdataConcurrentValue("v1");
         var value2 = new TestdataConcurrentValue("v2");
         value2.setConcurrentValueGroup(Collections.emptyList());
@@ -57,7 +57,7 @@ public class GraphStructureTest {
     }
 
     @Test
-    public void concurrentValuesStructureWithGroups() {
+    void concurrentValuesStructureWithGroups() {
         var value1 = new TestdataConcurrentValue("v1");
         var value2 = new TestdataConcurrentValue("v2");
         var group = List.of(value1, value2);
@@ -69,14 +69,14 @@ public class GraphStructureTest {
     }
 
     @Test
-    public void followerStructure() {
+    void followerStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataFollowerSolution.buildSolutionDescriptor()))
                 .hasFieldOrPropertyWithValue("structure", NO_DYNAMIC_EDGES);
     }
 
     @Test
-    public void emptyStructure() {
+    void emptyStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataSolution.buildSolutionDescriptor()))
                 .hasFieldOrPropertyWithValue("structure", EMPTY);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
@@ -1,11 +1,20 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
+import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.ARBITRARY;
+import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.EMPTY;
+import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.NO_DYNAMIC_EDGES;
+import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.SINGLE_DIRECTIONAL_PARENT;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
 
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 import ai.timefold.solver.core.testdomain.declarative.concurrent.TestdataConcurrentSolution;
+import ai.timefold.solver.core.testdomain.declarative.concurrent.TestdataConcurrentValue;
 import ai.timefold.solver.core.testdomain.declarative.extended.TestdataDeclarativeExtendedSolution;
 import ai.timefold.solver.core.testdomain.declarative.follower.TestdataFollowerSolution;
+import ai.timefold.solver.core.testdomain.declarative.simple_chained.TestdataChainedSimpleVarSolution;
 import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclarativeSimpleListSolution;
 
 import org.junit.jupiter.api.Test;
@@ -15,34 +24,61 @@ public class GraphStructureTest {
     public void simpleListStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataDeclarativeSimpleListSolution.buildSolutionDescriptor()))
-                .isEqualTo(GraphStructure.SINGLE_DIRECTIONAL_PARENT);
+                .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
+                .hasFieldOrPropertyWithValue("direction", ParentVariableType.PREVIOUS);
+    }
+
+    @Test
+    public void simpleChainedStructure() {
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataChainedSimpleVarSolution.buildSolutionDescriptor()))
+                .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
+                .hasFieldOrPropertyWithValue("direction", ParentVariableType.CHAINED_NEXT);
     }
 
     @Test
     public void extendedSimpleListStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataDeclarativeExtendedSolution.buildSolutionDescriptor()))
-                .isEqualTo(GraphStructure.SINGLE_DIRECTIONAL_PARENT);
+                .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
+                .hasFieldOrPropertyWithValue("direction", ParentVariableType.PREVIOUS);
     }
 
     @Test
-    public void concurrentValuesStructure() {
+    public void concurrentValuesStructureWithoutGroups() {
+        var value1 = new TestdataConcurrentValue("v1");
+        var value2 = new TestdataConcurrentValue("v2");
+        value2.setConcurrentValueGroup(Collections.emptyList());
         assertThat(GraphStructure.determineGraphStructure(
-                TestdataConcurrentSolution.buildSolutionDescriptor()))
-                .isEqualTo(GraphStructure.ARBITRARY);
+                TestdataConcurrentSolution.buildSolutionDescriptor(),
+                value1, value2))
+                .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
+                .hasFieldOrPropertyWithValue("direction", ParentVariableType.PREVIOUS);
+    }
+
+    @Test
+    public void concurrentValuesStructureWithGroups() {
+        var value1 = new TestdataConcurrentValue("v1");
+        var value2 = new TestdataConcurrentValue("v2");
+        var group = List.of(value1, value2);
+        value2.setConcurrentValueGroup(group);
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataConcurrentSolution.buildSolutionDescriptor(),
+                value1, value2))
+                .hasFieldOrPropertyWithValue("structure", ARBITRARY);
     }
 
     @Test
     public void followerStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataFollowerSolution.buildSolutionDescriptor()))
-                .isEqualTo(GraphStructure.NO_DYNAMIC_EDGES);
+                .hasFieldOrPropertyWithValue("structure", NO_DYNAMIC_EDGES);
     }
 
     @Test
     public void emptyStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataSolution.buildSolutionDescriptor()))
-                .isEqualTo(GraphStructure.EMPTY);
+                .hasFieldOrPropertyWithValue("structure", EMPTY);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/follower/FollowerValuesShadowVariableTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/follower/FollowerValuesShadowVariableTest.java
@@ -65,7 +65,7 @@ class FollowerValuesShadowVariableTest {
                         followerB1, followerB2),
                 List.of(value1, value2));
 
-        var solutionDescriptor = TestdataFollowerSolution.getSolutionDescriptor();
+        var solutionDescriptor = TestdataFollowerSolution.buildSolutionDescriptor();
         var variableMetamodel = solutionDescriptor.getMetaModel().entity(TestdataLeaderEntity.class).variable("value");
         var moveAsserter = MoveAsserter.create(solutionDescriptor);
 

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/simple_chained/SimpleChainedTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/simple_chained/SimpleChainedTest.java
@@ -1,0 +1,50 @@
+package ai.timefold.solver.core.preview.api.variable.declarative.simple_chained;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+
+import ai.timefold.solver.core.api.solver.SolverFactory;
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
+import ai.timefold.solver.core.testdomain.declarative.simple_chained.TestdataChainedSimpleVarConstraintProvider;
+import ai.timefold.solver.core.testdomain.declarative.simple_chained.TestdataChainedSimpleVarEntity;
+import ai.timefold.solver.core.testdomain.declarative.simple_chained.TestdataChainedSimpleVarSolution;
+import ai.timefold.solver.core.testdomain.declarative.simple_chained.TestdataChainedSimpleVarValue;
+
+import org.junit.jupiter.api.Test;
+
+public class SimpleChainedTest {
+    @Test
+    public void simpleChained() {
+        var solverConfig = new SolverConfig()
+                .withSolutionClass(TestdataChainedSimpleVarSolution.class)
+                .withEntityClasses(TestdataChainedSimpleVarEntity.class, TestdataChainedSimpleVarValue.class)
+                .withConstraintProviderClass(TestdataChainedSimpleVarConstraintProvider.class)
+                .withPreviewFeature(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES)
+                .withEnvironmentMode(EnvironmentMode.FULL_ASSERT)
+                .withTerminationConfig(new TerminationConfig().withBestScoreLimit("-48"));
+
+        var entityList = List.of(new TestdataChainedSimpleVarEntity("e1", Duration.ofDays(1)),
+                new TestdataChainedSimpleVarEntity("e2", Duration.ofDays(2)),
+                new TestdataChainedSimpleVarEntity("e3", Duration.ofDays(3)));
+        var valueList = List.of(
+                new TestdataChainedSimpleVarValue("a1", Duration.ofDays(1)),
+                new TestdataChainedSimpleVarValue("a2", Duration.ofDays(2)),
+                new TestdataChainedSimpleVarValue("a3", Duration.ofDays(3)));
+        var problem = new TestdataChainedSimpleVarSolution(entityList, valueList);
+        var solverFactory = SolverFactory.<TestdataChainedSimpleVarSolution> create(solverConfig);
+        var solver = solverFactory.buildSolver();
+        var solution = solver.solve(problem);
+
+        // In the optimal solution, each value is paired with the opposite entity
+        // i.e. v1 -> e3, v2 -> e2, and v3 -> e1.
+        var values = solution.getValues();
+        for (var value : values) {
+            assertThat(value.getCumulativeDurationInDays()).isEqualTo(4);
+        }
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/simple_chained/SimpleChainedTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/simple_chained/SimpleChainedTest.java
@@ -17,9 +17,9 @@ import ai.timefold.solver.core.testdomain.declarative.simple_chained.TestdataCha
 
 import org.junit.jupiter.api.Test;
 
-public class SimpleChainedTest {
+class SimpleChainedTest {
     @Test
-    public void simpleChained() {
+    void simpleChained() {
         var solverConfig = new SolverConfig()
                 .withSolutionClass(TestdataChainedSimpleVarSolution.class)
                 .withEntityClasses(TestdataChainedSimpleVarEntity.class, TestdataChainedSimpleVarValue.class)

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/simple_list/SimpleListTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/simple_list/SimpleListTest.java
@@ -1,0 +1,63 @@
+package ai.timefold.solver.core.preview.api.variable.declarative.simple_list;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.solver.SolverFactory;
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclarativeSimpleListConstraintProvider;
+import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclarativeSimpleListEntity;
+import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclarativeSimpleListSolution;
+import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclarativeSimpleListValue;
+
+import org.junit.jupiter.api.Test;
+
+public class SimpleListTest {
+    @Test
+    public void simpleList() {
+        var solverConfig = new SolverConfig()
+                .withSolutionClass(TestdataDeclarativeSimpleListSolution.class)
+                .withEntityClasses(TestdataDeclarativeSimpleListEntity.class, TestdataDeclarativeSimpleListValue.class)
+                .withConstraintProviderClass(TestdataDeclarativeSimpleListConstraintProvider.class)
+                .withPreviewFeature(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES)
+                .withEnvironmentMode(EnvironmentMode.FULL_ASSERT)
+                .withTerminationConfig(new TerminationConfig().withBestScoreLimit("-344"));
+
+        var entityList = List.of(new TestdataDeclarativeSimpleListEntity("e1", 0, 0));
+        var valueList = List.of(
+                new TestdataDeclarativeSimpleListValue("v1", 1, 60),
+                new TestdataDeclarativeSimpleListValue("v2", 2, 120),
+                new TestdataDeclarativeSimpleListValue("v3", 3, 30));
+        var problem = new TestdataDeclarativeSimpleListSolution(entityList, valueList);
+        var solverFactory = SolverFactory.<TestdataDeclarativeSimpleListSolution> create(solverConfig);
+        var solver = solverFactory.buildSolver();
+        var solution = solver.solve(problem);
+
+        // Note that we minimize the end time of all values, and not
+        // the end time of the last value. Since duration is cumulative and the
+        // difference in duration is larger than the difference in positions,
+        // the solver wants to do the shortest duration first, and thus the
+        // best solution is the one that maximizes distance.
+        assertThat(solution.getEntityList().get(0).getValues())
+                .map(TestdataObject::getCode)
+                .containsExactly("v3", "v1", "v2");
+
+        var v1 = solution.getValueList().get(0);
+        var v2 = solution.getValueList().get(1);
+        var v3 = solution.getValueList().get(2);
+
+        assertThat(v3.getStartTime()).isEqualTo(3);
+        assertThat(v3.getEndTime()).isEqualTo(33);
+
+        assertThat(v1.getStartTime()).isEqualTo(35);
+        assertThat(v1.getEndTime()).isEqualTo(95);
+
+        assertThat(v2.getStartTime()).isEqualTo(96);
+        assertThat(v2.getEndTime()).isEqualTo(216);
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/simple_list/SimpleListTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/simple_list/SimpleListTest.java
@@ -17,9 +17,9 @@ import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclar
 
 import org.junit.jupiter.api.Test;
 
-public class SimpleListTest {
+class SimpleListTest {
     @Test
-    public void simpleList() {
+    void simpleList() {
         var solverConfig = new SolverConfig()
                 .withSolutionClass(TestdataDeclarativeSimpleListSolution.class)
                 .withEntityClasses(TestdataDeclarativeSimpleListEntity.class, TestdataDeclarativeSimpleListValue.class)

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/extended/TestdataDeclarativeExtendedBaseValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/extended/TestdataDeclarativeExtendedBaseValue.java
@@ -6,7 +6,6 @@ import ai.timefold.solver.core.testdomain.TestdataObject;
 
 @PlanningEntity
 public class TestdataDeclarativeExtendedBaseValue extends TestdataObject {
-    @PreviousElementShadowVariable(sourceVariableName = "values")
     TestdataDeclarativeExtendedBaseValue previous;
 
     public TestdataDeclarativeExtendedBaseValue() {
@@ -17,6 +16,7 @@ public class TestdataDeclarativeExtendedBaseValue extends TestdataObject {
         super(code);
     }
 
+    @PreviousElementShadowVariable(sourceVariableName = "values")
     public TestdataDeclarativeExtendedBaseValue getPrevious() {
         return previous;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/extended/TestdataDeclarativeExtendedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/extended/TestdataDeclarativeExtendedSolution.java
@@ -1,16 +1,27 @@
 package ai.timefold.solver.core.testdomain.declarative.extended;
 
 import java.util.List;
+import java.util.Set;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
 import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.testdomain.TestdataObject;
 
 @PlanningSolution
 public class TestdataDeclarativeExtendedSolution extends TestdataObject {
+    public static SolutionDescriptor<TestdataDeclarativeExtendedSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(Set.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
+                TestdataDeclarativeExtendedSolution.class,
+                TestdataDeclarativeExtendedEntity.class,
+                TestdataDeclarativeExtendedBaseValue.class,
+                TestdataDeclarativeExtendedSubclassValue.class);
+    }
+
     @PlanningEntityCollectionProperty
     List<TestdataDeclarativeExtendedEntity> entities;
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/follower/TestdataFollowerSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/follower/TestdataFollowerSolution.java
@@ -17,7 +17,7 @@ import ai.timefold.solver.core.testdomain.TestdataValue;
 
 @PlanningSolution
 public class TestdataFollowerSolution extends TestdataObject {
-    public static SolutionDescriptor<TestdataFollowerSolution> getSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataFollowerSolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(Set.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
                 TestdataFollowerSolution.class, TestdataLeaderEntity.class, TestdataFollowerEntity.class);
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_chained/TestdataChainedSimpleVarConstraintProvider.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_chained/TestdataChainedSimpleVarConstraintProvider.java
@@ -1,0 +1,20 @@
+package ai.timefold.solver.core.testdomain.declarative.simple_chained;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+
+import org.jspecify.annotations.NonNull;
+
+public class TestdataChainedSimpleVarConstraintProvider implements ConstraintProvider {
+    @Override
+    public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory constraintFactory) {
+        return new Constraint[] {
+                constraintFactory.forEach(TestdataChainedSimpleVarValue.class)
+                        .filter(entity -> !(entity instanceof TestdataChainedSimpleVarEntity))
+                        .penalize(SimpleScore.ONE, value -> value.cumulativeDurationInDays * value.cumulativeDurationInDays)
+                        .asConstraint("Minimize cumulative duration in days product")
+        };
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_chained/TestdataChainedSimpleVarEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_chained/TestdataChainedSimpleVarEntity.java
@@ -1,0 +1,46 @@
+package ai.timefold.solver.core.testdomain.declarative.simple_chained;
+
+import java.time.Duration;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariableGraphType;
+
+@PlanningEntity
+public class TestdataChainedSimpleVarEntity extends TestdataChainedSimpleVarValue {
+    String id;
+
+    @PlanningVariable(graphType = PlanningVariableGraphType.CHAINED)
+    TestdataChainedSimpleVarValue previous;
+
+    public TestdataChainedSimpleVarEntity() {
+    }
+
+    public TestdataChainedSimpleVarEntity(String id, Duration duration) {
+        super(id, duration);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public TestdataChainedSimpleVarValue getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(TestdataChainedSimpleVarValue previous) {
+        this.previous = previous;
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataChainedSimpleVarEntity{" +
+                "id=" + id +
+                ", previous=" + previous +
+                '}';
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_chained/TestdataChainedSimpleVarSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_chained/TestdataChainedSimpleVarSolution.java
@@ -1,0 +1,75 @@
+package ai.timefold.solver.core.testdomain.declarative.simple_chained;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+@PlanningSolution
+public class TestdataChainedSimpleVarSolution {
+
+    public static SolutionDescriptor<TestdataChainedSimpleVarSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(EnumSet.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
+                TestdataChainedSimpleVarSolution.class, TestdataChainedSimpleVarEntity.class,
+                TestdataChainedSimpleVarValue.class);
+    }
+
+    @PlanningEntityCollectionProperty
+    List<TestdataChainedSimpleVarEntity> entities;
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataChainedSimpleVarValue> values;
+
+    @PlanningScore
+    SimpleScore score;
+
+    public TestdataChainedSimpleVarSolution() {
+    }
+
+    public TestdataChainedSimpleVarSolution(List<TestdataChainedSimpleVarEntity> entities,
+            List<TestdataChainedSimpleVarValue> values) {
+        this.values = values;
+        this.entities = entities;
+    }
+
+    public List<TestdataChainedSimpleVarValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataChainedSimpleVarValue> values) {
+        this.values = values;
+    }
+
+    public List<TestdataChainedSimpleVarEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(
+            List<TestdataChainedSimpleVarEntity> entities) {
+        this.entities = entities;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataChainedSimpleVarSolution{" +
+                "entities=" + entities +
+                ", values=" + values +
+                ", score=" + score +
+                '}';
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_chained/TestdataChainedSimpleVarValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_chained/TestdataChainedSimpleVarValue.java
@@ -1,0 +1,59 @@
+package ai.timefold.solver.core.testdomain.declarative.simple_chained;
+
+import java.time.Duration;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+
+@PlanningEntity
+public class TestdataChainedSimpleVarValue {
+    String id;
+
+    @InverseRelationShadowVariable(sourceVariableName = "previous")
+    TestdataChainedSimpleVarEntity next;
+
+    Duration duration;
+
+    @ShadowVariable(supplierName = "updateCumulativeDurationInDays")
+    int cumulativeDurationInDays;
+
+    public TestdataChainedSimpleVarValue() {
+    }
+
+    public TestdataChainedSimpleVarValue(String id, Duration duration) {
+        this.id = id;
+        this.duration = duration;
+        this.cumulativeDurationInDays = (int) duration.toDays();
+    }
+
+    public TestdataChainedSimpleVarEntity getNext() {
+        return next;
+    }
+
+    public void setNext(TestdataChainedSimpleVarEntity next) {
+        this.next = next;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Duration duration) {
+        this.duration = duration;
+    }
+
+    public int getCumulativeDurationInDays() {
+        return cumulativeDurationInDays;
+    }
+
+    @ShadowSources("next.cumulativeDurationInDays")
+    public int updateCumulativeDurationInDays() {
+        if (next == null) {
+            return (int) duration.toDays();
+        } else {
+            return next.getCumulativeDurationInDays() + (int) duration.toDays();
+        }
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_list/TestdataDeclarativeSimpleListConstraintProvider.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_list/TestdataDeclarativeSimpleListConstraintProvider.java
@@ -1,0 +1,20 @@
+package ai.timefold.solver.core.testdomain.declarative.simple_list;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+
+import org.jspecify.annotations.NonNull;
+
+public class TestdataDeclarativeSimpleListConstraintProvider implements ConstraintProvider {
+    @Override
+    public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory constraintFactory) {
+        return new Constraint[] {
+                constraintFactory.forEach(TestdataDeclarativeSimpleListValue.class)
+                        .penalize(SimpleScore.ONE,
+                                value -> value.endTime)
+                        .asConstraint("Minimize end time")
+        };
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_list/TestdataDeclarativeSimpleListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_list/TestdataDeclarativeSimpleListEntity.java
@@ -1,0 +1,53 @@
+package ai.timefold.solver.core.testdomain.declarative.simple_list;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+
+@PlanningEntity
+public class TestdataDeclarativeSimpleListEntity extends TestdataObject {
+    @PlanningListVariable
+    List<TestdataDeclarativeSimpleListValue> values;
+
+    int position;
+    int startTime;
+
+    public TestdataDeclarativeSimpleListEntity() {
+        this.values = new ArrayList<>();
+    }
+
+    public TestdataDeclarativeSimpleListEntity(String code, int position, int startTime) {
+        super(code);
+        this.values = new ArrayList<>();
+        this.position = position;
+        this.startTime = startTime;
+    }
+
+    public List<TestdataDeclarativeSimpleListValue> getValues() {
+        return values;
+    }
+
+    public void setValues(
+            List<TestdataDeclarativeSimpleListValue> values) {
+        this.values = values;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public int getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(int startTime) {
+        this.startTime = startTime;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_list/TestdataDeclarativeSimpleListSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_list/TestdataDeclarativeSimpleListSolution.java
@@ -1,0 +1,67 @@
+package ai.timefold.solver.core.testdomain.declarative.simple_list;
+
+import java.util.List;
+import java.util.Set;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+@PlanningSolution
+public class TestdataDeclarativeSimpleListSolution {
+    public static SolutionDescriptor<TestdataDeclarativeSimpleListSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(Set.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
+                TestdataDeclarativeSimpleListSolution.class,
+                TestdataDeclarativeSimpleListEntity.class,
+                TestdataDeclarativeSimpleListValue.class);
+    }
+
+    @PlanningEntityCollectionProperty
+    List<TestdataDeclarativeSimpleListEntity> entityList;
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataDeclarativeSimpleListValue> valueList;
+
+    @PlanningScore
+    SimpleScore score;
+
+    public TestdataDeclarativeSimpleListSolution() {
+    }
+
+    public TestdataDeclarativeSimpleListSolution(List<TestdataDeclarativeSimpleListEntity> entityList,
+            List<TestdataDeclarativeSimpleListValue> valueList) {
+        this.entityList = entityList;
+        this.valueList = valueList;
+    }
+
+    public List<TestdataDeclarativeSimpleListEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(
+            List<TestdataDeclarativeSimpleListEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public List<TestdataDeclarativeSimpleListValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(
+            List<TestdataDeclarativeSimpleListValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_list/TestdataDeclarativeSimpleListValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/simple_list/TestdataDeclarativeSimpleListValue.java
@@ -1,0 +1,103 @@
+package ai.timefold.solver.core.testdomain.declarative.simple_list;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+
+@PlanningEntity
+public class TestdataDeclarativeSimpleListValue extends TestdataObject {
+    int position;
+    int duration;
+
+    @PreviousElementShadowVariable(sourceVariableName = "values")
+    TestdataDeclarativeSimpleListValue previous;
+
+    @InverseRelationShadowVariable(sourceVariableName = "values")
+    TestdataDeclarativeSimpleListEntity entity;
+
+    @ShadowVariable(supplierName = "startTimeSupplier")
+    Integer startTime;
+
+    @ShadowVariable(supplierName = "endTimeSupplier")
+    Integer endTime;
+
+    public TestdataDeclarativeSimpleListValue() {
+    }
+
+    public TestdataDeclarativeSimpleListValue(String code, int position, int duration) {
+        super(code);
+        this.position = position;
+        this.duration = duration;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+
+    public void setDuration(int duration) {
+        this.duration = duration;
+    }
+
+    public TestdataDeclarativeSimpleListValue getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(TestdataDeclarativeSimpleListValue previous) {
+        this.previous = previous;
+    }
+
+    public TestdataDeclarativeSimpleListEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataDeclarativeSimpleListEntity entity) {
+        this.entity = entity;
+    }
+
+    public Integer getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Integer startTime) {
+        this.startTime = startTime;
+    }
+
+    public Integer getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Integer endTime) {
+        this.endTime = endTime;
+    }
+
+    @ShadowSources({ "entity", "previous.endTime" })
+    public Integer startTimeSupplier() {
+        if (entity == null) {
+            return null;
+        }
+        if (previous == null) {
+            return entity.startTime + Math.abs(position - entity.position);
+        }
+        return previous.endTime + Math.abs(position - previous.position);
+    }
+
+    @ShadowSources("startTime")
+    public Integer endTimeSupplier() {
+        if (startTime == null) {
+            return null;
+        }
+        return startTime + duration;
+    }
+
+}


### PR DESCRIPTION
- If only one entity has declarative variables, and all sources are either of the form "previous.*", "undirectional" or "declarative", then create a cascading updater using next to get successor and (index, id(entity)) for the initial sort.
- If only one entity has declarative variables, and all sources are either of the form "next.*", "undirectional" or "declarative", then create a cascading updater using previous to get successor and (-index, id(entity)) for the initial sort.
- If there are no dynamic edges, use a fixed topological order for each variable.
- Otherwise use the current approach.
    
Undirectional mean variables that don't create edges in the graph (such as accessing a fact on the inverse or genuine variables).