### PR TITLE
docs: correct wording for enterprise edition license.

### DIFF
--- a/.github/workflows/release-changelog-template.md
+++ b/.github/workflows/release-changelog-template.md
@@ -13,7 +13,8 @@ _Timefold Solver Community Edition_ is an open source project, and you are more 
 For more, see [Contributing](https://github.com/TimefoldAI/timefold-solver/blob/main/CONTRIBUTING.adoc).
 
 Should your business need to scale to truly massive data sets or require enterprise-grade support,
-check out [_Timefold Solver Enterprise Edition_](https://timefold.ai/pricing). 
+check out [_Timefold Solver Enterprise Edition_](https://docs.timefold.ai/timefold-solver/latest/enterprise-edition/enterprise-edition). 
+Timefold Solver Enterprise Edition requires [a license](https://timefold.ai/pricing). 
 
 # How to use Timefold Solver
 

--- a/README.adoc
+++ b/README.adoc
@@ -66,7 +66,7 @@ For more, see link:CONTRIBUTING.adoc[Contributing].
 There are two editions of Timefold Solver:
 
 - Timefold Solver Community Edition (this repo).
-- https://timefold.ai/pricing[Timefold Solver Enterprise Edition], a licensed version of Timefold Solver.
+- Timefold Solver Enterprise Edition, a https://timefold.ai/pricing[licensed version] of Timefold Solver.
 
 === Key Features of Timefold Solver Enterprise Edition (EE)
 


### PR DESCRIPTION
The link is technically correct. Moving it to a slightly different word to clarify.