### PR TITLE
test: put a resource lock on Spring XML/Yaml tests

### DIFF
--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverMultipleSolverAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverMultipleSolverAutoConfigurationTest.java
@@ -46,6 +46,7 @@ import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -55,6 +56,7 @@ import org.springframework.test.context.TestExecutionListeners;
 
 @TestExecutionListeners
 @Execution(ExecutionMode.CONCURRENT)
+@ResourceLock("yamlAndXml")
 class TimefoldSolverMultipleSolverAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner;

--- a/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverWithSolverConfigXmlAutoConfigurationTest.java
+++ b/spring-integration/spring-boot-autoconfigure/src/test/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverWithSolverConfigXmlAutoConfigurationTest.java
@@ -38,6 +38,7 @@ import ai.timefold.solver.test.api.score.stream.ConstraintVerifier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -45,6 +46,7 @@ import org.springframework.test.context.TestExecutionListeners;
 
 @TestExecutionListeners
 @Execution(ExecutionMode.CONCURRENT)
+@ResourceLock("yamlAndXml")
 class TimefoldSolverWithSolverConfigXmlAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner;


### PR DESCRIPTION
For machines with high core counts, Spring will randomly throw exception during tests. It seems to have something to do with XML/Yaml file configuration, but the actual exception is random. These ResourceLocks seems to prevent the exception (ran for 2 hours without exception, whereas without the lock, I get an exception within a minute).