### PR TITLE
chore: declare version of JFreeChart

### DIFF
--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -27,6 +27,7 @@
     <version.org.assertj>3.27.3</version.org.assertj>
     <version.org.awaitility>4.3.0</version.org.awaitility>
     <version.org.freemarker>2.3.34</version.org.freemarker>
+    <version.org.jfree.jfreechart>1.5.6</version.org.jfree.jfreechart>
     <version.org.jspecify>1.0.0</version.org.jspecify>
     <version.org.junit.jupiter>5.13.1</version.org.junit.jupiter>
     <version.org.openrewrite.recipe>3.9.0</version.org.openrewrite.recipe>


### PR DESCRIPTION
For some reason, it was missing.
(Detected by Maven 4.)