### PR TITLE
feat: allow using builtin variable after builtin variable source in declarative shadow variables

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ChangedVariableNotifier.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ChangedVariableNotifier.java
@@ -1,9 +1,13 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
+import java.util.Collections;
 import java.util.function.BiConsumer;
 
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.inverserelation.CollectionInverseVariableDemand;
+import ai.timefold.solver.core.impl.domain.variable.inverserelation.CollectionInverseVariableSupply;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 import org.jspecify.annotations.Nullable;
 
@@ -16,6 +20,17 @@ public record ChangedVariableNotifier<Solution_>(BiConsumer<VariableDescriptor<S
             (a, b) -> {
             },
             null);
+
+    public CollectionInverseVariableSupply getCollectionInverseVariableSupply(VariableMetaModel<?, ?, ?> variableMetaModel) {
+        if (innerScoreDirector == null) {
+            return entity -> Collections.emptyList();
+        } else {
+            var solutionDescriptor = innerScoreDirector.getSolutionDescriptor();
+            var variableDescriptor = solutionDescriptor.getEntityDescriptorStrict(variableMetaModel.entity().type())
+                    .getVariableDescriptor(variableMetaModel.name());
+            return innerScoreDirector.getSupplyManager().demand(new CollectionInverseVariableDemand<>(variableDescriptor));
+        }
+    }
 
     @SuppressWarnings("unchecked")
     public static <Solution_> ChangedVariableNotifier<Solution_> empty() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
@@ -167,7 +167,7 @@ public record RootVariableSource<Entity_, Value_>(
         for (var i = 0; i < chainStartingFromSourceVariableList.size(); i++) {
             var chainStartingFromSourceVariable = chainStartingFromSourceVariableList.get(i);
             var newSourceReference =
-                    createVariableSourceReferenceFromChain(variablePath, variableSourceReferences, listMemberAccessors,
+                    createVariableSourceReferenceFromChain(listMemberAccessors,
                             solutionMetaModel,
                             rootEntityClass, targetVariableName, chainStartingFromSourceVariable,
                             chainToVariable,
@@ -247,7 +247,6 @@ public record RootVariableSource<Entity_, Value_>(
     }
 
     private static <Entity_> @NonNull VariableSourceReference createVariableSourceReferenceFromChain(
-            String variablePath, List<VariableSourceReference> variableSourceReferences,
             List<MemberAccessor> listMemberAccessors,
             PlanningSolutionMetaModel<?> solutionMetaModel,
             Class<? extends Entity_> rootEntityClass, String targetVariableName, List<MemberAccessor> afterChain,
@@ -266,20 +265,6 @@ public record RootVariableSource<Entity_, Value_>(
                             .variable(maybeDownstreamVariable.getName());
         }
         var isDeclarative = isDeclarativeShadowVariable(variableMemberAccessor);
-        if (!isDeclarative) {
-            for (var previousVariableSourceReference : variableSourceReferences) {
-                if (!previousVariableSourceReference.isDeclarative()) {
-                    throw new IllegalArgumentException(
-                            """
-                                    The source path (%s) starting from root entity class (%s) \
-                                    accesses a non-declarative shadow variable (%s) \
-                                    after another non-declarative shadow variable (%s)."""
-                                    .formatted(
-                                            variablePath, rootEntityClass.getSimpleName(), variableMemberAccessor.getName(),
-                                            previousVariableSourceReference.variableMetaModel().name()));
-                }
-            }
-        }
 
         return new VariableSourceReference(
                 solutionMetaModel.entity(variableMemberAccessor.getDeclaringClass()).variable(variableMemberAccessor.getName()),

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
@@ -75,6 +75,7 @@ public record RootVariableSource<Entity_, Value_>(
         List<MemberAccessor> listMemberAccessors = new ArrayList<>();
         var hasListMemberAccessor = false;
         List<List<MemberAccessor>> chainStartingFromSourceVariableList = new ArrayList<>();
+        List<Integer> factCountAfterSourceVariableToNextVariableList = new ArrayList<>();
         boolean isAfterVariable = false;
         Class<?> currentEntity = rootEntityClass;
         var factCountSinceLastVariable = 0;
@@ -101,6 +102,7 @@ public record RootVariableSource<Entity_, Value_>(
                                 descriptorPolicy);
                 listMemberAccessors.add(memberAccessor);
                 chainToVariable = new ArrayList<>();
+
                 factCountSinceLastVariable = 0;
 
                 currentEntity = ConfigUtils.extractGenericTypeParameterOrFail(ShadowSources.class.getSimpleName(),
@@ -129,6 +131,7 @@ public record RootVariableSource<Entity_, Value_>(
                     chainStartingFromSourceVariable.add(memberAccessor);
                     chainStartingFromSourceVariableList.add(chainStartingFromSourceVariable);
 
+                    factCountAfterSourceVariableToNextVariableList.add(factCountSinceLastVariable);
                     isAfterVariable = true;
                     factCountSinceLastVariable = 0;
 
@@ -167,10 +170,11 @@ public record RootVariableSource<Entity_, Value_>(
         for (var i = 0; i < chainStartingFromSourceVariableList.size(); i++) {
             var chainStartingFromSourceVariable = chainStartingFromSourceVariableList.get(i);
             var newSourceReference =
-                    createVariableSourceReferenceFromChain(listMemberAccessors,
+                    createVariableSourceReferenceFromChain(variablePath,
+                            listMemberAccessors,
                             solutionMetaModel,
                             rootEntityClass, targetVariableName, chainStartingFromSourceVariable,
-                            chainToVariable,
+                            chainToVariable, factCountAfterSourceVariableToNextVariableList.get(i),
                             i == 0,
                             i == chainStartingFromSourceVariableList.size() - 1);
             variableSourceReferences.add(newSourceReference);
@@ -202,6 +206,13 @@ public record RootVariableSource<Entity_, Value_>(
             // Child variable is accessed from a fact from the parent,
             // so it is an indirect variable.
             parentVariableType = ParentVariableType.INDIRECT;
+        }
+
+        if (variableSourceReferences.size() > 2) {
+            throw new IllegalArgumentException("""
+                    The source path (%s) starting from root class (%s) \
+                    references (%d) variables while a maximum of 2 is allowed."
+                    """.formatted(variablePath, rootEntityClass.getCanonicalName(), variableSourceReferences.size()));
         }
 
         return new RootVariableSource<>(rootEntityClass,
@@ -247,10 +258,12 @@ public record RootVariableSource<Entity_, Value_>(
     }
 
     private static <Entity_> @NonNull VariableSourceReference createVariableSourceReferenceFromChain(
+            String variablePath,
             List<MemberAccessor> listMemberAccessors,
             PlanningSolutionMetaModel<?> solutionMetaModel,
             Class<? extends Entity_> rootEntityClass, String targetVariableName, List<MemberAccessor> afterChain,
-            List<MemberAccessor> chainToVariable, boolean isTopLevel, boolean isBottomLevel) {
+            List<MemberAccessor> chainToVariable, int factCountTillNextVariable,
+            boolean isTopLevel, boolean isBottomLevel) {
         var variableMemberAccessor = afterChain.get(0);
         var sourceVariablePath = new VariablePath(variableMemberAccessor.getDeclaringClass(),
                 variableMemberAccessor.getName(),
@@ -265,6 +278,15 @@ public record RootVariableSource<Entity_, Value_>(
                             .variable(maybeDownstreamVariable.getName());
         }
         var isDeclarative = isDeclarativeShadowVariable(variableMemberAccessor);
+
+        if (!isDeclarative && !isTopLevel && factCountTillNextVariable != 0) {
+            throw new IllegalArgumentException(
+                    """
+                            The source path (%s) starting from root class (%s) \
+                            has a non-declarative variable (%s) accessed via a fact after another variable."
+                            """.formatted(variablePath, rootEntityClass.getCanonicalName(),
+                            variableMemberAccessor.getName()));
+        }
 
         return new VariableSourceReference(
                 solutionMetaModel.entity(variableMemberAccessor.getDeclaringClass()).variable(variableMemberAccessor.getName()),

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableSourceReference.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableSourceReference.java
@@ -11,7 +11,7 @@ import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public record VariableSourceReference(VariableMetaModel<?, ?, ?> variableMetaModel,
-        List<MemberAccessor> chainToVariableEntity,
+        List<MemberAccessor> chainFromRootEntityToVariableEntity,
         boolean onRootEntity,
         boolean isTopLevel,
         boolean isBottomLevel,

--- a/core/src/main/java/ai/timefold/solver/core/preview/api/domain/variable/declarative/ShadowSources.java
+++ b/core/src/main/java/ai/timefold/solver/core/preview/api/domain/variable/declarative/ShadowSources.java
@@ -24,12 +24,12 @@ public @interface ShadowSources {
      * "variableName", for referring any variable on the same planning entity.
      * </li>
      * <li>
-     * A list of names seperated by ".", such as "variableOrFact.fact.entity.supplierVariable",
-     * for referencing a supplier variable accessible from the planning entity.
+     * A list of names seperated by ".", such as "variableOrFact.fact.entity.variable",
+     * for referencing a variable accessible from the planning entity.
      * The first property may be a fact or any non-supplier variable; the remaining properties before the end
-     * must be facts, and the final property must be a supplier variable.
-     * For the path "a.b", it refers to the supplier variable "b"
-     * on the property/variable "a" of the planning entity.
+     * must be facts, and the final property must be a variable.
+     * For the path "a.b", it refers to the variable "b"
+     * on the property/variable "a" on the planning entity.
      * In general, if you access a variable in your method using a chain like {@code a.b.c}, that
      * chain should be included as a source.
      * </li>

--- a/core/src/main/java/ai/timefold/solver/core/preview/api/domain/variable/declarative/ShadowSources.java
+++ b/core/src/main/java/ai/timefold/solver/core/preview/api/domain/variable/declarative/ShadowSources.java
@@ -15,7 +15,8 @@ import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ShadowSources {
     /**
-     * The paths to variables the method uses to compute the value of a {@link ShadowVariable#supplierName() supplier variable}.
+     * The paths to variables the method uses to compute the value of a {@link ShadowVariable#supplierName() declarative shadow
+     * variable}.
      * <p>
      * Each path is a {@link String} that is one of the following three forms:
      *
@@ -26,7 +27,7 @@ public @interface ShadowSources {
      * <li>
      * A list of names seperated by ".", such as "variableOrFact.fact.entity.variable",
      * for referencing a variable accessible from the planning entity.
-     * The first property may be a fact or any non-supplier variable; the remaining properties before the end
+     * The first property may be a fact or any non-declarative variable; the remaining properties before the end
      * must be facts, and the final property must be a variable.
      * For the path "a.b", it refers to the variable "b"
      * on the property/variable "a" on the planning entity.
@@ -87,9 +88,9 @@ public @interface ShadowSources {
      * 
      * The value {@code { "previous.endTime", "entity", "dependencies[].endTime") }} is used
      * for {@link ShadowSources} since it accesses
-     * the end time supplier variable of its previous element variable ("previous.endTime"),
+     * the end time declarative shadow variable of its previous element variable ("previous.endTime"),
      * a fact on its inverse relation variable ("entity"),
-     * and the end time supplier variable on each element in its dependencies ("dependencies[].endTime").
+     * and the end time declarative shadow variable on each element in its dependencies ("dependencies[].endTime").
      * <p>
      * 
      * @return A non-empty list of variables the supplier method accesses.

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/dynamic_follower/DynamicFollowerValuesShadowVariableTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/variable/declarative/dynamic_follower/DynamicFollowerValuesShadowVariableTest.java
@@ -1,0 +1,145 @@
+package ai.timefold.solver.core.preview.api.variable.declarative.dynamic_follower;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.solver.SolverFactory;
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
+import ai.timefold.solver.core.impl.move.streams.maybeapi.generic.move.ChangeMove;
+import ai.timefold.solver.core.impl.solver.MoveAsserter;
+import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningVariableMetaModel;
+import ai.timefold.solver.core.testdomain.TestdataValue;
+import ai.timefold.solver.core.testdomain.declarative.dynamic_follower.TestdataDynamicFollowerConstraintProvider;
+import ai.timefold.solver.core.testdomain.declarative.dynamic_follower.TestdataDynamicFollowerEntity;
+import ai.timefold.solver.core.testdomain.declarative.dynamic_follower.TestdataDynamicFollowerSolution;
+import ai.timefold.solver.core.testdomain.declarative.dynamic_follower.TestdataDynamicLeaderEntity;
+
+import org.junit.jupiter.api.Test;
+
+class DynamicFollowerValuesShadowVariableTest {
+    @Test
+    void testSolve() {
+        var problem = TestdataDynamicFollowerSolution.generateSolution(3, 8, 2);
+
+        var solverConfig = new SolverConfig()
+                .withSolutionClass(TestdataDynamicFollowerSolution.class)
+                .withEntityClasses(TestdataDynamicLeaderEntity.class, TestdataDynamicFollowerEntity.class)
+                .withConstraintProviderClass(TestdataDynamicFollowerConstraintProvider.class)
+                .withPreviewFeature(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES)
+                .withEnvironmentMode(EnvironmentMode.FULL_ASSERT)
+                .withTerminationConfig(new TerminationConfig()
+                        .withMoveCountLimit(1_000L));
+
+        var solverFactory = SolverFactory.<TestdataDynamicFollowerSolution> create(solverConfig);
+        var solver = solverFactory.buildSolver();
+        var solution = solver.solve(problem);
+
+        for (var follower : solution.getFollowers()) {
+            assertThat(follower.getValue()).isEqualTo(follower.getLeader().getValue());
+        }
+    }
+
+    @Test
+    void testLeaderValueChangeMove() {
+        var leaderA = new TestdataDynamicLeaderEntity("Leader A");
+        var leaderB = new TestdataDynamicLeaderEntity("Leader B");
+
+        var follower1 = new TestdataDynamicFollowerEntity("Follower 1", leaderA);
+        var follower2 = new TestdataDynamicFollowerEntity("Follower 2", leaderA);
+        var follower3 = new TestdataDynamicFollowerEntity("Follower 3", leaderB);
+
+        var value1 = new TestdataValue("1");
+        var value2 = new TestdataValue("2");
+
+        var solution = new TestdataDynamicFollowerSolution("Solution",
+                List.of(leaderA, leaderB),
+                List.of(follower1, follower2, follower3),
+                List.of(value1, value2));
+
+        var solutionDescriptor = TestdataDynamicFollowerSolution.buildSolutionDescriptor();
+        var variableMetamodel = solutionDescriptor.getMetaModel().entity(TestdataDynamicLeaderEntity.class).variable("value");
+        var moveAsserter = MoveAsserter.create(solutionDescriptor);
+
+        moveAsserter.assertMoveAndApply(solution, new ChangeMove<>(
+                (PlanningVariableMetaModel<TestdataDynamicFollowerSolution, ? super TestdataDynamicLeaderEntity, ? super TestdataValue>) variableMetamodel,
+                leaderA, value1), newSolution -> {
+                    assertThat(follower1.getValue()).isEqualTo(value1);
+                    assertThat(follower2.getValue()).isEqualTo(value1);
+                    assertThat(follower3.getValue()).isEqualTo(null);
+                });
+
+        moveAsserter.assertMoveAndApply(solution, new ChangeMove<>(
+                (PlanningVariableMetaModel<TestdataDynamicFollowerSolution, ? super TestdataDynamicLeaderEntity, ? super TestdataValue>) variableMetamodel,
+                leaderB, value2), newSolution -> {
+                    assertThat(follower1.getValue()).isEqualTo(value1);
+                    assertThat(follower2.getValue()).isEqualTo(value1);
+                    assertThat(follower3.getValue()).isEqualTo(value2);
+                });
+
+        moveAsserter.assertMoveAndApply(solution, new ChangeMove<>(
+                (PlanningVariableMetaModel<TestdataDynamicFollowerSolution, ? super TestdataDynamicLeaderEntity, ? super TestdataValue>) variableMetamodel,
+                leaderA, value2), newSolution -> {
+                    assertThat(follower1.getValue()).isEqualTo(value2);
+                    assertThat(follower2.getValue()).isEqualTo(value2);
+                    assertThat(follower3.getValue()).isEqualTo(value2);
+                });
+    }
+
+    @Test
+    void testLeaderChangeMove() {
+        var leaderA = new TestdataDynamicLeaderEntity("Leader A");
+        var leaderB = new TestdataDynamicLeaderEntity("Leader B");
+
+        var follower1 = new TestdataDynamicFollowerEntity("Follower 1", leaderA);
+        var follower2 = new TestdataDynamicFollowerEntity("Follower 2", leaderA);
+        var follower3 = new TestdataDynamicFollowerEntity("Follower 3", leaderB);
+
+        var value1 = new TestdataValue("1");
+        var value2 = new TestdataValue("2");
+
+        leaderA.setValue(value1);
+        leaderB.setValue(value2);
+
+        follower1.setValue(value1);
+        follower2.setValue(value1);
+        follower3.setValue(value2);
+
+        var solution = new TestdataDynamicFollowerSolution("Solution",
+                List.of(leaderA, leaderB),
+                List.of(follower1, follower2, follower3),
+                List.of(value1, value2));
+
+        var solutionDescriptor = TestdataDynamicFollowerSolution.buildSolutionDescriptor();
+        var variableMetamodel =
+                solutionDescriptor.getMetaModel().entity(TestdataDynamicFollowerEntity.class).variable("leader");
+        var moveAsserter = MoveAsserter.create(solutionDescriptor);
+
+        moveAsserter.assertMoveAndApply(solution, new ChangeMove<>(
+                (PlanningVariableMetaModel<TestdataDynamicFollowerSolution, ? super TestdataDynamicFollowerEntity, ? super TestdataDynamicLeaderEntity>) variableMetamodel,
+                follower1, leaderB), newSolution -> {
+                    assertThat(follower1.getValue()).isEqualTo(value2);
+                    assertThat(follower2.getValue()).isEqualTo(value1);
+                    assertThat(follower3.getValue()).isEqualTo(value2);
+                });
+
+        moveAsserter.assertMoveAndApply(solution, new ChangeMove<>(
+                (PlanningVariableMetaModel<TestdataDynamicFollowerSolution, ? super TestdataDynamicFollowerEntity, ? super TestdataDynamicLeaderEntity>) variableMetamodel,
+                follower3, leaderA), newSolution -> {
+                    assertThat(follower1.getValue()).isEqualTo(value2);
+                    assertThat(follower2.getValue()).isEqualTo(value1);
+                    assertThat(follower3.getValue()).isEqualTo(value1);
+                });
+
+        moveAsserter.assertMoveAndApply(solution, new ChangeMove<>(
+                (PlanningVariableMetaModel<TestdataDynamicFollowerSolution, ? super TestdataDynamicFollowerEntity, ? super TestdataDynamicLeaderEntity>) variableMetamodel,
+                follower1, null), newSolution -> {
+                    assertThat(follower1.getValue()).isEqualTo(null);
+                    assertThat(follower2.getValue()).isEqualTo(value1);
+                    assertThat(follower3.getValue()).isEqualTo(value1);
+                });
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicFollowerConstraintProvider.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicFollowerConstraintProvider.java
@@ -1,0 +1,21 @@
+package ai.timefold.solver.core.testdomain.declarative.dynamic_follower;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+
+import org.jspecify.annotations.NonNull;
+
+public class TestdataDynamicFollowerConstraintProvider implements ConstraintProvider {
+    @Override
+    public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory constraintFactory) {
+        return new Constraint[] {
+                constraintFactory.forEach(TestdataDynamicHasValue.class)
+                        .groupBy(TestdataDynamicHasValue::getValue, ConstraintCollectors.count())
+                        .penalize(SimpleScore.ONE, (value, count) -> count * count)
+                        .asConstraint("Minimize value count")
+        };
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicFollowerEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicFollowerEntity.java
@@ -1,0 +1,54 @@
+package ai.timefold.solver.core.testdomain.declarative.dynamic_follower;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.preview.api.domain.variable.declarative.ShadowSources;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+import ai.timefold.solver.core.testdomain.TestdataValue;
+
+@PlanningEntity
+public class TestdataDynamicFollowerEntity extends TestdataObject implements TestdataDynamicHasValue {
+    @PlanningVariable
+    TestdataDynamicLeaderEntity leader;
+
+    @ShadowVariable(supplierName = "valueSupplier")
+    TestdataValue value;
+
+    public TestdataDynamicFollowerEntity() {
+    }
+
+    public TestdataDynamicFollowerEntity(String code) {
+        super(code);
+    }
+
+    public TestdataDynamicFollowerEntity(String code, TestdataDynamicLeaderEntity leader) {
+        super(code);
+        this.leader = leader;
+    }
+
+    @Override
+    public TestdataValue getValue() {
+        return value;
+    }
+
+    public void setValue(TestdataValue value) {
+        this.value = value;
+    }
+
+    @ShadowSources(value = "leader.value")
+    public TestdataValue valueSupplier() {
+        if (leader == null) {
+            return null;
+        }
+        return leader.value;
+    }
+
+    public TestdataDynamicLeaderEntity getLeader() {
+        return leader;
+    }
+
+    public void setLeader(TestdataDynamicLeaderEntity leader) {
+        this.leader = leader;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicFollowerSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicFollowerSolution.java
@@ -1,0 +1,100 @@
+package ai.timefold.solver.core.testdomain.declarative.dynamic_follower;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.config.solver.PreviewFeature;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+import ai.timefold.solver.core.testdomain.TestdataValue;
+
+@PlanningSolution
+public class TestdataDynamicFollowerSolution extends TestdataObject {
+    public static SolutionDescriptor<TestdataDynamicFollowerSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(Set.of(PreviewFeature.DECLARATIVE_SHADOW_VARIABLES),
+                TestdataDynamicFollowerSolution.class, TestdataDynamicLeaderEntity.class, TestdataDynamicFollowerEntity.class);
+    }
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataDynamicLeaderEntity> leaders;
+
+    @PlanningEntityCollectionProperty
+    List<TestdataDynamicFollowerEntity> followers;
+
+    @ValueRangeProvider
+    List<TestdataValue> values;
+
+    @PlanningScore
+    SimpleScore score;
+
+    public TestdataDynamicFollowerSolution() {
+    }
+
+    public TestdataDynamicFollowerSolution(String code, List<TestdataDynamicLeaderEntity> leaders,
+            List<TestdataDynamicFollowerEntity> followers,
+            List<TestdataValue> values) {
+        super(code);
+        this.leaders = leaders;
+        this.followers = followers;
+        this.values = values;
+    }
+
+    public static TestdataDynamicFollowerSolution generateSolution(int leaderCount, int followerCount, int valueCount) {
+        var leaders = new ArrayList<TestdataDynamicLeaderEntity>(leaderCount);
+        var followers = new ArrayList<TestdataDynamicFollowerEntity>(followerCount);
+        var values = new ArrayList<TestdataValue>(valueCount);
+
+        for (int i = 0; i < leaderCount; i++) {
+            leaders.add(new TestdataDynamicLeaderEntity("Leader %d".formatted(i)));
+        }
+
+        for (var i = 0; i < followerCount; i++) {
+            followers.add(new TestdataDynamicFollowerEntity("Follower %d".formatted(i)));
+        }
+
+        for (var i = 0; i < valueCount; i++) {
+            values.add(new TestdataValue("Value %d".formatted(i)));
+        }
+
+        return new TestdataDynamicFollowerSolution("Solution", leaders, followers, values);
+    }
+
+    public List<TestdataDynamicLeaderEntity> getLeaders() {
+        return leaders;
+    }
+
+    public void setLeaders(List<TestdataDynamicLeaderEntity> leaders) {
+        this.leaders = leaders;
+    }
+
+    public List<TestdataDynamicFollowerEntity> getFollowers() {
+        return followers;
+    }
+
+    public void setFollowers(List<TestdataDynamicFollowerEntity> followers) {
+        this.followers = followers;
+    }
+
+    public List<TestdataValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataValue> values) {
+        this.values = values;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicHasValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicHasValue.java
@@ -1,0 +1,7 @@
+package ai.timefold.solver.core.testdomain.declarative.dynamic_follower;
+
+import ai.timefold.solver.core.testdomain.TestdataValue;
+
+public interface TestdataDynamicHasValue {
+    TestdataValue getValue();
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicLeaderEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/declarative/dynamic_follower/TestdataDynamicLeaderEntity.java
@@ -1,0 +1,28 @@
+package ai.timefold.solver.core.testdomain.declarative.dynamic_follower;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+import ai.timefold.solver.core.testdomain.TestdataValue;
+
+@PlanningEntity
+public class TestdataDynamicLeaderEntity extends TestdataObject implements TestdataDynamicHasValue {
+    @PlanningVariable
+    TestdataValue value;
+
+    public TestdataDynamicLeaderEntity() {
+    }
+
+    public TestdataDynamicLeaderEntity(String code) {
+        super(code);
+    }
+
+    @Override
+    public TestdataValue getValue() {
+        return value;
+    }
+
+    public void setValue(TestdataValue value) {
+        this.value = value;
+    }
+}

--- a/docs/src/modules/ROOT/pages/using-timefold-solver/modeling-planning-problems.adoc
+++ b/docs/src/modules/ROOT/pages/using-timefold-solver/modeling-planning-problems.adoc
@@ -871,7 +871,7 @@ These paths must follow 1 of 3 syntactic forms:
 
 |Chained Property Path
 |"a.b.c"
-|Refers to a supplier variable reachable via chained properties. Intermediate elements must be facts or variables; the final one must be a supplier variable.
+|Refers to a supplier variable reachable via chained properties. Intermediate elements must be facts or variables; the final one must be a variable.
 
 |Collection Element Access
 |"collectionVar[].varName"

--- a/docs/src/modules/ROOT/pages/using-timefold-solver/modeling-planning-problems.adoc
+++ b/docs/src/modules/ROOT/pages/using-timefold-solver/modeling-planning-problems.adoc
@@ -871,7 +871,7 @@ These paths must follow 1 of 3 syntactic forms:
 
 |Chained Property Path
 |"a.b.c"
-|Refers to a supplier variable reachable via chained properties. Intermediate elements must be facts or variables; the final one must be a variable.
+|Refers to a variable reachable via chained properties. Intermediate elements must be facts or variables; the final one must be a variable.
 
 |Collection Element Access
 |"collectionVar[].varName"
@@ -962,7 +962,7 @@ public class Job {
 In certain cases, shadow variables may form an infinite loop.
 When this occurs, the solver detects the cycle, breaks the loop, and assigns `null` to the involved shadow variables.
 
-A supplier variable is considered part of a _loop_ if:
+A declarative shadow variable is considered part of a _loop_ if:
 
 - It directly or indirectly depends on itself.
 For example, if variable `a` depends on `b` and `b` depends on `a`, both are in a loop.


### PR DESCRIPTION
Required to convert [LineOperatorUpdatingVariableListener](https://github.com/TimefoldAI/timefold-quickstarts/blob/stable/java/food-packaging/src/main/java/org/acme/foodpackaging/domain/LineOperatorUpdatingVariableListener.java) to declarative shadow variables.