### PR TITLE
deps: upgrade quarkus 3.29.2, avoid generating duplicate member accessor classes

### DIFF
--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -21,7 +21,7 @@
     <!-- Dependencies -->
     <!-- ************************************************************************ -->
     <version.ch.qos.logback>1.5.20</version.ch.qos.logback>
-    <version.io.quarkus>3.28.5</version.io.quarkus>
+    <version.io.quarkus>3.29.2</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.logging.log4j>2.25.2</version.org.apache.logging.log4j>
     <version.org.assertj>3.27.6</version.org.assertj>

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -1006,9 +1006,13 @@ class TimefoldProcessor {
                 }
             });
 
+            var visited = new HashSet<AnnotationTarget>();
             for (var annotatedMember : membersToGeneratedAccessorsForCollection) {
                 ClassInfo classInfo = null;
                 String memberName = null;
+                if (!visited.add(annotatedMember.target())) {
+                    continue;
+                }
                 switch (annotatedMember.target().kind()) {
                     case FIELD -> {
                         var fieldInfo = annotatedMember.target().asField();


### PR DESCRIPTION
Previously, it generated a MemberAccessor once per annotation
on the member. This worked before (as the classes are identicial),
but Quarkus added a duplicate generated class check recently,
causing build failures. Now, we check if we already generated
a given MemberAccessor before creating a new generated class.