### PR TITLE
feat: improve error message when a declarative supplier is missing in Quarkus

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
@@ -52,10 +52,10 @@ public class DeclarativeShadowVariableDescriptor<Solution_> extends ShadowVariab
 
         if (method == null) {
             throw new IllegalArgumentException("""
-                    @%s (%s) has a supplierMethod (%s) that does not exist inside its declaring class (%s).
+                    @%s (%s) defines a supplierMethod (%s) that does not exist inside its declaring class (%s).
                     Maybe you misspelled the supplierMethod name?"""
                     .formatted(ShadowVariable.class.getSimpleName(), variableName, methodName,
-                            variableMemberAccessor.getDeclaringClass().getSimpleName()));
+                            variableMemberAccessor.getDeclaringClass().getCanonicalName()));
         }
 
         var shadowVariableUpdater = method.getAnnotation(ShadowSources.class);

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
@@ -51,8 +51,11 @@ public class DeclarativeShadowVariableDescriptor<Solution_> extends ShadowVariab
         var method = ReflectionHelper.getDeclaredMethod(variableMemberAccessor.getDeclaringClass(), methodName);
 
         if (method == null) {
-            throw new IllegalArgumentException("Could not find method named %s on the class %s. Maybe you misspelled it?"
-                    .formatted(methodName, variableMemberAccessor.getDeclaringClass().getSimpleName()));
+            throw new IllegalArgumentException("""
+                    @%s (%s) has a supplierMethod (%s) that does not exist inside its declaring class (%s).
+                    Maybe you misspelled the supplierMethod name?"""
+                    .formatted(ShadowVariable.class.getSimpleName(), variableName, methodName,
+                            variableMemberAccessor.getDeclaringClass().getSimpleName()));
         }
 
         var shadowVariableUpdater = method.getAnnotation(ShadowSources.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -24,6 +24,7 @@ import ai.timefold.solver.core.testdomain.chained.TestdataChainedEntity;
 import ai.timefold.solver.core.testdomain.chained.TestdataChainedSolution;
 import ai.timefold.solver.core.testdomain.collection.TestdataArrayBasedSolution;
 import ai.timefold.solver.core.testdomain.collection.TestdataSetBasedSolution;
+import ai.timefold.solver.core.testdomain.declarative.missing.TestdataDeclarativeMissingSupplierSolution;
 import ai.timefold.solver.core.testdomain.immutable.enumeration.TestdataEnumSolution;
 import ai.timefold.solver.core.testdomain.immutable.record.TestdataRecordSolution;
 import ai.timefold.solver.core.testdomain.inheritance.solution.baseannotated.childnot.TestdataOnlyBaseAnnotatedChildEntity;
@@ -670,5 +671,14 @@ class SolutionDescriptorTest {
                 .hasMessageContaining("with list variables")
                 .hasMessageContaining("on a single planning entity")
                 .hasMessageContaining("is not supported");
+    }
+
+    @Test
+    void missingDeclarativeSupplierMethod() {
+        assertThatCode(TestdataDeclarativeMissingSupplierSolution::buildSolutionDescriptor)
+                .hasMessageContaining("Could not find method named")
+                .hasMessageContaining("calculateEndTime")
+                .hasMessageContaining("on the class TestdataDeclarativeMissingSupplierValue")
+                .hasMessageContaining("Maybe you misspelled it");
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -676,9 +676,9 @@ class SolutionDescriptorTest {
     @Test
     void missingDeclarativeSupplierMethod() {
         assertThatCode(TestdataDeclarativeMissingSupplierSolution::buildSolutionDescriptor)
-                .hasMessageContaining("Could not find method named")
-                .hasMessageContaining("calculateEndTime")
-                .hasMessageContaining("on the class TestdataDeclarativeMissingSupplierValue")
-                .hasMessageContaining("Maybe you misspelled it");
+                .hasMessageContainingAll("@ShadowVariable (endTime)",
+                        "supplierMethod (calculateEndTime) that does not exist",
+                        "inside its declaring class (TestdataDeclarativeMissingSupplierValue).",
+                        "Maybe you misspelled the supplierMethod name?");
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -678,7 +678,7 @@ class SolutionDescriptorTest {
         assertThatCode(TestdataDeclarativeMissingSupplierSolution::buildSolutionDescriptor)
                 .hasMessageContainingAll("@ShadowVariable (endTime)",
                         "supplierMethod (calculateEndTime) that does not exist",
-                        "inside its declaring class (TestdataDeclarativeMissingSupplierValue).",
+                        "inside its declaring class (ai.timefold.solver.core.testdomain.declarative.missing.TestdataDeclarativeMissingSupplierValue).",
                         "Maybe you misspelled the supplierMethod name?");
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/missing/TestdataDeclarativeMissingSupplierEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/missing/TestdataDeclarativeMissingSupplierEntity.java
@@ -1,0 +1,57 @@
+package ai.timefold.solver.core.testdomain.declarative.missing;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+
+@PlanningEntity
+public class TestdataDeclarativeMissingSupplierEntity {
+    String id;
+    @PlanningVariable
+    TestdataDeclarativeMissingSupplierValue value;
+
+    @ShadowVariable(supplierName = "updateDurationInDays")
+    long durationInDays;
+
+    public TestdataDeclarativeMissingSupplierEntity(String id, TestdataDeclarativeMissingSupplierValue value) {
+        this.id = id;
+        this.value = value;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public TestdataDeclarativeMissingSupplierValue getValue() {
+        return value;
+    }
+
+    public void setValue(TestdataDeclarativeMissingSupplierValue value) {
+        this.value = value;
+    }
+
+    @ShadowSources("value")
+    public long updateDurationInDays() {
+        if (value != null) {
+            return value.getDuration().toDays();
+        }
+        return 0;
+    }
+
+    public long getDurationInDays() {
+        return durationInDays;
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataDeclarativeMissingSupplierEntity{" +
+                "id=" + id +
+                ", value=" + value +
+                '}';
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/missing/TestdataDeclarativeMissingSupplierSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/missing/TestdataDeclarativeMissingSupplierSolution.java
@@ -1,0 +1,75 @@
+package ai.timefold.solver.core.testdomain.declarative.missing;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+@PlanningSolution
+public class TestdataDeclarativeMissingSupplierSolution {
+
+    public static SolutionDescriptor<TestdataDeclarativeMissingSupplierSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(EnumSet.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
+                TestdataDeclarativeMissingSupplierSolution.class, TestdataDeclarativeMissingSupplierEntity.class,
+                TestdataDeclarativeMissingSupplierValue.class);
+    }
+
+    @PlanningEntityCollectionProperty
+    List<TestdataDeclarativeMissingSupplierEntity> entities;
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataDeclarativeMissingSupplierValue> values;
+
+    @PlanningScore
+    HardSoftScore score;
+
+    public TestdataDeclarativeMissingSupplierSolution() {
+    }
+
+    public TestdataDeclarativeMissingSupplierSolution(List<TestdataDeclarativeMissingSupplierEntity> entities,
+            List<TestdataDeclarativeMissingSupplierValue> values) {
+        this.values = values;
+        this.entities = entities;
+    }
+
+    public List<TestdataDeclarativeMissingSupplierValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataDeclarativeMissingSupplierValue> values) {
+        this.values = values;
+    }
+
+    public List<TestdataDeclarativeMissingSupplierEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(
+            List<TestdataDeclarativeMissingSupplierEntity> entities) {
+        this.entities = entities;
+    }
+
+    public HardSoftScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftScore score) {
+        this.score = score;
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataDeclarativeMissingSupplierSolution{" +
+                "entities=" + entities +
+                ", values=" + values +
+                ", score=" + score +
+                '}';
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/missing/TestdataDeclarativeMissingSupplierValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/missing/TestdataDeclarativeMissingSupplierValue.java
@@ -1,0 +1,98 @@
+package ai.timefold.solver.core.testdomain.declarative.missing;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowVariableLooped;
+
+@PlanningEntity
+public class TestdataDeclarativeMissingSupplierValue {
+    public static final LocalDateTime DEFAULT_TIME =
+            LocalDateTime.of(2025, 4, 29, 18, 40, 0);
+
+    String id;
+
+    @ShadowVariable(supplierName = "calculateStartTime")
+    LocalDateTime startTime;
+
+    @ShadowVariable(supplierName = "calculateEndTime")
+    LocalDateTime endTime;
+
+    @ShadowVariableLooped
+    boolean isInvalid;
+
+    @InverseRelationShadowVariable(sourceVariableName = "value")
+    List<TestdataDeclarativeMissingSupplierEntity> entityList = new ArrayList<>();
+
+    Duration duration;
+
+    public TestdataDeclarativeMissingSupplierValue() {
+    }
+
+    public TestdataDeclarativeMissingSupplierValue(String id, Duration duration) {
+        this.id = id;
+        this.duration = duration;
+    }
+
+    public List<TestdataDeclarativeMissingSupplierEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataDeclarativeMissingSupplierEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    @ShadowSources({ "entityList" })
+    public LocalDateTime calculateStartTime() {
+        LocalDateTime readyTime = DEFAULT_TIME.plusDays(10);
+        if (!entityList.isEmpty()) {
+            readyTime = DEFAULT_TIME.plusDays(entityList.size());
+        }
+        return readyTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Duration duration) {
+        this.duration = duration;
+    }
+
+    public boolean isInvalid() {
+        return isInvalid;
+    }
+
+    public void setInvalid(boolean invalid) {
+        isInvalid = invalid;
+    }
+
+    @Override
+    public String toString() {
+        return id + "{" +
+                "endTime=" + endTime +
+                "]}";
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -1044,10 +1044,10 @@ class TimefoldProcessor {
                     var methodInfo = classInfo.method(targetMethodName);
                     if (methodInfo == null) {
                         throw new IllegalArgumentException("""
-                                @%s (%s) has a supplierMethod (%s) that does not exist inside its declaring class (%s).
+                                @%s (%s) defines a supplierMethod (%s) that does not exist inside its declaring class (%s).
                                 Maybe you misspelled the supplierMethod name?"""
                                 .formatted(ShadowVariable.class.getSimpleName(), memberName, targetMethodName,
-                                        classInfo.simpleName()));
+                                        classInfo.name().toString()));
                     }
                     buildMethodAccessor(annotatedMember, generatedMemberAccessorsClassNameSet, entityEnhancer,
                             classOutput,

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMissingSupplierForDeclarativeVariableTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMissingSupplierForDeclarativeVariableTest.java
@@ -1,0 +1,40 @@
+
+package ai.timefold.solver.quarkus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import ai.timefold.solver.quarkus.testdomain.suppliervariable.missing.TestdataQuarkusDeclarativeMissingSupplierEasyScoreCalculator;
+import ai.timefold.solver.quarkus.testdomain.suppliervariable.missing.TestdataQuarkusDeclarativeMissingSupplierEntity;
+import ai.timefold.solver.quarkus.testdomain.suppliervariable.missing.TestdataQuarkusDeclarativeMissingSupplierSolution;
+import ai.timefold.solver.quarkus.testdomain.suppliervariable.missing.TestdataQuarkusDeclarativeMissingSupplierValue;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldProcessorMissingSupplierForDeclarativeVariableTest {
+
+    // Empty classes
+    @RegisterExtension
+    static final QuarkusUnitTest config1 = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(
+                    TestdataQuarkusDeclarativeMissingSupplierSolution.class,
+                    TestdataQuarkusDeclarativeMissingSupplierEntity.class,
+                    TestdataQuarkusDeclarativeMissingSupplierValue.class,
+                    TestdataQuarkusDeclarativeMissingSupplierEasyScoreCalculator.class))
+            .assertException(t -> assertThat(t)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContainingAll(
+                            "Could not find method named calculateEndTime",
+                            "on the class TestdataQuarkusDeclarativeMissingSupplierValue",
+                            "Maybe you misspelled it"));
+
+    @Test
+    void test() {
+        fail("Should not call this method.");
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMissingSupplierForDeclarativeVariableTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMissingSupplierForDeclarativeVariableTest.java
@@ -31,7 +31,7 @@ class TimefoldProcessorMissingSupplierForDeclarativeVariableTest {
                     .hasMessageContainingAll(
                             "@ShadowVariable (endTime)",
                             "supplierMethod (calculateEndTime) that does not exist",
-                            "inside its declaring class (TestdataQuarkusDeclarativeMissingSupplierValue).",
+                            "inside its declaring class (ai.timefold.solver.quarkus.testdomain.suppliervariable.missing.TestdataQuarkusDeclarativeMissingSupplierValue).",
                             "Maybe you misspelled the supplierMethod name?"));
 
     @Test

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMissingSupplierForDeclarativeVariableTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorMissingSupplierForDeclarativeVariableTest.java
@@ -29,9 +29,10 @@ class TimefoldProcessorMissingSupplierForDeclarativeVariableTest {
             .assertException(t -> assertThat(t)
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContainingAll(
-                            "Could not find method named calculateEndTime",
-                            "on the class TestdataQuarkusDeclarativeMissingSupplierValue",
-                            "Maybe you misspelled it"));
+                            "@ShadowVariable (endTime)",
+                            "supplierMethod (calculateEndTime) that does not exist",
+                            "inside its declaring class (TestdataQuarkusDeclarativeMissingSupplierValue).",
+                            "Maybe you misspelled the supplierMethod name?"));
 
     @Test
     void test() {

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/suppliervariable/missing/TestdataQuarkusDeclarativeMissingSupplierEasyScoreCalculator.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/suppliervariable/missing/TestdataQuarkusDeclarativeMissingSupplierEasyScoreCalculator.java
@@ -1,0 +1,15 @@
+package ai.timefold.solver.quarkus.testdomain.suppliervariable.missing;
+
+import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
+
+import org.jspecify.annotations.NonNull;
+
+public class TestdataQuarkusDeclarativeMissingSupplierEasyScoreCalculator
+        implements EasyScoreCalculator<TestdataQuarkusDeclarativeMissingSupplierSolution, HardSoftScore> {
+    @Override
+    public @NonNull HardSoftScore calculateScore(
+            @NonNull TestdataQuarkusDeclarativeMissingSupplierSolution testdataQuarkusDeclarativeMissingSupplierSolution) {
+        return HardSoftScore.ZERO;
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/suppliervariable/missing/TestdataQuarkusDeclarativeMissingSupplierEntity.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/suppliervariable/missing/TestdataQuarkusDeclarativeMissingSupplierEntity.java
@@ -1,0 +1,57 @@
+package ai.timefold.solver.quarkus.testdomain.suppliervariable.missing;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+
+@PlanningEntity
+public class TestdataQuarkusDeclarativeMissingSupplierEntity {
+    String id;
+    @PlanningVariable
+    TestdataQuarkusDeclarativeMissingSupplierValue value;
+
+    @ShadowVariable(supplierName = "updateDurationInDays")
+    long durationInDays;
+
+    public TestdataQuarkusDeclarativeMissingSupplierEntity(String id, TestdataQuarkusDeclarativeMissingSupplierValue value) {
+        this.id = id;
+        this.value = value;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public TestdataQuarkusDeclarativeMissingSupplierValue getValue() {
+        return value;
+    }
+
+    public void setValue(TestdataQuarkusDeclarativeMissingSupplierValue value) {
+        this.value = value;
+    }
+
+    @ShadowSources("value")
+    public long updateDurationInDays() {
+        if (value != null) {
+            return value.getDuration().toDays();
+        }
+        return 0;
+    }
+
+    public long getDurationInDays() {
+        return durationInDays;
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataDeclarativeMissingSupplierEntity{" +
+                "id=" + id +
+                ", value=" + value +
+                '}';
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/suppliervariable/missing/TestdataQuarkusDeclarativeMissingSupplierSolution.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/suppliervariable/missing/TestdataQuarkusDeclarativeMissingSupplierSolution.java
@@ -1,0 +1,66 @@
+package ai.timefold.solver.quarkus.testdomain.suppliervariable.missing;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+
+@PlanningSolution
+public class TestdataQuarkusDeclarativeMissingSupplierSolution {
+
+    @PlanningEntityCollectionProperty
+    List<TestdataQuarkusDeclarativeMissingSupplierEntity> entities;
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataQuarkusDeclarativeMissingSupplierValue> values;
+
+    @PlanningScore
+    HardSoftScore score;
+
+    public TestdataQuarkusDeclarativeMissingSupplierSolution() {
+    }
+
+    public TestdataQuarkusDeclarativeMissingSupplierSolution(List<TestdataQuarkusDeclarativeMissingSupplierEntity> entities,
+            List<TestdataQuarkusDeclarativeMissingSupplierValue> values) {
+        this.values = values;
+        this.entities = entities;
+    }
+
+    public List<TestdataQuarkusDeclarativeMissingSupplierValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataQuarkusDeclarativeMissingSupplierValue> values) {
+        this.values = values;
+    }
+
+    public List<TestdataQuarkusDeclarativeMissingSupplierEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(
+            List<TestdataQuarkusDeclarativeMissingSupplierEntity> entities) {
+        this.entities = entities;
+    }
+
+    public HardSoftScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftScore score) {
+        this.score = score;
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataDeclarativeMissingSupplierSolution{" +
+                "entities=" + entities +
+                ", values=" + values +
+                ", score=" + score +
+                '}';
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/suppliervariable/missing/TestdataQuarkusDeclarativeMissingSupplierValue.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/suppliervariable/missing/TestdataQuarkusDeclarativeMissingSupplierValue.java
@@ -1,0 +1,98 @@
+package ai.timefold.solver.quarkus.testdomain.suppliervariable.missing;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowVariableLooped;
+
+@PlanningEntity
+public class TestdataQuarkusDeclarativeMissingSupplierValue {
+    public static final LocalDateTime DEFAULT_TIME =
+            LocalDateTime.of(2025, 4, 29, 18, 40, 0);
+
+    String id;
+
+    @ShadowVariable(supplierName = "calculateStartTime")
+    LocalDateTime startTime;
+
+    @ShadowVariable(supplierName = "calculateEndTime")
+    LocalDateTime endTime;
+
+    @ShadowVariableLooped
+    boolean isInvalid;
+
+    @InverseRelationShadowVariable(sourceVariableName = "value")
+    List<TestdataQuarkusDeclarativeMissingSupplierEntity> entityList = new ArrayList<>();
+
+    Duration duration;
+
+    public TestdataQuarkusDeclarativeMissingSupplierValue() {
+    }
+
+    public TestdataQuarkusDeclarativeMissingSupplierValue(String id, Duration duration) {
+        this.id = id;
+        this.duration = duration;
+    }
+
+    public List<TestdataQuarkusDeclarativeMissingSupplierEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataQuarkusDeclarativeMissingSupplierEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    @ShadowSources({ "entityList" })
+    public LocalDateTime calculateStartTime() {
+        LocalDateTime readyTime = DEFAULT_TIME.plusDays(10);
+        if (!entityList.isEmpty()) {
+            readyTime = DEFAULT_TIME.plusDays(entityList.size());
+        }
+        return readyTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Duration duration) {
+        this.duration = duration;
+    }
+
+    public boolean isInvalid() {
+        return isInvalid;
+    }
+
+    public void setInvalid(boolean invalid) {
+        isInvalid = invalid;
+    }
+
+    @Override
+    public String toString() {
+        return id + "{" +
+                "endTime=" + endTime +
+                "]}";
+    }
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverAutoConfigurationTest.java
@@ -984,8 +984,9 @@ class TimefoldSolverAutoConfigurationTest {
                         "timefold.solver.termination.best-score-limit=0")
                 .run(context -> {
                     context.getBean(SolverFactory.class);
-                })).hasMessageContainingAll("Could not find method named value1AndValue2Supplier",
-                        "on the class TestdataSpringMissingSupplierVariableEntity.",
-                        "Maybe you misspelled it?");
+                })).hasMessageContainingAll("@ShadowVariable (value1AndValue2)",
+                        "supplierMethod (value1AndValue2Supplier) that does not exist",
+                        "inside its declaring class (TestdataSpringMissingSupplierVariableEntity).",
+                        "Maybe you misspelled the supplierMethod name?");
     }
 }

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverAutoConfigurationTest.java
@@ -986,7 +986,7 @@ class TimefoldSolverAutoConfigurationTest {
                     context.getBean(SolverFactory.class);
                 })).hasMessageContainingAll("@ShadowVariable (value1AndValue2)",
                         "supplierMethod (value1AndValue2Supplier) that does not exist",
-                        "inside its declaring class (TestdataSpringMissingSupplierVariableEntity).",
+                        "inside its declaring class (ai.timefold.solver.spring.boot.autoconfigure.missingsuppliervariable.domain.TestdataSpringMissingSupplierVariableEntity).",
                         "Maybe you misspelled the supplierMethod name?");
     }
 }

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/missingsuppliervariable/MissingSupplierVariableSpringTestConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/missingsuppliervariable/MissingSupplierVariableSpringTestConfiguration.java
@@ -1,0 +1,16 @@
+package ai.timefold.solver.spring.boot.autoconfigure.missingsuppliervariable;
+
+import ai.timefold.solver.spring.boot.autoconfigure.missingsuppliervariable.constraints.TestdataSpringMissingSupplierVariableConstraintProvider;
+import ai.timefold.solver.spring.boot.autoconfigure.missingsuppliervariable.domain.TestdataSpringMissingSupplierVariableSolution;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan(basePackageClasses = { TestdataSpringMissingSupplierVariableSolution.class,
+        TestdataSpringMissingSupplierVariableConstraintProvider.class })
+@AutoConfigurationPackage
+public class MissingSupplierVariableSpringTestConfiguration {
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/missingsuppliervariable/constraints/TestdataSpringMissingSupplierVariableConstraintProvider.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/missingsuppliervariable/constraints/TestdataSpringMissingSupplierVariableConstraintProvider.java
@@ -1,0 +1,32 @@
+package ai.timefold.solver.spring.boot.autoconfigure.missingsuppliervariable.constraints;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.api.score.stream.Joiners;
+import ai.timefold.solver.spring.boot.autoconfigure.missingsuppliervariable.domain.TestdataSpringMissingSupplierVariableEntity;
+
+import org.jspecify.annotations.NonNull;
+
+public class TestdataSpringMissingSupplierVariableConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.forEach(TestdataSpringMissingSupplierVariableEntity.class)
+                        .join(TestdataSpringMissingSupplierVariableEntity.class,
+                                Joiners.equal(TestdataSpringMissingSupplierVariableEntity::getValue1,
+                                        TestdataSpringMissingSupplierVariableEntity::getValue2))
+                        .filter((a, b) -> {
+                            if (a.getValue1AndValue2() == null || b.getValue1AndValue2() == null) {
+                                throw new IllegalStateException();
+                            }
+                            return a.getValue1AndValue2().equals(b.getValue1AndValue2());
+                        })
+                        .penalize(SimpleScore.ONE)
+                        .asConstraint("Don't assign 2 entities the same value.")
+        };
+    }
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/missingsuppliervariable/domain/TestdataSpringMissingSupplierVariableEntity.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/missingsuppliervariable/domain/TestdataSpringMissingSupplierVariableEntity.java
@@ -1,0 +1,41 @@
+package ai.timefold.solver.spring.boot.autoconfigure.missingsuppliervariable.domain;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+
+@PlanningEntity
+public class TestdataSpringMissingSupplierVariableEntity {
+
+    private String value1;
+    private String value2;
+    private String value1AndValue2;
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue1() {
+        return value1;
+    }
+
+    public void setValue1(String value1) {
+        this.value1 = value1;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue2() {
+        return value2;
+    }
+
+    public void setValue2(String value2) {
+        this.value2 = value2;
+    }
+
+    @ShadowVariable(supplierName = "value1AndValue2Supplier")
+    public String getValue1AndValue2() {
+        return value1AndValue2;
+    }
+
+    public void setValue1AndValue2(String value1AndValue2) {
+        this.value1AndValue2 = value1AndValue2;
+    }
+
+}

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/missingsuppliervariable/domain/TestdataSpringMissingSupplierVariableSolution.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/missingsuppliervariable/domain/TestdataSpringMissingSupplierVariableSolution.java
@@ -1,0 +1,48 @@
+package ai.timefold.solver.spring.boot.autoconfigure.missingsuppliervariable.domain;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataSpringMissingSupplierVariableSolution {
+
+    private List<String> valueList;
+    private List<TestdataSpringMissingSupplierVariableEntity> entityList;
+
+    private SimpleScore score;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataSpringMissingSupplierVariableEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataSpringMissingSupplierVariableEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}


### PR DESCRIPTION
Does not affect Spring since Spring does not generate it own member accessors.