### PR TITLE
fix: start the termination counter at the first step

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/DiminishedReturnsTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/DiminishedReturnsTermination.java
@@ -180,6 +180,8 @@ final class DiminishedReturnsTermination<Solution_, Score_ extends Score<Score_>
 
     @Override
     public void stepStarted(AbstractStepScope<Solution_> stepScope) {
+        // We reset the count only when the first step begins,
+        // as all necessary resources are loaded, and the phase is ready for execution
         if (locked) {
             start(System.nanoTime(), stepScope.getPhaseScope().getBestScore());
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -5,6 +5,7 @@ import java.time.Clock;
 import ai.timefold.solver.core.impl.constructionheuristic.scope.ConstructionHeuristicPhaseScope;
 import ai.timefold.solver.core.impl.phase.custom.scope.CustomPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
+import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
@@ -18,6 +19,7 @@ final class UnimprovedTimeMillisSpentTermination<Solution_>
     private final long unimprovedTimeMillisSpentLimit;
     private final Clock clock;
 
+    boolean locked = true;
     private boolean currentPhaseSendsBestSolutionEvents = false;
     private long phaseStartedTimeMillis = -1L;
 
@@ -50,7 +52,16 @@ final class UnimprovedTimeMillisSpentTermination<Solution_>
          * and resetting the counter to zero when the next phase starts.
          */
         currentPhaseSendsBestSolutionEvents = phaseScope.isPhaseSendingBestSolutionEvents();
-        phaseStartedTimeMillis = clock.millis();
+    }
+
+    @Override
+    public void stepStarted(AbstractStepScope<Solution_> stepScope) {
+        // We reset the count only when the first step begins,
+        // as all necessary resources are loaded, and the phase is ready for execution
+        if (locked) {
+            phaseStartedTimeMillis = clock.millis();
+            locked = false;
+        }
     }
 
     @Override
@@ -61,6 +72,9 @@ final class UnimprovedTimeMillisSpentTermination<Solution_>
 
     @Override
     public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
+        if (locked) {
+            return false;
+        }
         var bestSolutionTimeMillis = phaseScope.getPhaseBestSolutionTimeMillis();
         return isTerminated(bestSolutionTimeMillis);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -19,7 +19,7 @@ final class UnimprovedTimeMillisSpentTermination<Solution_>
     private final long unimprovedTimeMillisSpentLimit;
     private final Clock clock;
 
-    boolean locked = true;
+    private boolean isCounterStarted = false;
     private boolean currentPhaseSendsBestSolutionEvents = false;
     private long phaseStartedTimeMillis = -1L;
 
@@ -58,9 +58,9 @@ final class UnimprovedTimeMillisSpentTermination<Solution_>
     public void stepStarted(AbstractStepScope<Solution_> stepScope) {
         // We reset the count only when the first step begins,
         // as all necessary resources are loaded, and the phase is ready for execution
-        if (locked) {
+        if (!isCounterStarted) {
             phaseStartedTimeMillis = clock.millis();
-            locked = false;
+            isCounterStarted = true;
         }
     }
 
@@ -72,7 +72,7 @@ final class UnimprovedTimeMillisSpentTermination<Solution_>
 
     @Override
     public boolean isPhaseTerminated(AbstractPhaseScope<Solution_> phaseScope) {
-        if (locked) {
+        if (!isCounterStarted) {
             return false;
         }
         var bestSolutionTimeMillis = phaseScope.getPhaseBestSolutionTimeMillis();

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
@@ -12,6 +12,7 @@ import java.time.Clock;
 import ai.timefold.solver.core.impl.constructionheuristic.scope.ConstructionHeuristicPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
+import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 
@@ -49,13 +50,16 @@ class UnimprovedTimeMillisSpentTerminationTest {
 
     @Test
     void phaseTermination() {
-        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
-        AbstractPhaseScope<TestdataSolution> phaseScope = spy(new LocalSearchPhaseScope<>(solverScope, 0));
-        Clock clock = mock(Clock.class);
+        var solverScope = new SolverScope<TestdataSolution>();
+        var phaseScope = spy(new LocalSearchPhaseScope<TestdataSolution>(solverScope, 0));
+        var stepScope = mock(AbstractStepScope.class);
 
-        UniversalTermination<TestdataSolution> termination = new UnimprovedTimeMillisSpentTermination<>(1000L, clock);
+        var clock = mock(Clock.class);
+
+        var termination = new UnimprovedTimeMillisSpentTermination<TestdataSolution>(1000L, clock);
         termination.solvingStarted(solverScope);
         termination.phaseStarted(phaseScope);
+        termination.stepStarted(stepScope);
 
         doReturn(1000L).when(clock).millis();
         doReturn(500L).when(phaseScope).getPhaseBestSolutionTimeMillis();
@@ -130,5 +134,36 @@ class UnimprovedTimeMillisSpentTerminationTest {
         doReturn(1000L).when(phaseScope).getPhaseBestSolutionTimeMillis();
         assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
         assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.0, withPrecision(0.0));
+    }
+
+    @Test
+    void phaseTerminationAndLongInitializationPeriod() {
+        // The goal is to verify termination after a long initialization,
+        // ensuring the termination does not occur until all necessary resources,
+        // such as distance matrices, are fully loaded.
+        var solverScope = new SolverScope<TestdataSolution>();
+        var phaseScope = spy(new LocalSearchPhaseScope<>(solverScope, 0));
+        var stepScope = mock(AbstractStepScope.class);
+
+        Clock clock = mock(Clock.class);
+
+        var termination = new UnimprovedTimeMillisSpentTermination<TestdataSolution>(1000L, clock);
+        termination.solvingStarted(solverScope);
+        termination.phaseStarted(phaseScope);
+
+        // The termination is not started yet
+        assertThat(termination.locked).isTrue();
+        doReturn(10000L).when(clock).millis();
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+
+        // The counter is started
+        termination.stepStarted(stepScope);
+        doReturn(10500L).when(clock).millis();
+        doReturn(10000L).when(phaseScope).getPhaseBestSolutionTimeMillis();
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+
+        // Timeout
+        doReturn(12000L).when(clock).millis();
+        assertThat(termination.isPhaseTerminated(phaseScope)).isTrue();
     }
 }


### PR DESCRIPTION
When the phase start takes a long time (such as when nearby distance matrix is computed), that time will eat into the grace period of diminished returns, and possibly entirely eradicate it. Therefore we only start the grace period at first step start.