### PR TITLE
perf: Use a single node to represent multiple shadow variables in graphs

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
@@ -96,7 +96,7 @@ final class AffectedEntitiesUpdater<Solution_>
         for (var node : entityVariablePairFunction.apply(affectedEntity)) {
             // All variables come from the same entity,
             // therefore all have the same looped marker.
-            shadowVariableLoopedDescriptor = node.variableReferences()[0].shadowVariableLoopedDescriptor();
+            shadowVariableLoopedDescriptor = node.variableReferences().get(0).shadowVariableLoopedDescriptor();
             if (graph.isLooped(loopedTracker, node.graphNodeId())) {
                 isEntityLooped = true;
                 break;
@@ -117,12 +117,12 @@ final class AffectedEntitiesUpdater<Solution_>
     private boolean updateEntityShadowVariables(EntityVariablePair<Solution_> entityVariable, boolean isLooped) {
         var entity = entityVariable.entity();
         var shadowVariableReferences = entityVariable.variableReferences();
-        var loopDescriptor = shadowVariableReferences[0].shadowVariableLoopedDescriptor();
+        var loopDescriptor = shadowVariableReferences.get(0).shadowVariableLoopedDescriptor();
         var anyChanged = false;
 
         if (loopDescriptor != null) {
-            var oldLooped = (boolean) loopDescriptor.getValue(entity);
-            if (oldLooped != isLooped) {
+            var oldLooped = loopDescriptor.getValue(entity);
+            if (!Objects.equals(oldLooped, isLooped)) {
                 // Loop status change; add to affected entities
                 affectedEntities.add(entityVariable);
                 anyChanged = true;
@@ -130,14 +130,14 @@ final class AffectedEntitiesUpdater<Solution_>
         }
 
         for (var shadowVariableReference : shadowVariableReferences) {
-            anyChanged |= updateShadowVariable(entityVariable, isLooped, shadowVariableReference, entity, anyChanged);
+            anyChanged |= updateShadowVariable(entityVariable, isLooped, shadowVariableReference, entity);
         }
 
         return anyChanged;
     }
 
     private boolean updateShadowVariable(EntityVariablePair<Solution_> entityVariable, boolean isLooped,
-            VariableUpdaterInfo<Solution_> shadowVariableReference, Object entity, boolean anyChanged) {
+            VariableUpdaterInfo<Solution_> shadowVariableReference, Object entity) {
         var oldValue = shadowVariableReference.memberAccessor().executeGetter(entity);
         if (isLooped) {
             if (oldValue != null) {
@@ -180,7 +180,7 @@ final class AffectedEntitiesUpdater<Solution_>
         }
 
         public void add(EntityVariablePair<Solution_> shadowVariable) {
-            var shadowVariableLoopedDescriptor = shadowVariable.variableReferences()[0].shadowVariableLoopedDescriptor();
+            var shadowVariableLoopedDescriptor = shadowVariable.variableReferences().get(0).shadowVariableLoopedDescriptor();
             if (shadowVariableLoopedDescriptor == null) {
                 return;
             }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EntityVariablePair.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EntityVariablePair.java
@@ -1,11 +1,11 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public record EntityVariablePair<Solution_>(Object entity, VariableUpdaterInfo<Solution_>[] variableReferences,
+public record EntityVariablePair<Solution_>(Object entity, List<VariableUpdaterInfo<Solution_>> variableReferences,
         int graphNodeId) {
     @Override
     public boolean equals(Object object) {
@@ -21,6 +21,6 @@ public record EntityVariablePair<Solution_>(Object entity, VariableUpdaterInfo<S
 
     @Override
     public String toString() {
-        return entity + ":" + Arrays.stream(variableReferences).map(VariableUpdaterInfo::id).toList();
+        return entity + ":" + variableReferences.stream().map(VariableUpdaterInfo::id).toList();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EntityVariablePair.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EntityVariablePair.java
@@ -1,9 +1,12 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
+import java.util.Arrays;
+
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public record EntityVariablePair<Solution_>(Object entity, VariableUpdaterInfo<Solution_> variableReference, int graphNodeId) {
+public record EntityVariablePair<Solution_>(Object entity, VariableUpdaterInfo<Solution_>[] variableReferences,
+        int graphNodeId) {
     @Override
     public boolean equals(Object object) {
         if (!(object instanceof EntityVariablePair<?> that))
@@ -18,6 +21,6 @@ public record EntityVariablePair<Solution_>(Object entity, VariableUpdaterInfo<S
 
     @Override
     public String toString() {
-        return entity + ":" + variableReference.id();
+        return entity + ":" + Arrays.stream(variableReferences).map(VariableUpdaterInfo::id).toList();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EntityVariableUpdaterLookup.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EntityVariableUpdaterLookup.java
@@ -1,0 +1,74 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import ai.timefold.solver.core.impl.util.MutableReference;
+import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
+
+public class EntityVariableUpdaterLookup<Solution_> {
+    private final Map<VariableMetaModel<?, ?, ?>, Lookup<Solution_>> variableToEntityLookup;
+    private final Supplier<Lookup<Solution_>> entityLookupSupplier;
+    private int nextId = 0;
+
+    private record Lookup<Solution_>(Function<Object, VariableUpdaterInfo<Solution_>[]> getter,
+            BiConsumer<Object, Supplier<VariableUpdaterInfo<Solution_>[]>> setter) {
+        VariableUpdaterInfo<Solution_>[] getUpdaters(Object entity) {
+            return getter.apply(entity);
+        }
+
+        void setUpdaters(Object entity, Supplier<VariableUpdaterInfo<Solution_>[]> updatersSupplier) {
+            setter.accept(entity, updatersSupplier);
+        }
+    }
+
+    private EntityVariableUpdaterLookup(Supplier<Lookup<Solution_>> entityLookupSupplier) {
+        this.variableToEntityLookup = new LinkedHashMap<>();
+        this.entityLookupSupplier = entityLookupSupplier;
+    }
+
+    public static <Solution_> EntityVariableUpdaterLookup<Solution_> entityIndependentLookup() {
+        Supplier<Lookup<Solution_>> lookupSupplier = () -> {
+            var sharedValue = new MutableReference<VariableUpdaterInfo<Solution_>[]>(null);
+            return new Lookup<>(ignored -> sharedValue.getValue(),
+                    (ignored, valueSupplier) -> {
+                        if (sharedValue.getValue() == null) {
+                            sharedValue.setValue(valueSupplier.get());
+                        }
+                    });
+        };
+        return new EntityVariableUpdaterLookup<>(lookupSupplier);
+    }
+
+    public static <Solution_> EntityVariableUpdaterLookup<Solution_> entityDependentLookup() {
+        Supplier<Lookup<Solution_>> lookupSupplier = () -> {
+            var valueMap = new IdentityHashMap<Object, VariableUpdaterInfo<Solution_>[]>();
+            return new Lookup<>(valueMap::get,
+                    (entity, valueSupplier) -> valueMap.computeIfAbsent(entity, ignored -> valueSupplier.get()));
+        };
+        return new EntityVariableUpdaterLookup<>(lookupSupplier);
+    }
+
+    public VariableUpdaterInfo<Solution_>[] getUpdatersForVariableOnEntity(VariableMetaModel<?, ?, ?> variableMetaModel,
+            Object entity) {
+        var entityLookup = variableToEntityLookup.get(variableMetaModel);
+        return entityLookup.getUpdaters(entity);
+    }
+
+    public VariableUpdaterInfo<Solution_>[] computeUpdatersForVariableOnEntity(VariableMetaModel<?, ?, ?> variableMetaModel,
+            Object entity,
+            Supplier<VariableUpdaterInfo<Solution_>[]> updatersSupplier) {
+        var entityLookup = variableToEntityLookup.computeIfAbsent(variableMetaModel, ignored -> entityLookupSupplier.get());
+        entityLookup.setUpdaters(entity, updatersSupplier);
+        return entityLookup.getUpdaters(entity);
+    }
+
+    public int getNextId() {
+        return nextId++;
+    }
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
@@ -64,7 +64,7 @@ public enum GraphStructure {
             return new GraphStructureAndDirection(EMPTY, null, null);
         }
 
-        if (!doesEntitiesUseDeclarativeShadowVariables(entities, declarativeShadowVariableDescriptors)) {
+        if (!doEntitiesUseDeclarativeShadowVariables(declarativeShadowVariableDescriptors, entities)) {
             return new GraphStructureAndDirection(EMPTY, null, null);
         }
 
@@ -109,11 +109,9 @@ public enum GraphStructure {
                     }
                     // The group variable is unused/always empty
                 }
-                case INDIRECT, INVERSE, VARIABLE, CHAINED_NEXT -> {
-                    // CHAINED_NEXT has a complex comparator function;
-                    // so use ARBITRARY despite the fact it can be represented using SINGLE_DIRECTIONAL_PARENT
-                    isArbitrary = true;
-                }
+                // CHAINED_NEXT has a complex comparator function;
+                // so use ARBITRARY despite the fact it can be represented using SINGLE_DIRECTIONAL_PARENT
+                case INDIRECT, INVERSE, VARIABLE, CHAINED_NEXT -> isArbitrary = true;
                 case NEXT, PREVIOUS -> {
                     if (parentMetaModel == null) {
                         parentMetaModel = variableSource.variableSourceReferences().get(0).variableMetaModel();
@@ -140,8 +138,8 @@ public enum GraphStructure {
         }
     }
 
-    private static <Solution_> boolean doesEntitiesUseDeclarativeShadowVariables(Object[] entities,
-            List<DeclarativeShadowVariableDescriptor<Solution_>> declarativeShadowVariableDescriptors) {
+    private static <Solution_> boolean doEntitiesUseDeclarativeShadowVariables(
+            List<DeclarativeShadowVariableDescriptor<Solution_>> declarativeShadowVariableDescriptors, Object... entities) {
         boolean anyDeclarativeEntities = false;
         for (var declarativeShadowVariable : declarativeShadowVariableDescriptors) {
             var entityClass = declarativeShadowVariable.getEntityDescriptor().getEntityClass();

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
@@ -50,6 +50,7 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
             var variableMetaModel = variableDescriptor.getVariableMetaModel();
             var variableUpdaterInfo = new VariableUpdaterInfo<>(
                     variableMetaModel,
+                    updaterIndex,
                     variableDescriptor,
                     loopedDescriptor,
                     variableDescriptor.getMemberAccessor(),

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
@@ -35,8 +35,8 @@ public final class VariableReferenceGraphBuilder<Solution_> {
         isGraphFixed = true;
     }
 
-    public <Entity_> void addVariableReferenceEntity(Entity_ entity, VariableUpdaterInfo<Solution_>[] variableReferences) {
-        var groupId = variableReferences[0].groupId();
+    public <Entity_> void addVariableReferenceEntity(Entity_ entity, List<VariableUpdaterInfo<Solution_>> variableReferences) {
+        var groupId = variableReferences.get(0).groupId();
         var instanceMap = variableGroupIdToInstanceMap.get(groupId);
         var instance = instanceMap == null ? null : instanceMap.get(entity);
         if (instance != null) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
@@ -47,13 +47,13 @@ public final class VariableReferenceGraphBuilder<Solution_> {
             variableGroupIdToInstanceMap.put(groupId, instanceMap);
         }
 
-        for (var variable : variableReferences) {
-            if (!variableReferenceToInstanceMap.containsKey(variable.id())) {
-                variableReferenceToInstanceMap.put(variable.id(), instanceMap);
-            }
-        }
         var node = new EntityVariablePair<>(entity, variableReferences, instanceList.size());
         instanceMap.put(entity, node);
+        for (var variable : variableReferences) {
+            var variableInstanceMap =
+                    variableReferenceToInstanceMap.computeIfAbsent(variable.id(), ignored -> new IdentityHashMap<>());
+            variableInstanceMap.put(entity, node);
+        }
         instanceList.add(node);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
@@ -21,30 +21,38 @@ public final class VariableReferenceGraphBuilder<Solution_> {
     final List<EntityVariablePair<Solution_>> instanceList;
     final Map<EntityVariablePair<Solution_>, List<EntityVariablePair<Solution_>>> fixedEdges;
     final Map<VariableMetaModel<?, ?, ?>, Map<Object, EntityVariablePair<Solution_>>> variableReferenceToInstanceMap;
+    final Map<Integer, Map<Object, EntityVariablePair<Solution_>>> variableGroupIdToInstanceMap;
     boolean isGraphFixed;
 
     public VariableReferenceGraphBuilder(ChangedVariableNotifier<Solution_> changedVariableNotifier) {
         this.changedVariableNotifier = changedVariableNotifier;
         instanceList = new ArrayList<>();
         variableReferenceToInstanceMap = new HashMap<>();
+        variableGroupIdToInstanceMap = new HashMap<>();
         variableReferenceToBeforeProcessor = new HashMap<>();
         variableReferenceToAfterProcessor = new HashMap<>();
         fixedEdges = new HashMap<>();
         isGraphFixed = true;
     }
 
-    public <Entity_> void addVariableReferenceEntity(Entity_ entity, VariableUpdaterInfo<Solution_> variableReference) {
-        var variableId = variableReference.id();
-        var instanceMap = variableReferenceToInstanceMap.get(variableId);
+    public <Entity_> void addVariableReferenceEntity(Entity_ entity, VariableUpdaterInfo<Solution_>[] variableReferences) {
+        var groupId = variableReferences[0].groupId();
+        var instanceMap = variableGroupIdToInstanceMap.get(groupId);
         var instance = instanceMap == null ? null : instanceMap.get(entity);
         if (instance != null) {
             return;
         }
         if (instanceMap == null) {
             instanceMap = new IdentityHashMap<>();
-            variableReferenceToInstanceMap.put(variableId, instanceMap);
+            variableGroupIdToInstanceMap.put(groupId, instanceMap);
         }
-        var node = new EntityVariablePair<>(entity, variableReference, instanceList.size());
+
+        for (var variable : variableReferences) {
+            if (!variableReferenceToInstanceMap.containsKey(variable.id())) {
+                variableReferenceToInstanceMap.put(variable.id(), instanceMap);
+            }
+        }
+        var node = new EntityVariablePair<>(entity, variableReferences, instanceList.size());
         instanceMap.put(entity, node);
         instanceList.add(node);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableUpdaterInfo.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableUpdaterInfo.java
@@ -16,4 +16,9 @@ public record VariableUpdaterInfo<Solution_>(
         @Nullable ShadowVariableLoopedVariableDescriptor<Solution_> shadowVariableLoopedDescriptor,
         MemberAccessor memberAccessor,
         Function<Object, Object> calculator) {
+
+    public VariableUpdaterInfo<Solution_> withGroupId(int groupId) {
+        return new VariableUpdaterInfo<>(id, groupId, variableDescriptor, shadowVariableLoopedDescriptor, memberAccessor,
+                calculator);
+    }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableUpdaterInfo.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableUpdaterInfo.java
@@ -11,6 +11,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public record VariableUpdaterInfo<Solution_>(
         VariableMetaModel<Solution_, ?, ?> id,
+        int groupId,
         DeclarativeShadowVariableDescriptor<Solution_> variableDescriptor,
         @Nullable ShadowVariableLoopedVariableDescriptor<Solution_> shadowVariableLoopedDescriptor,
         MemberAccessor memberAccessor,

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.ARBITRARY;
+import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.ARBITRARY_SINGLE_ENTITY_SINGLE_DIRECTIONAL_PARENT_TYPE;
 import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.EMPTY;
 import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.NO_DYNAMIC_EDGES;
 import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.SINGLE_DIRECTIONAL_PARENT;
@@ -12,35 +13,64 @@ import java.util.List;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 import ai.timefold.solver.core.testdomain.declarative.concurrent.TestdataConcurrentSolution;
 import ai.timefold.solver.core.testdomain.declarative.concurrent.TestdataConcurrentValue;
+import ai.timefold.solver.core.testdomain.declarative.extended.TestdataDeclarativeExtendedBaseValue;
 import ai.timefold.solver.core.testdomain.declarative.extended.TestdataDeclarativeExtendedSolution;
+import ai.timefold.solver.core.testdomain.declarative.extended.TestdataDeclarativeExtendedSubclassValue;
+import ai.timefold.solver.core.testdomain.declarative.follower.TestdataFollowerEntity;
 import ai.timefold.solver.core.testdomain.declarative.follower.TestdataFollowerSolution;
+import ai.timefold.solver.core.testdomain.declarative.multi_directional_parent.TestdataMultiDirectionConcurrentEntity;
+import ai.timefold.solver.core.testdomain.declarative.multi_directional_parent.TestdataMultiDirectionConcurrentSolution;
+import ai.timefold.solver.core.testdomain.declarative.multi_directional_parent.TestdataMultiDirectionConcurrentValue;
+import ai.timefold.solver.core.testdomain.declarative.multi_entity.TestdataMultiEntityDependencyEntity;
+import ai.timefold.solver.core.testdomain.declarative.multi_entity.TestdataMultiEntityDependencySolution;
+import ai.timefold.solver.core.testdomain.declarative.multi_entity.TestdataMultiEntityDependencyValue;
 import ai.timefold.solver.core.testdomain.declarative.simple_chained.TestdataChainedSimpleVarSolution;
+import ai.timefold.solver.core.testdomain.declarative.simple_chained.TestdataChainedSimpleVarValue;
 import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclarativeSimpleListSolution;
+import ai.timefold.solver.core.testdomain.declarative.simple_list.TestdataDeclarativeSimpleListValue;
 
 import org.junit.jupiter.api.Test;
 
 class GraphStructureTest {
     @Test
-    void simpleListStructure() {
+    void emptySimpleListStructure() {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataDeclarativeSimpleListSolution.buildSolutionDescriptor()))
+                .hasFieldOrPropertyWithValue("structure", EMPTY);
+    }
+
+    @Test
+    void simpleListStructure() {
+        var entity = new TestdataDeclarativeSimpleListValue();
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataDeclarativeSimpleListSolution.buildSolutionDescriptor(), entity))
                 .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
                 .hasFieldOrPropertyWithValue("direction", ParentVariableType.PREVIOUS);
     }
 
     @Test
     void simpleChainedStructure() {
+        var entity = new TestdataChainedSimpleVarValue();
         assertThat(GraphStructure.determineGraphStructure(
-                TestdataChainedSimpleVarSolution.buildSolutionDescriptor()))
-                .hasFieldOrPropertyWithValue("structure", ARBITRARY);
+                TestdataChainedSimpleVarSolution.buildSolutionDescriptor(), entity))
+                .hasFieldOrPropertyWithValue("structure", ARBITRARY_SINGLE_ENTITY_SINGLE_DIRECTIONAL_PARENT_TYPE);
     }
 
     @Test
     void extendedSimpleListStructure() {
+        var entity = new TestdataDeclarativeExtendedSubclassValue();
         assertThat(GraphStructure.determineGraphStructure(
-                TestdataDeclarativeExtendedSolution.buildSolutionDescriptor()))
+                TestdataDeclarativeExtendedSolution.buildSolutionDescriptor(), entity))
                 .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
                 .hasFieldOrPropertyWithValue("direction", ParentVariableType.PREVIOUS);
+    }
+
+    @Test
+    void extendedSimpleListStructureWithoutDeclarativeEntities() {
+        var entity = new TestdataDeclarativeExtendedBaseValue();
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataDeclarativeExtendedSolution.buildSolutionDescriptor(), entity))
+                .hasFieldOrPropertyWithValue("structure", EMPTY);
     }
 
     @Test
@@ -64,14 +94,44 @@ class GraphStructureTest {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataConcurrentSolution.buildSolutionDescriptor(),
                 value1, value2))
-                .hasFieldOrPropertyWithValue("structure", ARBITRARY);
+                .hasFieldOrPropertyWithValue("structure", ARBITRARY_SINGLE_ENTITY_SINGLE_DIRECTIONAL_PARENT_TYPE);
     }
 
     @Test
     void followerStructure() {
+        var entity = new TestdataFollowerEntity();
         assertThat(GraphStructure.determineGraphStructure(
-                TestdataFollowerSolution.buildSolutionDescriptor()))
+                TestdataFollowerSolution.buildSolutionDescriptor(), entity))
                 .hasFieldOrPropertyWithValue("structure", NO_DYNAMIC_EDGES);
+    }
+
+    @Test
+    void multiEntity() {
+        var entity = new TestdataMultiEntityDependencyEntity();
+        var value = new TestdataMultiEntityDependencyValue();
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataMultiEntityDependencySolution.buildSolutionDescriptor(), entity, value))
+                .hasFieldOrPropertyWithValue("structure", ARBITRARY);
+    }
+
+    @Test
+    void multiDirectionalParents() {
+        var entity = new TestdataMultiDirectionConcurrentEntity();
+        var value = new TestdataMultiDirectionConcurrentValue();
+        value.setConcurrentValueGroup(List.of(value));
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataMultiDirectionConcurrentSolution.buildSolutionDescriptor(), entity, value))
+                .hasFieldOrPropertyWithValue("structure", ARBITRARY);
+    }
+
+    @Test
+    void multiDirectionalParentsEmptyGroups() {
+        var entity = new TestdataMultiDirectionConcurrentEntity();
+        var value = new TestdataMultiDirectionConcurrentValue();
+        assertThat(GraphStructure.determineGraphStructure(
+                TestdataMultiDirectionConcurrentSolution.buildSolutionDescriptor(), entity, value))
+                .hasFieldOrPropertyWithValue("structure", SINGLE_DIRECTIONAL_PARENT)
+                .hasFieldOrPropertyWithValue("direction", ParentVariableType.PREVIOUS);
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraphTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraphTest.java
@@ -19,8 +19,6 @@ class SingleDirectionalParentVariableReferenceGraphTest {
     @Test
     void supplierMethodsAreOnlyCalledOnce() {
         var solutionDescriptor = TestdataCountingSolution.buildSolutionDescriptor();
-        var graphStructureAndDirection = GraphStructure.determineGraphStructure(solutionDescriptor);
-
         var entity1 = new TestdataCountingEntity("e1");
         var entity2 = new TestdataCountingEntity("e2");
 
@@ -29,6 +27,10 @@ class SingleDirectionalParentVariableReferenceGraphTest {
         var value3 = new TestdataCountingValue("v3");
         var value4 = new TestdataCountingValue("v4");
         var value5 = new TestdataCountingValue("v5");
+
+        var graphStructureAndDirection = GraphStructure.determineGraphStructure(solutionDescriptor,
+                entity1, entity2, value1, value2, value3, value4, value5);
+        assertThat(graphStructureAndDirection.structure()).isEqualTo(GraphStructure.SINGLE_DIRECTIONAL_PARENT);
 
         var scoreDirector = Mockito.mock(InnerScoreDirector.class);
         var listStateSupply = Mockito.mock(ListVariableStateSupply.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -20,6 +21,7 @@ import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 import ai.timefold.solver.core.impl.domain.variable.declarative.DefaultTopologicalOrderGraph;
 import ai.timefold.solver.core.impl.domain.variable.declarative.EntityVariablePair;
 import ai.timefold.solver.core.impl.domain.variable.declarative.TopologicalOrderGraph;
+import ai.timefold.solver.core.impl.domain.variable.declarative.VariableUpdaterInfo;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.inverserelation.ExternalizedSingletonInverseVariableSupply;
 import ai.timefold.solver.core.impl.domain.variable.inverserelation.SingletonInverseVariableDemand;
@@ -164,20 +166,21 @@ class VariableListenerSupportTest {
 
     private static class MockTopologicalOrderGraph extends DefaultTopologicalOrderGraph implements TopologicalOrderGraph {
         Object[] nodeToEntities;
-        VariableMetaModel<?, ?, ?>[] nodeToVariableMetamodel;
+        VariableMetaModel<?, ?, ?>[][] nodeToVariableMetamodel;
 
         public MockTopologicalOrderGraph(int size) {
             super(size);
             nodeToEntities = new Object[size];
-            nodeToVariableMetamodel = new VariableMetaModel[size];
+            nodeToVariableMetamodel = new VariableMetaModel[size][];
         }
 
         @Override
         public <Solution_> void withNodeData(List<EntityVariablePair<Solution_>> nodes) {
             nodeToEntities = nodes.stream().map(EntityVariablePair::entity).toArray(Object[]::new);
             nodeToVariableMetamodel = nodes.stream()
-                    .map(e -> e.variableReference().id())
-                    .toArray(VariableMetaModel[]::new);
+                    .map(e -> Arrays.stream(e.variableReferences()).map(VariableUpdaterInfo::id)
+                            .toArray(VariableMetaModel[]::new))
+                    .toArray(VariableMetaModel[][]::new);
         }
 
         public void addEdge(VariableMetaModel<?, ?, ?> fromId, Object fromEntity, VariableMetaModel<?, ?, ?> toId,
@@ -193,14 +196,16 @@ class VariableListenerSupportTest {
         @Override
         public void addEdge(int fromNode, int toNode) {
             super.addEdge(fromNode, toNode);
-            addEdge(nodeToVariableMetamodel[fromNode], nodeToEntities[fromNode], nodeToVariableMetamodel[toNode],
+            addEdge(nodeToVariableMetamodel[fromNode][nodeToVariableMetamodel[fromNode].length - 1], nodeToEntities[fromNode],
+                    nodeToVariableMetamodel[toNode][0],
                     nodeToEntities[toNode]);
         }
 
         @Override
         public void removeEdge(int fromNode, int toNode) {
             super.removeEdge(fromNode, toNode);
-            removeEdge(nodeToVariableMetamodel[fromNode], nodeToEntities[fromNode], nodeToVariableMetamodel[toNode],
+            removeEdge(nodeToVariableMetamodel[fromNode][nodeToVariableMetamodel[fromNode].length - 1],
+                    nodeToEntities[fromNode], nodeToVariableMetamodel[toNode][0],
                     nodeToEntities[toNode]);
         }
     }
@@ -285,7 +290,7 @@ class VariableListenerSupportTest {
 
         for (var visit : solution.getValues()) {
             verifyAddEdge.accept(serviceReadyTime, visit, serviceStartTime, visit);
-            verifyAddEdge.accept(serviceStartTime, visit, serviceFinishTime, visit);
+            // serviceStartTime and serviceFinishTime are in the same group, so no edge between them!
 
             if (visit.getPreviousValue() != null) {
                 verifyAddEdge.accept(serviceFinishTime, visit.getPreviousValue(), serviceReadyTime, visit);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -178,7 +177,8 @@ class VariableListenerSupportTest {
         public <Solution_> void withNodeData(List<EntityVariablePair<Solution_>> nodes) {
             nodeToEntities = nodes.stream().map(EntityVariablePair::entity).toArray(Object[]::new);
             nodeToVariableMetamodel = nodes.stream()
-                    .map(e -> Arrays.stream(e.variableReferences()).map(VariableUpdaterInfo::id)
+                    .map(e -> e.variableReferences().stream()
+                            .map(VariableUpdaterInfo::id)
                             .toArray(VariableMetaModel[]::new))
                     .toArray(VariableMetaModel[][]::new);
         }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
@@ -289,8 +289,12 @@ class VariableListenerSupportTest {
                 };
 
         for (var visit : solution.getValues()) {
-            verifyAddEdge.accept(serviceReadyTime, visit, serviceStartTime, visit);
-            // serviceStartTime and serviceFinishTime are in the same group, so no edge between them!
+
+            // If a visit does not have a concurrent group, all variables of that visit share the same node.
+            if (visit.getConcurrentValueGroup() != null) {
+                // serviceStartTime and serviceFinishTime are in the same group, so no edge between them!
+                verifyAddEdge.accept(serviceReadyTime, visit, serviceStartTime, visit);
+            }
 
             if (visit.getPreviousValue() != null) {
                 verifyAddEdge.accept(serviceFinishTime, visit.getPreviousValue(), serviceReadyTime, visit);

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_directional_parent/TestdataMultiDirectionConcurrentEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_directional_parent/TestdataMultiDirectionConcurrentEntity.java
@@ -1,0 +1,60 @@
+package ai.timefold.solver.core.testdomain.declarative.multi_directional_parent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+
+@PlanningEntity
+public class TestdataMultiDirectionConcurrentEntity {
+    String id;
+
+    @PlanningListVariable
+    List<TestdataMultiDirectionConcurrentValue> values;
+
+    public TestdataMultiDirectionConcurrentEntity() {
+        values = new ArrayList<>();
+    }
+
+    public TestdataMultiDirectionConcurrentEntity(String id) {
+        this.id = id;
+        values = new ArrayList<>();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<TestdataMultiDirectionConcurrentValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataMultiDirectionConcurrentValue> values) {
+        this.values = values;
+    }
+
+    public void updateValueShadows() {
+        TestdataMultiDirectionConcurrentValue previousVisit = null;
+        for (var visit : values) {
+            visit.setEntity(this);
+            visit.setPreviousValue(previousVisit);
+            if (previousVisit != null) {
+                previousVisit.setNextValue(visit);
+            }
+            previousVisit = visit;
+        }
+        if (previousVisit != null) {
+            previousVisit.setNextValue(null);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_directional_parent/TestdataMultiDirectionConcurrentSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_directional_parent/TestdataMultiDirectionConcurrentSolution.java
@@ -1,0 +1,55 @@
+package ai.timefold.solver.core.testdomain.declarative.multi_directional_parent;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+@PlanningSolution
+public class TestdataMultiDirectionConcurrentSolution {
+    public static SolutionDescriptor<TestdataMultiDirectionConcurrentSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(EnumSet.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
+                TestdataMultiDirectionConcurrentSolution.class,
+                TestdataMultiDirectionConcurrentEntity.class, TestdataMultiDirectionConcurrentValue.class);
+    }
+
+    @PlanningEntityCollectionProperty
+    List<TestdataMultiDirectionConcurrentEntity> entities;
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataMultiDirectionConcurrentValue> values;
+
+    @PlanningScore
+    HardSoftScore score;
+
+    public List<TestdataMultiDirectionConcurrentEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(List<TestdataMultiDirectionConcurrentEntity> entities) {
+        this.entities = entities;
+    }
+
+    public List<TestdataMultiDirectionConcurrentValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataMultiDirectionConcurrentValue> values) {
+        this.values = values;
+    }
+
+    public HardSoftScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftScore score) {
+        this.score = score;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_directional_parent/TestdataMultiDirectionConcurrentValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_directional_parent/TestdataMultiDirectionConcurrentValue.java
@@ -1,0 +1,167 @@
+package ai.timefold.solver.core.testdomain.declarative.multi_directional_parent;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.IndexShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.NextElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowVariableLooped;
+
+@PlanningEntity
+public class TestdataMultiDirectionConcurrentValue {
+    public static final LocalDateTime BASE_START_TIME = LocalDate.of(2025, 1, 1).atTime(LocalTime.of(9, 0));
+    String id;
+
+    @InverseRelationShadowVariable(sourceVariableName = "values")
+    TestdataMultiDirectionConcurrentEntity entity;
+
+    @ShadowVariable(supplierName = "serviceReadyTimeUpdater")
+    LocalDateTime serviceReadyTime;
+
+    @ShadowVariable(supplierName = "serviceStartTimeUpdater")
+    LocalDateTime serviceStartTime;
+
+    @ShadowVariable(supplierName = "serviceFinishTimeUpdater")
+    LocalDateTime serviceFinishTime;
+
+    @PreviousElementShadowVariable(sourceVariableName = "values")
+    TestdataMultiDirectionConcurrentValue previousValue;
+
+    @NextElementShadowVariable(sourceVariableName = "values")
+    TestdataMultiDirectionConcurrentValue nextValue;
+
+    @IndexShadowVariable(sourceVariableName = "values")
+    Integer index;
+
+    List<TestdataMultiDirectionConcurrentValue> concurrentValueGroup;
+
+    @ShadowVariableLooped
+    boolean isInvalid;
+
+    public TestdataMultiDirectionConcurrentValue() {
+    }
+
+    public TestdataMultiDirectionConcurrentValue(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public TestdataMultiDirectionConcurrentEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataMultiDirectionConcurrentEntity entity) {
+        this.entity = entity;
+    }
+
+    public TestdataMultiDirectionConcurrentValue getPreviousValue() {
+        return previousValue;
+    }
+
+    public void setPreviousValue(TestdataMultiDirectionConcurrentValue previousValue) {
+        this.previousValue = previousValue;
+    }
+
+    public TestdataMultiDirectionConcurrentValue getNextValue() {
+        return nextValue;
+    }
+
+    public void setNextValue(TestdataMultiDirectionConcurrentValue nextValue) {
+        this.nextValue = nextValue;
+    }
+
+    public Integer getIndex() {
+        return index;
+    }
+
+    public void setIndex(Integer index) {
+        this.index = index;
+    }
+
+    public LocalDateTime getServiceStartTime() {
+        return serviceStartTime;
+    }
+
+    public void setServiceStartTime(LocalDateTime serviceStartTime) {
+        this.serviceStartTime = serviceStartTime;
+    }
+
+    @ShadowSources({ "previousValue.serviceFinishTime", "entity" })
+    public LocalDateTime serviceReadyTimeUpdater() {
+        if (previousValue != null) {
+            return previousValue.serviceFinishTime.plusMinutes(30L);
+        }
+        if (entity != null) {
+            return BASE_START_TIME;
+        }
+        return null;
+    }
+
+    @ShadowSources({ "serviceReadyTime", "concurrentValueGroup[].nextValue" })
+    public LocalDateTime serviceStartTimeUpdater() {
+        if (serviceReadyTime == null) {
+            return null;
+        }
+        var startTime = serviceReadyTime;
+        if (concurrentValueGroup != null) {
+            for (var visit : concurrentValueGroup) {
+                if (visit.serviceReadyTime != null && startTime.isBefore(visit.serviceReadyTime)) {
+                    startTime = visit.serviceReadyTime;
+                }
+            }
+        }
+        return startTime;
+    }
+
+    @ShadowSources("serviceStartTime")
+    public LocalDateTime serviceFinishTimeUpdater() {
+        if (serviceStartTime == null) {
+            return null;
+        }
+        return serviceStartTime.plusMinutes(30L);
+    }
+
+    public LocalDateTime getServiceFinishTime() {
+        return serviceFinishTime;
+    }
+
+    public void setServiceFinishTime(LocalDateTime serviceFinishTime) {
+        this.serviceFinishTime = serviceFinishTime;
+    }
+
+    public List<TestdataMultiDirectionConcurrentValue> getConcurrentValueGroup() {
+        return concurrentValueGroup;
+    }
+
+    public void setConcurrentValueGroup(List<TestdataMultiDirectionConcurrentValue> concurrentValueGroup) {
+        this.concurrentValueGroup = concurrentValueGroup;
+    }
+
+    public boolean isInvalid() {
+        return isInvalid;
+    }
+
+    public void setInvalid(boolean invalid) {
+        isInvalid = invalid;
+    }
+
+    @Override
+    public String toString() {
+        return (previousValue != null) ? previousValue + " -> " + id
+                : (entity != null) ? entity.id + " -> " + id : "null -> " + id;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_entity/TestdataMultiEntityDependencyDelay.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_entity/TestdataMultiEntityDependencyDelay.java
@@ -1,0 +1,4 @@
+package ai.timefold.solver.core.testdomain.declarative.multi_entity;
+
+public record TestdataMultiEntityDependencyDelay(int delay) {
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_entity/TestdataMultiEntityDependencyEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_entity/TestdataMultiEntityDependencyEntity.java
@@ -1,0 +1,75 @@
+package ai.timefold.solver.core.testdomain.declarative.multi_entity;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+
+@PlanningEntity
+public class TestdataMultiEntityDependencyEntity {
+    @PlanningListVariable
+    List<TestdataMultiEntityDependencyValue> values;
+
+    @PlanningVariable
+    TestdataMultiEntityDependencyDelay delay;
+
+    @ShadowVariable(supplierName = "readyTimeSupplier")
+    LocalDateTime readyTime;
+
+    LocalDateTime startTime;
+
+    public TestdataMultiEntityDependencyEntity() {
+        this(LocalDateTime.ofEpochSecond(0L, 0, ZoneOffset.UTC));
+    }
+
+    public TestdataMultiEntityDependencyEntity(LocalDateTime startTime) {
+        this.startTime = startTime;
+        this.values = new ArrayList<>();
+    }
+
+    public List<TestdataMultiEntityDependencyValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataMultiEntityDependencyValue> values) {
+        this.values = values;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getReadyTime() {
+        return readyTime;
+    }
+
+    public void setReadyTime(LocalDateTime readyTime) {
+        this.readyTime = readyTime;
+    }
+
+    @ShadowSources("delay")
+    public LocalDateTime readyTimeSupplier() {
+        if (delay == null) {
+            return null;
+        }
+        return startTime.plusHours(delay.delay());
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataPredecessorEntity{" +
+                "values=" + values +
+                ", startTime=" + startTime +
+                '}';
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_entity/TestdataMultiEntityDependencySolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_entity/TestdataMultiEntityDependencySolution.java
@@ -1,0 +1,94 @@
+package ai.timefold.solver.core.testdomain.declarative.multi_entity;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+@PlanningSolution
+public class TestdataMultiEntityDependencySolution {
+    public static SolutionDescriptor<TestdataMultiEntityDependencySolution> buildDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(Set.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
+                TestdataMultiEntityDependencySolution.class,
+                TestdataMultiEntityDependencyEntity.class,
+                TestdataMultiEntityDependencyValue.class);
+    }
+
+    @PlanningEntityCollectionProperty
+    List<TestdataMultiEntityDependencyEntity> entities;
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataMultiEntityDependencyValue> values;
+
+    @ValueRangeProvider
+    List<TestdataMultiEntityDependencyDelay> delays;
+
+    @PlanningScore
+    HardSoftScore score;
+
+    public TestdataMultiEntityDependencySolution() {
+    }
+
+    public TestdataMultiEntityDependencySolution(List<TestdataMultiEntityDependencyEntity> entities,
+            List<TestdataMultiEntityDependencyValue> values) {
+        this.values = values;
+        this.entities = entities;
+    }
+
+    public static SolutionDescriptor<TestdataMultiEntityDependencySolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(EnumSet.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
+                TestdataMultiEntityDependencySolution.class, TestdataMultiEntityDependencyEntity.class,
+                TestdataMultiEntityDependencyValue.class);
+    }
+
+    public List<TestdataMultiEntityDependencyValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataMultiEntityDependencyValue> values) {
+        this.values = values;
+    }
+
+    public List<TestdataMultiEntityDependencyEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(
+            List<TestdataMultiEntityDependencyEntity> entities) {
+        this.entities = entities;
+    }
+
+    public List<TestdataMultiEntityDependencyDelay> getDelays() {
+        return delays;
+    }
+
+    public void setDelays(
+            List<TestdataMultiEntityDependencyDelay> delays) {
+        this.delays = delays;
+    }
+
+    public HardSoftScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftScore score) {
+        this.score = score;
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataPredecessorSolution{" +
+                "entities=" + entities +
+                ", values=" + values +
+                ", score=" + score +
+                '}';
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_entity/TestdataMultiEntityDependencyValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/multi_entity/TestdataMultiEntityDependencyValue.java
@@ -1,0 +1,140 @@
+package ai.timefold.solver.core.testdomain.declarative.multi_entity;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowVariableLooped;
+
+import org.apache.commons.lang3.ObjectUtils;
+
+@PlanningEntity
+public class TestdataMultiEntityDependencyValue {
+    String id;
+    List<TestdataMultiEntityDependencyValue> dependencies;
+
+    @PreviousElementShadowVariable(sourceVariableName = "values")
+    TestdataMultiEntityDependencyValue previousValue;
+
+    @ShadowVariable(supplierName = "calculateStartTime")
+    LocalDateTime startTime;
+
+    @ShadowVariable(supplierName = "calculateEndTime")
+    LocalDateTime endTime;
+
+    @ShadowVariableLooped
+    boolean isInvalid;
+
+    @InverseRelationShadowVariable(sourceVariableName = "values")
+    TestdataMultiEntityDependencyEntity entity;
+
+    Duration duration;
+
+    public TestdataMultiEntityDependencyValue() {
+    }
+
+    public TestdataMultiEntityDependencyValue(String id, Duration duration) {
+        this(id, duration, null);
+    }
+
+    public TestdataMultiEntityDependencyValue(String id, Duration duration,
+            List<TestdataMultiEntityDependencyValue> dependencies) {
+        this.id = id;
+        this.duration = duration;
+        this.dependencies = dependencies;
+    }
+
+    public List<TestdataMultiEntityDependencyValue> getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(
+            List<TestdataMultiEntityDependencyValue> dependencies) {
+        this.dependencies = dependencies;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    @ShadowSources({ "dependencies[].endTime", "previousValue.endTime", "entity.readyTime" })
+    public LocalDateTime calculateStartTime() {
+        LocalDateTime readyTime;
+        if (previousValue != null) {
+            readyTime = previousValue.endTime;
+        } else if (entity != null) {
+            readyTime = entity.readyTime;
+            if (readyTime == null) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+
+        if (dependencies != null) {
+            for (var dependency : dependencies) {
+                if (dependency.endTime == null) {
+                    return null;
+                }
+                readyTime = ObjectUtils.max(readyTime, dependency.endTime);
+            }
+        }
+        return readyTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    @ShadowSources({ "startTime" })
+    public LocalDateTime calculateEndTime() {
+        if (startTime == null) {
+            return null;
+        }
+        return startTime.plus(duration);
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Duration duration) {
+        this.duration = duration;
+    }
+
+    public boolean isInvalid() {
+        return isInvalid;
+    }
+
+    public void setInvalid(boolean invalid) {
+        isInvalid = invalid;
+    }
+
+    public TestdataMultiEntityDependencyEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataMultiEntityDependencyEntity entity) {
+        this.entity = entity;
+    }
+
+    @Override
+    public String toString() {
+        return id + "{" +
+                "endTime=" + endTime +
+                '}';
+    }
+}


### PR DESCRIPTION
When there is only a single declarative entity and all non-declarative parents go in the same direction (ex: previous), then some variables can share the same node in the graph. In particular, there is a static topological order when only the variables on a single entity is considered, and as long as the next declarative shadow variable does not have any new non-declarative parents (i.e. group), it can be grouped into the same node as the previous one. All nodes share the same node if no groups are used.

Also fixed a bug in the topological sort done to determine variable trigger order when groups are used (previously it added group variables, which caused it to create a cycle and make all topological orders valid).