### PR TITLE
fix: correctly handle when HashSet and other set implementations are used as fields in Gizmo

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
@@ -232,7 +232,7 @@ public final class FieldAccessingSolutionCloner<Solution_> implements SolutionCl
     }
 
     @SuppressWarnings("unchecked")
-    private static <E> Collection<E> constructCloneCollection(Collection<E> originalCollection) {
+    public static <E> Collection<E> constructCloneCollection(Collection<E> originalCollection) {
         // TODO Don't hardcode all standard collections
         if (originalCollection instanceof PlanningCloneable<?> planningCloneable) {
             return (Collection<E>) planningCloneable.createNewInstance();
@@ -302,7 +302,7 @@ public final class FieldAccessingSolutionCloner<Solution_> implements SolutionCl
     }
 
     @SuppressWarnings("unchecked")
-    private static <K, V> Map<K, V> constructCloneMap(Map<K, V> originalMap) {
+    public static <K, V> Map<K, V> constructCloneMap(Map<K, V> originalMap) {
         if (originalMap instanceof PlanningCloneable<?> planningCloneable) {
             return (Map<K, V>) planningCloneable.createNewInstance();
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtils.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -17,7 +18,6 @@ import ai.timefold.solver.core.impl.domain.solution.cloner.PlanningCloneable;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 
 public final class GizmoCloningUtils {
-
     public static Set<Class<?>> getDeepClonedClasses(SolutionDescriptor<?> solutionDescriptor,
             Collection<Class<?>> entitySubclasses) {
         Set<Class<?>> deepClonedClassSet = new HashSet<>();
@@ -46,7 +46,11 @@ public final class GizmoCloningUtils {
                         deepClonedClassSet.add(deepClonedTypeArgument);
                     }
                 }
+
+                // Ignore Collections, Maps, and PlanningCloneables, as there is collection/map/clonable logic to clone them.
                 if (DeepCloningUtils.isFieldDeepCloned(solutionDescriptor, field, clazz)
+                        && !Collection.class.isAssignableFrom(field.getType())
+                        && !Map.class.isAssignableFrom(field.getType())
                         && !PlanningCloneable.class.isAssignableFrom(field.getType())
                         && !deepClonedClassSet.contains(field.getType())) {
                     classesToProcess.add(field.getType());

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
@@ -660,17 +660,22 @@ public class GizmoSolutionClonerImplementor {
         blockCreator.ifInstanceOfElse(constructedCollection, deeplyClonedFieldClass, (isInstanceCreator, casted) -> {
             isInstanceCreator.set(cloneResultHolder, casted);
         }, isNotInstanceCreator -> {
-            var baseMessage = isNotInstanceCreator.localVar("message",
-                    Const.of("Constructed type (%s) is not assignable to field type (%s)."));
-            var formattedMessage = isNotInstanceCreator.invokeVirtual(
-                    MethodDesc.of(String.class, "formatted", String.class, String[].class),
-                    baseMessage,
-                    isNotInstanceCreator.newArray(String.class,
-                            isNotInstanceCreator
-                                    .withClass(isNotInstanceCreator.withObject(constructedCollection).getClass_())
-                                    .getName(),
-                            Const.of(deeplyClonedFieldClass.getName())));
-            isNotInstanceCreator.throw_(isNotInstanceCreator.new_(IllegalStateException.class, formattedMessage));
+            try {
+                var baseMessage = isNotInstanceCreator.localVar("message",
+                        Const.of("Constructed type (%s) is not assignable to field type (%s)."));
+                // Apparently we need to get the method from String.class so it sees the String[] as varargs?
+                var formattedMessage = isNotInstanceCreator.invokeVirtual(
+                        MethodDesc.of(String.class.getMethod("formatted", Object[].class)),
+                        baseMessage,
+                        isNotInstanceCreator.newArray(String.class,
+                                isNotInstanceCreator
+                                        .withClass(isNotInstanceCreator.withObject(constructedCollection).getClass_())
+                                        .getName(),
+                                Const.of(deeplyClonedFieldClass.getName())));
+                isNotInstanceCreator.throw_(isNotInstanceCreator.new_(IllegalStateException.class, formattedMessage));
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
         });
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
@@ -659,20 +659,19 @@ public class GizmoSolutionClonerImplementor {
             Var constructedCollection) {
         blockCreator.ifInstanceOfElse(constructedCollection, deeplyClonedFieldClass, (isInstanceCreator, casted) -> {
             isInstanceCreator.set(cloneResultHolder, casted);
-        },
-                isNotInstanceCreator -> {
-                    var baseMessage = isNotInstanceCreator.localVar("message",
-                            Const.of("Constructed type (%s) is not assignable to field type (%s)."));
-                    var formattedMessage = isNotInstanceCreator.invokeVirtual(
-                            MethodDesc.of(String.class, "formatted", String.class, String[].class),
-                            baseMessage,
-                            isNotInstanceCreator.newArray(String.class,
-                                    isNotInstanceCreator
-                                            .withClass(isNotInstanceCreator.withObject(constructedCollection).getClass_())
-                                            .getName(),
-                                    Const.of(deeplyClonedFieldClass.getName())));
-                    isNotInstanceCreator.throw_(isNotInstanceCreator.new_(IllegalStateException.class, formattedMessage));
-                });
+        }, isNotInstanceCreator -> {
+            var baseMessage = isNotInstanceCreator.localVar("message",
+                    Const.of("Constructed type (%s) is not assignable to field type (%s)."));
+            var formattedMessage = isNotInstanceCreator.invokeVirtual(
+                    MethodDesc.of(String.class, "formatted", String.class, String[].class),
+                    baseMessage,
+                    isNotInstanceCreator.newArray(String.class,
+                            isNotInstanceCreator
+                                    .withClass(isNotInstanceCreator.withObject(constructedCollection).getClass_())
+                                    .getName(),
+                            Const.of(deeplyClonedFieldClass.getName())));
+            isNotInstanceCreator.throw_(isNotInstanceCreator.new_(IllegalStateException.class, formattedMessage));
+        });
     }
 
     /**

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -633,12 +634,29 @@ public abstract class AbstractSolutionClonerTest {
         originalEntitySet.addAll(Arrays.asList(a, b, c, d));
         original.setEntitySet(originalEntitySet);
 
+        original.setEntityHashSet(new HashSet<>(originalEntitySet));
+        original.setEntityLinkedHashSet(new LinkedHashSet<>(originalEntitySet));
+        original.setEntityTreeSet(new TreeSet<>(entityComparator));
+        original.getEntityTreeSet().addAll(originalEntitySet);
+
         var clone = cloner.cloneSolution(original);
         assertThat(clone).isNotSameAs(original);
         assertThat(clone.getValueSet()).isSameAs(valueSet);
         assertThat(clone.getScore()).isEqualTo(original.getScore());
 
         var cloneEntitySet = clone.getEntitySet();
+        assertThat(cloneEntitySet)
+                .isInstanceOf(SortedSet.class)
+                .isNotSameAs(originalEntitySet);
+        assertThat(clone.getEntityLinkedHashSet())
+                .isInstanceOf(LinkedHashSet.class)
+                .isNotSameAs(original.getEntityLinkedHashSet());
+        assertThat(clone.getEntityTreeSet())
+                .isInstanceOf(TreeSet.class)
+                .isNotSameAs(original.getEntityTreeSet());
+        assertThat(clone.getEntityHashSet())
+                .isInstanceOf(HashSet.class)
+                .isNotSameAs(original.getEntityHashSet());
         assertThat(cloneEntitySet)
                 .isInstanceOf(SortedSet.class)
                 .isNotSameAs(originalEntitySet);
@@ -655,6 +673,10 @@ public abstract class AbstractSolutionClonerTest {
         assertSetBasedEntityClone(b, cloneB, "b", "1");
         assertSetBasedEntityClone(c, cloneC, "c", "3");
         assertSetBasedEntityClone(d, cloneD, "d", "3");
+
+        assertThat(clone.getEntityHashSet()).containsExactlyInAnyOrder(cloneA, cloneB, cloneC, cloneD);
+        assertThat(clone.getEntityLinkedHashSet()).containsExactly(cloneD, cloneC, cloneB, cloneA);
+        assertThat(clone.getEntityTreeSet()).containsExactly(cloneD, cloneC, cloneB, cloneA);
 
         b.setValue(val2);
         assertCode("2", b.getValue());

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtilsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoCloningUtilsTest.java
@@ -3,7 +3,6 @@ package ai.timefold.solver.core.impl.domain.solution.cloner.gizmo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Map;
 
 import ai.timefold.solver.core.testdomain.clone.deepcloning.AnnotatedTestdataVariousTypes;
 import ai.timefold.solver.core.testdomain.clone.deepcloning.ExtraDeepClonedObject;
@@ -27,8 +26,6 @@ class GizmoCloningUtilsTest {
                         TestdataFieldAnnotatedDeepCloningEntity.class,
                         AnnotatedTestdataVariousTypes.class,
                         TestdataFieldAnnotatedDeepCloningSolution.class,
-                        TestdataVariousTypes.class,
-                        List.class,
-                        Map.class);
+                        TestdataVariousTypes.class);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerTest.java
@@ -44,7 +44,9 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
         var classOutput =
                 GizmoSolutionClonerImplementor.createClassOutputWithDebuggingCapability(classBytecodeHolder);
 
-        System.setProperty("gizmo.debug", "true");
+        if (GizmoSolutionClonerImplementor.DEBUG) {
+            System.setProperty("gizmo.debug", "true");
+        }
         var gizmo = Gizmo.create(classOutput);
 
         gizmo.class_(className, classCreator -> {
@@ -112,8 +114,10 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
                             member = new GizmoMemberDescriptor(name, getterDescriptor, memberDescriptor, declaringClass,
                                     setterDescriptor);
                         } else {
-                            throw new IllegalStateException("Failed to generate GizmoMemberDescriptor for (" + name + "): " +
-                                    "Field is not public and does not have both a getter and a setter.");
+                            throw new IllegalStateException("""
+                                    Failed to generate GizmoMemberDescriptor for (%s#%s):
+                                    Field is not public and does not have both a getter and a setter.
+                                    """.formatted(declaringClass.getName(), name));
                         }
                     }
                     solutionFieldToMemberDescriptor.put(field, member);

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/collection/TestdataSetBasedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/collection/TestdataSetBasedSolution.java
@@ -1,6 +1,9 @@
 package ai.timefold.solver.core.testdomain.collection;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
 import ai.timefold.solver.core.api.domain.solution.PlanningScore;
@@ -21,6 +24,10 @@ public class TestdataSetBasedSolution extends TestdataObject {
 
     private Set<TestdataValue> valueSet;
     private Set<TestdataSetBasedEntity> entitySet;
+
+    private HashSet<TestdataSetBasedEntity> entityHashSet;
+    private LinkedHashSet<TestdataSetBasedEntity> entityLinkedHashSet;
+    private TreeSet<TestdataSetBasedEntity> entityTreeSet;
 
     private SimpleScore score;
 
@@ -48,6 +55,31 @@ public class TestdataSetBasedSolution extends TestdataObject {
 
     public void setEntitySet(Set<TestdataSetBasedEntity> entitySet) {
         this.entitySet = entitySet;
+    }
+
+    public HashSet<TestdataSetBasedEntity> getEntityHashSet() {
+        return entityHashSet;
+    }
+
+    public void setEntityHashSet(HashSet<TestdataSetBasedEntity> entityHashSet) {
+        this.entityHashSet = entityHashSet;
+    }
+
+    public LinkedHashSet<TestdataSetBasedEntity> getEntityLinkedHashSet() {
+        return entityLinkedHashSet;
+    }
+
+    public void setEntityLinkedHashSet(
+            LinkedHashSet<TestdataSetBasedEntity> entityLinkedHashSet) {
+        this.entityLinkedHashSet = entityLinkedHashSet;
+    }
+
+    public TreeSet<TestdataSetBasedEntity> getEntityTreeSet() {
+        return entityTreeSet;
+    }
+
+    public void setEntityTreeSet(TreeSet<TestdataSetBasedEntity> entityTreeSet) {
+        this.entityTreeSet = entityTreeSet;
     }
 
     @PlanningScore


### PR DESCRIPTION
In Gizmo 1, everything was casted to the expected type automatically (even for invalid casts such as `HashSet s = (HashSet) new TreeSet();`). Gizmo 2 doesn't do this, so we need to remove an invalid branches that would never be entered.