### PR TITLE
deps: migrate ConstraintVerifier SyntheticBeanBuildItem to use gizmo2

### DIFF
--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -21,7 +21,7 @@
     <!-- Dependencies -->
     <!-- ************************************************************************ -->
     <version.ch.qos.logback>1.5.20</version.ch.qos.logback>
-    <version.io.quarkus>3.29.2</version.io.quarkus>
+    <version.io.quarkus>3.30.0</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.logging.log4j>2.25.2</version.org.apache.logging.log4j>
     <version.org.assertj>3.27.6</version.org.assertj>


### PR DESCRIPTION
Gizmo1 and Gizmo2 are seperate artifacts and can co-exist.
Quarkus recently changed SyntheticBeanBuildItem to use Gizmo2, so the
ConstraintVerifier creation code was rewritten to use Gizmo2.
The SolutionCloner and MemberAccessor still use Gizmo1.