### PR TITLE
fix: process each entity only once and in topological order

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
@@ -18,6 +18,7 @@ import org.jspecify.annotations.Nullable;
 
 public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet_> implements VariableReferenceGraph
         permits DefaultVariableReferenceGraph, FixedVariableReferenceGraph {
+
     // These structures are immutable.
     protected final List<EntityVariablePair<Solution_>> instanceList;
     protected final Map<VariableMetaModel<?, ?, ?>, Map<Object, EntityVariablePair<Solution_>>> variableReferenceToInstanceMap;

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -41,7 +41,6 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         this.graphCreator = graphCreator;
     }
 
-    @SuppressWarnings("unchecked")
     public static <Solution_> VariableReferenceGraph buildGraph(
             SolutionDescriptor<Solution_> solutionDescriptor,
             VariableReferenceGraphBuilder<Solution_> variableReferenceGraphBuilder, Object[] entities,
@@ -76,7 +75,6 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         var topologicalSorter =
                 getTopologicalSorter(solutionDescriptor,
                         Objects.requireNonNull(changedVariableNotifier.innerScoreDirector()),
-                        Objects.requireNonNull(graphStructureAndDirection.parentMetaModel()),
                         Objects.requireNonNull(graphStructureAndDirection.direction()));
 
         return new SingleDirectionalParentVariableReferenceGraph<>(sortedDeclarativeVariables,
@@ -118,9 +116,8 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         return sortedDeclarativeVariables;
     }
 
-    private static <Solution_> TopologicalSorter getTopologicalSorter(
-            SolutionDescriptor<Solution_> solutionDescriptor, InnerScoreDirector<Solution_, ?> scoreDirector,
-            VariableMetaModel<?, ?, ?> parentMetaModel, ParentVariableType parentVariableType) {
+    private static <Solution_> TopologicalSorter getTopologicalSorter(SolutionDescriptor<Solution_> solutionDescriptor,
+            InnerScoreDirector<Solution_, ?> scoreDirector, ParentVariableType parentVariableType) {
         return switch (parentVariableType) {
             case PREVIOUS -> {
                 var listStateSupply = scoreDirector.getListVariableStateSupply(solutionDescriptor.getListVariableDescriptor());
@@ -149,7 +146,7 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         var variableIdToUpdater = new HashMap<VariableMetaModel<?, ?, ?>, VariableUpdaterInfo<Solution_>>();
 
         // Create graph node for each entity/declarative shadow variable pair.
-        // Maps a variable id to it source aliases;
+        // Maps a variable id to its source aliases;
         // For instance, "previousVisit.startTime" is a source alias of "startTime"
         // One way to view this concept is "previousVisit.startTime" is a pointer
         // to "startTime" of some visit, and thus alias it.

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -9,8 +9,7 @@ import java.util.function.IntFunction;
 
 import org.jspecify.annotations.NonNull;
 
-final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableReferenceGraph<Solution_, BitSet>
-        implements VariableReferenceGraph {
+final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableReferenceGraph<Solution_, BitSet> {
     // These structures are mutable.
     private final Consumer<BitSet> affectedEntitiesUpdater;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -8,8 +8,7 @@ import java.util.function.IntFunction;
 import org.jspecify.annotations.NonNull;
 
 public final class FixedVariableReferenceGraph<Solution_>
-        extends AbstractVariableReferenceGraph<Solution_, PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder>>
-        implements VariableReferenceGraph {
+        extends AbstractVariableReferenceGraph<Solution_, PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder>> {
     // These are immutable
     private final ChangedVariableNotifier<Solution_> changedVariableNotifier;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
@@ -80,10 +80,12 @@ public enum GraphStructure {
                     }
                     // The group variable is unused/always empty
                 }
-                case INDIRECT, INVERSE, VARIABLE -> {
+                case INDIRECT, INVERSE, VARIABLE, CHAINED_NEXT -> {
+                    // CHAINED_NEXT has a complex comparator function;
+                    // so use ARBITRARY despite the fact it can be represented using SINGLE_DIRECTIONAL_PARENT
                     return new GraphStructureAndDirection(ARBITRARY, null, null);
                 }
-                case NEXT, PREVIOUS, CHAINED_NEXT -> {
+                case NEXT, PREVIOUS -> {
                     if (parentMetaModel == null) {
                         parentMetaModel = variableSource.variableSourceReferences().get(0).variableMetaModel();
                         directionalType = parentVariableType;

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
@@ -6,7 +6,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.UnaryOperator;
@@ -14,6 +13,7 @@ import java.util.function.UnaryOperator;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 public final class SingleDirectionalParentVariableReferenceGraph<Solution_> implements VariableReferenceGraph {
+
     private final Set<VariableMetaModel<?, ?, ?>> monitoredSourceVariableSet;
     private final VariableUpdaterInfo<Solution_>[] sortedVariableUpdaterInfos;
     private final UnaryOperator<Object> successorFunction;
@@ -79,7 +79,7 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
     public void updateChanged() {
         isUpdating = true;
         changedEntities.sort(topologicalOrderComparator);
-        Map<Object, Object> processed = new IdentityHashMap<>();
+        var processed = new IdentityHashMap<>();
         for (var changedEntity : changedEntities) {
             var key = keyFunction.apply(changedEntity);
             var lastProcessed = processed.get(key);

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalSorter.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalSorter.java
@@ -1,0 +1,13 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import java.util.Comparator;
+import java.util.function.UnaryOperator;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+public record TopologicalSorter(UnaryOperator<@Nullable Object> successor,
+        Comparator<Object> comparator,
+        UnaryOperator<Object> key) {
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -3,8 +3,7 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 public sealed interface VariableReferenceGraph
-        permits AbstractVariableReferenceGraph, DefaultVariableReferenceGraph, EmptyVariableReferenceGraph,
-        FixedVariableReferenceGraph, SingleDirectionalParentVariableReferenceGraph {
+        permits AbstractVariableReferenceGraph, EmptyVariableReferenceGraph, SingleDirectionalParentVariableReferenceGraph {
 
     void updateChanged();
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
@@ -70,12 +70,7 @@ public final class VariableReferenceGraphBuilder<Solution_> {
                 .add(consumer);
     }
 
-    @SuppressWarnings("unchecked")
     public VariableReferenceGraph build(IntFunction<TopologicalOrderGraph> graphCreator) {
-        // TODO empty shows up in VRP example when using it as CVRP, not CVRPTW
-        //  In that case, TimeWindowedCustomer does not exist
-        //  and therefore Customer has no shadow variable.
-        //  Surely there has to be an earlier way to catch this?
         if (instanceList.isEmpty()) {
             return EmptyVariableReferenceGraph.INSTANCE;
         }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
@@ -32,8 +32,7 @@ class GraphStructureTest {
     void simpleChainedStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataChainedSimpleVarSolution.buildSolutionDescriptor()))
-                .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
-                .hasFieldOrPropertyWithValue("direction", ParentVariableType.CHAINED_NEXT);
+                .hasFieldOrPropertyWithValue("structure", ARBITRARY);
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraphTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraphTest.java
@@ -15,8 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 class SingleDirectionalParentVariableReferenceGraphTest {
+
     @Test
-    public void supplierMethodsAreOnlyCalledOnce() {
+    void supplierMethodsAreOnlyCalledOnce() {
         var solutionDescriptor = TestdataCountingSolution.buildSolutionDescriptor();
         var graphStructureAndDirection = GraphStructure.determineGraphStructure(solutionDescriptor);
 
@@ -123,4 +124,5 @@ class SingleDirectionalParentVariableReferenceGraphTest {
         assertThat(value4.getCount()).isEqualTo(3);
         assertThat(value5.getCount()).isZero();
     }
+
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraphTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraphTest.java
@@ -1,0 +1,126 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.List;
+
+import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
+import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.testdomain.declarative.counting.TestdataCountingEntity;
+import ai.timefold.solver.core.testdomain.declarative.counting.TestdataCountingSolution;
+import ai.timefold.solver.core.testdomain.declarative.counting.TestdataCountingValue;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class SingleDirectionalParentVariableReferenceGraphTest {
+    @Test
+    public void supplierMethodsAreOnlyCalledOnce() {
+        var solutionDescriptor = TestdataCountingSolution.buildSolutionDescriptor();
+        var graphStructureAndDirection = GraphStructure.determineGraphStructure(solutionDescriptor);
+
+        var entity1 = new TestdataCountingEntity("e1");
+        var entity2 = new TestdataCountingEntity("e2");
+
+        var value1 = new TestdataCountingValue("v1");
+        var value2 = new TestdataCountingValue("v2");
+        var value3 = new TestdataCountingValue("v3");
+        var value4 = new TestdataCountingValue("v4");
+        var value5 = new TestdataCountingValue("v5");
+
+        var scoreDirector = Mockito.mock(InnerScoreDirector.class);
+        var listStateSupply = Mockito.mock(ListVariableStateSupply.class);
+        Mockito.when(scoreDirector.getListVariableStateSupply(Mockito.any()))
+                .thenReturn(listStateSupply);
+
+        value1.setEntity(entity1);
+        value1.setPrevious(null);
+        Mockito.when(listStateSupply.getIndex(value1)).thenReturn(0);
+        Mockito.when(listStateSupply.getNextElement(value1)).thenReturn(null);
+        Mockito.when(listStateSupply.getInverseSingleton(value1)).thenReturn(entity1);
+
+        value2.setEntity(entity2);
+        value2.setPrevious(null);
+        Mockito.when(listStateSupply.getIndex(value2)).thenReturn(0);
+        Mockito.when(listStateSupply.getNextElement(value2)).thenReturn(value3);
+        Mockito.when(listStateSupply.getInverseSingleton(value2)).thenReturn(entity2);
+
+        value3.setEntity(entity2);
+        value3.setPrevious(value2);
+        Mockito.when(listStateSupply.getIndex(value3)).thenReturn(1);
+        Mockito.when(listStateSupply.getNextElement(value3)).thenReturn(value4);
+        Mockito.when(listStateSupply.getInverseSingleton(value3)).thenReturn(entity2);
+
+        value4.setEntity(entity2);
+        value4.setPrevious(value3);
+        Mockito.when(listStateSupply.getIndex(value4)).thenReturn(2);
+        Mockito.when(listStateSupply.getNextElement(value4)).thenReturn(null);
+        Mockito.when(listStateSupply.getInverseSingleton(value4)).thenReturn(entity2);
+
+        value5.setEntity(null);
+        value5.setPrevious(null);
+        Mockito.when(listStateSupply.getIndex(value5)).thenReturn(-1);
+        Mockito.when(listStateSupply.getNextElement(value5)).thenReturn(null);
+        Mockito.when(listStateSupply.getInverseSingleton(value5)).thenReturn(null);
+
+        var values = List.of(value1, value2, value3, value4, value5);
+
+        @SuppressWarnings("unchecked")
+        var graph = DefaultShadowVariableSessionFactory.buildSingleDirectionalParentGraph(solutionDescriptor,
+                ChangedVariableNotifier.of(scoreDirector),
+                graphStructureAndDirection,
+                new Object[] { entity1, entity2, value5, value4, value3, value2, value1 });
+
+        assertThat(value1.getCount()).isZero();
+        assertThat(value2.getCount()).isZero();
+        assertThat(value3.getCount()).isOne();
+        assertThat(value4.getCount()).isEqualTo(2);
+        assertThat(value5.getCount()).isNull();
+
+        values.forEach(TestdataCountingValue::reset);
+        Mockito.reset(listStateSupply);
+
+        value2.setPrevious(value3);
+        value3.setPrevious(value5);
+        value5.setEntity(entity2);
+        value4.setPrevious(value2);
+
+        Mockito.when(listStateSupply.getIndex(value1)).thenReturn(0);
+        Mockito.when(listStateSupply.getNextElement(value1)).thenReturn(null);
+        Mockito.when(listStateSupply.getInverseSingleton(value1)).thenReturn(entity1);
+
+        Mockito.when(listStateSupply.getIndex(value5)).thenReturn(0);
+        Mockito.when(listStateSupply.getNextElement(value5)).thenReturn(value3);
+        Mockito.when(listStateSupply.getInverseSingleton(value5)).thenReturn(entity2);
+
+        Mockito.when(listStateSupply.getIndex(value3)).thenReturn(1);
+        Mockito.when(listStateSupply.getNextElement(value3)).thenReturn(value2);
+        Mockito.when(listStateSupply.getInverseSingleton(value3)).thenReturn(entity2);
+
+        Mockito.when(listStateSupply.getIndex(value2)).thenReturn(2);
+        Mockito.when(listStateSupply.getNextElement(value2)).thenReturn(value4);
+        Mockito.when(listStateSupply.getInverseSingleton(value2)).thenReturn(entity2);
+
+        Mockito.when(listStateSupply.getIndex(value4)).thenReturn(3);
+        Mockito.when(listStateSupply.getNextElement(value4)).thenReturn(null);
+        Mockito.when(listStateSupply.getInverseSingleton(value4)).thenReturn(entity2);
+
+        var previousVariableMetamodel =
+                solutionDescriptor.getMetaModel().entity(TestdataCountingValue.class).variable("previous");
+        var entityVariableMetamodel = solutionDescriptor.getMetaModel().entity(TestdataCountingValue.class).variable("entity");
+
+        graph.afterVariableChanged(previousVariableMetamodel, value2);
+        graph.afterVariableChanged(previousVariableMetamodel, value3);
+        graph.afterVariableChanged(entityVariableMetamodel, value5);
+        graph.afterVariableChanged(previousVariableMetamodel, value4);
+
+        assertThatCode(graph::updateChanged).doesNotThrowAnyException();
+
+        assertThat(value1.getCount()).isZero();
+        assertThat(value2.getCount()).isEqualTo(2);
+        assertThat(value3.getCount()).isOne();
+        assertThat(value4.getCount()).isEqualTo(3);
+        assertThat(value5.getCount()).isZero();
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/counting/TestdataCountingEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/counting/TestdataCountingEntity.java
@@ -1,0 +1,31 @@
+package ai.timefold.solver.core.testdomain.declarative.counting;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+
+@PlanningEntity
+public class TestdataCountingEntity extends TestdataObject {
+    @PlanningListVariable
+    List<TestdataCountingValue> values;
+
+    public TestdataCountingEntity() {
+        values = new ArrayList<>();
+    }
+
+    public TestdataCountingEntity(String code) {
+        super(code);
+        values = new ArrayList<>();
+    }
+
+    public List<TestdataCountingValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataCountingValue> values) {
+        this.values = values;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/counting/TestdataCountingSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/counting/TestdataCountingSolution.java
@@ -1,0 +1,64 @@
+package ai.timefold.solver.core.testdomain.declarative.counting;
+
+import java.util.List;
+import java.util.Set;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+
+@PlanningSolution
+public class TestdataCountingSolution extends TestdataObject {
+    public static SolutionDescriptor<TestdataCountingSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(Set.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
+                TestdataCountingSolution.class, TestdataCountingEntity.class, TestdataCountingValue.class);
+    }
+
+    @PlanningEntityCollectionProperty
+    List<TestdataCountingEntity> entities;
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataCountingValue> values;
+
+    @PlanningScore
+    SimpleScore score;
+
+    public TestdataCountingSolution() {
+    }
+
+    public TestdataCountingSolution(String code, List<TestdataCountingEntity> entities, List<TestdataCountingValue> values) {
+        super(code);
+        this.entities = entities;
+        this.values = values;
+    }
+
+    public List<TestdataCountingEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(List<TestdataCountingEntity> entities) {
+        this.entities = entities;
+    }
+
+    public List<TestdataCountingValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataCountingValue> values) {
+        this.values = values;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/counting/TestdataCountingValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/counting/TestdataCountingValue.java
@@ -1,0 +1,73 @@
+package ai.timefold.solver.core.testdomain.declarative.counting;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+
+@PlanningEntity
+public class TestdataCountingValue extends TestdataObject {
+    @PreviousElementShadowVariable(sourceVariableName = "values")
+    TestdataCountingValue previous;
+
+    @InverseRelationShadowVariable(sourceVariableName = "values")
+    TestdataCountingEntity entity;
+
+    @ShadowVariable(supplierName = "countSupplier")
+    Integer count;
+
+    int calledCount = 0;
+
+    public TestdataCountingValue() {
+    }
+
+    public TestdataCountingValue(String code) {
+        super(code);
+    }
+
+    public TestdataCountingValue getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(TestdataCountingValue previous) {
+        this.previous = previous;
+    }
+
+    public TestdataCountingEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataCountingEntity entity) {
+        this.entity = entity;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    @ShadowSources({ "previous.count", "entity" })
+    public Integer countSupplier() {
+        if (calledCount != 0) {
+            throw new IllegalStateException("Supplier for entity %s was already called."
+                    .formatted(entity));
+        }
+        calledCount++;
+        if (entity == null) {
+            return null;
+        }
+        if (previous == null) {
+            return 0;
+        }
+        return previous.count + 1;
+    }
+
+    public void reset() {
+        calledCount = 0;
+    }
+}


### PR DESCRIPTION
Previously, the code relied on eventually consistency to avoid collections (that is, sometimes suppliers will be called with stale data, but will always eventually be called with correct data).
Now, an initial sort is done to ensure no data is stale, and a map and comparator are utilized to prevent unnecessary computations.