### PR TITLE
perf: optimize memory usage of precompute

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/PrecomputeBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/PrecomputeBiNode.java
@@ -1,10 +1,11 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
-import ai.timefold.solver.core.impl.bavet.NodeNetwork;
+import java.util.function.Supplier;
+
 import ai.timefold.solver.core.impl.bavet.common.AbstractPrecomputeNode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.BiTuple;
-import ai.timefold.solver.core.impl.bavet.common.tuple.RecordingTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
+import ai.timefold.solver.core.impl.score.stream.bavet.common.BavetPrecomputeBuildHelper;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -12,12 +13,11 @@ import org.jspecify.annotations.NullMarked;
 public final class PrecomputeBiNode<A, B> extends AbstractPrecomputeNode<BiTuple<A, B>> {
     private final int outputStoreSize;
 
-    public PrecomputeBiNode(NodeNetwork nodeNetwork,
-            RecordingTupleLifecycle<BiTuple<A, B>> recordingTupleNode,
+    public PrecomputeBiNode(Supplier<BavetPrecomputeBuildHelper<BiTuple<A, B>>> precomputeBuildHelperSupplier,
             int outputStoreSize,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle,
             Class<?>[] sourceClasses) {
-        super(nodeNetwork, recordingTupleNode, nextNodesTupleLifecycle, sourceClasses);
+        super(precomputeBuildHelperSupplier, nextNodesTupleLifecycle, sourceClasses);
         this.outputStoreSize = outputStoreSize;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractPrecomputeNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractPrecomputeNode.java
@@ -1,9 +1,10 @@
 package ai.timefold.solver.core.impl.bavet.common;
 
-import ai.timefold.solver.core.impl.bavet.NodeNetwork;
+import java.util.function.Supplier;
+
 import ai.timefold.solver.core.impl.bavet.common.tuple.AbstractTuple;
-import ai.timefold.solver.core.impl.bavet.common.tuple.RecordingTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
+import ai.timefold.solver.core.impl.score.stream.bavet.common.BavetPrecomputeBuildHelper;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -14,12 +15,10 @@ public abstract class AbstractPrecomputeNode<Tuple_ extends AbstractTuple> exten
     private final RecordAndReplayPropagator<Tuple_> recordAndReplayPropagator;
     private final Class<?>[] sourceClasses;
 
-    protected AbstractPrecomputeNode(NodeNetwork innerNodeNetwork,
-            RecordingTupleLifecycle<Tuple_> recordingTupleLifecycle,
+    protected AbstractPrecomputeNode(Supplier<BavetPrecomputeBuildHelper<Tuple_>> precomputeBuildHelperSupplier,
             TupleLifecycle<Tuple_> nextNodesTupleLifecycle,
             Class<?>[] sourceClasses) {
-        this.recordAndReplayPropagator = new RecordAndReplayPropagator<>(innerNodeNetwork,
-                recordingTupleLifecycle,
+        this.recordAndReplayPropagator = new RecordAndReplayPropagator<>(precomputeBuildHelperSupplier,
                 this::remapTuple,
                 nextNodesTupleLifecycle);
         this.sourceClasses = sourceClasses;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/RecordAndReplayPropagator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/RecordAndReplayPropagator.java
@@ -143,7 +143,7 @@ public final class RecordAndReplayPropagator<Tuple_ extends AbstractTuple>
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private <A> List<BavetRootNode<A>> getRootNodes(Object object, NodeNetwork internalNodeNetwork,
+    private static <A> List<BavetRootNode<A>> getRootNodes(Object object, NodeNetwork internalNodeNetwork,
             Map<Class<?>, List<BavetRootNode<?>>> objectClassToRootNodes) {
         return (List) objectClassToRootNodes.computeIfAbsent(object.getClass(), clazz -> {
             var out = new ArrayList<BavetRootNode<?>>();

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/RecordingTupleLifecycle.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/RecordingTupleLifecycle.java
@@ -23,7 +23,13 @@ public class RecordingTupleLifecycle<Tuple_ extends AbstractTuple> implements Tu
     @Override
     public void insert(Tuple_ tuple) {
         if (tupleRecorder != null) {
-            throw new IllegalStateException("Impossible state: tuple %s was inserted during recording".formatted(tuple));
+            throw new IllegalStateException("""
+                    Illegal state: tuple %s was inserted during recording.
+                    Certain operations like flattenLast will create new tuples
+                    on update if its mapping function returns a new instance.
+                    Maybe refactor the code to avoid creating new instances,
+                    or avoid using precompute if that is not possible.
+                    """.formatted(tuple));
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/PrecomputeQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/PrecomputeQuadNode.java
@@ -1,10 +1,11 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
-import ai.timefold.solver.core.impl.bavet.NodeNetwork;
+import java.util.function.Supplier;
+
 import ai.timefold.solver.core.impl.bavet.common.AbstractPrecomputeNode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.QuadTuple;
-import ai.timefold.solver.core.impl.bavet.common.tuple.RecordingTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
+import ai.timefold.solver.core.impl.score.stream.bavet.common.BavetPrecomputeBuildHelper;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -12,12 +13,11 @@ import org.jspecify.annotations.NullMarked;
 public final class PrecomputeQuadNode<A, B, C, D> extends AbstractPrecomputeNode<QuadTuple<A, B, C, D>> {
     private final int outputStoreSize;
 
-    public PrecomputeQuadNode(NodeNetwork nodeNetwork,
-            RecordingTupleLifecycle<QuadTuple<A, B, C, D>> recordingTupleNode,
+    public PrecomputeQuadNode(Supplier<BavetPrecomputeBuildHelper<QuadTuple<A, B, C, D>>> precomputeBuildHelperSupplier,
             int outputStoreSize,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle,
             Class<?>[] sourceClasses) {
-        super(nodeNetwork, recordingTupleNode, nextNodesTupleLifecycle, sourceClasses);
+        super(precomputeBuildHelperSupplier, nextNodesTupleLifecycle, sourceClasses);
         this.outputStoreSize = outputStoreSize;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/PrecomputeTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/PrecomputeTriNode.java
@@ -1,10 +1,11 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
-import ai.timefold.solver.core.impl.bavet.NodeNetwork;
+import java.util.function.Supplier;
+
 import ai.timefold.solver.core.impl.bavet.common.AbstractPrecomputeNode;
-import ai.timefold.solver.core.impl.bavet.common.tuple.RecordingTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TriTuple;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
+import ai.timefold.solver.core.impl.score.stream.bavet.common.BavetPrecomputeBuildHelper;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -12,12 +13,11 @@ import org.jspecify.annotations.NullMarked;
 public final class PrecomputeTriNode<A, B, C> extends AbstractPrecomputeNode<TriTuple<A, B, C>> {
     private final int outputStoreSize;
 
-    public PrecomputeTriNode(NodeNetwork nodeNetwork,
-            RecordingTupleLifecycle<TriTuple<A, B, C>> recordingTupleNode,
+    public PrecomputeTriNode(Supplier<BavetPrecomputeBuildHelper<TriTuple<A, B, C>>> precomputeBuildHelperSupplier,
             int outputStoreSize,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle,
             Class<?>[] sourceClasses) {
-        super(nodeNetwork, recordingTupleNode, nextNodesTupleLifecycle, sourceClasses);
+        super(precomputeBuildHelperSupplier, nextNodesTupleLifecycle, sourceClasses);
         this.outputStoreSize = outputStoreSize;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/PrecomputeUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/PrecomputeUniNode.java
@@ -1,10 +1,11 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
-import ai.timefold.solver.core.impl.bavet.NodeNetwork;
+import java.util.function.Supplier;
+
 import ai.timefold.solver.core.impl.bavet.common.AbstractPrecomputeNode;
-import ai.timefold.solver.core.impl.bavet.common.tuple.RecordingTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
+import ai.timefold.solver.core.impl.score.stream.bavet.common.BavetPrecomputeBuildHelper;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -12,12 +13,11 @@ import org.jspecify.annotations.NullMarked;
 public final class PrecomputeUniNode<A> extends AbstractPrecomputeNode<UniTuple<A>> {
     private final int outputStoreSize;
 
-    public PrecomputeUniNode(NodeNetwork nodeNetwork,
-            RecordingTupleLifecycle<UniTuple<A>> recordingTupleNode,
+    public PrecomputeUniNode(Supplier<BavetPrecomputeBuildHelper<UniTuple<A>>> precomputeBuildHelperSupplier,
             int outputStoreSize,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle,
             Class<?>[] sourceClasses) {
-        super(nodeNetwork, recordingTupleNode, nextNodesTupleLifecycle, sourceClasses);
+        super(precomputeBuildHelperSupplier, nextNodesTupleLifecycle, sourceClasses);
         this.outputStoreSize = outputStoreSize;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -282,6 +282,15 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         setWorkingSolutionWithoutUpdatingShadows(workingSolution);
         forceTriggerVariableListeners();
         expectShadowVariablesInCorrectState = originalShouldAssert;
+        afterSetWorkingSolution();
+    }
+
+    /**
+     * Note: by default does nothing. Subclasses should override this if they
+     * need to compute something after shadow variables are set.
+     */
+    public void afterSetWorkingSolution() {
+        // Do nothing
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -289,7 +289,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
      * Note: by default does nothing. Subclasses should override this if they
      * need to compute something after shadow variables are set.
      */
-    public void afterSetWorkingSolution() {
+    protected void afterSetWorkingSolution() {
         // Do nothing
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
@@ -79,6 +79,13 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
     }
 
     @Override
+    public void afterSetWorkingSolution() {
+        // Settle the node network to calculate precomputes
+        // This is required so precomputes are not considered by terminations
+        session.settle();
+    }
+
+    @Override
     public InnerScore<Score_> calculateScore() {
         variableListenerSupport.assertNotificationQueuesAreEmpty();
         var score = session.calculateScore();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
@@ -79,7 +79,7 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
     }
 
     @Override
-    public void afterSetWorkingSolution() {
+    protected void afterSetWorkingSolution() {
         // Settle the node network to calculate precomputes
         // This is required so precomputes are not considered by terminations
         session.settle();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetPrecomputeBiConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetPrecomputeBiConstraintStream.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.score.stream.bavet.bi;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.bavet.bi.PrecomputeBiNode;
@@ -34,14 +35,14 @@ public class BavetPrecomputeBiConstraintStream<Solution_, A, B> extends BavetAbs
 
     @Override
     public <Score_ extends Score<Score_>> void buildNode(ConstraintNodeBuildHelper<Solution_, Score_> buildHelper) {
-        var precomputeBuildHelper = new BavetPrecomputeBuildHelper<BiTuple<A, B>>(recordingPrecomputedConstraintStream);
+        Supplier<BavetPrecomputeBuildHelper<BiTuple<A, B>>> precomputeBuildHelperSupplier =
+                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
 
-        buildHelper.addNode(new PrecomputeBiNode<>(precomputeBuildHelper.getNodeNetwork(),
-                precomputeBuildHelper.getRecordingTupleLifecycle(),
+        buildHelper.addNode(new PrecomputeBiNode<>(precomputeBuildHelperSupplier,
                 outputStoreSize,
                 buildHelper.getAggregatedTupleLifecycle(aftStream.getChildStreamList()),
-                precomputeBuildHelper.getSourceClasses()),
+                precomputeBuildHelperSupplier.get().getSourceClasses()),
                 this);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetPrecomputeBiConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetPrecomputeBiConstraintStream.java
@@ -18,6 +18,7 @@ import ai.timefold.solver.core.impl.score.stream.common.RetrievalSemantics;
 public class BavetPrecomputeBiConstraintStream<Solution_, A, B> extends BavetAbstractBiConstraintStream<Solution_, A, B>
         implements TupleSource {
     private final BavetAbstractConstraintStream<Solution_> recordingPrecomputedConstraintStream;
+    private final Set<Class<?>> entityClassSet;
     private BavetAftBridgeBiConstraintStream<Solution_, A, B> aftStream;
 
     public BavetPrecomputeBiConstraintStream(
@@ -26,6 +27,7 @@ public class BavetPrecomputeBiConstraintStream<Solution_, A, B> extends BavetAbs
         super(constraintFactory, RetrievalSemantics.STANDARD);
         this.recordingPrecomputedConstraintStream = new BavetRecordingBiConstraintStream<>(constraintFactory,
                 precomputedConstraintStream);
+        this.entityClassSet = constraintFactory.getSolutionDescriptor().getEntityClassSet();
         precomputedConstraintStream.getChildStreamList().add(recordingPrecomputedConstraintStream);
     }
 
@@ -36,7 +38,7 @@ public class BavetPrecomputeBiConstraintStream<Solution_, A, B> extends BavetAbs
     @Override
     public <Score_ extends Score<Score_>> void buildNode(ConstraintNodeBuildHelper<Solution_, Score_> buildHelper) {
         Supplier<BavetPrecomputeBuildHelper<BiTuple<A, B>>> precomputeBuildHelperSupplier =
-                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream);
+                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream, entityClassSet);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
 
         buildHelper.addNode(new PrecomputeBiNode<>(precomputeBuildHelperSupplier,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/BavetPrecomputeBuildHelper.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/common/BavetPrecomputeBuildHelper.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
 import ai.timefold.solver.core.api.score.stream.ConstraintStream;
@@ -26,9 +27,11 @@ public final class BavetPrecomputeBuildHelper<Tuple_ extends AbstractTuple> {
     private final NodeNetwork nodeNetwork;
     private final RecordingTupleLifecycle<Tuple_> recordingTupleLifecycle;
     private final Class<?>[] sourceClasses;
+    private final Set<Class<?>> entityClassSet;
 
     public <Solution_> BavetPrecomputeBuildHelper(
-            BavetAbstractConstraintStream<Solution_> recordingPrecomputeConstraintStream) {
+            BavetAbstractConstraintStream<Solution_> recordingPrecomputeConstraintStream,
+            Set<Class<?>> entityClassSet) {
         if (recordingPrecomputeConstraintStream.getRetrievalSemantics() != RetrievalSemantics.PRECOMPUTE) {
             throw new IllegalStateException(
                     "Impossible state: %s is not %s but is instead %s. Maybe you accidentally used a %s from %s instead of %s?"
@@ -37,6 +40,7 @@ public final class BavetPrecomputeBuildHelper<Tuple_ extends AbstractTuple> {
                                     ConstraintStream.class.getSimpleName(), ConstraintFactory.class.getSimpleName(),
                                     PrecomputeFactory.class.getSimpleName()));
         }
+        this.entityClassSet = entityClassSet;
 
         var streamList = new ArrayList<BavetAbstractConstraintStream<Solution_>>();
         var queue = new ArrayDeque<BavetAbstractConstraintStream<Solution_>>();
@@ -92,5 +96,14 @@ public final class BavetPrecomputeBuildHelper<Tuple_ extends AbstractTuple> {
 
     public Class<?>[] getSourceClasses() {
         return sourceClasses;
+    }
+
+    public boolean isSourceEntityClass(Class<?> maybeSourceEntityClass) {
+        for (var entityClass : entityClassSet) {
+            if (entityClass.isAssignableFrom(maybeSourceEntityClass)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetPrecomputeQuadConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetPrecomputeQuadConstraintStream.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.score.stream.bavet.quad;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.bavet.common.BavetAbstractConstraintStream;
@@ -35,14 +36,14 @@ public class BavetPrecomputeQuadConstraintStream<Solution_, A, B, C, D>
 
     @Override
     public <Score_ extends Score<Score_>> void buildNode(ConstraintNodeBuildHelper<Solution_, Score_> buildHelper) {
-        var precomputeBuildHelper = new BavetPrecomputeBuildHelper<QuadTuple<A, B, C, D>>(recordingPrecomputedConstraintStream);
+        Supplier<BavetPrecomputeBuildHelper<QuadTuple<A, B, C, D>>> precomputeBuildHelperSupplier =
+                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
 
-        buildHelper.addNode(new PrecomputeQuadNode<>(precomputeBuildHelper.getNodeNetwork(),
-                precomputeBuildHelper.getRecordingTupleLifecycle(),
+        buildHelper.addNode(new PrecomputeQuadNode<>(precomputeBuildHelperSupplier,
                 outputStoreSize,
                 buildHelper.getAggregatedTupleLifecycle(aftStream.getChildStreamList()),
-                precomputeBuildHelper.getSourceClasses()),
+                precomputeBuildHelperSupplier.get().getSourceClasses()),
                 this);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetPrecomputeQuadConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/quad/BavetPrecomputeQuadConstraintStream.java
@@ -19,6 +19,7 @@ public class BavetPrecomputeQuadConstraintStream<Solution_, A, B, C, D>
         extends BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
         implements TupleSource {
     private final BavetAbstractConstraintStream<Solution_> recordingPrecomputedConstraintStream;
+    private final Set<Class<?>> entityClassSet;
     private BavetAftBridgeQuadConstraintStream<Solution_, A, B, C, D> aftStream;
 
     public BavetPrecomputeQuadConstraintStream(
@@ -27,6 +28,7 @@ public class BavetPrecomputeQuadConstraintStream<Solution_, A, B, C, D>
         super(constraintFactory, RetrievalSemantics.STANDARD);
         this.recordingPrecomputedConstraintStream = new BavetRecordingQuadConstraintStream<>(constraintFactory,
                 precomputedConstraintStream);
+        this.entityClassSet = constraintFactory.getSolutionDescriptor().getEntityClassSet();
         precomputedConstraintStream.getChildStreamList().add(recordingPrecomputedConstraintStream);
     }
 
@@ -37,7 +39,7 @@ public class BavetPrecomputeQuadConstraintStream<Solution_, A, B, C, D>
     @Override
     public <Score_ extends Score<Score_>> void buildNode(ConstraintNodeBuildHelper<Solution_, Score_> buildHelper) {
         Supplier<BavetPrecomputeBuildHelper<QuadTuple<A, B, C, D>>> precomputeBuildHelperSupplier =
-                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream);
+                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream, entityClassSet);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
 
         buildHelper.addNode(new PrecomputeQuadNode<>(precomputeBuildHelperSupplier,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetPrecomputeTriConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetPrecomputeTriConstraintStream.java
@@ -18,6 +18,7 @@ import ai.timefold.solver.core.impl.score.stream.common.RetrievalSemantics;
 public class BavetPrecomputeTriConstraintStream<Solution_, A, B, C> extends BavetAbstractTriConstraintStream<Solution_, A, B, C>
         implements TupleSource {
     private final BavetAbstractConstraintStream<Solution_> recordingPrecomputedConstraintStream;
+    private final Set<Class<?>> entityClassSet;
     private BavetAftBridgeTriConstraintStream<Solution_, A, B, C> aftStream;
 
     public BavetPrecomputeTriConstraintStream(
@@ -26,6 +27,7 @@ public class BavetPrecomputeTriConstraintStream<Solution_, A, B, C> extends Bave
         super(constraintFactory, RetrievalSemantics.STANDARD);
         this.recordingPrecomputedConstraintStream = new BavetRecordingTriConstraintStream<>(constraintFactory,
                 precomputedConstraintStream);
+        this.entityClassSet = constraintFactory.getSolutionDescriptor().getEntityClassSet();
         precomputedConstraintStream.getChildStreamList().add(recordingPrecomputedConstraintStream);
     }
 
@@ -36,7 +38,7 @@ public class BavetPrecomputeTriConstraintStream<Solution_, A, B, C> extends Bave
     @Override
     public <Score_ extends Score<Score_>> void buildNode(ConstraintNodeBuildHelper<Solution_, Score_> buildHelper) {
         Supplier<BavetPrecomputeBuildHelper<TriTuple<A, B, C>>> precomputeBuildHelperSupplier =
-                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream);
+                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream, entityClassSet);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
 
         buildHelper.addNode(new PrecomputeTriNode<>(precomputeBuildHelperSupplier,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetPrecomputeTriConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/tri/BavetPrecomputeTriConstraintStream.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.score.stream.bavet.tri;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.bavet.common.BavetAbstractConstraintStream;
@@ -34,14 +35,14 @@ public class BavetPrecomputeTriConstraintStream<Solution_, A, B, C> extends Bave
 
     @Override
     public <Score_ extends Score<Score_>> void buildNode(ConstraintNodeBuildHelper<Solution_, Score_> buildHelper) {
-        var precomputedBuildHelper = new BavetPrecomputeBuildHelper<TriTuple<A, B, C>>(recordingPrecomputedConstraintStream);
+        Supplier<BavetPrecomputeBuildHelper<TriTuple<A, B, C>>> precomputeBuildHelperSupplier =
+                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
 
-        buildHelper.addNode(new PrecomputeTriNode<>(precomputedBuildHelper.getNodeNetwork(),
-                precomputedBuildHelper.getRecordingTupleLifecycle(),
+        buildHelper.addNode(new PrecomputeTriNode<>(precomputeBuildHelperSupplier,
                 outputStoreSize,
                 buildHelper.getAggregatedTupleLifecycle(aftStream.getChildStreamList()),
-                precomputedBuildHelper.getSourceClasses()),
+                precomputeBuildHelperSupplier.get().getSourceClasses()),
                 this);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetPrecomputeUniConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetPrecomputeUniConstraintStream.java
@@ -18,6 +18,7 @@ import ai.timefold.solver.core.impl.score.stream.common.RetrievalSemantics;
 public class BavetPrecomputeUniConstraintStream<Solution_, A> extends BavetAbstractUniConstraintStream<Solution_, A>
         implements TupleSource {
     private final BavetAbstractConstraintStream<Solution_> recordingPrecomputedConstraintStream;
+    private final Set<Class<?>> entityClassSet;
     private BavetAftBridgeUniConstraintStream<Solution_, A> aftStream;
 
     public BavetPrecomputeUniConstraintStream(
@@ -26,6 +27,7 @@ public class BavetPrecomputeUniConstraintStream<Solution_, A> extends BavetAbstr
         super(constraintFactory, RetrievalSemantics.STANDARD);
         this.recordingPrecomputedConstraintStream = new BavetRecordingUniConstraintStream<>(constraintFactory,
                 precomputedConstraintStream);
+        this.entityClassSet = constraintFactory.getSolutionDescriptor().getEntityClassSet();
         precomputedConstraintStream.getChildStreamList().add(recordingPrecomputedConstraintStream);
     }
 
@@ -36,7 +38,7 @@ public class BavetPrecomputeUniConstraintStream<Solution_, A> extends BavetAbstr
     @Override
     public <Score_ extends Score<Score_>> void buildNode(ConstraintNodeBuildHelper<Solution_, Score_> buildHelper) {
         Supplier<BavetPrecomputeBuildHelper<UniTuple<A>>> precomputeBuildHelperSupplier =
-                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream);
+                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream, entityClassSet);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
 
         buildHelper.addNode(new PrecomputeUniNode<>(precomputeBuildHelperSupplier,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetPrecomputeUniConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/uni/BavetPrecomputeUniConstraintStream.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.score.stream.bavet.uni;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.bavet.common.BavetAbstractConstraintStream;
@@ -34,14 +35,14 @@ public class BavetPrecomputeUniConstraintStream<Solution_, A> extends BavetAbstr
 
     @Override
     public <Score_ extends Score<Score_>> void buildNode(ConstraintNodeBuildHelper<Solution_, Score_> buildHelper) {
-        var precomputeBuildHelper = new BavetPrecomputeBuildHelper<UniTuple<A>>(recordingPrecomputedConstraintStream);
+        Supplier<BavetPrecomputeBuildHelper<UniTuple<A>>> precomputeBuildHelperSupplier =
+                () -> new BavetPrecomputeBuildHelper<>(recordingPrecomputedConstraintStream);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
 
-        buildHelper.addNode(new PrecomputeUniNode<>(precomputeBuildHelper.getNodeNetwork(),
-                precomputeBuildHelper.getRecordingTupleLifecycle(),
+        buildHelper.addNode(new PrecomputeUniNode<>(precomputeBuildHelperSupplier,
                 outputStoreSize,
                 buildHelper.getAggregatedTupleLifecycle(aftStream.getChildStreamList()),
-                precomputeBuildHelper.getSourceClasses()),
+                precomputeBuildHelperSupplier.get().getSourceClasses()),
                 this);
     }
 


### PR DESCRIPTION
Also settle the node network in Bavet when
the working solution is set to a new instance so
time taken by precomputes are not considered by
terminations.