### PR TITLE
perf: group declarative variables after aligned variables when possible

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -189,14 +189,14 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
             List<DeclarativeShadowVariableDescriptor<Solution_>> sortedDeclarativeVariableDescriptors,
             List<VariableUpdaterInfo<Solution_>> allUpdaters,
             List<VariableUpdaterInfo<Solution_>> groupedUpdaters,
-            Map<DeclarativeShadowVariableDescriptor<Solution_>, Map<Object, VariableUpdaterInfo<Solution_>>> variableToEntityToGroupUpdater) {
+            Map<DeclarativeShadowVariableDescriptor<Solution_>, Map<Object, List<VariableUpdaterInfo<Solution_>>>> variableToEntityToGroupUpdater) {
 
         public List<VariableUpdaterInfo<Solution_>> getUpdatersForEntityVariable(Object entity,
                 DeclarativeShadowVariableDescriptor<Solution_> declarativeShadowVariableDescriptor) {
             if (variableToEntityToGroupUpdater.containsKey(declarativeShadowVariableDescriptor)) {
-                var updater = variableToEntityToGroupUpdater.get(declarativeShadowVariableDescriptor).get(entity);
-                if (updater != null) {
-                    return List.of(updater);
+                var updaters = variableToEntityToGroupUpdater.get(declarativeShadowVariableDescriptor).get(entity);
+                if (updaters != null) {
+                    return updaters;
                 }
             }
             for (var shadowVariableDescriptor : sortedDeclarativeVariableDescriptors) {
@@ -225,24 +225,7 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         var groupVariables = new ArrayList<DeclarativeShadowVariableDescriptor<Solution_>>();
         groupIndexToVariables.put(0, groupVariables);
         for (var declarativeShadowVariableDescriptor : sortedDeclarativeVariableDescriptors) {
-            // If a @ShadowSources has a group source (i.e. "visitGroup[].arrivalTimes"),
-            // create a new group since it must wait until all members of that group are processed
-            var hasGroupSources = Arrays.stream(declarativeShadowVariableDescriptor.getSources())
-                    .anyMatch(rootVariableSource -> rootVariableSource.parentVariableType() == ParentVariableType.GROUP);
-
-            // If a @ShadowSources has an alignment key,
-            // create a new group since multiple entities must be updated for this node
-            var hasAlignmentKey = declarativeShadowVariableDescriptor.getAlignmentKeyMap() != null;
-
-            // If the previous @ShadowSources has an alignment key,
-            // create a new group since we are updating a single entity again
-            // NOTE: Can potentially be optimized/share a node if VariableUpdaterInfo
-            //       update each group member independently after the alignmentKey
-            var previousHasAlignmentKey = !groupVariables.isEmpty() && groupVariables.get(0).getAlignmentKeyMap() != null;
-
-            if (!groupVariables.isEmpty() && (hasGroupSources
-                    || hasAlignmentKey
-                    || previousHasAlignmentKey)) {
+            if (shouldCreateNewGroupForVariable(declarativeShadowVariableDescriptor, groupVariables)) {
                 groupVariables = new ArrayList<>();
                 groupIndexToVariables.put(groupIndexToVariables.size(), groupVariables);
             }
@@ -252,11 +235,12 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         var out = new HashMap<VariableMetaModel<Solution_, ?, ?>, GroupVariableUpdaterInfo<Solution_>>();
         var allUpdaters = new ArrayList<VariableUpdaterInfo<Solution_>>();
         var groupedUpdaters =
-                new HashMap<DeclarativeShadowVariableDescriptor<Solution_>, Map<Object, VariableUpdaterInfo<Solution_>>>();
+                new HashMap<DeclarativeShadowVariableDescriptor<Solution_>, Map<Object, List<VariableUpdaterInfo<Solution_>>>>();
         var updaterKey = 0;
         for (var entryKey = 0; entryKey < groupIndexToVariables.size(); entryKey++) {
             var entryGroupVariables = groupIndexToVariables.get(entryKey);
             var updaters = new ArrayList<VariableUpdaterInfo<Solution_>>();
+            var alignmentKeyToGroupIndex = new HashMap<Object, Integer>();
             for (var declarativeShadowVariableDescriptor : entryGroupVariables) {
                 var updater = new VariableUpdaterInfo<>(
                         declarativeShadowVariableDescriptor.getVariableMetaModel(),
@@ -265,31 +249,11 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
                         declarativeShadowVariableDescriptor.getEntityDescriptor().getShadowVariableLoopedDescriptor(),
                         declarativeShadowVariableDescriptor.getMemberAccessor(),
                         declarativeShadowVariableDescriptor.getCalculator()::executeGetter);
-                if (declarativeShadowVariableDescriptor.getAlignmentKeyMap() != null) {
-                    var alignmentKeyFunction = declarativeShadowVariableDescriptor.getAlignmentKeyMap();
-                    var alignmentKeyToAlignedEntitiesMap = new HashMap<Object, List<Object>>();
-                    for (var entity : entities) {
-                        if (declarativeShadowVariableDescriptor.getEntityDescriptor().getEntityClass().isInstance(entity)) {
-                            var alignmentKey = alignmentKeyFunction.apply(entity);
-                            alignmentKeyToAlignedEntitiesMap.computeIfAbsent(alignmentKey, k -> new ArrayList<>()).add(entity);
-                        }
-                    }
-                    for (var alignmentGroup : alignmentKeyToAlignedEntitiesMap.entrySet()) {
-                        var updaterCopy = updater.withGroupId(updaterKey);
-                        if (alignmentGroup.getKey() == null) {
-                            updaters.add(updaterCopy);
-                            allUpdaters.add(updaterCopy);
-                        } else {
-                            updaterCopy = updaterCopy.withGroupEntities(alignmentGroup.getValue().toArray(new Object[0]));
-                            var variableUpdaterMap = groupedUpdaters.computeIfAbsent(declarativeShadowVariableDescriptor,
-                                    ignored -> new IdentityHashMap<>());
-                            for (var entity : alignmentGroup.getValue()) {
-                                variableUpdaterMap.put(entity, updaterCopy);
-                            }
-                        }
-                        updaterKey++;
-                    }
-                    updaterKey--; // it will be incremented again at end of the loop
+                if (entryGroupVariables.get(0).getAlignmentKeyMap() != null) {
+                    updaterKey = processAlignmentGroupVariableAndGetNextUpdaterKey(entities,
+                            declarativeShadowVariableDescriptor, entryGroupVariables, updater,
+                            updaterKey, updaters,
+                            allUpdaters, alignmentKeyToGroupIndex, groupedUpdaters);
                 } else {
                     updaters.add(updater);
                     allUpdaters.add(updater);
@@ -301,10 +265,70 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
             for (var declarativeShadowVariableDescriptor : entryGroupVariables) {
                 out.put(declarativeShadowVariableDescriptor.getVariableMetaModel(), groupVariableUpdaterInfo);
             }
-            updaterKey++;
+            if (entryGroupVariables.get(0).getAlignmentKeyMap() == null) {
+                updaterKey++;
+            }
         }
         allUpdaters.replaceAll(updater -> updater.withGroupId(groupIndexToVariables.size()));
         return out;
+    }
+
+    private static <Solution_> boolean shouldCreateNewGroupForVariable(
+            DeclarativeShadowVariableDescriptor<Solution_> declarativeShadowVariableDescriptor,
+            List<DeclarativeShadowVariableDescriptor<Solution_>> groupVariables) {
+        // If a @ShadowSources has a group source (i.e. "visitGroup[].arrivalTimes"),
+        // create a new group since it must wait until all members of that group are processed
+        var hasGroupSources = Arrays.stream(declarativeShadowVariableDescriptor.getSources())
+                .anyMatch(rootVariableSource -> rootVariableSource.parentVariableType() == ParentVariableType.GROUP);
+
+        // If a @ShadowSources has an alignment key,
+        // create a new group since multiple entities must be updated for this node
+        var alignmentKey = declarativeShadowVariableDescriptor.getAlignmentKeyName();
+        var previousAlignmentKey = groupVariables.isEmpty() ? null : groupVariables.get(0).getAlignmentKeyName();
+
+        return !groupVariables.isEmpty() && (hasGroupSources
+                || (alignmentKey != null && !Objects.equals(alignmentKey, previousAlignmentKey)));
+    }
+
+    private static <Solution_> int processAlignmentGroupVariableAndGetNextUpdaterKey(Object[] entities,
+            DeclarativeShadowVariableDescriptor<Solution_> declarativeShadowVariableDescriptor,
+            List<DeclarativeShadowVariableDescriptor<Solution_>> entryGroupVariables, VariableUpdaterInfo<Solution_> updater,
+            int updaterKey, List<VariableUpdaterInfo<Solution_>> updaters,
+            List<VariableUpdaterInfo<Solution_>> allUpdaters, HashMap<Object, Integer> alignmentKeyToGroupIndex,
+            Map<DeclarativeShadowVariableDescriptor<Solution_>, Map<Object, List<VariableUpdaterInfo<Solution_>>>> groupedUpdaters) {
+        var alignmentKeyFunction = entryGroupVariables.get(0).getAlignmentKeyMap();
+        var alignmentKeyToAlignedEntitiesMap = new HashMap<Object, List<Object>>();
+        for (var entity : entities) {
+            if (declarativeShadowVariableDescriptor.getEntityDescriptor().getEntityClass().isInstance(entity)) {
+                var alignmentKey = alignmentKeyFunction.apply(entity);
+                alignmentKeyToAlignedEntitiesMap.computeIfAbsent(alignmentKey, k -> new ArrayList<>()).add(entity);
+            }
+        }
+        for (var alignmentGroup : alignmentKeyToAlignedEntitiesMap.entrySet()) {
+            if (alignmentGroup.getKey() == null) {
+                var updaterCopy = updater.withGroupId(updaterKey);
+                updaters.add(updaterCopy);
+                allUpdaters.add(updaterCopy);
+                updaterKey++;
+            } else {
+                final var newAlignmentUpdaterKey = updaterKey;
+                final var alignmentUpdaterKey = (int) alignmentKeyToGroupIndex.computeIfAbsent(alignmentGroup.getKey(),
+                        ignored -> newAlignmentUpdaterKey);
+                if (alignmentUpdaterKey == newAlignmentUpdaterKey) {
+                    updaterKey++;
+                }
+                var updaterCopy = updater.withGroupId(alignmentUpdaterKey);
+                updaterCopy = updaterCopy.withGroupEntities(alignmentGroup.getValue().toArray(new Object[0]),
+                        declarativeShadowVariableDescriptor.getAlignmentKeyName() != null);
+                var variableUpdaterMap = groupedUpdaters.computeIfAbsent(declarativeShadowVariableDescriptor,
+                        ignored -> groupedUpdaters.getOrDefault(entryGroupVariables.get(0),
+                                new IdentityHashMap<>()));
+                for (var entity : alignmentGroup.getValue()) {
+                    variableUpdaterMap.computeIfAbsent(entity, ignored -> new ArrayList<>()).add(updaterCopy);
+                }
+            }
+        }
+        return updaterKey;
     }
 
     private static <Solution_> VariableReferenceGraph buildArbitrarySingleEntityGraph(

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -19,9 +19,16 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
 
         var entityToVariableReferenceMap = new IdentityHashMap<Object, List<GraphNode<Solution_>>>();
         for (var instance : nodeList) {
-            var entity = instance.entity();
-            entityToVariableReferenceMap.computeIfAbsent(entity, ignored -> new ArrayList<>())
-                    .add(instance);
+            if (instance.groupEntityIds() == null) {
+                var entity = instance.entity();
+                entityToVariableReferenceMap.computeIfAbsent(entity, ignored -> new ArrayList<>())
+                        .add(instance);
+            } else {
+                for (var groupEntity : instance.variableReferences().get(0).groupEntities()) {
+                    entityToVariableReferenceMap.computeIfAbsent(groupEntity, ignored -> new ArrayList<>())
+                            .add(instance);
+                }
+            }
         }
         // Immutable optimized version of the map, now that it won't be updated anymore.
         var immutableEntityToVariableReferenceMap = mapOfListsDeepCopyOf(entityToVariableReferenceMap);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
@@ -297,12 +297,15 @@ class VariableListenerSupportTest {
                 // which is the first member of the group
                 for (var element : visit.getConcurrentValueGroup()) {
                     verifyAddEdge.accept(serviceReadyTime, element, serviceStartTime, visit);
-                    verifyAddEdge.accept(serviceStartTime, visit, serviceFinishTime, element);
+                    // start and finish time use the same node, so no edge between them
                 }
             }
 
             if (visit.getPreviousValue() != null) {
-                verifyAddEdge.accept(serviceFinishTime, visit.getPreviousValue(), serviceReadyTime, visit);
+                var previousRepresentative =
+                        visit.getPreviousValue().getConcurrentValueGroup() == null ? visit.getPreviousValue()
+                                : visit.getPreviousValue().getConcurrentValueGroup().get(0);
+                verifyAddEdge.accept(serviceFinishTime, previousRepresentative, serviceReadyTime, visit);
             }
         }
         // Note: addEdge only adds an edge if it does not already exists in the graph,


### PR DESCRIPTION
- When there are declarative variables after aligned variables, they are grouped into the same graph node.
- `ShadowVariableLooped` is now guarantee to be updated before the calculator method is called.
- `LoopedTracker` now has access to an `int[][] entityIdToNodeIds` that it can use to determine if an entity is looped (an entity is looped if any of its variables are looped, and variables may correspond to different graph nodes).
-  Each node in the graph now have an `int entityId` and an `int[] groupEntityIds` which is computed when a node is created.