### PR TITLE
fix: FilteringValueSelector.ofAssigned checks if selection is null

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueSelector.java
@@ -43,6 +43,10 @@ public class FilteringValueSelector<Solution_>
         }
         // We need to filter out unassigned vars.
         return FilteringValueSelector.of(valueSelector, (scoreDirector, selection) -> {
+            if (selection == null) {
+                // null is considered an unassigned value
+                return false;
+            }
             var listVariableStateSupply = listVariableStateSupplier.get();
             if (listVariableStateSupply.getUnassignedCount() == 0) {
                 return true;


### PR DESCRIPTION
Value selectors can return nulls as a valid selection. In particular, when entity value ranges are used with allows unassigned, `null` may be returned.