### PR TITLE
fix: fail fast when referenced entities are not included in ConstraintVerifier.given or updateShadowVariables

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableUpdateHelper.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableUpdateHelper.java
@@ -136,7 +136,8 @@ public final class ShadowVariableUpdateHelper<Solution_> {
             return new InternalShadowVariableSession<>(solutionDescriptor,
                     DefaultShadowVariableSessionFactory.buildGraph(
                             new DefaultShadowVariableSessionFactory.GraphDescriptor<>(solutionDescriptor,
-                                    ChangedVariableNotifier.empty(), entities).withDiscoveredReferencedEntities()));
+                                    ChangedVariableNotifier.empty(), entities)
+                                    .assertingNoReferencedMissingEntities()));
         }
 
         /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableUpdateHelper.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableUpdateHelper.java
@@ -136,7 +136,7 @@ public final class ShadowVariableUpdateHelper<Solution_> {
             return new InternalShadowVariableSession<>(solutionDescriptor,
                     DefaultShadowVariableSessionFactory.buildGraph(
                             new DefaultShadowVariableSessionFactory.GraphDescriptor<>(solutionDescriptor,
-                                    ChangedVariableNotifier.empty(), entities)));
+                                    ChangedVariableNotifier.empty(), entities).withDiscoveredReferencedEntities()));
         }
 
         /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ConsistencyTracker.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ConsistencyTracker.java
@@ -59,7 +59,7 @@ public record ConsistencyTracker<Solution_>(
                         new GraphStructure.GraphStructureAndDirection(GraphStructure.ARBITRARY, null, null),
                         new DefaultShadowVariableSessionFactory.GraphDescriptor<>(solutionDescriptor,
                                 ChangedVariableNotifier.empty(),
-                                entities).withConsistencyTracker(this));
+                                entities).withConsistencyTracker(this).withDiscoveredReferencedEntities());
 
         // Graph will either be DefaultVariableReferenceGraph or EmptyVariableReferenceGraph
         // If it is empty, we don't need to do anything.

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ConsistencyTracker.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ConsistencyTracker.java
@@ -58,8 +58,9 @@ public record ConsistencyTracker<Solution_>(
                         // if the user specified a specific inconsistency value.
                         new GraphStructure.GraphStructureAndDirection(GraphStructure.ARBITRARY, null, null),
                         new DefaultShadowVariableSessionFactory.GraphDescriptor<>(solutionDescriptor,
-                                ChangedVariableNotifier.empty(),
-                                entities).withConsistencyTracker(this).withDiscoveredReferencedEntities());
+                                ChangedVariableNotifier.empty(), entities)
+                                .withConsistencyTracker(this)
+                                .assertingNoReferencedMissingEntities());
 
         // Graph will either be DefaultVariableReferenceGraph or EmptyVariableReferenceGraph
         // If it is empty, we don't need to do anything.

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DeclarativeShadowVariableDescriptor.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Member;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import ai.timefold.solver.core.api.domain.variable.ShadowSources;
@@ -159,6 +160,12 @@ public class DeclarativeShadowVariableDescriptor<Solution_> extends ShadowVariab
                                     propertyName));
         }
         return member;
+    }
+
+    void visitAllReferencedEntities(Object entity, BiConsumer<RootVariableSource<?, ?>, Object> visitor) {
+        for (var source : sources) {
+            source.visitAllReferencedEntities(entity, referencedEntity -> visitor.accept(source, referencedEntity));
+        }
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -133,7 +133,7 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
                     .limit(LIMIT)
                     .collect(Collectors.joining("  - ", "  - ", "")),
                     (missingEntitySet.size() > LIMIT) ? // Comments to force formatter to not put the conditional on one line
-                            "(%d more...)\n".formatted(missingEntitySet.size() - LIMIT) : //
+                            "(%d more...)%n".formatted(missingEntitySet.size() - LIMIT) : //
                             "", //
                     SolutionManager.class.getSimpleName()));
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -81,9 +81,10 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
                     return """
                             The entity's (%s) shadow variable (%s) refers to a declarative shadow variable on a non-given entity (%s)
                             variable via the source path (%s).
-                            """.formatted(sourceEntity, referringShadowVariable.getVariableName(),
-                            missingReferredEntity,
-                            referredVariableSource.variablePath());
+                            """
+                            .formatted(sourceEntity, referringShadowVariable.getVariableName(),
+                                    missingReferredEntity,
+                                    referredVariableSource.variablePath());
                 }
 
                 @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSource.java
@@ -232,6 +232,16 @@ public record RootVariableSource<Entity_, Value_>(
         }
     }
 
+    void visitAllReferencedEntities(Object rootObject, Consumer<Object> visitor) {
+        for (var variableSourceReference : variableSourceReferences) {
+            if (!variableSourceReference.isDeclarative()) {
+                continue;
+            }
+            getEntityVisitor(variableSourceReference.chainFromRootEntityToVariableEntity())
+                    .accept(rootObject, visitor);
+        }
+    }
+
     private static <Value_> @NonNull BiConsumer<Object, Consumer<Value_>> getRegularSourceEntityVisitor(
             List<MemberAccessor> finalChainToVariable) {
         return (entity, consumer) -> {

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
@@ -379,10 +379,10 @@ public class SolutionManagerTest {
                 .hasMessageContainingAll(
                         "The entity's (%s) shadow variable (serviceStartTime) refers to a declarative shadow variable on a non-given entity (%s)"
                                 .formatted(a1,
-                                a2),
+                                        a2),
                         "The entity's (%s) shadow variable (serviceReadyTime) refers to a declarative shadow variable on a non-given entity (%s)"
                                 .formatted(a2,
-                                b2),
+                                        b2),
                         "The entity's (%s) shadow variable (serviceStartTime) refers to a declarative shadow variable on a non-given entity (%s)"
                                 .formatted(b2, b1));
     }

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
@@ -377,11 +377,13 @@ public class SolutionManagerTest {
         assertThatCode(() -> SolutionManager.updateShadowVariables(TestdataConcurrentSolution.class, a1, e1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContainingAll(
-                        "The entity's (%s) shadow variable (serviceStartTime) refers to a non-given entity (%s)".formatted(a1,
+                        "The entity's (%s) shadow variable (serviceStartTime) refers to a declarative shadow variable on a non-given entity (%s)"
+                                .formatted(a1,
                                 a2),
-                        "The entity's (%s) shadow variable (serviceReadyTime) refers to a non-given entity (%s)".formatted(a2,
+                        "The entity's (%s) shadow variable (serviceReadyTime) refers to a declarative shadow variable on a non-given entity (%s)"
+                                .formatted(a2,
                                 b2),
-                        "The entity's (%s) shadow variable (serviceStartTime) refers to a non-given entity (%s)"
+                        "The entity's (%s) shadow variable (serviceStartTime) refers to a declarative shadow variable on a non-given entity (%s)"
                                 .formatted(b2, b1));
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
@@ -53,6 +53,7 @@ import ai.timefold.solver.core.testdomain.unassignedvar.TestdataAllowsUnassigned
 import ai.timefold.solver.core.testdomain.unassignedvar.TestdataAllowsUnassignedSolution;
 
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -338,6 +339,50 @@ public class SolutionManagerTest {
         var score = solutionManager.update(solution, SolutionUpdatePolicy.UPDATE_SCORE_ONLY);
         assertThat(score).isEqualTo(HardSoftScore.ofHard(-4));
         assertThat(solution.getScore()).isEqualTo(HardSoftScore.ofHard(-4));
+    }
+
+    @Test
+    void updateShadowVariableFailsIfReferencedEntitiesAreNotGiven() {
+        var e1 = new TestdataConcurrentEntity("e1");
+        var e2 = new TestdataConcurrentEntity("e2");
+
+        var a1 = new TestdataConcurrentValue("a1");
+        var a2 = new TestdataConcurrentValue("a2");
+        var b1 = new TestdataConcurrentValue("b1");
+        var b2 = new TestdataConcurrentValue("b2");
+
+        var groupA = List.of(a1, a2);
+        var groupB = List.of(b1, b2);
+
+        a1.setConcurrentValueGroup(groupA);
+        a2.setConcurrentValueGroup(groupA);
+
+        b1.setConcurrentValueGroup(groupB);
+        b2.setConcurrentValueGroup(groupB);
+
+        e1.setValues(List.of(a1, b1));
+        e2.setValues(List.of(b2, a2));
+
+        b1.setPreviousValue(a1);
+        a2.setPreviousValue(b2);
+
+        a1.setNextValue(b1);
+        b2.setNextValue(a2);
+
+        a1.setEntity(e1);
+        b1.setEntity(e1);
+        a2.setEntity(e2);
+        b2.setEntity(e2);
+
+        assertThatCode(() -> SolutionManager.updateShadowVariables(TestdataConcurrentSolution.class, a1, e1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContainingAll(
+                        "The entity's (%s) shadow variable (serviceStartTime) refers to a non-given entity (%s)".formatted(a1,
+                                a2),
+                        "The entity's (%s) shadow variable (serviceReadyTime) refers to a non-given entity (%s)".formatted(a2,
+                                b2),
+                        "The entity's (%s) shadow variable (serviceStartTime) refers to a non-given entity (%s)"
+                                .formatted(b2, b1));
     }
 
     @ParameterizedTest

--- a/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
+++ b/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
@@ -163,8 +163,8 @@ class SingleConstraintAssertionTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContainingAll(
                         "Found referenced entities that were not given",
-                        "The entity's (current{endTime=null}) shadow variable (startTime) refers to a non-given entity (dependency{endTime=null})",
-                        "The entity's (dependency{endTime=null}) shadow variable (startTime) refers to a non-given entity (previous{endTime=null})");
+                        "The entity's (current{endTime=null}) shadow variable (startTime) refers to a declarative shadow variable on a non-given entity (dependency{endTime=null})",
+                        "The entity's (dependency{endTime=null}) shadow variable (startTime) refers to a declarative shadow variable on a non-given entity (previous{endTime=null})");
     }
 
     @Test


### PR DESCRIPTION
Let a, b be entities, and let a.start = b.end + 1. Previously, if you were to do

    constraintVerifier.verifyThat(...).given(a)

or

    SolutionManager.updateShadowVariables(Solution.class, a)

an non-descriptive IllegalArgumentException would be thrown, since a references a non-given entity b, which is unknown to the ShadowVariableGraph.

Now, we discover all entities referenced by the given entities, and how they are referenced, and include them in the exception message.