### PR TITLE
fix: process deep-cloned entities in a queue for GizmoSolutionCloner

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoClassLoader.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoClassLoader.java
@@ -10,15 +10,20 @@ import java.util.Map;
  */
 public final class GizmoClassLoader extends ClassLoader {
 
-    private final Map<String, byte[]> classNameToBytecodeMap = new HashMap<>();
+    private final Map<String, byte[]> classNameToBytecodeMap;
 
     public GizmoClassLoader() {
+        this(new HashMap<>());
+    }
+
+    public GizmoClassLoader(Map<String, byte[]> classNameToBytecodeMap) {
         /*
          * As parent, Gizmo needs to use the same ClassLoader that loaded its own class.
          * Otherwise, issues will arise in Quarkus with MemberAccessors which were first loaded by Quarkus
          * and then loaded again by Gizmo, which uses the default parent ClassLoader.
          */
         super(GizmoClassLoader.class.getClassLoader());
+        this.classNameToBytecodeMap = classNameToBytecodeMap;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerClassOutput.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerClassOutput.java
@@ -1,0 +1,28 @@
+package ai.timefold.solver.core.impl.domain.solution.cloner.gizmo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import io.quarkus.gizmo.ClassOutput;
+
+record GizmoSolutionClonerClassOutput(Map<String, byte[]> classNameToBytecode) implements ClassOutput {
+    @Override
+    public void write(String classInternalName, byte[] byteCode) {
+        classNameToBytecode.put(classInternalName.replace('/', '.'), byteCode);
+        if (GizmoSolutionClonerImplementor.DEBUG) {
+            Path debugRoot = Paths.get("target/timefold-solver-generated-classes");
+            Path rest = Paths.get(classInternalName + ".class");
+            Path destination = debugRoot.resolve(rest);
+
+            try {
+                Files.createDirectories(destination.getParent());
+                Files.write(destination, byteCode);
+            } catch (IOException e) {
+                throw new IllegalStateException("Fail to write debug class file (%s).".formatted(destination), e);
+            }
+        }
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
@@ -10,6 +10,7 @@ import java.lang.reflect.WildcardType;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -21,11 +22,11 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -37,15 +38,13 @@ import ai.timefold.solver.core.impl.domain.solution.cloner.DeepCloningUtils;
 import ai.timefold.solver.core.impl.domain.solution.cloner.FieldAccessingSolutionCloner;
 import ai.timefold.solver.core.impl.domain.solution.cloner.PlanningCloneable;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import ai.timefold.solver.core.impl.util.MutableReference;
+import ai.timefold.solver.core.impl.util.Pair;
 
 import io.quarkus.gizmo.AssignableResultHandle;
-import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 
@@ -59,6 +58,30 @@ public class GizmoSolutionClonerImplementor {
     private static final String FALLBACK_CLONER = "fallbackCloner";
     public static final boolean DEBUG = false;
 
+    protected record ClonerDescriptor(SolutionDescriptor<?> solutionDescriptor,
+            Map<Class<?>, GizmoSolutionOrEntityDescriptor> memoizedSolutionOrEntityDescriptorMap,
+            SortedSet<Class<?>> deepClonedClassesSortedSet,
+            ClassCreator classCreator) {
+    }
+
+    protected record ClonerMethodDescriptor(GizmoSolutionOrEntityDescriptor entityDescriptor,
+            BytecodeCreator bytecodeCreator,
+            ResultHandle createdCloneMap,
+            boolean isBottom,
+            ResultHandle cloneQueue) {
+        public ClonerMethodDescriptor withBytecodeCreator(BytecodeCreator bytecodeCreator) {
+            return new ClonerMethodDescriptor(entityDescriptor, bytecodeCreator, createdCloneMap, isBottom, cloneQueue);
+        }
+
+        public ClonerMethodDescriptor withCreatedCloneMap(ResultHandle createdCloneMap) {
+            return new ClonerMethodDescriptor(entityDescriptor, bytecodeCreator, createdCloneMap, isBottom, cloneQueue);
+        }
+
+        public ClonerMethodDescriptor withCloneQueue(ResultHandle cloneQueue) {
+            return new ClonerMethodDescriptor(entityDescriptor, bytecodeCreator, createdCloneMap, isBottom, cloneQueue);
+        }
+    }
+
     /**
      * Return a comparator that sorts classes into instanceof check order.
      * In particular, if x is a subclass of y, then x will appear earlier
@@ -69,7 +92,7 @@ public class GizmoSolutionClonerImplementor {
      *         x &lt; y if x is assignable from y.
      */
     public static Comparator<Class<?>> getInstanceOfComparator(Set<Class<?>> deepClonedClassSet) {
-        Map<Class<?>, Integer> classToSubclassLevel = new HashMap<>();
+        var classToSubclassLevel = new HashMap<Class<?>, Integer>();
         deepClonedClassSet
                 .forEach(clazz -> {
                     if (deepClonedClassSet.stream()
@@ -78,22 +101,22 @@ public class GizmoSolutionClonerImplementor {
                         classToSubclassLevel.put(clazz, 0);
                     }
                 });
-        boolean isChanged = true;
+        var isChanged = true;
         while (isChanged) {
             // Need to iterate over all classes
             // since maxSubclassLevel can change
             // (for instance, Tiger extends Cat (1) implements Animal (0))
             isChanged = false;
             for (Class<?> clazz : deepClonedClassSet) {
-                Optional<Integer> maxParentSubclassLevel = classToSubclassLevel.keySet().stream()
+                var maxParentSubclassLevel = classToSubclassLevel.keySet().stream()
                         .filter(otherClazz -> otherClazz != clazz && otherClazz.isAssignableFrom(clazz))
                         .map(classToSubclassLevel::get)
                         .max(Integer::compare);
 
                 if (maxParentSubclassLevel.isPresent()) {
-                    Integer oldVal = classToSubclassLevel.getOrDefault(clazz, -1);
-                    Integer newVal = maxParentSubclassLevel.get() + 1;
-                    if (newVal.compareTo(oldVal) > 0) {
+                    var oldVal = (int) classToSubclassLevel.getOrDefault(clazz, -1);
+                    var newVal = maxParentSubclassLevel.get() + 1;
+                    if (newVal > oldVal) {
                         isChanged = true;
                         classToSubclassLevel.put(clazz, newVal);
                     }
@@ -105,8 +128,8 @@ public class GizmoSolutionClonerImplementor {
                 .thenComparing(Class::getName).reversed();
     }
 
-    protected void createFields(ClassCreator classCreator) {
-        classCreator.getFieldCreator(FALLBACK_CLONER, FieldAccessingSolutionCloner.class)
+    protected void createFields(ClonerDescriptor clonerDescriptor) {
+        clonerDescriptor.classCreator.getFieldCreator(FALLBACK_CLONER, FieldAccessingSolutionCloner.class)
                 .setModifiers(Modifier.PRIVATE | Modifier.STATIC);
     }
 
@@ -137,51 +160,49 @@ public class GizmoSolutionClonerImplementor {
             Set<Class<?>> solutionClassSet,
             Map<Class<?>, GizmoSolutionOrEntityDescriptor> memoizedSolutionOrEntityDescriptorMap,
             Set<Class<?>> deepClonedClassSet) {
-        GizmoSolutionClonerImplementor implementor = implementorSupplier.get();
+        var implementor = implementorSupplier.get();
         // Classes that are not instances of any other class in the collection
         // have a subclass level of 0.
         // Other classes subclass level is the maximum of the subclass level
         // of the classes it is a subclass of + 1
-        Set<Class<?>> deepCloneClassesThatAreNotSolutionSet =
+        var deepCloneClassesThatAreNotSolutionSet =
                 deepClonedClassSet.stream()
                         .filter(clazz -> !solutionClassSet.contains(clazz) && !clazz.isArray())
                         .filter(GizmoSolutionClonerImplementor::isCloneableClass)
                         .collect(Collectors.toSet());
 
-        Comparator<Class<?>> instanceOfComparator = getInstanceOfComparator(deepClonedClassSet);
-        SortedSet<Class<?>> deepCloneClassesThatAreNotSolutionSortedSet = new TreeSet<>(instanceOfComparator);
+        var instanceOfComparator = getInstanceOfComparator(deepClonedClassSet);
+        var deepCloneClassesThatAreNotSolutionSortedSet = new TreeSet<>(instanceOfComparator);
         deepCloneClassesThatAreNotSolutionSortedSet.addAll(deepCloneClassesThatAreNotSolutionSet);
 
-        implementor.createFields(classCreator);
-        implementor.createConstructor(classCreator);
-        implementor.createSetSolutionDescriptor(classCreator, solutionDescriptor);
-        implementor.createCloneSolution(classCreator, solutionDescriptor);
-        implementor.createCloneSolutionRun(classCreator, solutionDescriptor, solutionClassSet,
-                memoizedSolutionOrEntityDescriptorMap,
-                deepCloneClassesThatAreNotSolutionSortedSet, instanceOfComparator);
+        var clonerDescriptor = new ClonerDescriptor(solutionDescriptor, memoizedSolutionOrEntityDescriptorMap,
+                deepCloneClassesThatAreNotSolutionSortedSet,
+                classCreator);
 
-        for (Class<?> deepClonedClass : deepCloneClassesThatAreNotSolutionSortedSet) {
-            implementor.createDeepCloneHelperMethod(classCreator, deepClonedClass, solutionDescriptor,
-                    memoizedSolutionOrEntityDescriptorMap,
-                    deepCloneClassesThatAreNotSolutionSortedSet);
+        implementor.createFields(clonerDescriptor);
+        implementor.createConstructor(clonerDescriptor);
+        implementor.createSetSolutionDescriptor(clonerDescriptor);
+        implementor.createCloneSolution(clonerDescriptor);
+        implementor.createCloneSolutionRun(clonerDescriptor, solutionClassSet, instanceOfComparator);
+
+        for (var deepClonedClass : deepCloneClassesThatAreNotSolutionSortedSet) {
+            implementor.createDeepCloneHelperMethod(clonerDescriptor, deepClonedClass);
         }
 
-        Set<Class<?>> abstractDeepCloneClassSet =
+        var abstractDeepCloneClassSet =
                 deepClonedClassSet.stream()
                         .filter(clazz -> !solutionClassSet.contains(clazz) && !clazz.isArray())
                         .filter(Predicate.not(GizmoSolutionClonerImplementor::isCloneableClass))
                         .collect(Collectors.toSet());
 
-        for (Class<?> abstractDeepClonedClass : abstractDeepCloneClassSet) {
-            implementor.createAbstractDeepCloneHelperMethod(classCreator, abstractDeepClonedClass, solutionDescriptor,
-                    memoizedSolutionOrEntityDescriptorMap,
-                    deepCloneClassesThatAreNotSolutionSortedSet);
+        for (var abstractDeepClonedClass : abstractDeepCloneClassSet) {
+            implementor.createAbstractDeepCloneHelperMethod(clonerDescriptor, abstractDeepClonedClass);
         }
     }
 
-    public static ClassOutput createClassOutputWithDebuggingCapability(MutableReference<byte[]> classBytecodeHolder) {
+    public static ClassOutput createClassOutputWithDebuggingCapability(List<Pair<String, byte[]>> classBytecodeHolder) {
         return (path, byteCode) -> {
-            classBytecodeHolder.setValue(byteCode);
+            classBytecodeHolder.add(new Pair<>(path.replace('/', '.'), byteCode));
 
             if (DEBUG) {
                 Path debugRoot = Paths.get("target/timefold-solver-generated-classes");
@@ -200,13 +221,13 @@ public class GizmoSolutionClonerImplementor {
 
     static <T> SolutionCloner<T> createClonerFor(SolutionDescriptor<T> solutionDescriptor,
             GizmoClassLoader gizmoClassLoader) {
-        GizmoSolutionClonerImplementor implementor = new GizmoSolutionClonerImplementor();
-        String className = GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor);
+        var implementor = new GizmoSolutionClonerImplementor();
+        var className = GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor);
         if (gizmoClassLoader.hasBytecodeFor(className)) {
             return implementor.createInstance(className, gizmoClassLoader, solutionDescriptor);
         }
-        MutableReference<byte[]> classBytecodeHolder = new MutableReference<>(null);
-        ClassCreator classCreator = ClassCreator.builder()
+        var classBytecodeHolder = new ArrayList<Pair<String, byte[]>>();
+        var classCreator = ClassCreator.builder()
                 .className(className)
                 .interfaces(GizmoSolutionCloner.class)
                 .superClass(Object.class)
@@ -214,16 +235,17 @@ public class GizmoSolutionClonerImplementor {
                 .setFinal(true)
                 .build();
 
-        Set<Class<?>> deepClonedClassSet = GizmoCloningUtils.getDeepClonedClasses(solutionDescriptor, Collections.emptyList());
+        var deepClonedClassSet = GizmoCloningUtils.getDeepClonedClasses(solutionDescriptor, Collections.emptyList());
 
         defineClonerFor(() -> implementor, classCreator, solutionDescriptor,
                 Collections.singleton(solutionDescriptor.getSolutionClass()),
                 new HashMap<>(), deepClonedClassSet);
 
         classCreator.close();
-        byte[] classBytecode = classBytecodeHolder.getValue();
+        for (var bytecodeEntry : classBytecodeHolder) {
+            gizmoClassLoader.storeBytecode(bytecodeEntry.key(), bytecodeEntry.value());
+        }
 
-        gizmoClassLoader.storeBytecode(className, classBytecode);
         return implementor.createInstance(className, gizmoClassLoader, solutionDescriptor);
     }
 
@@ -231,9 +253,9 @@ public class GizmoSolutionClonerImplementor {
             SolutionDescriptor<T> solutionDescriptor) {
         try {
             @SuppressWarnings("unchecked")
-            Class<? extends GizmoSolutionCloner<T>> outClass =
+            var outClass =
                     (Class<? extends GizmoSolutionCloner<T>>) gizmoClassLoader.loadClass(className);
-            GizmoSolutionCloner<T> out = outClass.getConstructor().newInstance();
+            var out = outClass.getConstructor().newInstance();
             out.setSolutionDescriptor(solutionDescriptor);
             return out;
         } catch (InvocationTargetException | InstantiationException | IllegalAccessException | ClassNotFoundException
@@ -242,10 +264,10 @@ public class GizmoSolutionClonerImplementor {
         }
     }
 
-    private void createConstructor(ClassCreator classCreator) {
-        MethodCreator methodCreator = classCreator.getMethodCreator(
-                MethodDescriptor.ofConstructor(classCreator.getClassName()));
-        ResultHandle thisObj = methodCreator.getThis();
+    private void createConstructor(ClonerDescriptor clonerDescriptor) {
+        var methodCreator = clonerDescriptor.classCreator.getMethodCreator(
+                MethodDescriptor.ofConstructor(clonerDescriptor.classCreator.getClassName()));
+        var thisObj = methodCreator.getThis();
 
         // Invoke Object's constructor
         methodCreator.invokeSpecialMethod(MethodDescriptor.ofConstructor(Object.class), thisObj);
@@ -254,13 +276,13 @@ public class GizmoSolutionClonerImplementor {
         methodCreator.returnValue(thisObj);
     }
 
-    protected void createSetSolutionDescriptor(ClassCreator classCreator, SolutionDescriptor<?> solutionDescriptor) {
-        MethodCreator methodCreator = classCreator.getMethodCreator(
+    protected void createSetSolutionDescriptor(ClonerDescriptor clonerDescriptor) {
+        var methodCreator = clonerDescriptor.classCreator.getMethodCreator(
                 MethodDescriptor.ofMethod(GizmoSolutionCloner.class, "setSolutionDescriptor", void.class,
                         SolutionDescriptor.class));
 
         methodCreator.writeStaticField(FieldDescriptor.of(
-                GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor),
+                GizmoSolutionClonerFactory.getGeneratedClassName(clonerDescriptor.solutionDescriptor),
                 FALLBACK_CLONER, FieldAccessingSolutionCloner.class),
                 methodCreator.newInstance(
                         MethodDescriptor.ofConstructor(FieldAccessingSolutionCloner.class, SolutionDescriptor.class),
@@ -269,121 +291,134 @@ public class GizmoSolutionClonerImplementor {
         methodCreator.returnValue(null);
     }
 
-    private void createCloneSolution(ClassCreator classCreator, SolutionDescriptor<?> solutionDescriptor) {
-        Class<?> solutionClass = solutionDescriptor.getSolutionClass();
-        MethodCreator methodCreator =
-                classCreator.getMethodCreator(MethodDescriptor.ofMethod(SolutionCloner.class,
+    private void createCloneSolution(ClonerDescriptor clonerDescriptor) {
+        var solutionClass = clonerDescriptor.solutionDescriptor.getSolutionClass();
+        var methodCreator =
+                clonerDescriptor.classCreator.getMethodCreator(MethodDescriptor.ofMethod(SolutionCloner.class,
                         "cloneSolution",
                         Object.class,
                         Object.class));
 
-        ResultHandle thisObj = methodCreator.getMethodParam(0);
+        var thisObj = methodCreator.getMethodParam(0);
 
-        ResultHandle clone = methodCreator.invokeStaticMethod(
+        var clone = methodCreator.invokeStaticMethod(
                 MethodDescriptor.ofMethod(
-                        GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor),
+                        GizmoSolutionClonerFactory.getGeneratedClassName(clonerDescriptor.solutionDescriptor),
                         "cloneSolutionRun", solutionClass, solutionClass, Map.class),
                 thisObj,
                 methodCreator.newInstance(MethodDescriptor.ofConstructor(IdentityHashMap.class)));
         methodCreator.returnValue(clone);
     }
 
-    private void createCloneSolutionRun(ClassCreator classCreator, SolutionDescriptor<?> solutionDescriptor,
-            Set<Class<?>> solutionClassSet,
-            Map<Class<?>, GizmoSolutionOrEntityDescriptor> memoizedSolutionOrEntityDescriptorMap,
-            SortedSet<Class<?>> deepClonedClassesSortedSet, Comparator<Class<?>> instanceOfComparator) {
-        Class<?> solutionClass = solutionDescriptor.getSolutionClass();
-        MethodCreator methodCreator =
-                classCreator.getMethodCreator("cloneSolutionRun", solutionClass, solutionClass, Map.class);
-        methodCreator.setModifiers(Modifier.STATIC | Modifier.PRIVATE);
+    private void createCloneSolutionRun(ClonerDescriptor clonerDescriptor,
+            Set<Class<?>> solutionClassSet, Comparator<Class<?>> instanceOfComparator) {
+        var solutionClass = clonerDescriptor.solutionDescriptor.getSolutionClass();
+        var methodCreator =
+                clonerDescriptor.classCreator.getMethodCreator("cloneSolutionRun", solutionClass, solutionClass, Map.class);
+        methodCreator.setModifiers(Modifier.STATIC | Modifier.PUBLIC);
 
-        ResultHandle thisObj = methodCreator.getMethodParam(0);
-        BranchResult solutionNullBranchResult = methodCreator.ifNull(thisObj);
-        BytecodeCreator solutionIsNullBranch = solutionNullBranchResult.trueBranch();
-        solutionIsNullBranch.returnValue(thisObj); // thisObj is null
-
-        BytecodeCreator solutionIsNotNullBranch = solutionNullBranchResult.falseBranch();
-
-        ResultHandle createdCloneMap = methodCreator.getMethodParam(1);
-
-        ResultHandle maybeClone = solutionIsNotNullBranch.invokeInterfaceMethod(
-                GET_METHOD, createdCloneMap, thisObj);
-        BranchResult hasCloneBranchResult = solutionIsNotNullBranch.ifNotNull(maybeClone);
-        BytecodeCreator hasCloneBranch = hasCloneBranchResult.trueBranch();
-        hasCloneBranch.returnValue(maybeClone);
-
-        BytecodeCreator noCloneBranch = hasCloneBranchResult.falseBranch();
-        List<Class<?>> sortedSolutionClassList = new ArrayList<>(solutionClassSet);
-        sortedSolutionClassList.sort(instanceOfComparator);
-
-        BytecodeCreator currentBranch = noCloneBranch;
-        ResultHandle thisObjClass =
-                currentBranch.invokeVirtualMethod(MethodDescriptor.ofMethod(Object.class, "getClass", Class.class), thisObj);
-        for (Class<?> solutionSubclass : sortedSolutionClassList) {
-            ResultHandle solutionSubclassResultHandle = currentBranch.loadClass(solutionSubclass);
-            ResultHandle isSubclass =
-                    currentBranch.invokeVirtualMethod(EQUALS_METHOD, solutionSubclassResultHandle, thisObjClass);
-            BranchResult isSubclassBranchResult = currentBranch.ifTrue(isSubclass);
-
-            BytecodeCreator isSubclassBranch = isSubclassBranchResult.trueBranch();
-
-            GizmoSolutionOrEntityDescriptor solutionSubclassDescriptor =
-                    memoizedSolutionOrEntityDescriptorMap.computeIfAbsent(solutionSubclass,
-                            key -> new GizmoSolutionOrEntityDescriptor(solutionDescriptor, solutionSubclass));
-
-            ResultHandle clone;
-            if (PlanningCloneable.class.isAssignableFrom(solutionSubclass)) {
-                clone = isSubclassBranch.invokeInterfaceMethod(
-                        MethodDescriptor.ofMethod(PlanningCloneable.class, "createNewInstance", Object.class),
-                        thisObj);
-                clone = isSubclassBranch.checkCast(clone, solutionSubclass);
-            } else {
-                clone = isSubclassBranch.newInstance(MethodDescriptor.ofConstructor(solutionSubclass));
-            }
-
-            isSubclassBranch.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class, Object.class),
-                    createdCloneMap, thisObj, clone);
-
-            for (GizmoMemberDescriptor shallowlyClonedField : solutionSubclassDescriptor.getShallowClonedMemberDescriptors()) {
-                writeShallowCloneInstructions(solutionSubclassDescriptor, isSubclassBranch, shallowlyClonedField, thisObj,
-                        clone, createdCloneMap, deepClonedClassesSortedSet);
-            }
-
-            for (Field deeplyClonedField : solutionSubclassDescriptor.getDeepClonedFields()) {
-                GizmoMemberDescriptor gizmoMemberDescriptor =
-                        solutionSubclassDescriptor.getMemberDescriptorForField(deeplyClonedField);
-
-                ResultHandle fieldValue = gizmoMemberDescriptor.readMemberValue(isSubclassBranch, thisObj);
-                AssignableResultHandle cloneValue = isSubclassBranch.createVariable(deeplyClonedField.getType());
-                writeDeepCloneInstructions(isSubclassBranch, solutionSubclassDescriptor, deeplyClonedField,
-                        gizmoMemberDescriptor, fieldValue, cloneValue, createdCloneMap, deepClonedClassesSortedSet);
-
-                if (!gizmoMemberDescriptor.writeMemberValue(isSubclassBranch, clone, cloneValue)) {
-                    throw new IllegalStateException("The member (" + gizmoMemberDescriptor.getName() + ") of class (" +
-                            gizmoMemberDescriptor.getDeclaringClassName() +
-                            ") does not have a setter.");
-                }
-            }
-            isSubclassBranch.returnValue(clone);
-
-            currentBranch = isSubclassBranchResult.falseBranch();
+        var thisObj = methodCreator.getMethodParam(0);
+        var solutionNullBranchResult = methodCreator.ifNull(thisObj);
+        try (var solutionIsNullBranch = solutionNullBranchResult.trueBranch()) {
+            solutionIsNullBranch.returnValue(thisObj); // thisObj is null
         }
-        ResultHandle errorBuilder = currentBranch.newInstance(MethodDescriptor.ofConstructor(StringBuilder.class, String.class),
-                currentBranch.load("Failed to create clone: encountered ("));
-        final MethodDescriptor APPEND =
-                MethodDescriptor.ofMethod(StringBuilder.class, "append", StringBuilder.class, Object.class);
 
-        currentBranch.invokeVirtualMethod(APPEND, errorBuilder, thisObjClass);
-        currentBranch.invokeVirtualMethod(APPEND, errorBuilder, currentBranch.load(") which is not a known subclass of " +
-                "the solution class (" + solutionDescriptor.getSolutionClass() + "). The known subclasses are " +
-                solutionClassSet.stream().map(Class::getName).collect(Collectors.joining(", ", "[", "]")) + "." +
-                "\nMaybe use DomainAccessType.REFLECTION?"));
-        ResultHandle errorMsg = currentBranch
-                .invokeVirtualMethod(MethodDescriptor.ofMethod(Object.class, "toString", String.class), errorBuilder);
-        ResultHandle error = currentBranch
-                .newInstance(MethodDescriptor.ofConstructor(IllegalArgumentException.class, String.class), errorMsg);
-        currentBranch.throwException(error);
+        try (var solutionIsNotNullBranch = solutionNullBranchResult.falseBranch()) {
+            var createdCloneMap = methodCreator.getMethodParam(1);
+
+            var maybeClone = solutionIsNotNullBranch.invokeInterfaceMethod(
+                    GET_METHOD, createdCloneMap, thisObj);
+            var hasCloneBranchResult = solutionIsNotNullBranch.ifNotNull(maybeClone);
+            try (var hasCloneBranch = hasCloneBranchResult.trueBranch()) {
+                hasCloneBranch.returnValue(maybeClone);
+            }
+
+            var noCloneBranch = hasCloneBranchResult.falseBranch();
+            var sortedSolutionClassList = new ArrayList<>(solutionClassSet);
+            sortedSolutionClassList.sort(instanceOfComparator);
+
+            var currentBranch = noCloneBranch;
+            var thisObjClass =
+                    currentBranch.invokeVirtualMethod(MethodDescriptor.ofMethod(Object.class, "getClass", Class.class),
+                            thisObj);
+            for (Class<?> solutionSubclass : sortedSolutionClassList) {
+                var solutionSubclassResultHandle = currentBranch.loadClass(solutionSubclass);
+                var isSubclass =
+                        currentBranch.invokeVirtualMethod(EQUALS_METHOD, solutionSubclassResultHandle, thisObjClass);
+                var isSubclassBranchResult = currentBranch.ifTrue(isSubclass);
+
+                var isSubclassBranch = isSubclassBranchResult.trueBranch();
+
+                var solutionSubclassDescriptor =
+                        clonerDescriptor.memoizedSolutionOrEntityDescriptorMap.computeIfAbsent(solutionSubclass,
+                                key -> new GizmoSolutionOrEntityDescriptor(clonerDescriptor.solutionDescriptor,
+                                        solutionSubclass));
+
+                ResultHandle clone;
+                if (PlanningCloneable.class.isAssignableFrom(solutionSubclass)) {
+                    clone = isSubclassBranch.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(PlanningCloneable.class, "createNewInstance", Object.class),
+                            thisObj);
+                    clone = isSubclassBranch.checkCast(clone, solutionSubclass);
+                } else {
+                    clone = isSubclassBranch.newInstance(MethodDescriptor.ofConstructor(solutionSubclass));
+                }
+
+                isSubclassBranch.invokeInterfaceMethod(
+                        MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class, Object.class),
+                        createdCloneMap, thisObj, clone);
+
+                for (GizmoMemberDescriptor shallowlyClonedField : solutionSubclassDescriptor
+                        .getShallowClonedMemberDescriptors()) {
+                    writeShallowCloneInstructions(clonerDescriptor, new ClonerMethodDescriptor(
+                            solutionSubclassDescriptor,
+                            isSubclassBranch, createdCloneMap,
+                            true, isSubclassBranch.newInstance(MethodDescriptor.ofConstructor(ArrayDeque.class))),
+                            shallowlyClonedField, thisObj, clone);
+                }
+
+                for (Field deeplyClonedField : solutionSubclassDescriptor.getDeepClonedFields()) {
+                    var gizmoMemberDescriptor =
+                            solutionSubclassDescriptor.getMemberDescriptorForField(deeplyClonedField);
+
+                    var fieldValue = gizmoMemberDescriptor.readMemberValue(isSubclassBranch, thisObj);
+                    var cloneValue = isSubclassBranch.createVariable(deeplyClonedField.getType());
+                    writeDeepCloneInstructions(clonerDescriptor,
+                            new ClonerMethodDescriptor(solutionSubclassDescriptor, isSubclassBranch, createdCloneMap,
+                                    true, isSubclassBranch.newInstance(MethodDescriptor.ofConstructor(ArrayDeque.class))),
+                            deeplyClonedField,
+                            gizmoMemberDescriptor, fieldValue, cloneValue);
+
+                    if (!gizmoMemberDescriptor.writeMemberValue(isSubclassBranch, clone, cloneValue)) {
+                        throw new IllegalStateException("The member (" + gizmoMemberDescriptor.getName() + ") of class (" +
+                                gizmoMemberDescriptor.getDeclaringClassName() +
+                                ") does not have a setter.");
+                    }
+                }
+                isSubclassBranch.returnValue(clone);
+                currentBranch.close();
+
+                currentBranch = isSubclassBranchResult.falseBranch();
+            }
+            var errorBuilder = currentBranch.newInstance(MethodDescriptor.ofConstructor(StringBuilder.class, String.class),
+                    currentBranch.load("Failed to create clone: encountered ("));
+            var APPEND =
+                    MethodDescriptor.ofMethod(StringBuilder.class, "append", StringBuilder.class, Object.class);
+
+            currentBranch.invokeVirtualMethod(APPEND, errorBuilder, thisObjClass);
+            currentBranch.invokeVirtualMethod(APPEND, errorBuilder, currentBranch.load(") which is not a known subclass of " +
+                    "the solution class (" + clonerDescriptor.solutionDescriptor.getSolutionClass()
+                    + "). The known subclasses are "
+                    +
+                    solutionClassSet.stream().map(Class::getName).collect(Collectors.joining(", ", "[", "]")) + "." +
+                    "\nMaybe use DomainAccessType.REFLECTION?"));
+            var errorMsg = currentBranch
+                    .invokeVirtualMethod(MethodDescriptor.ofMethod(Object.class, "toString", String.class), errorBuilder);
+            var error = currentBranch
+                    .newInstance(MethodDescriptor.ofConstructor(IllegalArgumentException.class, String.class), errorMsg);
+            currentBranch.throwException(error);
+            currentBranch.close();
+        }
     }
 
     /**
@@ -395,18 +430,13 @@ public class GizmoSolutionClonerImplementor {
      * // If getter a method (i.e. Quarkus)
      * clone.setMember(original.getMember());
      * </pre>
-     *
-     * @param methodCreator
-     * @param shallowlyClonedField
-     * @param thisObj
-     * @param clone
      */
-    private void writeShallowCloneInstructions(GizmoSolutionOrEntityDescriptor solutionInfo,
-            BytecodeCreator methodCreator, GizmoMemberDescriptor shallowlyClonedField,
-            ResultHandle thisObj, ResultHandle clone, ResultHandle createdCloneMap,
-            SortedSet<Class<?>> deepClonedClassesSortedSet) {
+    private void writeShallowCloneInstructions(ClonerDescriptor clonerDescriptor,
+            ClonerMethodDescriptor clonerMethodDescriptor,
+            GizmoMemberDescriptor shallowlyClonedField,
+            ResultHandle thisObj, ResultHandle clone) {
         try {
-            boolean isArray = shallowlyClonedField.getTypeName().endsWith("[]");
+            var isArray = shallowlyClonedField.getTypeName().endsWith("[]");
             Class<?> type = null;
             if (shallowlyClonedField.getType() instanceof Class) {
                 type = (Class<?>) shallowlyClonedField.getType();
@@ -420,18 +450,20 @@ public class GizmoSolutionClonerImplementor {
 
             if (type != null && !isArray) {
                 entitySubclasses =
-                        deepClonedClassesSortedSet.stream().filter(type::isAssignableFrom).toList();
+                        clonerDescriptor.deepClonedClassesSortedSet.stream().filter(type::isAssignableFrom).toList();
             }
 
-            ResultHandle fieldValue = shallowlyClonedField.readMemberValue(methodCreator, thisObj);
+            var fieldValue = shallowlyClonedField.readMemberValue(clonerMethodDescriptor.bytecodeCreator, thisObj);
             if (!entitySubclasses.isEmpty()) {
-                AssignableResultHandle cloneResultHolder = methodCreator.createVariable(type);
-                writeDeepCloneEntityOrFactInstructions(methodCreator, solutionInfo, type,
-                        fieldValue, cloneResultHolder, createdCloneMap, deepClonedClassesSortedSet,
+                var cloneResultHolder = clonerMethodDescriptor.bytecodeCreator.createVariable(type);
+                writeDeepCloneEntityOrFactInstructions(clonerDescriptor,
+                        clonerMethodDescriptor,
+                        type,
+                        fieldValue, cloneResultHolder,
                         UnhandledCloneType.SHALLOW);
                 fieldValue = cloneResultHolder;
             }
-            if (!shallowlyClonedField.writeMemberValue(methodCreator, clone, fieldValue)) {
+            if (!shallowlyClonedField.writeMemberValue(clonerMethodDescriptor.bytecodeCreator, clone, fieldValue)) {
                 throw new IllegalStateException("Field (" + shallowlyClonedField.getName() + ") of class (" +
                         shallowlyClonedField.getDeclaringClassName() +
                         ") does not have a setter.");
@@ -442,42 +474,48 @@ public class GizmoSolutionClonerImplementor {
     }
 
     /**
-     * @see #writeDeepCloneInstructions(BytecodeCreator, GizmoSolutionOrEntityDescriptor, Class, Type, ResultHandle,
-     *      AssignableResultHandle, ResultHandle, SortedSet)
+     * @see #writeDeepCloneInstructions(ClonerDescriptor, ClonerMethodDescriptor, Class, Type, ResultHandle,
+     *      AssignableResultHandle)
      */
-    private void writeDeepCloneInstructions(BytecodeCreator bytecodeCreator,
-            GizmoSolutionOrEntityDescriptor solutionDescriptor, Field deeplyClonedField,
-            GizmoMemberDescriptor gizmoMemberDescriptor, ResultHandle toClone, AssignableResultHandle cloneResultHolder,
-            ResultHandle createdCloneMap, SortedSet<Class<?>> deepClonedClassesSortedSet) {
-        BranchResult isNull = bytecodeCreator.ifNull(toClone);
+    private void writeDeepCloneInstructions(ClonerDescriptor clonerDescriptor,
+            ClonerMethodDescriptor clonerMethodDescriptor,
+            Field deeplyClonedField,
+            GizmoMemberDescriptor gizmoMemberDescriptor, ResultHandle toClone, AssignableResultHandle cloneResultHolder) {
+        var isNull = clonerMethodDescriptor.bytecodeCreator.ifNull(toClone);
 
-        BytecodeCreator isNullBranch = isNull.trueBranch();
-        isNullBranch.assign(cloneResultHolder, isNullBranch.loadNull());
+        try (var isNullBranch = isNull.trueBranch()) {
+            isNullBranch.assign(cloneResultHolder, isNullBranch.loadNull());
+        }
 
-        BytecodeCreator isNotNullBranch = isNull.falseBranch();
-
-        Class<?> deeplyClonedFieldClass = deeplyClonedField.getType();
-        Type type = gizmoMemberDescriptor.getType();
-        if (solutionDescriptor.getSolutionDescriptor().getSolutionClass().isAssignableFrom(deeplyClonedFieldClass)) {
-            writeDeepCloneSolutionInstructions(bytecodeCreator, solutionDescriptor, toClone, cloneResultHolder,
-                    createdCloneMap);
-        } else if (Collection.class.isAssignableFrom(deeplyClonedFieldClass)) {
-            writeDeepCloneCollectionInstructions(isNotNullBranch, solutionDescriptor, deeplyClonedFieldClass, type,
-                    toClone, cloneResultHolder, createdCloneMap, deepClonedClassesSortedSet);
-        } else if (Map.class.isAssignableFrom(deeplyClonedFieldClass)) {
-            writeDeepCloneMapInstructions(isNotNullBranch, solutionDescriptor, deeplyClonedFieldClass, type,
-                    toClone, cloneResultHolder, createdCloneMap, deepClonedClassesSortedSet);
-        } else if (deeplyClonedFieldClass.isArray()) {
-            writeDeepCloneArrayInstructions(isNotNullBranch, solutionDescriptor, deeplyClonedFieldClass,
-                    toClone, cloneResultHolder, createdCloneMap, deepClonedClassesSortedSet);
-        } else {
-            UnhandledCloneType unknownClassCloneType =
-                    (DeepCloningUtils.isFieldDeepCloned(solutionDescriptor.solutionDescriptor,
-                            deeplyClonedField, deeplyClonedField.getDeclaringClass()))
-                                    ? UnhandledCloneType.DEEP
-                                    : UnhandledCloneType.SHALLOW;
-            writeDeepCloneEntityOrFactInstructions(isNotNullBranch, solutionDescriptor, deeplyClonedFieldClass,
-                    toClone, cloneResultHolder, createdCloneMap, deepClonedClassesSortedSet, unknownClassCloneType);
+        try (var isNotNullBranch = isNull.falseBranch()) {
+            var deeplyClonedFieldClass = deeplyClonedField.getType();
+            var type = gizmoMemberDescriptor.getType();
+            if (clonerMethodDescriptor.entityDescriptor.getSolutionDescriptor().getSolutionClass()
+                    .isAssignableFrom(deeplyClonedFieldClass)) {
+                writeDeepCloneSolutionInstructions(clonerMethodDescriptor, toClone, cloneResultHolder);
+            } else if (Collection.class.isAssignableFrom(deeplyClonedFieldClass)) {
+                writeDeepCloneCollectionInstructions(clonerDescriptor,
+                        clonerMethodDescriptor.withBytecodeCreator(isNotNullBranch),
+                        deeplyClonedFieldClass, type,
+                        toClone, cloneResultHolder);
+            } else if (Map.class.isAssignableFrom(deeplyClonedFieldClass)) {
+                writeDeepCloneMapInstructions(clonerDescriptor, clonerMethodDescriptor.withBytecodeCreator(isNotNullBranch),
+                        deeplyClonedFieldClass, type,
+                        toClone, cloneResultHolder);
+            } else if (deeplyClonedFieldClass.isArray()) {
+                writeDeepCloneArrayInstructions(clonerDescriptor, clonerMethodDescriptor.withBytecodeCreator(isNotNullBranch),
+                        deeplyClonedFieldClass, toClone, cloneResultHolder);
+            } else {
+                var unknownClassCloneType =
+                        (DeepCloningUtils.isFieldDeepCloned(clonerMethodDescriptor.entityDescriptor.solutionDescriptor,
+                                deeplyClonedField, deeplyClonedField.getDeclaringClass()))
+                                        ? UnhandledCloneType.DEEP
+                                        : UnhandledCloneType.SHALLOW;
+                writeDeepCloneEntityOrFactInstructions(clonerDescriptor,
+                        clonerMethodDescriptor.withBytecodeCreator(isNotNullBranch),
+                        deeplyClonedFieldClass,
+                        toClone, cloneResultHolder, unknownClassCloneType);
+            }
         }
     }
 
@@ -523,70 +561,72 @@ public class GizmoSolutionClonerImplementor {
      *     // ...
      * }
      * </pre>
-     *
-     * @param bytecodeCreator
-     * @param solutionDescriptor
-     * @param deeplyClonedFieldClass
-     * @param type
-     * @param toClone
-     * @param cloneResultHolder
      */
-    private void writeDeepCloneInstructions(BytecodeCreator bytecodeCreator,
-            GizmoSolutionOrEntityDescriptor solutionDescriptor,
+    private void writeDeepCloneInstructions(ClonerDescriptor clonerDescriptor,
+            ClonerMethodDescriptor clonerMethodDescriptor,
             Class<?> deeplyClonedFieldClass, java.lang.reflect.Type type, ResultHandle toClone,
-            AssignableResultHandle cloneResultHolder, ResultHandle createdCloneMap,
-            SortedSet<Class<?>> deepClonedClassesSortedSet) {
-        BranchResult isNull = bytecodeCreator.ifNull(toClone);
+            AssignableResultHandle cloneResultHolder) {
+        var isNull = clonerMethodDescriptor.bytecodeCreator.ifNull(toClone);
 
-        BytecodeCreator isNullBranch = isNull.trueBranch();
-        isNullBranch.assign(cloneResultHolder, isNullBranch.loadNull());
+        try (var isNullBranch = isNull.trueBranch()) {
+            isNullBranch.assign(cloneResultHolder, isNullBranch.loadNull());
+        }
 
-        BytecodeCreator isNotNullBranch = isNull.falseBranch();
-
-        if (solutionDescriptor.getSolutionDescriptor().getSolutionClass().isAssignableFrom(deeplyClonedFieldClass)) {
-            writeDeepCloneSolutionInstructions(bytecodeCreator, solutionDescriptor, toClone, cloneResultHolder,
-                    createdCloneMap);
-        } else if (Collection.class.isAssignableFrom(deeplyClonedFieldClass)) {
-            // Clone collection
-            writeDeepCloneCollectionInstructions(isNotNullBranch, solutionDescriptor, deeplyClonedFieldClass, type,
-                    toClone, cloneResultHolder, createdCloneMap, deepClonedClassesSortedSet);
-        } else if (Map.class.isAssignableFrom(deeplyClonedFieldClass)) {
-            // Clone map
-            writeDeepCloneMapInstructions(isNotNullBranch, solutionDescriptor, deeplyClonedFieldClass, type,
-                    toClone, cloneResultHolder, createdCloneMap, deepClonedClassesSortedSet);
-        } else if (deeplyClonedFieldClass.isArray()) {
-            // Clone array
-            writeDeepCloneArrayInstructions(isNotNullBranch, solutionDescriptor, deeplyClonedFieldClass,
-                    toClone, cloneResultHolder, createdCloneMap, deepClonedClassesSortedSet);
-        } else {
-            // Clone entity
-            UnhandledCloneType unknownClassCloneType =
-                    (DeepCloningUtils.isClassDeepCloned(solutionDescriptor.solutionDescriptor, deeplyClonedFieldClass))
-                            ? UnhandledCloneType.DEEP
-                            : UnhandledCloneType.SHALLOW;
-            writeDeepCloneEntityOrFactInstructions(isNotNullBranch, solutionDescriptor, deeplyClonedFieldClass,
-                    toClone, cloneResultHolder, createdCloneMap, deepClonedClassesSortedSet, unknownClassCloneType);
+        try (var isNotNullBranch = isNull.falseBranch()) {
+            if (clonerMethodDescriptor.entityDescriptor.getSolutionDescriptor().getSolutionClass()
+                    .isAssignableFrom(deeplyClonedFieldClass)) {
+                writeDeepCloneSolutionInstructions(clonerMethodDescriptor, toClone, cloneResultHolder);
+            } else if (Collection.class.isAssignableFrom(deeplyClonedFieldClass)) {
+                // Clone collection
+                writeDeepCloneCollectionInstructions(clonerDescriptor,
+                        clonerMethodDescriptor.withBytecodeCreator(isNotNullBranch),
+                        deeplyClonedFieldClass, type,
+                        toClone, cloneResultHolder);
+            } else if (Map.class.isAssignableFrom(deeplyClonedFieldClass)) {
+                // Clone map
+                writeDeepCloneMapInstructions(clonerDescriptor, clonerMethodDescriptor.withBytecodeCreator(isNotNullBranch),
+                        deeplyClonedFieldClass, type,
+                        toClone, cloneResultHolder);
+            } else if (deeplyClonedFieldClass.isArray()) {
+                // Clone array
+                writeDeepCloneArrayInstructions(clonerDescriptor, clonerMethodDescriptor.withBytecodeCreator(isNotNullBranch),
+                        deeplyClonedFieldClass,
+                        toClone, cloneResultHolder);
+            } else {
+                // Clone entity
+                UnhandledCloneType unknownClassCloneType =
+                        (DeepCloningUtils.isClassDeepCloned(clonerMethodDescriptor.entityDescriptor.solutionDescriptor,
+                                deeplyClonedFieldClass))
+                                        ? UnhandledCloneType.DEEP
+                                        : UnhandledCloneType.SHALLOW;
+                writeDeepCloneEntityOrFactInstructions(clonerDescriptor,
+                        clonerMethodDescriptor.withBytecodeCreator(isNotNullBranch),
+                        deeplyClonedFieldClass,
+                        toClone, cloneResultHolder, unknownClassCloneType);
+            }
         }
     }
 
-    private void writeDeepCloneSolutionInstructions(BytecodeCreator bytecodeCreator,
-            GizmoSolutionOrEntityDescriptor solutionDescriptor, ResultHandle toClone, AssignableResultHandle cloneResultHolder,
-            ResultHandle createdCloneMap) {
-        BranchResult isNull = bytecodeCreator.ifNull(toClone);
+    private void writeDeepCloneSolutionInstructions(
+            ClonerMethodDescriptor clonerMethodDescriptor, ResultHandle toClone, AssignableResultHandle cloneResultHolder) {
+        var isNull = clonerMethodDescriptor.bytecodeCreator.ifNull(toClone);
 
-        BytecodeCreator isNullBranch = isNull.trueBranch();
-        isNullBranch.assign(cloneResultHolder, isNullBranch.loadNull());
+        try (var isNullBranch = isNull.trueBranch()) {
+            isNullBranch.assign(cloneResultHolder, isNullBranch.loadNull());
+        }
 
-        BytecodeCreator isNotNullBranch = isNull.falseBranch();
-
-        ResultHandle clone = isNotNullBranch.invokeStaticMethod(
-                MethodDescriptor.ofMethod(
-                        GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor.getSolutionDescriptor()),
-                        "cloneSolutionRun", solutionDescriptor.getSolutionDescriptor().getSolutionClass(),
-                        solutionDescriptor.getSolutionDescriptor().getSolutionClass(), Map.class),
-                toClone,
-                createdCloneMap);
-        isNotNullBranch.assign(cloneResultHolder, clone);
+        try (var isNotNullBranch = isNull.falseBranch()) {
+            var clone = isNotNullBranch.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(
+                            GizmoSolutionClonerFactory
+                                    .getGeneratedClassName(clonerMethodDescriptor.entityDescriptor.getSolutionDescriptor()),
+                            "cloneSolutionRun",
+                            clonerMethodDescriptor.entityDescriptor.getSolutionDescriptor().getSolutionClass(),
+                            clonerMethodDescriptor.entityDescriptor.getSolutionDescriptor().getSolutionClass(), Map.class),
+                    toClone,
+                    clonerMethodDescriptor.createdCloneMap);
+            isNotNullBranch.assign(cloneResultHolder, clone);
+        }
     }
 
     /**
@@ -604,15 +644,15 @@ public class GizmoSolutionClonerImplementor {
      * cloneResultHolder = clone;
      * </pre>
      **/
-    private void writeDeepCloneCollectionInstructions(BytecodeCreator bytecodeCreator,
-            GizmoSolutionOrEntityDescriptor solutionDescriptor,
+    private void writeDeepCloneCollectionInstructions(ClonerDescriptor clonerDescriptor,
+            ClonerMethodDescriptor clonerMethodDescriptor,
             Class<?> deeplyClonedFieldClass, java.lang.reflect.Type type, ResultHandle toClone,
-            AssignableResultHandle cloneResultHolder, ResultHandle createdCloneMap,
-            SortedSet<Class<?>> deepClonedClassesSortedSet) {
+            AssignableResultHandle cloneResultHolder) {
+        var bytecodeCreator = clonerMethodDescriptor.bytecodeCreator;
         // Clone collection
-        AssignableResultHandle cloneCollection = bytecodeCreator.createVariable(deeplyClonedFieldClass);
+        var cloneCollection = bytecodeCreator.createVariable(deeplyClonedFieldClass);
 
-        ResultHandle size = bytecodeCreator
+        var size = bytecodeCreator
                 .invokeInterfaceMethod(MethodDescriptor.ofMethod(Collection.class, "size", int.class), toClone);
 
         if (PlanningCloneable.class.isAssignableFrom(deeplyClonedFieldClass)) {
@@ -626,77 +666,86 @@ public class GizmoSolutionClonerImplementor {
             bytecodeCreator.assign(cloneCollection,
                     bytecodeCreator.newInstance(MethodDescriptor.ofConstructor(ArrayList.class, int.class), size));
         } else if (Set.class.isAssignableFrom(deeplyClonedFieldClass)) {
-            ResultHandle isSortedSet = bytecodeCreator.instanceOf(toClone, SortedSet.class);
-            BranchResult isSortedSetBranchResult = bytecodeCreator.ifTrue(isSortedSet);
-            BytecodeCreator isSortedSetBranch = isSortedSetBranchResult.trueBranch();
-            ResultHandle setComparator = isSortedSetBranch
-                    .invokeInterfaceMethod(MethodDescriptor.ofMethod(SortedSet.class,
-                            "comparator", Comparator.class), toClone);
-            isSortedSetBranch.assign(cloneCollection,
-                    isSortedSetBranch.newInstance(MethodDescriptor.ofConstructor(TreeSet.class, Comparator.class),
-                            setComparator));
-            BytecodeCreator isNotSortedSetBranch = isSortedSetBranchResult.falseBranch();
-            isNotSortedSetBranch.assign(cloneCollection,
-                    isNotSortedSetBranch.newInstance(MethodDescriptor.ofConstructor(LinkedHashSet.class, int.class), size));
+            var isSortedSet = bytecodeCreator.instanceOf(toClone, SortedSet.class);
+            var isSortedSetBranchResult = bytecodeCreator.ifTrue(isSortedSet);
+            try (var isSortedSetBranch = isSortedSetBranchResult.trueBranch()) {
+                var setComparator = isSortedSetBranch
+                        .invokeInterfaceMethod(MethodDescriptor.ofMethod(SortedSet.class,
+                                "comparator", Comparator.class), toClone);
+                isSortedSetBranch.assign(cloneCollection,
+                        isSortedSetBranch.newInstance(MethodDescriptor.ofConstructor(TreeSet.class, Comparator.class),
+                                setComparator));
+            }
+            try (var isNotSortedSetBranch = isSortedSetBranchResult.falseBranch()) {
+                isNotSortedSetBranch.assign(cloneCollection,
+                        isNotSortedSetBranch.newInstance(MethodDescriptor.ofConstructor(LinkedHashSet.class, int.class), size));
+            }
         } else {
             // field is probably of type collection
-            ResultHandle isSet = bytecodeCreator.instanceOf(toClone, Set.class);
-            BranchResult isSetBranchResult = bytecodeCreator.ifTrue(isSet);
-            BytecodeCreator isSetBranch = isSetBranchResult.trueBranch();
-            ResultHandle isSortedSet = isSetBranch.instanceOf(toClone, SortedSet.class);
-            BranchResult isSortedSetBranchResult = isSetBranch.ifTrue(isSortedSet);
-            BytecodeCreator isSortedSetBranch = isSortedSetBranchResult.trueBranch();
-            ResultHandle setComparator = isSortedSetBranch
-                    .invokeInterfaceMethod(MethodDescriptor.ofMethod(SortedSet.class,
-                            "comparator", Comparator.class), toClone);
-            isSortedSetBranch.assign(cloneCollection,
-                    isSortedSetBranch.newInstance(MethodDescriptor.ofConstructor(TreeSet.class, Comparator.class),
-                            setComparator));
-            BytecodeCreator isNotSortedSetBranch = isSortedSetBranchResult.falseBranch();
-            isNotSortedSetBranch.assign(cloneCollection,
-                    isNotSortedSetBranch.newInstance(MethodDescriptor.ofConstructor(LinkedHashSet.class, int.class), size));
+            var isSet = bytecodeCreator.instanceOf(toClone, Set.class);
+            var isSetBranchResult = bytecodeCreator.ifTrue(isSet);
+            try (var isSetBranch = isSetBranchResult.trueBranch()) {
+                var isSortedSet = isSetBranch.instanceOf(toClone, SortedSet.class);
+                var isSortedSetBranchResult = isSetBranch.ifTrue(isSortedSet);
+                try (var isSortedSetBranch = isSortedSetBranchResult.trueBranch()) {
+                    ResultHandle setComparator = isSortedSetBranch
+                            .invokeInterfaceMethod(MethodDescriptor.ofMethod(SortedSet.class,
+                                    "comparator", Comparator.class), toClone);
+                    isSortedSetBranch.assign(cloneCollection,
+                            isSortedSetBranch.newInstance(MethodDescriptor.ofConstructor(TreeSet.class, Comparator.class),
+                                    setComparator));
+                }
+                try (var isNotSortedSetBranch = isSortedSetBranchResult.falseBranch()) {
+                    isNotSortedSetBranch.assign(cloneCollection,
+                            isNotSortedSetBranch.newInstance(MethodDescriptor.ofConstructor(LinkedHashSet.class, int.class),
+                                    size));
+                }
+            }
             // Default to ArrayList
-            BytecodeCreator isNotSetBranch = isSetBranchResult.falseBranch();
-            isNotSetBranch.assign(cloneCollection,
-                    isNotSetBranch.newInstance(MethodDescriptor.ofConstructor(ArrayList.class, int.class), size));
+            try (var isNotSetBranch = isSetBranchResult.falseBranch()) {
+                isNotSetBranch.assign(cloneCollection,
+                        isNotSetBranch.newInstance(MethodDescriptor.ofConstructor(ArrayList.class, int.class), size));
+            }
         }
-        ResultHandle iterator = bytecodeCreator
+        var iterator = bytecodeCreator
                 .invokeInterfaceMethod(MethodDescriptor.ofMethod(Iterable.class, "iterator", Iterator.class), toClone);
 
-        BytecodeCreator whileLoopBlock = bytecodeCreator.whileLoop(conditionBytecode -> {
+        try (var whileLoopBlock = bytecodeCreator.whileLoop(conditionBytecode -> {
             ResultHandle hasNext = conditionBytecode
                     .invokeInterfaceMethod(MethodDescriptor.ofMethod(Iterator.class, "hasNext", boolean.class), iterator);
             return conditionBytecode.ifTrue(hasNext);
-        }).block();
-
-        Class<?> elementClass;
-        java.lang.reflect.Type elementClassType;
-        if (type instanceof ParameterizedType parameterizedType) {
-            // Assume Collection follow Collection<T> convention of first type argument = element class
-            elementClassType = parameterizedType.getActualTypeArguments()[0];
-            if (elementClassType instanceof Class<?> class1) {
-                elementClass = class1;
-            } else if (elementClassType instanceof ParameterizedType parameterizedElementClassType) {
-                elementClass = (Class<?>) parameterizedElementClassType.getRawType();
-            } else if (elementClassType instanceof WildcardType wildcardType) {
-                elementClass = (Class<?>) wildcardType.getUpperBounds()[0];
+        }).block()) {
+            Class<?> elementClass;
+            java.lang.reflect.Type elementClassType;
+            if (type instanceof ParameterizedType parameterizedType) {
+                // Assume Collection follow Collection<T> convention of first type argument = element class
+                elementClassType = parameterizedType.getActualTypeArguments()[0];
+                if (elementClassType instanceof Class<?> class1) {
+                    elementClass = class1;
+                } else if (elementClassType instanceof ParameterizedType parameterizedElementClassType) {
+                    elementClass = (Class<?>) parameterizedElementClassType.getRawType();
+                } else if (elementClassType instanceof WildcardType wildcardType) {
+                    elementClass = (Class<?>) wildcardType.getUpperBounds()[0];
+                } else {
+                    throw new IllegalStateException("Unhandled type " + elementClassType + ".");
+                }
             } else {
-                throw new IllegalStateException("Unhandled type " + elementClassType + ".");
+                throw new IllegalStateException("Cannot infer element type for Collection type (" + type + ").");
             }
-        } else {
-            throw new IllegalStateException("Cannot infer element type for Collection type (" + type + ").");
-        }
 
-        // Odd case of member get and set being on different classes; will work as we only
-        // use get on the original and set on the clone.
-        ResultHandle next =
-                whileLoopBlock.invokeInterfaceMethod(MethodDescriptor.ofMethod(Iterator.class, "next", Object.class), iterator);
-        final AssignableResultHandle clonedElement = whileLoopBlock.createVariable(elementClass);
-        writeDeepCloneInstructions(whileLoopBlock, solutionDescriptor,
-                elementClass, elementClassType, next, clonedElement, createdCloneMap, deepClonedClassesSortedSet);
-        whileLoopBlock.invokeInterfaceMethod(MethodDescriptor.ofMethod(Collection.class, "add", boolean.class, Object.class),
-                cloneCollection,
-                clonedElement);
+            // Odd case of member get and set being on different classes; will work as we only
+            // use get on the original and set on the clone.
+            var next =
+                    whileLoopBlock.invokeInterfaceMethod(MethodDescriptor.ofMethod(Iterator.class, "next", Object.class),
+                            iterator);
+            var clonedElement = whileLoopBlock.createVariable(elementClass);
+            writeDeepCloneInstructions(clonerDescriptor, clonerMethodDescriptor.withBytecodeCreator(whileLoopBlock),
+                    elementClass, elementClassType, next, clonedElement);
+            whileLoopBlock.invokeInterfaceMethod(
+                    MethodDescriptor.ofMethod(Collection.class, "add", boolean.class, Object.class),
+                    cloneCollection,
+                    clonedElement);
+        }
         bytecodeCreator.assign(cloneResultHolder, cloneCollection);
     }
 
@@ -716,19 +765,20 @@ public class GizmoSolutionClonerImplementor {
      * cloneResultHolder = clone;
      * </pre>
      **/
-    private void writeDeepCloneMapInstructions(BytecodeCreator bytecodeCreator,
-            GizmoSolutionOrEntityDescriptor solutionDescriptor,
+    private void writeDeepCloneMapInstructions(ClonerDescriptor clonerDescriptor,
+            ClonerMethodDescriptor clonerMethodDescriptor,
             Class<?> deeplyClonedFieldClass, java.lang.reflect.Type type, ResultHandle toClone,
-            AssignableResultHandle cloneResultHolder, ResultHandle createdCloneMap,
-            SortedSet<Class<?>> deepClonedClassesSortedSet) {
+            AssignableResultHandle cloneResultHolder) {
+        var bytecodeCreator = clonerMethodDescriptor.bytecodeCreator;
         ResultHandle cloneMap;
+
         if (PlanningCloneable.class.isAssignableFrom(deeplyClonedFieldClass)) {
             var emptyInstance = bytecodeCreator
                     .invokeInterfaceMethod(MethodDescriptor.ofMethod(PlanningCloneable.class, "createNewInstance",
                             Object.class), bytecodeCreator.checkCast(toClone, PlanningCloneable.class));
             cloneMap = bytecodeCreator.checkCast(emptyInstance, Map.class);
         } else {
-            Class<?> holderClass = deeplyClonedFieldClass;
+            var holderClass = deeplyClonedFieldClass;
             try {
                 holderClass.getConstructor();
             } catch (NoSuchMethodException e) {
@@ -742,7 +792,7 @@ public class GizmoSolutionClonerImplementor {
                 }
             }
 
-            ResultHandle size =
+            var size =
                     bytecodeCreator.invokeInterfaceMethod(MethodDescriptor.ofMethod(Map.class, "size", int.class), toClone);
             try {
                 holderClass.getConstructor(int.class);
@@ -752,12 +802,12 @@ public class GizmoSolutionClonerImplementor {
             }
         }
 
-        ResultHandle entrySet = bytecodeCreator
+        var entrySet = bytecodeCreator
                 .invokeInterfaceMethod(MethodDescriptor.ofMethod(Map.class, "entrySet", Set.class), toClone);
-        ResultHandle iterator = bytecodeCreator
+        var iterator = bytecodeCreator
                 .invokeInterfaceMethod(MethodDescriptor.ofMethod(Iterable.class, "iterator", Iterator.class), entrySet);
 
-        BytecodeCreator whileLoopBlock = bytecodeCreator.whileLoop(conditionBytecode -> {
+        var whileLoopBlock = bytecodeCreator.whileLoop(conditionBytecode -> {
             ResultHandle hasNext = conditionBytecode
                     .invokeInterfaceMethod(MethodDescriptor.ofMethod(Iterator.class, "hasNext", boolean.class), iterator);
             return conditionBytecode.ifTrue(hasNext);
@@ -790,23 +840,24 @@ public class GizmoSolutionClonerImplementor {
             throw new IllegalStateException("Cannot infer element type for Map type (" + type + ").");
         }
 
-        List<Class<?>> entitySubclasses = deepClonedClassesSortedSet.stream()
+        var entitySubclasses = clonerDescriptor.deepClonedClassesSortedSet.stream()
                 .filter(keyClass::isAssignableFrom).toList();
-        ResultHandle entry = whileLoopBlock
+        var entry = whileLoopBlock
                 .invokeInterfaceMethod(MethodDescriptor.ofMethod(Iterator.class, "next", Object.class), iterator);
-        ResultHandle toCloneValue = whileLoopBlock
+        var toCloneValue = whileLoopBlock
                 .invokeInterfaceMethod(MethodDescriptor.ofMethod(Map.Entry.class, "getValue", Object.class), entry);
 
-        final AssignableResultHandle clonedElement = whileLoopBlock.createVariable(elementClass);
-        writeDeepCloneInstructions(whileLoopBlock, solutionDescriptor,
-                elementClass, elementClassType, toCloneValue, clonedElement, createdCloneMap, deepClonedClassesSortedSet);
+        var clonedElement = whileLoopBlock.createVariable(elementClass);
+        writeDeepCloneInstructions(clonerDescriptor, clonerMethodDescriptor.withBytecodeCreator(whileLoopBlock),
+                elementClass, elementClassType, toCloneValue, clonedElement);
 
-        ResultHandle key = whileLoopBlock
+        var key = whileLoopBlock
                 .invokeInterfaceMethod(MethodDescriptor.ofMethod(Map.Entry.class, "getKey", Object.class), entry);
         if (!entitySubclasses.isEmpty()) {
-            AssignableResultHandle keyCloneResultHolder = whileLoopBlock.createVariable(keyClass);
-            writeDeepCloneEntityOrFactInstructions(whileLoopBlock, solutionDescriptor, keyClass,
-                    key, keyCloneResultHolder, createdCloneMap, deepClonedClassesSortedSet, UnhandledCloneType.DEEP);
+            var keyCloneResultHolder = whileLoopBlock.createVariable(keyClass);
+            writeDeepCloneEntityOrFactInstructions(clonerDescriptor, clonerMethodDescriptor.withBytecodeCreator(whileLoopBlock),
+                    keyClass,
+                    key, keyCloneResultHolder, UnhandledCloneType.DEEP);
             whileLoopBlock.invokeInterfaceMethod(
                     PUT_METHOD,
                     cloneMap, keyCloneResultHolder, clonedElement);
@@ -832,24 +883,25 @@ public class GizmoSolutionClonerImplementor {
      * cloneResultHolder = clone;
      * </pre>
      **/
-    private void writeDeepCloneArrayInstructions(BytecodeCreator bytecodeCreator,
-            GizmoSolutionOrEntityDescriptor solutionDescriptor,
-            Class<?> deeplyClonedFieldClass, ResultHandle toClone, AssignableResultHandle cloneResultHolder,
-            ResultHandle createdCloneMap, SortedSet<Class<?>> deepClonedClassesSortedSet) {
+    private void writeDeepCloneArrayInstructions(ClonerDescriptor clonerDescriptor,
+            ClonerMethodDescriptor clonerMethodDescriptor,
+            Class<?> deeplyClonedFieldClass, ResultHandle toClone, AssignableResultHandle cloneResultHolder) {
+        var bytecodeCreator = clonerMethodDescriptor.bytecodeCreator;
         // Clone array
-        Class<?> arrayComponent = deeplyClonedFieldClass.getComponentType();
-        ResultHandle arrayLength = bytecodeCreator.arrayLength(toClone);
-        ResultHandle arrayClone = bytecodeCreator.newArray(arrayComponent, arrayLength);
-        AssignableResultHandle iterations = bytecodeCreator.createVariable(int.class);
+        var arrayComponent = deeplyClonedFieldClass.getComponentType();
+        var arrayLength = bytecodeCreator.arrayLength(toClone);
+        var arrayClone = bytecodeCreator.newArray(arrayComponent, arrayLength);
+        var iterations = bytecodeCreator.createVariable(int.class);
         bytecodeCreator.assign(iterations, bytecodeCreator.load(0));
-        BytecodeCreator whileLoopBlock = bytecodeCreator
+        var whileLoopBlock = bytecodeCreator
                 .whileLoop(conditionBytecode -> conditionBytecode.ifIntegerLessThan(iterations, arrayLength))
                 .block();
-        ResultHandle toCloneElement = whileLoopBlock.readArrayValue(toClone, iterations);
-        AssignableResultHandle clonedElement = whileLoopBlock.createVariable(arrayComponent);
+        var toCloneElement = whileLoopBlock.readArrayValue(toClone, iterations);
+        var clonedElement = whileLoopBlock.createVariable(arrayComponent);
 
-        writeDeepCloneInstructions(whileLoopBlock, solutionDescriptor, arrayComponent,
-                arrayComponent, toCloneElement, clonedElement, createdCloneMap, deepClonedClassesSortedSet);
+        writeDeepCloneInstructions(clonerDescriptor, clonerMethodDescriptor.withBytecodeCreator(whileLoopBlock),
+                arrayComponent,
+                arrayComponent, toCloneElement, clonedElement);
         whileLoopBlock.writeArrayValue(arrayClone, iterations, clonedElement);
         whileLoopBlock.assign(iterations, whileLoopBlock.increment(iterations));
 
@@ -878,26 +930,36 @@ public class GizmoSolutionClonerImplementor {
      * }
      * </pre>
      **/
-    private void writeDeepCloneEntityOrFactInstructions(BytecodeCreator bytecodeCreator,
-            GizmoSolutionOrEntityDescriptor solutionDescriptor, Class<?> deeplyClonedFieldClass, ResultHandle toClone,
-            AssignableResultHandle cloneResultHolder, ResultHandle createdCloneMap,
-            SortedSet<Class<?>> deepClonedClassesSortedSet, UnhandledCloneType unhandledCloneType) {
-        List<Class<?>> deepClonedSubclasses = deepClonedClassesSortedSet.stream()
+    private void writeDeepCloneEntityOrFactInstructions(ClonerDescriptor clonerDescriptor,
+            ClonerMethodDescriptor clonerMethodDescriptor,
+            Class<?> deeplyClonedFieldClass,
+            ResultHandle toClone,
+            AssignableResultHandle cloneResultHolder,
+            UnhandledCloneType unhandledCloneType) {
+        var deepClonedSubclasses = clonerDescriptor.deepClonedClassesSortedSet.stream()
                 .filter(deeplyClonedFieldClass::isAssignableFrom)
-                .filter(type -> DeepCloningUtils.isClassDeepCloned(solutionDescriptor.getSolutionDescriptor(), type))
+                .filter(type -> DeepCloningUtils.isClassDeepCloned(
+                        clonerMethodDescriptor.entityDescriptor.getSolutionDescriptor(),
+                        type))
                 .toList();
-        BytecodeCreator currentBranch = bytecodeCreator;
+        var currentBranch = clonerMethodDescriptor.bytecodeCreator;
         // If the field holds an instance of one of the field's declared type's subtypes, clone the subtype instead.
         for (Class<?> deepClonedSubclass : deepClonedSubclasses) {
-            ResultHandle isInstance = currentBranch.instanceOf(toClone, deepClonedSubclass);
-            BranchResult isInstanceBranchResult = currentBranch.ifTrue(isInstance);
-            BytecodeCreator isInstanceBranch = isInstanceBranchResult.trueBranch();
-            ResultHandle cloneObj = isInstanceBranch.invokeStaticMethod(
-                    MethodDescriptor.ofMethod(
-                            GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor.getSolutionDescriptor()),
-                            getEntityHelperMethodName(deepClonedSubclass), deepClonedSubclass, deepClonedSubclass, Map.class),
-                    toClone, createdCloneMap);
-            isInstanceBranch.assign(cloneResultHolder, cloneObj);
+            var isInstance = currentBranch.instanceOf(toClone, deepClonedSubclass);
+            var isInstanceBranchResult = currentBranch.ifTrue(isInstance);
+            try (var isInstanceBranch = isInstanceBranchResult.trueBranch()) {
+                var cloneObj = isInstanceBranch.invokeStaticMethod(
+                        MethodDescriptor.ofMethod(
+                                GizmoSolutionClonerFactory
+                                        .getGeneratedClassName(clonerMethodDescriptor.entityDescriptor.getSolutionDescriptor()),
+                                getEntityHelperMethodName(deepClonedSubclass), deepClonedSubclass, deepClonedSubclass,
+                                Map.class,
+                                boolean.class, ArrayDeque.class),
+                        toClone, clonerMethodDescriptor.createdCloneMap, currentBranch.load(clonerMethodDescriptor.isBottom),
+                        clonerMethodDescriptor.cloneQueue);
+                isInstanceBranch.assign(cloneResultHolder, cloneObj);
+            }
+            currentBranch.close();
             currentBranch = isInstanceBranchResult.falseBranch();
         }
         // We are certain that the instance is of the same type as the declared field type.
@@ -905,15 +967,18 @@ public class GizmoSolutionClonerImplementor {
         switch (unhandledCloneType) {
             case SHALLOW -> currentBranch.assign(cloneResultHolder, toClone);
             case DEEP -> {
-                ResultHandle cloneObj = currentBranch.invokeStaticMethod(
+                var cloneObj = currentBranch.invokeStaticMethod(
                         MethodDescriptor.ofMethod(
-                                GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor.getSolutionDescriptor()),
+                                GizmoSolutionClonerFactory
+                                        .getGeneratedClassName(clonerMethodDescriptor.entityDescriptor.getSolutionDescriptor()),
                                 getEntityHelperMethodName(deeplyClonedFieldClass), deeplyClonedFieldClass,
-                                deeplyClonedFieldClass, Map.class),
-                        toClone, createdCloneMap);
+                                deeplyClonedFieldClass, Map.class, boolean.class, ArrayDeque.class),
+                        toClone, clonerMethodDescriptor.createdCloneMap, currentBranch.load(clonerMethodDescriptor.isBottom),
+                        clonerMethodDescriptor.cloneQueue);
                 currentBranch.assign(cloneResultHolder, cloneObj);
             }
         }
+        currentBranch.close();
     }
 
     protected String getEntityHelperMethodName(Class<?> entityClass) {
@@ -937,123 +1002,190 @@ public class GizmoSolutionClonerImplementor {
      *
      * @return The else branch {@link BytecodeCreator} outside of Quarkus, the original bytecodeCreator otherwise.
      */
-    protected BytecodeCreator createUnknownClassHandler(BytecodeCreator bytecodeCreator,
-            SolutionDescriptor<?> solutionDescriptor,
+    protected BytecodeCreator createUnknownClassHandler(ClonerDescriptor clonerDescriptor,
+            ClonerMethodDescriptor clonerMethodDescriptor,
             Class<?> entityClass,
-            ResultHandle toClone,
-            ResultHandle cloneMap) {
-        ResultHandle actualClass =
-                bytecodeCreator.invokeVirtualMethod(MethodDescriptor.ofMethod(Object.class, "getClass", Class.class),
+            ResultHandle toClone) {
+        var actualClass =
+                clonerMethodDescriptor.bytecodeCreator.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(Object.class, "getClass", Class.class),
                         toClone);
-        BranchResult branchResult = bytecodeCreator.ifReferencesNotEqual(actualClass,
-                bytecodeCreator.loadClass(entityClass));
+        var branchResult = clonerMethodDescriptor.bytecodeCreator.ifReferencesNotEqual(actualClass,
+                clonerMethodDescriptor.bytecodeCreator.loadClass(entityClass));
 
-        BytecodeCreator currentBranch = branchResult.trueBranch();
-
-        ResultHandle fallbackCloner =
-                currentBranch.readStaticField(FieldDescriptor.of(
-                        GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor),
-                        FALLBACK_CLONER, FieldAccessingSolutionCloner.class));
-        ResultHandle cloneObj =
-                currentBranch.invokeVirtualMethod(MethodDescriptor.ofMethod(FieldAccessingSolutionCloner.class,
-                        "gizmoFallbackDeepClone", Object.class, Object.class, Map.class),
-                        fallbackCloner, toClone, cloneMap);
-        currentBranch.returnValue(cloneObj);
+        try (var currentBranch = branchResult.trueBranch()) {
+            var fallbackCloner =
+                    currentBranch.readStaticField(FieldDescriptor.of(
+                            GizmoSolutionClonerFactory.getGeneratedClassName(clonerDescriptor.solutionDescriptor),
+                            FALLBACK_CLONER, FieldAccessingSolutionCloner.class));
+            var cloneObj =
+                    currentBranch.invokeVirtualMethod(MethodDescriptor.ofMethod(FieldAccessingSolutionCloner.class,
+                            "gizmoFallbackDeepClone", Object.class, Object.class, Map.class),
+                            fallbackCloner, toClone, clonerMethodDescriptor.createdCloneMap);
+            currentBranch.returnValue(cloneObj);
+        }
 
         return branchResult.falseBranch();
     }
 
-    // To prevent stack overflow on chained models
-    private void createDeepCloneHelperMethod(ClassCreator classCreator,
-            Class<?> entityClass,
-            SolutionDescriptor<?> solutionDescriptor,
-            Map<Class<?>, GizmoSolutionOrEntityDescriptor> memoizedSolutionOrEntityDescriptorMap,
-            SortedSet<Class<?>> deepClonedClassesSortedSet) {
-        MethodCreator methodCreator =
-                classCreator.getMethodCreator(getEntityHelperMethodName(entityClass), entityClass, entityClass, Map.class);
-        methodCreator.setModifiers(Modifier.STATIC | Modifier.PRIVATE);
+    /**
+     * Writes the following method:
+     *
+     * <pre>
+     * public static Entity $cloneEntity(Entity entity, Map cloneMap, boolean isBottom, ArrayDeque cloneQueue) {
+     *     var existingClonedEntity = (Entity) cloneMap.get(entity);
+     *     if (existingClonedEntity != null) {
+     *         return existingClonedEntity;
+     *     }
+     *     final var clonedEntity = new Entity();
+     *     clonedEntity.shallowField1 = entity.shallowField1;
+     *     // ...
+     *     clonedEntity.shallowFieldN = entity.shallowFieldN;
+     *     cloneQueue.push(() -> clonedEntity.deepClonedField1 = ...);
+     *     // ...
+     *     cloneQueue.push(() -> clonedEntity.deepClonedFieldN = ...);
+     *     if (isBottom) {
+     *         while (!cloneQueue.isEmpty()) {
+     *             cloneQueue.pop().run();
+     *         }
+     *     }
+     * }
+     * </pre>
+     *
+     * The cloneQueue is to prevent stack overflow on chained models, or models
+     * where many entities can be reached from a single entity.
+     **/
+    private void createDeepCloneHelperMethod(ClonerDescriptor clonerDescriptor,
+            Class<?> entityClass) {
+        var methodCreator =
+                clonerDescriptor.classCreator.getMethodCreator(getEntityHelperMethodName(entityClass), entityClass, entityClass,
+                        Map.class, boolean.class, ArrayDeque.class);
+        methodCreator.setModifiers(Modifier.STATIC | Modifier.PUBLIC);
 
-        GizmoSolutionOrEntityDescriptor entityDescriptor = memoizedSolutionOrEntityDescriptorMap.computeIfAbsent(entityClass,
-                key -> new GizmoSolutionOrEntityDescriptor(solutionDescriptor, entityClass));
+        var entityDescriptor =
+                clonerDescriptor.memoizedSolutionOrEntityDescriptorMap.computeIfAbsent(entityClass,
+                        key -> new GizmoSolutionOrEntityDescriptor(clonerDescriptor.solutionDescriptor, entityClass));
 
-        ResultHandle toClone = methodCreator.getMethodParam(0);
-        ResultHandle cloneMap = methodCreator.getMethodParam(1);
-        ResultHandle maybeClone = methodCreator.invokeInterfaceMethod(
+        var toClone = methodCreator.getMethodParam(0);
+        var cloneMap = methodCreator.getMethodParam(1);
+        var isBottom = methodCreator.getMethodParam(2);
+        var cloneQueue = methodCreator.getMethodParam(3);
+
+        var maybeClone = methodCreator.invokeInterfaceMethod(
                 GET_METHOD, cloneMap, toClone);
-        BranchResult hasCloneBranchResult = methodCreator.ifNotNull(maybeClone);
-        BytecodeCreator hasCloneBranch = hasCloneBranchResult.trueBranch();
-        hasCloneBranch.returnValue(maybeClone);
-
-        BytecodeCreator noCloneBranch = hasCloneBranchResult.falseBranch();
-        noCloneBranch = createUnknownClassHandler(noCloneBranch,
-                solutionDescriptor,
-                entityClass,
-                toClone,
-                cloneMap);
-
-        ResultHandle cloneObj;
-        if (PlanningCloneable.class.isAssignableFrom(entityClass)) {
-            cloneObj = noCloneBranch.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(PlanningCloneable.class, "createNewInstance", Object.class),
-                    toClone);
-            cloneObj = noCloneBranch.checkCast(cloneObj, entityClass);
-        } else {
-            cloneObj = noCloneBranch.newInstance(MethodDescriptor.ofConstructor(entityClass));
-        }
-        noCloneBranch.invokeInterfaceMethod(
-                MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class, Object.class),
-                cloneMap, toClone, cloneObj);
-
-        for (GizmoMemberDescriptor shallowlyClonedField : entityDescriptor.getShallowClonedMemberDescriptors()) {
-            writeShallowCloneInstructions(entityDescriptor, noCloneBranch, shallowlyClonedField, toClone, cloneObj, cloneMap,
-                    deepClonedClassesSortedSet);
+        var hasCloneBranchResult = methodCreator.ifNotNull(maybeClone);
+        try (var hasCloneBranch = hasCloneBranchResult.trueBranch()) {
+            hasCloneBranch.returnValue(maybeClone);
         }
 
-        for (Field deeplyClonedField : entityDescriptor.getDeepClonedFields()) {
-            GizmoMemberDescriptor gizmoMemberDescriptor =
-                    entityDescriptor.getMemberDescriptorForField(deeplyClonedField);
-            ResultHandle subfieldValue = gizmoMemberDescriptor.readMemberValue(noCloneBranch, toClone);
+        try (var originalNoCloneBranch = hasCloneBranchResult.falseBranch()) {
+            try (var newNoCloneBranch = createUnknownClassHandler(clonerDescriptor,
+                    new ClonerMethodDescriptor(entityDescriptor, originalNoCloneBranch, cloneMap, false, cloneQueue),
+                    entityClass,
+                    toClone)) {
+                ResultHandle cloneObj;
+                if (PlanningCloneable.class.isAssignableFrom(entityClass)) {
+                    cloneObj = newNoCloneBranch.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(PlanningCloneable.class, "createNewInstance", Object.class),
+                            toClone);
+                    cloneObj = newNoCloneBranch.checkCast(cloneObj, entityClass);
+                } else {
+                    cloneObj = newNoCloneBranch.newInstance(MethodDescriptor.ofConstructor(entityClass));
+                }
+                newNoCloneBranch.invokeInterfaceMethod(
+                        MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class, Object.class),
+                        cloneMap, toClone, cloneObj);
 
-            AssignableResultHandle cloneValue = noCloneBranch.createVariable(deeplyClonedField.getType());
-            writeDeepCloneInstructions(noCloneBranch, entityDescriptor, deeplyClonedField, gizmoMemberDescriptor, subfieldValue,
-                    cloneValue, cloneMap, deepClonedClassesSortedSet);
+                // When deep cloning fields, they cannot be the first entity in the stack, since
+                // the current entity is below them in the stack.
+                var clonerMethodDescriptor =
+                        new ClonerMethodDescriptor(entityDescriptor, newNoCloneBranch, cloneMap, false, cloneQueue);
+                for (GizmoMemberDescriptor shallowlyClonedField : entityDescriptor.getShallowClonedMemberDescriptors()) {
+                    writeShallowCloneInstructions(clonerDescriptor, clonerMethodDescriptor, shallowlyClonedField, toClone,
+                            cloneObj);
+                }
 
-            if (!gizmoMemberDescriptor.writeMemberValue(noCloneBranch, cloneObj, cloneValue)) {
-                throw new IllegalStateException("The member (" + gizmoMemberDescriptor.getName() + ") of class (" +
-                        gizmoMemberDescriptor.getDeclaringClassName() + ") does not have a setter.");
+                for (Field deeplyClonedField : entityDescriptor.getDeepClonedFields()) {
+                    var gizmoMemberDescriptor =
+                            entityDescriptor.getMemberDescriptorForField(deeplyClonedField);
+
+                    // Initialize the field inside a Runnable (BiConsumer here since you
+                    // cannot share ResultHandles across different BytecodeCreators).
+                    var consumer = newNoCloneBranch.createFunction(BiConsumer.class);
+                    var consumerCreator = consumer.getBytecode();
+                    var subfieldValue = gizmoMemberDescriptor.readMemberValue(consumerCreator, toClone);
+
+                    var cloneValue = consumerCreator.createVariable(deeplyClonedField.getType());
+                    writeDeepCloneInstructions(clonerDescriptor, clonerMethodDescriptor
+                            .withBytecodeCreator(consumerCreator)
+                            .withCreatedCloneMap(consumerCreator.getMethodParam(0))
+                            .withCloneQueue(consumerCreator.getMethodParam(1)),
+                            deeplyClonedField, gizmoMemberDescriptor, subfieldValue,
+                            cloneValue);
+
+                    if (!gizmoMemberDescriptor.writeMemberValue(consumerCreator, cloneObj, cloneValue)) {
+                        throw new IllegalStateException("The member (" + gizmoMemberDescriptor.getName() + ") of class (" +
+                                gizmoMemberDescriptor.getDeclaringClassName() + ") does not have a setter.");
+                    }
+                    consumerCreator.returnVoid();
+
+                    // Add the initializer to the queue
+                    newNoCloneBranch.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod(ArrayDeque.class, "push", void.class, Object.class),
+                            cloneQueue, consumer.getInstance());
+                }
+
+                // To prevent stack overflow, only the bottom/first encountered entity can
+                // create new deep cloned objects. Deep-cloned fields add their initializers
+                // (which potentially create a new deep cloned object) to the queue, and we
+                // iterate through the queue until it is empty, at which point this object
+                // is fully initialized.
+                try (var bottomObjectBranch = newNoCloneBranch.ifTrue(isBottom).trueBranch()) {
+                    try (var queueNotEmptyBlock = bottomObjectBranch.whileLoop(condition -> condition.ifFalse(
+                            condition.invokeVirtualMethod(MethodDescriptor.ofMethod(ArrayDeque.class, "isEmpty", boolean.class),
+                                    cloneQueue)))
+                            .block()) {
+                        var next = queueNotEmptyBlock
+                                .invokeVirtualMethod(MethodDescriptor.ofMethod(ArrayDeque.class, "pop", Object.class),
+                                        cloneQueue);
+                        queueNotEmptyBlock.invokeInterfaceMethod(
+                                MethodDescriptor.ofMethod(BiConsumer.class, "accept", void.class, Object.class, Object.class),
+                                queueNotEmptyBlock.checkCast(next, BiConsumer.class), cloneMap, cloneQueue);
+                    }
+                }
+
+                newNoCloneBranch.returnValue(cloneObj);
             }
         }
-
-        noCloneBranch.returnValue(cloneObj);
     }
 
-    protected void createAbstractDeepCloneHelperMethod(ClassCreator classCreator,
-            Class<?> entityClass,
-            SolutionDescriptor<?> solutionDescriptor,
-            Map<Class<?>, GizmoSolutionOrEntityDescriptor> memoizedSolutionOrEntityDescriptorMap,
-            SortedSet<Class<?>> deepClonedClassesSortedSet) {
-        MethodCreator methodCreator =
-                classCreator.getMethodCreator(getEntityHelperMethodName(entityClass), entityClass, entityClass, Map.class);
-        methodCreator.setModifiers(Modifier.STATIC | Modifier.PRIVATE);
+    protected void createAbstractDeepCloneHelperMethod(ClonerDescriptor clonerDescriptor,
+            Class<?> entityClass) {
+        var methodCreator =
+                clonerDescriptor.classCreator.getMethodCreator(getEntityHelperMethodName(entityClass), entityClass, entityClass,
+                        Map.class, boolean.class, ArrayDeque.class);
+        methodCreator.setModifiers(Modifier.STATIC | Modifier.PUBLIC);
 
-        ResultHandle toClone = methodCreator.getMethodParam(0);
-        ResultHandle cloneMap = methodCreator.getMethodParam(1);
-        ResultHandle maybeClone = methodCreator.invokeInterfaceMethod(
+        var toClone = methodCreator.getMethodParam(0);
+        var cloneMap = methodCreator.getMethodParam(1);
+        var maybeClone = methodCreator.invokeInterfaceMethod(
                 GET_METHOD, cloneMap, toClone);
-        BranchResult hasCloneBranchResult = methodCreator.ifNotNull(maybeClone);
-        BytecodeCreator hasCloneBranch = hasCloneBranchResult.trueBranch();
-        hasCloneBranch.returnValue(maybeClone);
+        var hasCloneBranchResult = methodCreator.ifNotNull(maybeClone);
+        try (var hasCloneBranch = hasCloneBranchResult.trueBranch()) {
+            hasCloneBranch.returnValue(maybeClone);
+        }
 
-        BytecodeCreator noCloneBranch = hasCloneBranchResult.falseBranch();
-        ResultHandle fallbackCloner =
-                noCloneBranch.readStaticField(FieldDescriptor.of(
-                        GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor),
-                        FALLBACK_CLONER, FieldAccessingSolutionCloner.class));
-        ResultHandle cloneObj =
-                noCloneBranch.invokeVirtualMethod(MethodDescriptor.ofMethod(FieldAccessingSolutionCloner.class,
-                        "gizmoFallbackDeepClone", Object.class, Object.class, Map.class),
-                        fallbackCloner, toClone, cloneMap);
-        noCloneBranch.returnValue(cloneObj);
+        try (var noCloneBranch = hasCloneBranchResult.falseBranch()) {
+            var fallbackCloner =
+                    noCloneBranch.readStaticField(FieldDescriptor.of(
+                            GizmoSolutionClonerFactory.getGeneratedClassName(clonerDescriptor.solutionDescriptor),
+                            FALLBACK_CLONER, FieldAccessingSolutionCloner.class));
+            var cloneObj =
+                    noCloneBranch.invokeVirtualMethod(MethodDescriptor.ofMethod(FieldAccessingSolutionCloner.class,
+                            "gizmoFallbackDeepClone", Object.class, Object.class, Map.class),
+                            fallbackCloner, toClone, cloneMap);
+            noCloneBranch.returnValue(cloneObj);
+        }
     }
 
     private enum UnhandledCloneType {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
@@ -151,10 +151,11 @@ public class GizmoSolutionClonerImplementor {
                 classCreator);
 
         implementor.createFields(clonerDescriptor);
-        implementor.createConstructor(clonerDescriptor);
         implementor.createSetSolutionDescriptor(clonerDescriptor);
-        implementor.createCloneSolution(clonerDescriptor);
-        implementor.createCloneSolutionRun(clonerDescriptor, solutionClassSet, instanceOfComparator);
+
+        createCloneSolutionRun(clonerDescriptor, solutionClassSet, instanceOfComparator);
+        createConstructor(clonerDescriptor);
+        createCloneSolution(clonerDescriptor);
 
         for (var deepClonedClass : deepCloneClassesThatAreNotSolutionSortedSet) {
             implementor.createDeepCloneHelperMethod(clonerDescriptor, deepClonedClass);
@@ -220,7 +221,7 @@ public class GizmoSolutionClonerImplementor {
         }
     }
 
-    private void createConstructor(ClonerDescriptor clonerDescriptor) {
+    private static void createConstructor(ClonerDescriptor clonerDescriptor) {
         var methodCreator = clonerDescriptor.classCreator.getMethodCreator(
                 MethodDescriptor.ofConstructor(clonerDescriptor.classCreator.getClassName()));
         var thisObj = methodCreator.getThis();
@@ -247,7 +248,7 @@ public class GizmoSolutionClonerImplementor {
         methodCreator.returnValue(null);
     }
 
-    private void createCloneSolution(ClonerDescriptor clonerDescriptor) {
+    private static void createCloneSolution(ClonerDescriptor clonerDescriptor) {
         var solutionClass = clonerDescriptor.solutionDescriptor.getSolutionClass();
         var methodCreator =
                 clonerDescriptor.classCreator.getMethodCreator(MethodDescriptor.ofMethod(SolutionCloner.class,
@@ -266,7 +267,7 @@ public class GizmoSolutionClonerImplementor {
         methodCreator.returnValue(clone);
     }
 
-    private void createCloneSolutionRun(ClonerDescriptor clonerDescriptor,
+    private static void createCloneSolutionRun(ClonerDescriptor clonerDescriptor,
             Set<Class<?>> solutionClassSet, Comparator<Class<?>> instanceOfComparator) {
         var solutionClass = clonerDescriptor.solutionDescriptor.getSolutionClass();
         var methodCreator =
@@ -360,7 +361,7 @@ public class GizmoSolutionClonerImplementor {
         }
     }
 
-    private void cloneDeepClonedFieldsOfSolution(ClonerDescriptor clonerDescriptor,
+    private static void cloneDeepClonedFieldsOfSolution(ClonerDescriptor clonerDescriptor,
             GizmoSolutionOrEntityDescriptor solutionSubclassDescriptor,
             BytecodeCreator isSubclassBranch, ResultHandle thisObj, ResultHandle createdCloneMap, ResultHandle clone) {
         for (Field deeplyClonedField : solutionSubclassDescriptor.getDeepClonedFields()) {
@@ -382,7 +383,7 @@ public class GizmoSolutionClonerImplementor {
         }
     }
 
-    private void cloneShallowlyClonedFieldsOfObject(GizmoSolutionOrEntityDescriptor solutionSubclassDescriptor,
+    private static void cloneShallowlyClonedFieldsOfObject(GizmoSolutionOrEntityDescriptor solutionSubclassDescriptor,
             ClonerDescriptor clonerDescriptor, ClonerMethodDescriptor solutionSubclassDescriptor1, ResultHandle thisObj,
             ResultHandle clone) {
         for (GizmoMemberDescriptor shallowlyClonedField : solutionSubclassDescriptor
@@ -402,7 +403,7 @@ public class GizmoSolutionClonerImplementor {
      * clone.setMember(original.getMember());
      * </pre>
      */
-    private void writeShallowCloneInstructions(ClonerDescriptor clonerDescriptor,
+    private static void writeShallowCloneInstructions(ClonerDescriptor clonerDescriptor,
             ClonerMethodDescriptor clonerMethodDescriptor,
             GizmoMemberDescriptor shallowlyClonedField,
             ResultHandle thisObj, ResultHandle clone) {
@@ -447,7 +448,7 @@ public class GizmoSolutionClonerImplementor {
      * @see #writeDeepCloneInstructions(ClonerDescriptor, ClonerMethodDescriptor, Class, Type, ResultHandle,
      *      AssignableResultHandle)
      */
-    private void writeDeepCloneInstructions(ClonerDescriptor clonerDescriptor,
+    private static void writeDeepCloneInstructions(ClonerDescriptor clonerDescriptor,
             ClonerMethodDescriptor clonerMethodDescriptor,
             Field deeplyClonedField,
             GizmoMemberDescriptor gizmoMemberDescriptor, ResultHandle toClone, AssignableResultHandle cloneResultHolder) {
@@ -532,7 +533,7 @@ public class GizmoSolutionClonerImplementor {
      * }
      * </pre>
      */
-    private void writeDeepCloneInstructions(ClonerDescriptor clonerDescriptor,
+    private static void writeDeepCloneInstructions(ClonerDescriptor clonerDescriptor,
             ClonerMethodDescriptor clonerMethodDescriptor,
             Class<?> deeplyClonedFieldClass, java.lang.reflect.Type type, ResultHandle toClone,
             AssignableResultHandle cloneResultHolder) {
@@ -577,7 +578,7 @@ public class GizmoSolutionClonerImplementor {
         }
     }
 
-    private void writeDeepCloneSolutionInstructions(
+    private static void writeDeepCloneSolutionInstructions(
             ClonerMethodDescriptor clonerMethodDescriptor, ResultHandle toClone, AssignableResultHandle cloneResultHolder) {
         var isNull = clonerMethodDescriptor.bytecodeCreator.ifNull(toClone);
 
@@ -614,7 +615,7 @@ public class GizmoSolutionClonerImplementor {
      * cloneResultHolder = clone;
      * </pre>
      **/
-    private void writeDeepCloneCollectionInstructions(ClonerDescriptor clonerDescriptor,
+    private static void writeDeepCloneCollectionInstructions(ClonerDescriptor clonerDescriptor,
             ClonerMethodDescriptor clonerMethodDescriptor,
             Class<?> deeplyClonedFieldClass, java.lang.reflect.Type type, ResultHandle toClone,
             AssignableResultHandle cloneResultHolder) {
@@ -735,7 +736,7 @@ public class GizmoSolutionClonerImplementor {
      * cloneResultHolder = clone;
      * </pre>
      **/
-    private void writeDeepCloneMapInstructions(ClonerDescriptor clonerDescriptor,
+    private static void writeDeepCloneMapInstructions(ClonerDescriptor clonerDescriptor,
             ClonerMethodDescriptor clonerMethodDescriptor,
             Class<?> deeplyClonedFieldClass, java.lang.reflect.Type type, ResultHandle toClone,
             AssignableResultHandle cloneResultHolder) {
@@ -853,7 +854,7 @@ public class GizmoSolutionClonerImplementor {
      * cloneResultHolder = clone;
      * </pre>
      **/
-    private void writeDeepCloneArrayInstructions(ClonerDescriptor clonerDescriptor,
+    private static void writeDeepCloneArrayInstructions(ClonerDescriptor clonerDescriptor,
             ClonerMethodDescriptor clonerMethodDescriptor,
             Class<?> deeplyClonedFieldClass, ResultHandle toClone, AssignableResultHandle cloneResultHolder) {
         var bytecodeCreator = clonerMethodDescriptor.bytecodeCreator;
@@ -900,7 +901,7 @@ public class GizmoSolutionClonerImplementor {
      * }
      * </pre>
      **/
-    private void writeDeepCloneEntityOrFactInstructions(ClonerDescriptor clonerDescriptor,
+    private static void writeDeepCloneEntityOrFactInstructions(ClonerDescriptor clonerDescriptor,
             ClonerMethodDescriptor clonerMethodDescriptor,
             Class<?> deeplyClonedFieldClass,
             ResultHandle toClone,
@@ -951,7 +952,7 @@ public class GizmoSolutionClonerImplementor {
         currentBranch.close();
     }
 
-    protected String getEntityHelperMethodName(Class<?> entityClass) {
+    protected static String getEntityHelperMethodName(Class<?> entityClass) {
         return "$clone" + entityClass.getName().replace('.', '_');
     }
 
@@ -1102,7 +1103,7 @@ public class GizmoSolutionClonerImplementor {
         }
     }
 
-    private void addDeepCloneFieldInitializerToQueue(ClonerDescriptor clonerDescriptor,
+    private static void addDeepCloneFieldInitializerToQueue(ClonerDescriptor clonerDescriptor,
             ClonerMethodDescriptor clonerMethodDescriptor,
             Field deeplyClonedField, ResultHandle toClone, ResultHandle cloneObj) {
         var entityDescriptor = clonerMethodDescriptor.entityDescriptor;

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -374,8 +374,8 @@ public abstract class AbstractSolutionClonerTest {
             cloneValue = cloneValue.getDependencies().get(0);
             originalValue = originalValue.getDependencies().get(0);
         }
-        assertThat(cloneValue).isNotNull();
-        assertThat(cloneValue).isNotSameAs(solutionValue);
+        assertThat(cloneValue).isNotNull()
+                .isNotSameAs(solutionValue);
         assertThat(cloneValue.getId()).isEqualTo(originalValue.getId());
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -4,6 +4,9 @@ import static ai.timefold.solver.core.testutil.PlannerAssert.assertCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,6 +64,9 @@ import ai.timefold.solver.core.testdomain.list.TestdataListValue;
 import ai.timefold.solver.core.testdomain.reflect.accessmodifier.TestdataAccessModifierSolution;
 import ai.timefold.solver.core.testdomain.reflect.field.TestdataFieldAnnotatedEntity;
 import ai.timefold.solver.core.testdomain.reflect.field.TestdataFieldAnnotatedSolution;
+import ai.timefold.solver.core.testdomain.shadow.dependency.TestdataDependencyEntity;
+import ai.timefold.solver.core.testdomain.shadow.dependency.TestdataDependencySolution;
+import ai.timefold.solver.core.testdomain.shadow.dependency.TestdataDependencyValue;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -322,6 +328,52 @@ public abstract class AbstractSolutionClonerTest {
         assertCode("2", b.getValue());
         // Clone remains unchanged
         assertCode("1", cloneB.getValue());
+    }
+
+    @Test
+    protected void cloneDeeplyNestedSolution() {
+        var solutionDescriptor = TestdataDependencySolution.buildSolutionDescriptor();
+        var cloner = createSolutionCloner(solutionDescriptor);
+
+        var startTime = LocalDate.of(2000, 1, 1).atTime(LocalTime.MIDNIGHT);
+        var solutionEntity = new TestdataDependencyEntity(LocalDate.of(2000, 1, 1).atTime(LocalTime.MIDNIGHT));
+        var solutionValue = new TestdataDependencyValue("root", Duration.ofHours(1L));
+
+        var outer = solutionValue;
+        var NESTED_COUNT = 10_000;
+
+        for (var i = 0; i < NESTED_COUNT; i++) {
+            var newValue = new TestdataDependencyValue(Integer.toString(i), Duration.ofHours(1L));
+            outer.setDependencies(List.of(newValue));
+            outer = newValue;
+        }
+
+        var original = new TestdataDependencySolution(List.of(solutionEntity), List.of(solutionValue));
+        var clone = cloner.cloneSolution(original);
+        assertThat(clone).isNotSameAs(original);
+        assertThat(clone.getEntities()).isNotSameAs(original.getEntities());
+        assertThat(clone.getEntities()).hasSize(1);
+        assertThat(clone.getEntities().get(0)).isNotSameAs(solutionEntity);
+        assertThat(clone.getEntities().get(0).getStartTime()).isEqualTo(startTime);
+
+        assertThat(clone.getValues()).isNotSameAs(original.getValues());
+        assertThat(clone.getValues()).hasSize(1);
+        assertThat(clone.getValues().get(0)).isNotSameAs(solutionValue);
+        assertThat(clone.getValues().get(0).getId()).isEqualTo(solutionValue.getId());
+
+        var cloneValue = clone.getValues().get(0);
+        var originalValue = solutionValue;
+
+        for (var i = 0; i < NESTED_COUNT; i++) {
+            assertThat(cloneValue).isNotNull();
+            assertThat(cloneValue).isNotSameAs(solutionValue);
+            assertThat(cloneValue.getId()).isEqualTo(originalValue.getId());
+            cloneValue = cloneValue.getDependencies().get(0);
+            originalValue = originalValue.getDependencies().get(0);
+        }
+        assertThat(cloneValue).isNotNull();
+        assertThat(cloneValue).isNotSameAs(solutionValue);
+        assertThat(cloneValue.getId()).isEqualTo(originalValue.getId());
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -14,10 +13,10 @@ import java.util.stream.Stream;
 
 import ai.timefold.solver.core.api.domain.solution.cloner.SolutionCloner;
 import ai.timefold.solver.core.impl.domain.common.ReflectionHelper;
+import ai.timefold.solver.core.impl.domain.common.accessor.gizmo.GizmoClassLoader;
 import ai.timefold.solver.core.impl.domain.common.accessor.gizmo.GizmoMemberDescriptor;
 import ai.timefold.solver.core.impl.domain.solution.cloner.AbstractSolutionClonerTest;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import ai.timefold.solver.core.impl.util.Pair;
 import ai.timefold.solver.core.testdomain.TestdataValue;
 import ai.timefold.solver.core.testdomain.inheritance.solution.baseannotated.childnot.TestdataOnlyBaseAnnotatedChildEntity;
 import ai.timefold.solver.core.testdomain.inheritance.solution.baseannotated.childnot.TestdataOnlyBaseAnnotatedExtendedSolution;
@@ -41,7 +40,7 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
     @Override
     protected <Solution_> SolutionCloner<Solution_> createSolutionCloner(SolutionDescriptor<Solution_> solutionDescriptor) {
         var className = GizmoSolutionClonerFactory.getGeneratedClassName(solutionDescriptor);
-        var classBytecodeHolder = new ArrayList<Pair<String, byte[]>>();
+        var classBytecodeHolder = new HashMap<String, byte[]>();
         var classOutput =
                 GizmoSolutionClonerImplementor.createClassOutputWithDebuggingCapability(classBytecodeHolder);
         var classCreator = ClassCreator.builder()
@@ -68,24 +67,7 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
                 memoizedSolutionOrEntityDescriptorMap, deepClonedClassSet);
         classCreator.close();
 
-        var gizmoClassLoader = new ClassLoader() {
-            // getName() is an abstract method in Java 11 but not in Java 8
-            @Override
-            public String getName() {
-                return "Timefold Gizmo SolutionCloner Test ClassLoader";
-            }
-
-            @Override
-            public Class<?> findClass(String name) throws ClassNotFoundException {
-                for (var entry : classBytecodeHolder) {
-                    if (entry.key().equals(name)) {
-                        return defineClass(name, entry.value(), 0, entry.value().length);
-                    }
-                }
-                // Not a Gizmo generated class; load from context class loader
-                return Thread.currentThread().getContextClassLoader().loadClass(name);
-            }
-        };
+        var gizmoClassLoader = new GizmoClassLoader(classBytecodeHolder);
 
         try {
             @SuppressWarnings("unchecked")
@@ -211,11 +193,11 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
 
         assertThatCode(() -> cloner.cloneSolution(original))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "Failed to create clone: encountered (" + original.getClass() + ") which is not a known subclass of " +
-                                "the solution class (" + TestdataOnlyBaseAnnotatedSolution.class
-                                + "). The known subclasses are " +
-                                "[" + TestdataOnlyBaseAnnotatedSolution.class.getName()
-                                + "].\nMaybe use DomainAccessType.REFLECTION?");
+                .hasMessageContainingAll(
+                        "Failed to create clone: encountered (%s)".formatted(original.getClass()),
+                        "which is not a known subclass of the solution class (%s)."
+                                .formatted(TestdataOnlyBaseAnnotatedSolution.class),
+                        "The known subclasses are: [%s]".formatted(TestdataOnlyBaseAnnotatedSolution.class.getName()),
+                        "Maybe use DomainAccessType.REFLECTION?");
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/dependency/TestdataDependencyConstraintProvider.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/dependency/TestdataDependencyConstraintProvider.java
@@ -20,7 +20,7 @@ public class TestdataDependencyConstraintProvider implements ConstraintProvider 
 
     public Constraint penalizeInconsistentTasks(@NonNull ConstraintFactory constraintFactory) {
         return constraintFactory.forEachUnfiltered(TestdataDependencyValue.class)
-                .filter(TestdataDependencyValue::isInvalid)
+                .filter(TestdataDependencyValue::getIsInvalid)
                 .penalize(HardSoftScore.ONE_HARD)
                 .asConstraint("Invalid task");
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/dependency/TestdataDependencyValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/dependency/TestdataDependencyValue.java
@@ -48,6 +48,14 @@ public class TestdataDependencyValue {
         this.dependencies = dependencies;
     }
 
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public List<TestdataDependencyValue> getDependencies() {
         return dependencies;
     }
@@ -111,11 +119,11 @@ public class TestdataDependencyValue {
         this.duration = duration;
     }
 
-    public Boolean isInvalid() {
+    public Boolean getIsInvalid() {
         return isInvalid;
     }
 
-    public void setInvalid(Boolean invalid) {
+    public void setIsInvalid(Boolean invalid) {
         isInvalid = invalid;
     }
 

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/QuarkusGizmoSolutionClonerImplementor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/QuarkusGizmoSolutionClonerImplementor.java
@@ -47,9 +47,8 @@ class QuarkusGizmoSolutionClonerImplementor extends GizmoSolutionClonerImplement
                         entityClass, Map.class);
         methodCreator.setModifiers(Modifier.STATIC | Modifier.PRIVATE);
 
-        GizmoSolutionOrEntityDescriptor entityDescriptor =
-                clonerDescriptor.memoizedSolutionOrEntityDescriptorMap().computeIfAbsent(entityClass,
-                        (key) -> new GizmoSolutionOrEntityDescriptor(clonerDescriptor.solutionDescriptor(), entityClass));
+        clonerDescriptor.memoizedSolutionOrEntityDescriptorMap().computeIfAbsent(entityClass,
+                key -> new GizmoSolutionOrEntityDescriptor(clonerDescriptor.solutionDescriptor(), entityClass));
 
         ResultHandle toClone = methodCreator.getMethodParam(0);
         ResultHandle cloneMap = methodCreator.getMethodParam(1);

--- a/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
+++ b/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
@@ -1330,15 +1330,15 @@ class SingleConstraintAssertionTest {
         dependent.setPreviousValue(null);
         dependency.setPreviousValue(dependent);
 
-        dependent.setInvalid(null);
-        dependency.setInvalid(null);
+        dependent.setIsInvalid(null);
+        dependency.setIsInvalid(null);
 
         constraintVerifierForConsistency.verifyThat(TestdataDependencyConstraintProvider::finishTasksAsSoonAsPossible)
                 .given(dependency, dependent)
                 .penalizes(0);
 
-        assertThat(dependent.isInvalid()).isNull();
-        assertThat(dependency.isInvalid()).isNull();
+        assertThat(dependent.getIsInvalid()).isNull();
+        assertThat(dependency.getIsInvalid()).isNull();
 
         dependent.setPreviousValue(dependency);
         dependency.setPreviousValue(null);
@@ -1352,8 +1352,8 @@ class SingleConstraintAssertionTest {
                 // 60 + 120 = 180
                 .penalizesBy(180);
 
-        assertThat(dependent.isInvalid()).isNull();
-        assertThat(dependency.isInvalid()).isNull();
+        assertThat(dependent.getIsInvalid()).isNull();
+        assertThat(dependency.getIsInvalid()).isNull();
     }
 
     @Test
@@ -1368,7 +1368,7 @@ class SingleConstraintAssertionTest {
         dependent.setPreviousValue(null);
         dependency.setPreviousValue(dependent);
 
-        dependency.setInvalid(false);
+        dependency.setIsInvalid(false);
         dependency.setStartTime(LocalDateTime.MIN.plusHours(1));
         dependency.setEndTime(LocalDateTime.MIN.plusHours(2));
 
@@ -1377,13 +1377,13 @@ class SingleConstraintAssertionTest {
                 .penalizesBy(120);
 
         var singleValue = new TestdataDependencyValue("single", Duration.ofHours(1L));
-        singleValue.setInvalid(false);
+        singleValue.setIsInvalid(false);
 
         constraintVerifierForConsistency.verifyThat(TestdataDependencyConstraintProvider::penalizeInconsistentTasks)
                 .given(singleValue)
                 .penalizes(0);
 
-        singleValue.setInvalid(true);
+        singleValue.setIsInvalid(true);
 
         constraintVerifierForConsistency.verifyThat(TestdataDependencyConstraintProvider::penalizeInconsistentTasks)
                 .given(singleValue)
@@ -1407,15 +1407,15 @@ class SingleConstraintAssertionTest {
         dependent.setPreviousValue(null);
         dependency.setPreviousValue(dependent);
 
-        dependent.setInvalid(null);
-        dependency.setInvalid(null);
+        dependent.setIsInvalid(null);
+        dependency.setIsInvalid(null);
 
         constraintVerifierForConsistency.verifyThat(TestdataDependencyConstraintProvider::finishTasksAsSoonAsPossible)
                 .givenSolution(solution)
                 .penalizes(0);
 
-        assertThat(dependent.isInvalid()).isNull();
-        assertThat(dependency.isInvalid()).isNull();
+        assertThat(dependent.getIsInvalid()).isNull();
+        assertThat(dependency.getIsInvalid()).isNull();
 
         entity.setValues(List.of(dependency, dependent));
         dependent.setPreviousValue(dependency);
@@ -1430,8 +1430,8 @@ class SingleConstraintAssertionTest {
                 // 60 + 120 = 180
                 .penalizesBy(180);
 
-        assertThat(dependent.isInvalid()).isNull();
-        assertThat(dependency.isInvalid()).isNull();
+        assertThat(dependent.getIsInvalid()).isNull();
+        assertThat(dependency.getIsInvalid()).isNull();
     }
 
     @Test
@@ -1450,7 +1450,7 @@ class SingleConstraintAssertionTest {
         dependent.setPreviousValue(null);
         dependency.setPreviousValue(dependent);
 
-        dependency.setInvalid(false);
+        dependency.setIsInvalid(false);
         dependency.setStartTime(LocalDateTime.MIN.plusHours(1));
         dependency.setEndTime(LocalDateTime.MIN.plusHours(2));
 
@@ -1469,14 +1469,14 @@ class SingleConstraintAssertionTest {
         solution.setEntities(List.of(entity));
         solution.setValues(List.of(singleValue));
 
-        singleValue.setInvalid(false);
+        singleValue.setIsInvalid(false);
         singleValue.setEntity(entity);
 
         constraintVerifierForConsistency.verifyThat(TestdataDependencyConstraintProvider::penalizeInconsistentTasks)
                 .givenSolution(solution)
                 .penalizes(0);
 
-        singleValue.setInvalid(true);
+        singleValue.setIsInvalid(true);
 
         constraintVerifierForConsistency.verifyThat(TestdataDependencyConstraintProvider::penalizeInconsistentTasks)
                 .givenSolution(solution)


### PR DESCRIPTION
- Previously, when a class is deep-cloned, a method that constructs and fully initializes a clone of that class is called. This has the potential to cause a StackOverflowException when a deep-cloned class refers to many other deep-cloned classes, such as in chained models.

- Now, when a field is deeped cloned, it adds the field initializer to a cloneQueue, and that cloneQueue can only be processed for the first entity being cloned. As such, stack-height does not grow indefinitely.

- Perform various cleanups in the GizmoSolutionCloner

- Change method `isInvalid` to `getIsInvalid` so the GizmoSolutionCloner recongize it as the getter of the corresponding field.