### PR TITLE
fix: correctly identify variable access as INDIRECT if accessed after a fact

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -61,7 +61,7 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
                         graphStructureAndDirection,
                         entities);
             }
-            case ARBITRARY_SINGLE_ENTITY_SINGLE_DIRECTIONAL_PARENT_TYPE ->
+            case ARBITRARY_SINGLE_ENTITY_AT_MOST_ONE_DIRECTIONAL_PARENT_TYPE ->
                 buildArbitrarySingleEntityGraph(solutionDescriptor, variableReferenceGraphBuilder, entities, graphCreator);
             case NO_DYNAMIC_EDGES, ARBITRARY ->
                 buildArbitraryGraph(solutionDescriptor, variableReferenceGraphBuilder, entities, graphCreator);

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructure.java
@@ -42,7 +42,7 @@ public enum GraphStructure {
      * entity that uses declarative shadow variables with all directional
      * parents being the same type.
      */
-    ARBITRARY_SINGLE_ENTITY_SINGLE_DIRECTIONAL_PARENT_TYPE,
+    ARBITRARY_SINGLE_ENTITY_AT_MOST_ONE_DIRECTIONAL_PARENT_TYPE,
 
     /**
      * A graph structure that accepts all graphs.
@@ -73,7 +73,7 @@ public enum GraphStructure {
                 .distinct().count() > 1;
 
         final var arbitraryGraphStructure = new GraphStructureAndDirection(
-                multipleDeclarativeEntityClasses ? ARBITRARY : ARBITRARY_SINGLE_ENTITY_SINGLE_DIRECTIONAL_PARENT_TYPE,
+                multipleDeclarativeEntityClasses ? ARBITRARY : ARBITRARY_SINGLE_ENTITY_AT_MOST_ONE_DIRECTIONAL_PARENT_TYPE,
                 null, null);
 
         var rootVariableSources = declarativeShadowVariableDescriptors.stream()

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
@@ -192,7 +192,7 @@ public record RootVariableSource<Entity_, Value_>(
             assertIsValidVariableReference(rootEntityClass, variablePath, variableSourceReference);
         }
 
-        if (parentVariableType != ParentVariableType.GROUP && variableSourceReferences.size() == 1) {
+        if (!parentVariableType.isIndirect() && variableSourceReferences.size() == 1) {
             // No variables are accessed from the parent, so there no
             // parent variable.
             parentVariableType = ParentVariableType.NO_PARENT;

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphStructureTest.java
@@ -1,9 +1,8 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.ARBITRARY;
-import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.ARBITRARY_SINGLE_ENTITY_SINGLE_DIRECTIONAL_PARENT_TYPE;
+import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.ARBITRARY_SINGLE_ENTITY_AT_MOST_ONE_DIRECTIONAL_PARENT_TYPE;
 import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.EMPTY;
-import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.NO_DYNAMIC_EDGES;
 import static ai.timefold.solver.core.impl.domain.variable.declarative.GraphStructure.SINGLE_DIRECTIONAL_PARENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,7 +52,7 @@ class GraphStructureTest {
         var entity = new TestdataChainedSimpleVarValue();
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataChainedSimpleVarSolution.buildSolutionDescriptor(), entity))
-                .hasFieldOrPropertyWithValue("structure", ARBITRARY_SINGLE_ENTITY_SINGLE_DIRECTIONAL_PARENT_TYPE);
+                .hasFieldOrPropertyWithValue("structure", ARBITRARY_SINGLE_ENTITY_AT_MOST_ONE_DIRECTIONAL_PARENT_TYPE);
     }
 
     @Test
@@ -94,7 +93,7 @@ class GraphStructureTest {
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataConcurrentSolution.buildSolutionDescriptor(),
                 value1, value2))
-                .hasFieldOrPropertyWithValue("structure", ARBITRARY_SINGLE_ENTITY_SINGLE_DIRECTIONAL_PARENT_TYPE);
+                .hasFieldOrPropertyWithValue("structure", ARBITRARY_SINGLE_ENTITY_AT_MOST_ONE_DIRECTIONAL_PARENT_TYPE);
     }
 
     @Test
@@ -102,7 +101,7 @@ class GraphStructureTest {
         var entity = new TestdataFollowerEntity();
         assertThat(GraphStructure.determineGraphStructure(
                 TestdataFollowerSolution.buildSolutionDescriptor(), entity))
-                .hasFieldOrPropertyWithValue("structure", NO_DYNAMIC_EDGES);
+                .hasFieldOrPropertyWithValue("structure", ARBITRARY_SINGLE_ENTITY_AT_MOST_ONE_DIRECTIONAL_PARENT_TYPE);
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSourceTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSourceTest.java
@@ -78,6 +78,7 @@ class RootVariableSourceTest {
 
         assertThat(rootVariableSource.rootEntity()).isEqualTo(TestdataInvalidDeclarativeValue.class);
         assertThat(rootVariableSource.variableSourceReferences()).hasSize(1);
+        assertThat(rootVariableSource.parentVariableType()).isEqualTo(ParentVariableType.NO_PARENT);
         var source = rootVariableSource.variableSourceReferences().get(0);
 
         assertEmptyChainToVariableEntity(source);
@@ -112,6 +113,7 @@ class RootVariableSourceTest {
 
         assertThat(rootVariableSource.rootEntity()).isEqualTo(TestdataInvalidDeclarativeValue.class);
         assertThat(rootVariableSource.variableSourceReferences()).hasSize(1);
+        assertThat(rootVariableSource.parentVariableType()).isEqualTo(ParentVariableType.NO_PARENT);
         var source = rootVariableSource.variableSourceReferences().get(0);
 
         assertEmptyChainToVariableEntity(source);
@@ -145,6 +147,7 @@ class RootVariableSourceTest {
 
         assertThat(rootVariableSource.rootEntity()).isEqualTo(TestdataInvalidDeclarativeValue.class);
         assertThat(rootVariableSource.variableSourceReferences()).hasSize(1);
+        assertThat(rootVariableSource.parentVariableType()).isEqualTo(ParentVariableType.GROUP);
         var source = rootVariableSource.variableSourceReferences().get(0);
 
         assertEmptyChainToVariableEntity(source);
@@ -183,6 +186,7 @@ class RootVariableSourceTest {
 
         assertThat(rootVariableSource.rootEntity()).isEqualTo(TestdataInvalidDeclarativeValue.class);
         assertThat(rootVariableSource.variableSourceReferences()).hasSize(1);
+        assertThat(rootVariableSource.parentVariableType()).isEqualTo(ParentVariableType.GROUP);
         var source = rootVariableSource.variableSourceReferences().get(0);
 
         assertEmptyChainToVariableEntity(source);
@@ -221,6 +225,7 @@ class RootVariableSourceTest {
 
         assertThat(rootVariableSource.rootEntity()).isEqualTo(TestdataInvalidDeclarativeValue.class);
         assertThat(rootVariableSource.variableSourceReferences()).hasSize(1);
+        assertThat(rootVariableSource.parentVariableType()).isEqualTo(ParentVariableType.GROUP);
         var source = rootVariableSource.variableSourceReferences().get(0);
 
         assertEmptyChainToVariableEntity(source);
@@ -261,6 +266,7 @@ class RootVariableSourceTest {
 
         assertThat(rootVariableSource.rootEntity()).isEqualTo(TestdataInvalidDeclarativeValue.class);
         assertThat(rootVariableSource.variableSourceReferences()).hasSize(2);
+        assertThat(rootVariableSource.parentVariableType()).isEqualTo(ParentVariableType.PREVIOUS);
         var previousSource = rootVariableSource.variableSourceReferences().get(0);
 
         assertEmptyChainToVariableEntity(previousSource);
@@ -305,6 +311,7 @@ class RootVariableSourceTest {
 
         assertThat(rootVariableSource.rootEntity()).isEqualTo(TestdataInvalidDeclarativeValue.class);
         assertThat(rootVariableSource.variableSourceReferences()).hasSize(1);
+        assertThat(rootVariableSource.parentVariableType()).isEqualTo(ParentVariableType.INDIRECT);
         var previousSource = rootVariableSource.variableSourceReferences().get(0);
 
         assertChainToVariableEntity(previousSource, "fact");
@@ -344,6 +351,7 @@ class RootVariableSourceTest {
 
         assertThat(rootVariableSource.rootEntity()).isEqualTo(TestdataInvalidDeclarativeValue.class);
         assertThat(rootVariableSource.variableSourceReferences()).hasSize(2);
+        assertThat(rootVariableSource.parentVariableType()).isEqualTo(ParentVariableType.GROUP);
         var previousSource = rootVariableSource.variableSourceReferences().get(0);
 
         assertEmptyChainToVariableEntity(previousSource);


### PR DESCRIPTION
The path "fact.variable" was incorrectly identified as "NO_PARENT" instead of "INDIRECT". This can cause an unsuitable graph structure to be used, causing score corruption.

Fixes #1696