### PR TITLE
fix: Pass SolverConfig's enabled preview feature set to ConstraintVerifier on creation

### DIFF
--- a/test/src/main/java/ai/timefold/solver/test/api/score/stream/ConstraintVerifier.java
+++ b/test/src/main/java/ai/timefold/solver/test/api/score/stream/ConstraintVerifier.java
@@ -61,7 +61,9 @@ public interface ConstraintVerifier<ConstraintProvider_ extends ConstraintProvid
         var nonNullSolverConfig = requireNonNull(solverConfig);
         var entityClassList = Objects.requireNonNull(nonNullSolverConfig.getEntityClassList());
         var solutionDescriptor =
-                SolutionDescriptor.buildSolutionDescriptor(requireNonNull(nonNullSolverConfig.getSolutionClass()),
+                SolutionDescriptor.buildSolutionDescriptor(
+                        nonNullSolverConfig.getEnablePreviewFeatureSet(),
+                        requireNonNull(nonNullSolverConfig.getSolutionClass()),
                         entityClassList.toArray(new Class<?>[] {}));
         var scoreDirectorFactoryConfig = requireNonNull(nonNullSolverConfig.getScoreDirectorFactoryConfig());
         var constraintProviderClass = requireNonNull(scoreDirectorFactoryConfig.getConstraintProviderClass());


### PR DESCRIPTION
## Overview
I noticed when trying out Declarative Shadow Variables that I had no way to enable preview features in the `ConstraintVerifier`. Specifically, when writing tests I hit [this case](https://github.com/TimefoldAI/timefold-solver/blob/7bce5c216bac44f0d08938b6679083d10bcda408/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java#L37) even if I created the `ConstraintVerifier` with a `SolverConfig` that included the declarative shadow variable preview feature.

## Contribution

This PR just passes the enabled preview feature set from the provided `SolverConfig` in `ConstraintVerifier::create` so we can test constraints using preview features. Let me know if there's a better way to achieve this.

## Additional Notes

I'd be happy to write a test for this if you think that's appropriate, but would appreciate a pointer to the best place / approach.

I'm a huge fan of the [1.24.0](https://github.com/TimefoldAI/timefold-solver/releases/tag/v1.24.0) features by the way -- very cool stuff!