### PR TITLE
fix: Address Quarkus warning about recorders not being injected as RuntimeValue

### DIFF
--- a/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/TimefoldRecorder.java
+++ b/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/TimefoldRecorder.java
@@ -29,9 +29,9 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class TimefoldRecorder {
-    final TimefoldRuntimeConfig timefoldRuntimeConfig;
+    final RuntimeValue<TimefoldRuntimeConfig> timefoldRuntimeConfig;
 
-    public TimefoldRecorder(final TimefoldRuntimeConfig timefoldRuntimeConfig) {
+    public TimefoldRecorder(final RuntimeValue<TimefoldRuntimeConfig> timefoldRuntimeConfig) {
         this.timefoldRuntimeConfig = timefoldRuntimeConfig;
     }
 
@@ -57,7 +57,7 @@ public class TimefoldRecorder {
     }
 
     public void assertNoUnmatchedRuntimeProperties(Set<String> names) {
-        assertNoUnmatchedProperties(names, timefoldRuntimeConfig.solver().keySet());
+        assertNoUnmatchedProperties(names, timefoldRuntimeConfig.getValue().solver().keySet());
     }
 
     public Supplier<SolverConfig> solverConfigSupplier(final String solverName,
@@ -112,7 +112,7 @@ public class TimefoldRecorder {
     }
 
     private void updateSolverConfigWithRuntimeProperties(String solverName, SolverConfig solverConfig) {
-        updateSolverConfigWithRuntimeProperties(solverConfig, timefoldRuntimeConfig
+        updateSolverConfigWithRuntimeProperties(solverConfig, timefoldRuntimeConfig.getValue()
                 .getSolverRuntimeConfig(solverName).orElse(null));
     }
 
@@ -163,7 +163,8 @@ public class TimefoldRecorder {
     }
 
     private void updateSolverManagerConfigWithRuntimeProperties(SolverManagerConfig solverManagerConfig) {
-        timefoldRuntimeConfig.solverManager().parallelSolverCount().ifPresent(solverManagerConfig::setParallelSolverCount);
+        timefoldRuntimeConfig.getValue().solverManager().parallelSolverCount()
+                .ifPresent(solverManagerConfig::setParallelSolverCount);
     }
 
 }

--- a/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/devui/TimefoldDevUIRecorder.java
+++ b/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/devui/TimefoldDevUIRecorder.java
@@ -18,9 +18,9 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class TimefoldDevUIRecorder {
-    final TimefoldRuntimeConfig timefoldRuntimeConfig;
+    final RuntimeValue<TimefoldRuntimeConfig> timefoldRuntimeConfig;
 
-    public TimefoldDevUIRecorder(final TimefoldRuntimeConfig timefoldRuntimeConfig) {
+    public TimefoldDevUIRecorder(final RuntimeValue<TimefoldRuntimeConfig> timefoldRuntimeConfig) {
         this.timefoldRuntimeConfig = timefoldRuntimeConfig;
     }
 
@@ -55,6 +55,6 @@ public class TimefoldDevUIRecorder {
 
     private void updateSolverConfigWithRuntimeProperties(String solverName, SolverConfig solverConfig) {
         TimefoldRecorder.updateSolverConfigWithRuntimeProperties(solverConfig,
-                timefoldRuntimeConfig.getSolverRuntimeConfig(solverName).orElse(null));
+                timefoldRuntimeConfig.getValue().getSolverRuntimeConfig(solverName).orElse(null));
     }
 }


### PR DESCRIPTION
Note: cannot call `getValue` in the constructor, since the constructor is called at build/deployment time when recording, so calling it results in `getValue` throwing an exception.

Fixes https://github.com/TimefoldAI/timefold-solver/issues/1732