### PR TITLE
fix: always update successors of single directional graph when non-declarative variables of parent are referenced

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -193,6 +193,17 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         var declarativeShadowVariables = graphDescriptor.solutionDescriptor().getDeclarativeShadowVariableDescriptors();
         var sortedDeclarativeVariables = topologicallySortedDeclarativeShadowVariables(declarativeShadowVariables);
 
+        var canTerminateEarly = true;
+        for (var declarativeShadowVariable : declarativeShadowVariables) {
+            for (var source : declarativeShadowVariable.getSources()) {
+                for (var sourceReference : source.variableSourceReferences()) {
+                    if (!sourceReference.isTopLevel() && !sourceReference.isDeclarative()) {
+                        canTerminateEarly = false;
+                    }
+                }
+            }
+        }
+
         var topologicalSorter =
                 getTopologicalSorter(graphDescriptor.solutionDescriptor(),
                         Objects.requireNonNull(graphDescriptor.changedVariableNotifier().innerScoreDirector()),
@@ -200,7 +211,9 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
 
         return new SingleDirectionalParentVariableReferenceGraph<>(graphDescriptor.consistencyTracker(),
                 sortedDeclarativeVariables,
-                topologicalSorter, graphDescriptor.changedVariableNotifier(), graphDescriptor.entities());
+                topologicalSorter, graphDescriptor.changedVariableNotifier(),
+                canTerminateEarly,
+                graphDescriptor.entities());
     }
 
     private static <Solution_> List<DeclarativeShadowVariableDescriptor<Solution_>>

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -193,16 +193,7 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         var declarativeShadowVariables = graphDescriptor.solutionDescriptor().getDeclarativeShadowVariableDescriptors();
         var sortedDeclarativeVariables = topologicallySortedDeclarativeShadowVariables(declarativeShadowVariables);
 
-        var canTerminateEarly = true;
-        for (var declarativeShadowVariable : declarativeShadowVariables) {
-            for (var source : declarativeShadowVariable.getSources()) {
-                for (var sourceReference : source.variableSourceReferences()) {
-                    if (!sourceReference.isTopLevel() && !sourceReference.isDeclarative()) {
-                        canTerminateEarly = false;
-                    }
-                }
-            }
-        }
+        var canTerminateEarly = hasNoNonDeclarativeSourcesFromParent(declarativeShadowVariables);
 
         var topologicalSorter =
                 getTopologicalSorter(graphDescriptor.solutionDescriptor(),
@@ -214,6 +205,20 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
                 topologicalSorter, graphDescriptor.changedVariableNotifier(),
                 canTerminateEarly,
                 graphDescriptor.entities());
+    }
+
+    private static <Solution_> boolean hasNoNonDeclarativeSourcesFromParent(
+            List<DeclarativeShadowVariableDescriptor<Solution_>> declarativeShadowVariables) {
+        for (var declarativeShadowVariable : declarativeShadowVariables) {
+            for (var source : declarativeShadowVariable.getSources()) {
+                for (var sourceReference : source.variableSourceReferences()) {
+                    if (!sourceReference.isTopLevel() && !sourceReference.isDeclarative()) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
     }
 
     private static <Solution_> List<DeclarativeShadowVariableDescriptor<Solution_>>

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedEntity.java
@@ -1,0 +1,31 @@
+package ai.timefold.solver.core.testdomain.shadow.mixed;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+
+@PlanningEntity
+public class TestdataMixedEntity extends TestdataObject {
+    @PlanningListVariable
+    List<TestdataMixedValue> valueList;
+
+    public TestdataMixedEntity() {
+        valueList = new ArrayList<>();
+    }
+
+    public TestdataMixedEntity(String code) {
+        super(code);
+        valueList = new ArrayList<>();
+    }
+
+    public List<TestdataMixedValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataMixedValue> valueList) {
+        this.valueList = valueList;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedSolution.java
@@ -1,0 +1,52 @@
+package ai.timefold.solver.core.testdomain.shadow.mixed;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataMixedSolution {
+    @PlanningEntityCollectionProperty
+    List<TestdataMixedEntity> mixedEntityList;
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataMixedValue> mixedValueList;
+
+    @ValueRangeProvider
+    List<Integer> delayList;
+
+    @PlanningScore
+    SimpleScore score;
+
+    public TestdataMixedSolution() {
+    }
+
+    public List<TestdataMixedEntity> getMixedEntityList() {
+        return mixedEntityList;
+    }
+
+    public void setMixedEntityList(List<TestdataMixedEntity> mixedEntityList) {
+        this.mixedEntityList = mixedEntityList;
+    }
+
+    public List<TestdataMixedValue> getMixedValueList() {
+        return mixedValueList;
+    }
+
+    public void setMixedValueList(List<TestdataMixedValue> mixedValueList) {
+        this.mixedValueList = mixedValueList;
+    }
+
+    public List<Integer> getDelayList() {
+        return delayList;
+    }
+
+    public void setDelayList(List<Integer> delayList) {
+        this.delayList = delayList;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedSolution.java
@@ -24,6 +24,7 @@ public class TestdataMixedSolution {
     SimpleScore score;
 
     public TestdataMixedSolution() {
+        // required for cloning
     }
 
     public List<TestdataMixedEntity> getMixedEntityList() {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedTest.java
@@ -1,0 +1,48 @@
+package ai.timefold.solver.core.testdomain.shadow.mixed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.heuristic.selector.move.generic.ChangeMove;
+import ai.timefold.solver.core.impl.solver.MoveAsserter;
+
+import org.junit.jupiter.api.Test;
+
+public class TestdataMixedTest {
+    @Test
+    void changingVariableOfParentShouldChangeDependentVariableOfChildren() {
+        var problem = new TestdataMixedSolution();
+
+        var entity = new TestdataMixedEntity("a");
+
+        var value1 = new TestdataMixedValue("v1");
+        var value2 = new TestdataMixedValue("v2");
+
+        problem.setMixedEntityList(List.of(entity));
+        problem.setMixedValueList(List.of(value1, value2));
+        problem.setDelayList(List.of(1, 2));
+
+        entity.setValueList(List.of(value1, value2));
+
+        value1.setDelay(1);
+        value1.setEntity(entity);
+
+        value2.setDelay(2);
+        value2.setPrevious(value1);
+        value2.setEntity(entity);
+        value2.setPreviousDelay(1);
+
+        var solutionDescriptor = SolutionDescriptor.buildSolutionDescriptor(TestdataMixedSolution.class,
+                TestdataMixedEntity.class, TestdataMixedValue.class);
+        var delayDescriptor =
+                solutionDescriptor.getEntityDescriptorStrict(TestdataMixedValue.class).getGenuineVariableDescriptor("delay");
+        var moveAsserter = MoveAsserter.create(solutionDescriptor);
+
+        moveAsserter.assertMoveAndUndo(problem, new ChangeMove<>(delayDescriptor, value1, 2), newSolution -> {
+            assertThat(value1.getDelay()).isEqualTo(2);
+            assertThat(value2.getPreviousDelay()).isEqualTo(2);
+        });
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedTest.java
@@ -10,7 +10,7 @@ import ai.timefold.solver.core.impl.solver.MoveAsserter;
 
 import org.junit.jupiter.api.Test;
 
-public class TestdataMixedTest {
+class TestdataMixedTest {
     @Test
     void changingVariableOfParentShouldChangeDependentVariableOfChildren() {
         var problem = new TestdataMixedSolution();

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedValue.java
@@ -1,0 +1,75 @@
+package ai.timefold.solver.core.testdomain.shadow.mixed;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowSources;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+
+@PlanningEntity
+public class TestdataMixedValue extends TestdataObject {
+    @PlanningVariable
+    Integer delay;
+
+    @InverseRelationShadowVariable(sourceVariableName = "valueList")
+    private TestdataMixedEntity entity;
+
+    @PreviousElementShadowVariable(sourceVariableName = "valueList")
+    private TestdataMixedValue previous;
+
+    @ShadowVariable(supplierName = "previousDelaySupplier")
+    private Integer previousDelay;
+
+    public TestdataMixedValue() {
+    }
+
+    public TestdataMixedValue(String code) {
+        super(code);
+    }
+
+    @ShadowSources({
+            "previous",
+            "previous.delay"
+    })
+    private Integer previousDelaySupplier() {
+        if (previous == null) {
+            return null;
+        } else {
+            return previous.delay;
+        }
+    }
+
+    public Integer getDelay() {
+        return delay;
+    }
+
+    public void setDelay(Integer delay) {
+        this.delay = delay;
+    }
+
+    public TestdataMixedEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataMixedEntity entity) {
+        this.entity = entity;
+    }
+
+    public TestdataMixedValue getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(TestdataMixedValue previous) {
+        this.previous = previous;
+    }
+
+    public Integer getPreviousDelay() {
+        return previousDelay;
+    }
+
+    public void setPreviousDelay(Integer previousDelay) {
+        this.previousDelay = previousDelay;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedValue.java
@@ -23,6 +23,7 @@ public class TestdataMixedValue extends TestdataObject {
     private Integer previousDelay;
 
     public TestdataMixedValue() {
+        // required for cloning
     }
 
     public TestdataMixedValue(String code) {


### PR DESCRIPTION
SingleDirectionalParentVariableReferenceGraph assumes that if no shadows of a changed entity is changed, then no shadows of its successors can change (unless the successor had a variable that changed). This is incorrect; consider [TestdataMixedValue("a"), TestdataMixedValue("b")]; if a.delay changes from 1 to 2, then its previousDelay is unchanged (as it has no previous), but b.previousDelay should change from 1 to 2.

SingleDirectionalParentVariableReferenceGraph now always update successors in the case that a declarative variable depends on a non-declarative variable in its parent.

Fixes https://github.com/TimefoldAI/timefold-solver/issues/1948.