### PR TITLE
perf: simplify handling of @ShadowVariableLooped 

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
@@ -1,16 +1,15 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
-import java.util.Arrays;
 import java.util.BitSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.PriorityQueue;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
-import ai.timefold.solver.core.impl.util.LinkedIdentityHashSet;
 
 final class AffectedEntitiesUpdater<Solution_>
         implements Consumer<BitSet> {
@@ -18,27 +17,58 @@ final class AffectedEntitiesUpdater<Solution_>
     // From WorkingReferenceGraph.
     private final BaseTopologicalOrderGraph graph;
     private final List<EntityVariablePair<Solution_>> instanceList; // Immutable.
-    private final Function<Object, List<EntityVariablePair<Solution_>>> entityVariablePairFunction;
     private final ChangedVariableNotifier<Solution_> changedVariableNotifier;
 
     // Internal state; expensive to create, therefore we reuse.
-    private final AffectedEntities<Solution_> affectedEntities;
     private final LoopedTracker loopedTracker;
     private final BitSet visited;
     private final PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder> changeQueue;
 
     AffectedEntitiesUpdater(BaseTopologicalOrderGraph graph, List<EntityVariablePair<Solution_>> instanceList,
             Function<Object, List<EntityVariablePair<Solution_>>> entityVariablePairFunction,
-            ChangedVariableNotifier<Solution_> changedVariableNotifier) {
+            int entityCount, ChangedVariableNotifier<Solution_> changedVariableNotifier) {
         this.graph = graph;
         this.instanceList = instanceList;
-        this.entityVariablePairFunction = entityVariablePairFunction;
         this.changedVariableNotifier = changedVariableNotifier;
         var instanceCount = instanceList.size();
-        this.affectedEntities = new AffectedEntities<>(this::updateLoopedStatusOfAffectedEntity);
-        this.loopedTracker = new LoopedTracker(instanceCount);
+        this.loopedTracker = new LoopedTracker(instanceCount,
+                createNodeToEntityNodes(entityCount, instanceList, entityVariablePairFunction));
         this.visited = new BitSet(instanceCount);
         this.changeQueue = new PriorityQueue<>(instanceCount);
+    }
+
+    static <Solution_> int[][] createNodeToEntityNodes(int entityCount,
+            List<EntityVariablePair<Solution_>> instanceList,
+            Function<Object, List<EntityVariablePair<Solution_>>> entityVariablePairFunction) {
+        record EntityIdPair(Object entity, int entityId) {
+            @Override
+            public boolean equals(Object o) {
+                if (!(o instanceof EntityIdPair that))
+                    return false;
+                return entityId == that.entityId;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hashCode(entityId);
+            }
+        }
+        int[][] out = new int[entityCount][];
+        var entityToNodes = new IdentityHashMap<Integer, int[]>();
+        var entityIdPairSet = instanceList.stream()
+                .map(node -> new EntityIdPair(node.entity(), node.entityId()))
+                .collect(Collectors.toSet());
+        for (var entityIdPair : entityIdPairSet) {
+            entityToNodes.put(entityIdPair.entityId(),
+                    entityVariablePairFunction.apply(entityIdPair.entity).stream().mapToInt(EntityVariablePair::graphNodeId)
+                            .toArray());
+        }
+
+        for (var entry : entityToNodes.entrySet()) {
+            out[entry.getKey()] = entry.getValue();
+        }
+
+        return out;
     }
 
     @Override
@@ -65,7 +95,6 @@ final class AffectedEntitiesUpdater<Solution_>
             }
         }
 
-        affectedEntities.processAndClear();
         // Prepare for the next time updateChanged() is called.
         // No need to clear changeQueue, as that already finishes empty.
         loopedTracker.clear();
@@ -91,50 +120,43 @@ final class AffectedEntitiesUpdater<Solution_>
         changed.clear();
     }
 
-    private void updateLoopedStatusOfAffectedEntity(Object affectedEntity) {
-        ShadowVariableLoopedVariableDescriptor<Solution_> shadowVariableLoopedDescriptor = null;
-        var isEntityLooped = false;
-        for (var node : entityVariablePairFunction.apply(affectedEntity)) {
-            // All variables come from the same entity,
-            // therefore all have the same looped marker.
-            shadowVariableLoopedDescriptor = node.variableReferences().get(0).shadowVariableLoopedDescriptor();
-            if (graph.isLooped(loopedTracker, node.graphNodeId())) {
-                isEntityLooped = true;
-                break;
-            }
-        }
-        if (shadowVariableLoopedDescriptor == null) {
-            // At this point, affectedEntity is guaranteed to have looped marker.
-            // Otherwise AffectedEntities would not have sent it here.
-            throw new IllegalStateException("Impossible state: loop marker descriptor does not exist.");
-        }
-        var oldValue = shadowVariableLoopedDescriptor.getValue(affectedEntity);
-        if (!Objects.equals(oldValue, isEntityLooped)) {
-            changeShadowVariableAndNotify(shadowVariableLoopedDescriptor, affectedEntity, isEntityLooped);
-        }
-
-    }
-
-    private boolean updateEntityShadowVariables(EntityVariablePair<Solution_> entityVariable, boolean isLooped) {
+    private boolean updateEntityShadowVariables(EntityVariablePair<Solution_> entityVariable, boolean isVariableLooped) {
         var entity = entityVariable.entity();
         var shadowVariableReferences = entityVariable.variableReferences();
         var loopDescriptor = shadowVariableReferences.get(0).shadowVariableLoopedDescriptor();
         var anyChanged = false;
 
         if (loopDescriptor != null) {
-            var oldLooped = loopDescriptor.getValue(entity);
-            if (!Objects.equals(oldLooped, isLooped)) {
-                // Loop status change; add to affected entities
-                affectedEntities.add(entityVariable);
-                anyChanged = true;
+            // Do not need to update anyChanged here; the graph already marked
+            // all nodes whose looped status changed for us
+            var groupEntities = shadowVariableReferences.get(0).groupEntities();
+            var groupEntityIds = entityVariable.groupEntityIds();
+
+            if (groupEntities != null) {
+                for (var i = 0; i < groupEntityIds.length; i++) {
+                    var groupEntity = groupEntities[i];
+                    var groupEntityId = groupEntityIds[i];
+                    updateLoopedStatusOfEntity(groupEntity, groupEntityId, loopDescriptor);
+                }
+            } else {
+                updateLoopedStatusOfEntity(entity, entityVariable.entityId(), loopDescriptor);
             }
         }
 
         for (var shadowVariableReference : shadowVariableReferences) {
-            anyChanged |= updateShadowVariable(isLooped, shadowVariableReference, entity);
+            anyChanged |= updateShadowVariable(isVariableLooped, shadowVariableReference, entity);
         }
 
         return anyChanged;
+    }
+
+    private void updateLoopedStatusOfEntity(Object entity, int entityId,
+            ShadowVariableLoopedVariableDescriptor<Solution_> loopDescriptor) {
+        var isEntityLooped = loopedTracker.isEntityLooped(graph, entityId);
+        var oldLooped = loopDescriptor.getValue(entity);
+        if (!Objects.equals(oldLooped, isEntityLooped)) {
+            changeShadowVariableAndNotify(loopDescriptor, entity, isEntityLooped);
+        }
     }
 
     private boolean updateShadowVariable(boolean isLooped,
@@ -152,37 +174,4 @@ final class AffectedEntitiesUpdater<Solution_>
         variableDescriptor.setValue(entity, newValue);
         changedVariableNotifier.afterVariableChanged().accept(variableDescriptor, entity);
     }
-
-    private static final class AffectedEntities<Solution_> {
-
-        private final Consumer<Object> consumer;
-        private final Set<Object> entitiesForLoopedVarUpdateSet;
-
-        public AffectedEntities(Consumer<Object> consumer) {
-            this.consumer = consumer;
-            this.entitiesForLoopedVarUpdateSet = new LinkedIdentityHashSet<>();
-        }
-
-        public void add(EntityVariablePair<Solution_> shadowVariable) {
-            var shadowVariableLoopedDescriptor = shadowVariable.variableReferences().get(0).shadowVariableLoopedDescriptor();
-            if (shadowVariableLoopedDescriptor == null) {
-                return;
-            }
-            var entityGroup = shadowVariable.variableReferences().get(0).groupEntities();
-            if (entityGroup == null) {
-                entitiesForLoopedVarUpdateSet.add(shadowVariable.entity());
-            } else {
-                entitiesForLoopedVarUpdateSet.addAll(Arrays.asList(entityGroup));
-            }
-        }
-
-        public void processAndClear() {
-            for (var entity : entitiesForLoopedVarUpdateSet) {
-                consumer.accept(entity);
-            }
-            entitiesForLoopedVarUpdateSet.clear();
-        }
-
-    }
-
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
@@ -23,6 +23,8 @@ import ai.timefold.solver.core.impl.domain.variable.supply.SupplyManager;
 import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningSolutionMetaModel;
 import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
 
+import org.jspecify.annotations.Nullable;
+
 public class DeclarativeShadowVariableDescriptor<Solution_> extends ShadowVariableDescriptor<Solution_> {
     MemberAccessor calculator;
     RootVariableSource<?, ?>[] sources;
@@ -186,6 +188,10 @@ public class DeclarativeShadowVariableDescriptor<Solution_> extends ShadowVariab
 
     public Function<Object, Object> getAlignmentKeyMap() {
         return alignmentKeyMap;
+    }
+
+    public @Nullable String getAlignmentKeyName() {
+        return alignmentKey;
     }
 
     public RootVariableSource<?, ?>[] getSources() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -17,8 +17,8 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
             IntFunction<TopologicalOrderGraph> graphCreator) {
         super(outerGraph, graphCreator);
 
-        var entityToVariableReferenceMap = new IdentityHashMap<Object, List<EntityVariablePair<Solution_>>>();
-        for (var instance : instanceList) {
+        var entityToVariableReferenceMap = new IdentityHashMap<Object, List<GraphNode<Solution_>>>();
+        for (var instance : nodeList) {
             var entity = instance.entity();
             entityToVariableReferenceMap.computeIfAbsent(entity, ignored -> new ArrayList<>())
                     .add(instance);
@@ -28,8 +28,9 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
         // This mutable structure is created once, and reused from there on.
         // Otherwise its internal collections were observed being re-created so often
         // that the allocation of arrays would become a major bottleneck.
-        affectedEntitiesUpdater = new AffectedEntitiesUpdater<>(graph, instanceList, immutableEntityToVariableReferenceMap::get,
-                outerGraph.entityToEntityId.size(), outerGraph.changedVariableNotifier);
+        affectedEntitiesUpdater =
+                new AffectedEntitiesUpdater<>(graph, nodeList, immutableEntityToVariableReferenceMap::get,
+                        outerGraph.entityToEntityId.size(), outerGraph.changedVariableNotifier);
     }
 
     @Override
@@ -38,7 +39,7 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
     }
 
     @Override
-    public void markChanged(@NonNull EntityVariablePair<Solution_> node) {
+    public void markChanged(@NonNull GraphNode<Solution_> node) {
         changeSet.set(node.graphNodeId());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -29,7 +29,7 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
         // Otherwise its internal collections were observed being re-created so often
         // that the allocation of arrays would become a major bottleneck.
         affectedEntitiesUpdater = new AffectedEntitiesUpdater<>(graph, instanceList, immutableEntityToVariableReferenceMap::get,
-                outerGraph.changedVariableNotifier);
+                outerGraph.entityToEntityId.size(), outerGraph.changedVariableNotifier);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EntityVariablePair.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EntityVariablePair.java
@@ -3,10 +3,11 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public record EntityVariablePair<Solution_>(Object entity, List<VariableUpdaterInfo<Solution_>> variableReferences,
-        int graphNodeId) {
+        int graphNodeId, int entityId, @Nullable int[] groupEntityIds) {
     @Override
     public boolean equals(Object object) {
         if (!(object instanceof EntityVariablePair<?> that))

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -18,12 +18,12 @@ public final class FixedVariableReferenceGraph<Solution_>
             IntFunction<TopologicalOrderGraph> graphCreator) {
         super(outerGraph, graphCreator);
         // We don't use a bit set to store changes, so pass a one-use instance
-        graph.commitChanges(new BitSet(instanceList.size()));
+        graph.commitChanges(new BitSet(nodeList.size()));
         isFinalized = true;
 
         // Now that we know the topological order of nodes, add
         // each node to changed.
-        for (var node = 0; node < instanceList.size(); node++) {
+        for (var node = 0; node < nodeList.size(); node++) {
             changeSet.add(graph.getTopologicalOrder(node));
         }
         changedVariableNotifier = outerGraph.changedVariableNotifier;
@@ -35,7 +35,7 @@ public final class FixedVariableReferenceGraph<Solution_>
     }
 
     @Override
-    public void markChanged(@NonNull EntityVariablePair<Solution_> node) {
+    public void markChanged(@NonNull GraphNode<Solution_> node) {
         // Before the graph is finalized, ignore changes, since
         // we don't know the topological order yet
         if (isFinalized) {
@@ -47,7 +47,7 @@ public final class FixedVariableReferenceGraph<Solution_>
     public void updateChanged() {
         BitSet visited;
         if (!changeSet.isEmpty()) {
-            visited = new BitSet(instanceList.size());
+            visited = new BitSet(nodeList.size());
             visited.set(changeSet.peek().nodeId());
         } else {
             return;
@@ -57,7 +57,7 @@ public final class FixedVariableReferenceGraph<Solution_>
         // their graph (i.e. have two variables ALWAYS depend on one-another).
         while (!changeSet.isEmpty()) {
             var changedNode = changeSet.poll();
-            var entityVariable = instanceList.get(changedNode.nodeId());
+            var entityVariable = nodeList.get(changedNode.nodeId());
             var entity = entityVariable.entity();
             var shadowVariableReferences = entityVariable.variableReferences();
             for (var shadowVariableReference : shadowVariableReferences) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/GraphNode.java
@@ -6,11 +6,11 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
-public record EntityVariablePair<Solution_>(Object entity, List<VariableUpdaterInfo<Solution_>> variableReferences,
+public record GraphNode<Solution_>(Object entity, List<VariableUpdaterInfo<Solution_>> variableReferences,
         int graphNodeId, int entityId, @Nullable int[] groupEntityIds) {
     @Override
     public boolean equals(Object object) {
-        if (!(object instanceof EntityVariablePair<?> that))
+        if (!(object instanceof GraphNode<?> that))
             return false;
         return graphNodeId == that.graphNodeId;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/LoopedTracker.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/LoopedTracker.java
@@ -14,14 +14,25 @@ public final class LoopedTracker {
     private static final LoopedStatus[] VALUES = LoopedStatus.values();
 
     private final DynamicIntArray looped;
+    private final int[][] entityIdToNodes;
 
-    public LoopedTracker(int nodeCount) {
+    public LoopedTracker(int nodeCount, int[][] entityIdToNodes) {
+        this.entityIdToNodes = entityIdToNodes;
         // We never fully clear the array, as that was shown to cause too much GC pressure.
         this.looped = new DynamicIntArray(nodeCount, PARTIAL);
     }
 
     public void mark(int node, LoopedStatus status) {
         looped.set(node, status.ordinal());
+    }
+
+    public boolean isEntityLooped(BaseTopologicalOrderGraph graph, int entityId) {
+        for (var entityNode : entityIdToNodes[entityId]) {
+            if (graph.isLooped(this, entityNode)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public LoopedStatus status(int node) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/LoopedTracker.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/LoopedTracker.java
@@ -2,6 +2,8 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import static ai.timefold.solver.core.impl.util.DynamicIntArray.ClearingStrategy.PARTIAL;
 
+import java.util.Arrays;
+
 import ai.timefold.solver.core.impl.util.DynamicIntArray;
 
 import org.jspecify.annotations.NullMarked;
@@ -16,8 +18,14 @@ public final class LoopedTracker {
     private final DynamicIntArray looped;
     private final int[][] entityIdToNodes;
 
+    // Needed so we can update all nodes in a cycle or depended on a cycle
+    // (only nodes that formed a cycle get marked as changed by the graph;
+    // their dependents don't)
+    private final boolean[] entityLoopedStatusChanged;
+
     public LoopedTracker(int nodeCount, int[][] entityIdToNodes) {
         this.entityIdToNodes = entityIdToNodes;
+        this.entityLoopedStatusChanged = new boolean[entityIdToNodes.length];
         // We never fully clear the array, as that was shown to cause too much GC pressure.
         this.looped = new DynamicIntArray(nodeCount, PARTIAL);
     }
@@ -26,13 +34,23 @@ public final class LoopedTracker {
         looped.set(node, status.ordinal());
     }
 
-    public boolean isEntityLooped(BaseTopologicalOrderGraph graph, int entityId) {
+    public boolean isEntityLooped(BaseTopologicalOrderGraph graph, int entityId, boolean wasEntityLooped) {
         for (var entityNode : entityIdToNodes[entityId]) {
             if (graph.isLooped(this, entityNode)) {
+                if (!wasEntityLooped) {
+                    entityLoopedStatusChanged[entityId] = true;
+                }
                 return true;
             }
         }
+        if (wasEntityLooped) {
+            entityLoopedStatusChanged[entityId] = true;
+        }
         return false;
+    }
+
+    public boolean didEntityLoopedStatusChange(int entityId) {
+        return entityLoopedStatusChanged[entityId];
     }
 
     public LoopedStatus status(int node) {
@@ -42,6 +60,7 @@ public final class LoopedTracker {
     }
 
     public void clear() {
+        Arrays.fill(entityLoopedStatusChanged, false);
         looped.clear();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
@@ -23,6 +23,7 @@ import ai.timefold.solver.core.impl.domain.policy.DescriptorPolicy;
 import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningSolutionMetaModel;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowVariableLooped;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
@@ -386,6 +387,19 @@ public record RootVariableSource<Entity_, Value_>(
         }
         if (getAnnotation(declaringClass, memberName, PlanningVariable.class) != null) {
             return ParentVariableType.VARIABLE;
+        }
+
+        if (getAnnotation(declaringClass, memberName, ShadowVariableLooped.class) != null) {
+            throw new IllegalArgumentException("""
+                    The source path (%s) starting from root class (%s) accesses a @%s property (%s).
+                    Supplier methods are only called when none of their dependencies are looped,
+                    so reading @%s properties are not needed since they are guaranteed to be false
+                    when the supplier is called.
+                    Maybe remove the source path (%s) from the @%s?
+                    """.formatted(
+                    variablePath, rootClass.getCanonicalName(), ShadowVariableLooped.class.getSimpleName(),
+                    memberName, ShadowVariableLooped.class.getSimpleName(),
+                    variablePath, ShadowSources.class.getSimpleName()));
         }
         return ParentVariableType.NO_PARENT;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
@@ -23,7 +23,6 @@ import ai.timefold.solver.core.impl.domain.policy.DescriptorPolicy;
 import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningSolutionMetaModel;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
-import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowVariableLooped;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
@@ -387,18 +386,6 @@ public record RootVariableSource<Entity_, Value_>(
         }
         if (getAnnotation(declaringClass, memberName, PlanningVariable.class) != null) {
             return ParentVariableType.VARIABLE;
-        }
-        if (getAnnotation(declaringClass, memberName, ShadowVariableLooped.class) != null) {
-            throw new IllegalArgumentException("""
-                    The source path (%s) starting from root class (%s) accesses a @%s property (%s).
-                    @%s properties cannot be used as a source, since they are not guaranteed to
-                    be updated when the supplier is called. Supplier methods are only called when
-                    none of their dependencies are looped, so reading @%s properties are not needed.
-                    Maybe remove the source path (%s) from the @%s?
-                    """.formatted(
-                    variablePath, rootClass.getCanonicalName(), ShadowVariableLooped.class.getSimpleName(),
-                    memberName, ShadowVariableLooped.class.getSimpleName(), ShadowVariableLooped.class.getSimpleName(),
-                    variablePath, ShadowSources.class.getSimpleName()));
         }
         return ParentVariableType.NO_PARENT;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalOrderGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalOrderGraph.java
@@ -18,7 +18,7 @@ public interface TopologicalOrderGraph extends BaseTopologicalOrderGraph {
      * @param nodes A list of entity/variable pairs, where the nth item in the list
      *        corresponds to the node with id n in the graph.
      */
-    default <Solution_> void withNodeData(List<EntityVariablePair<Solution_>> nodes) {
+    default <Solution_> void withNodeData(List<GraphNode<Solution_>> nodes) {
     }
 
     /**

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdaterTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdaterTest.java
@@ -55,7 +55,7 @@ class AffectedEntitiesUpdaterTest {
 
         var result = AffectedEntitiesUpdater.createNodeToEntityNodes(3,
                 List.of(a1, b1, a2, c1, b3, b2),
-                entity -> map.get(entity));
+                map::get);
 
         assertThat(result[0]).containsExactlyInAnyOrder(0, 1);
         assertThat(result[1]).containsExactlyInAnyOrder(2, 3, 4);

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdaterTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdaterTest.java
@@ -1,0 +1,64 @@
+package ai.timefold.solver.core.impl.domain.variable.declarative;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class AffectedEntitiesUpdaterTest {
+
+    @Test
+    void createNodeToEntityNodes() {
+        var a = "a";
+        var b = "b";
+        var c = "c";
+
+        var a1 = Mockito.mock(GraphNode.class);
+        when(a1.entity()).thenReturn(a);
+        when(a1.entityId()).thenReturn(0);
+        when(a1.graphNodeId()).thenReturn(0);
+
+        var a2 = Mockito.mock(GraphNode.class);
+        when(a2.entity()).thenReturn(a);
+        when(a2.entityId()).thenReturn(0);
+        when(a2.graphNodeId()).thenReturn(1);
+
+        var b1 = Mockito.mock(GraphNode.class);
+        when(b1.entity()).thenReturn(b);
+        when(b1.entityId()).thenReturn(1);
+        when(b1.graphNodeId()).thenReturn(2);
+
+        var b2 = Mockito.mock(GraphNode.class);
+        when(b2.entity()).thenReturn(b);
+        when(b2.entityId()).thenReturn(1);
+        when(b2.graphNodeId()).thenReturn(3);
+
+        var b3 = Mockito.mock(GraphNode.class);
+        when(b3.entity()).thenReturn(b);
+        when(b3.entityId()).thenReturn(1);
+        when(b3.graphNodeId()).thenReturn(4);
+
+        var c1 = Mockito.mock(GraphNode.class);
+        when(c1.entity()).thenReturn(c);
+        when(c1.entityId()).thenReturn(2);
+        when(c1.graphNodeId()).thenReturn(5);
+
+        var map = new HashMap<Object, List<GraphNode<Object>>>();
+
+        map.put(a, List.of(a1, a2));
+        map.put(b, List.of(b1, b2, b3));
+        map.put(c, List.of(c1));
+
+        var result = AffectedEntitiesUpdater.createNodeToEntityNodes(3,
+                List.of(a1, b1, a2, c1, b3, b2),
+                entity -> map.get(entity));
+
+        assertThat(result[0]).containsExactlyInAnyOrder(0, 1);
+        assertThat(result[1]).containsExactlyInAnyOrder(2, 3, 4);
+        assertThat(result[2]).containsExactlyInAnyOrder(5);
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSourceTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSourceTest.java
@@ -19,8 +19,6 @@ import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescripto
 import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningEntityMetaModel;
 import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningSolutionMetaModel;
 import ai.timefold.solver.core.preview.api.domain.metamodel.ShadowVariableMetaModel;
-import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
-import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowVariableLooped;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataObject;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
@@ -44,6 +42,8 @@ class RootVariableSourceTest {
                     .getMetaModel();
     private final PlanningEntityMetaModel<TestdataInvalidDeclarativeSolution, TestdataInvalidDeclarativeValue> shadowEntityMetaModel =
             planningSolutionMetaModel.entity(TestdataInvalidDeclarativeValue.class);
+    private final ShadowVariableMetaModel<TestdataInvalidDeclarativeSolution, TestdataInvalidDeclarativeValue, TestdataInvalidDeclarativeValue> isLoopedMetaModel =
+            shadowEntityMetaModel.shadowVariable("isLooped");
     private final ShadowVariableMetaModel<TestdataInvalidDeclarativeSolution, TestdataInvalidDeclarativeValue, TestdataInvalidDeclarativeValue> previousElementMetaModel =
             shadowEntityMetaModel.shadowVariable("previous");
     private final ShadowVariableMetaModel<TestdataInvalidDeclarativeSolution, TestdataInvalidDeclarativeValue, TestdataInvalidDeclarativeValue> shadowVariableMetaModel =
@@ -586,20 +586,37 @@ class RootVariableSourceTest {
     }
 
     @Test
-    void errorIfShadowVariableLoopedReferenced() {
-        assertThatCode(() -> RootVariableSource.from(
+    void shadowVariableLoopedReferenced() {
+        var rootVariableSource = RootVariableSource.from(
                 planningSolutionMetaModel,
                 TestdataInvalidDeclarativeValue.class,
                 "shadow",
                 "isLooped",
                 DEFAULT_MEMBER_ACCESSOR_FACTORY,
-                DEFAULT_DESCRIPTOR_POLICY))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContainingAll("The source path (isLooped)",
-                        "starting from root class (" + TestdataInvalidDeclarativeValue.class.getCanonicalName() + ")",
-                        "accesses a @" + ShadowVariableLooped.class.getSimpleName() + " property",
-                        "(isLooped)",
-                        "Maybe remove the source path (isLooped) from the @" + ShadowSources.class.getSimpleName());
+                DEFAULT_DESCRIPTOR_POLICY);
+
+        assertThat(rootVariableSource.rootEntity()).isEqualTo(TestdataInvalidDeclarativeValue.class);
+        assertThat(rootVariableSource.variableSourceReferences()).hasSize(1);
+        assertThat(rootVariableSource.parentVariableType()).isEqualTo(ParentVariableType.NO_PARENT);
+        var source = rootVariableSource.variableSourceReferences().get(0);
+
+        assertEmptyChainToVariableEntity(source);
+        assertThat(source.variableMetaModel()).isEqualTo(isLoopedMetaModel);
+        assertThat(source.isTopLevel()).isTrue();
+        assertThat(source.onRootEntity()).isTrue();
+        assertThat(source.isDeclarative()).isFalse();
+        assertThat(source.targetVariableMetamodel()).isEqualTo(shadowVariableMetaModel);
+        assertThat(source.downstreamDeclarativeVariableMetamodel()).isNull();
+
+        var entity = new TestdataInvalidDeclarativeValue("v1");
+        var result = source.targetEntityFunctionStartingFromVariableEntity().apply(entity);
+
+        assertThat(result).isSameAs(entity);
+
+        var rootVisitor = mock(Consumer.class);
+        rootVariableSource.valueEntityFunction().accept(entity, rootVisitor);
+        verify(rootVisitor).accept(entity);
+        verifyNoMoreInteractions(rootVisitor);
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import ai.timefold.solver.core.api.function.QuadConsumer;
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 import ai.timefold.solver.core.impl.domain.variable.declarative.DefaultTopologicalOrderGraph;
-import ai.timefold.solver.core.impl.domain.variable.declarative.EntityVariablePair;
+import ai.timefold.solver.core.impl.domain.variable.declarative.GraphNode;
 import ai.timefold.solver.core.impl.domain.variable.declarative.TopologicalOrderGraph;
 import ai.timefold.solver.core.impl.domain.variable.declarative.VariableUpdaterInfo;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
@@ -175,8 +175,8 @@ class VariableListenerSupportTest {
         }
 
         @Override
-        public <Solution_> void withNodeData(List<EntityVariablePair<Solution_>> nodes) {
-            nodeToEntities = nodes.stream().map(EntityVariablePair::entity).toArray(Object[]::new);
+        public <Solution_> void withNodeData(List<GraphNode<Solution_>> nodes) {
+            nodeToEntities = nodes.stream().map(GraphNode::entity).toArray(Object[]::new);
             nodeToVariableMetamodel = nodes.stream()
                     .map(e -> e.variableReferences().stream()
                             .map(VariableUpdaterInfo::id)

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/concurrent/TestdataConcurrentValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/concurrent/TestdataConcurrentValue.java
@@ -128,8 +128,7 @@ public class TestdataConcurrentValue {
     }
 
     @ShadowSources(
-            value = { "isInvalid", "concurrentValueGroup[].isInvalid", "serviceReadyTime",
-                    "concurrentValueGroup[].serviceReadyTime" },
+            value = { "serviceReadyTime", "concurrentValueGroup[].serviceReadyTime" },
             alignmentKey = "concurrentValueGroup")
     public LocalDateTime serviceStartTimeUpdater() {
         if (isInvalid) {


### PR DESCRIPTION
- @ShadowVariableLooped is now updated before the
  calculator is called

- Nodes in the graph now have entityId and groupEntityIds

- A mapping is created from entityId to graphNodeId, which
  LoopedTracker will used to lookup the nodes corresponding to
  a given entityId.
