### PR TITLE
fix: detect numeric overflow in scoring

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreContext.java
@@ -9,7 +9,8 @@ import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 import org.jspecify.annotations.NullMarked;
 
-final class BendableBigDecimalScoreContext extends ScoreContext<BendableBigDecimalScore, BendableBigDecimalScoreInliner> {
+final class BendableBigDecimalScoreContext
+        extends ScoreContext<BendableBigDecimalScore, BendableBigDecimalScoreInliner> {
 
     private final int hardScoreLevelCount;
     private final int softScoreLevelCount;

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreContext.java
@@ -32,16 +32,16 @@ final class BendableLongScoreContext extends ScoreContext<BendableLongScore, Ben
 
     public ScoreImpact<BendableLongScore> changeSoftScoreBy(long matchWeight,
             ConstraintMatchSupplier<BendableLongScore> constraintMatchSupplier) {
-        var softImpact = scoreLevelWeight * matchWeight;
-        inliner.softScores[scoreLevel] += softImpact;
+        var softImpact = Math.multiplyExact(scoreLevelWeight, matchWeight);
+        inliner.softScores[scoreLevel] = Math.addExact(inliner.softScores[scoreLevel], softImpact);
         var scoreImpact = new SingleSoftImpact(this, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<BendableLongScore> changeHardScoreBy(long matchWeight,
             ConstraintMatchSupplier<BendableLongScore> constraintMatchSupplier) {
-        var hardImpact = scoreLevelWeight * matchWeight;
-        inliner.hardScores[scoreLevel] += hardImpact;
+        var hardImpact = Math.multiplyExact(scoreLevelWeight, matchWeight);
+        inliner.hardScores[scoreLevel] = Math.addExact(inliner.hardScores[scoreLevel], hardImpact);
         var scoreImpact = new SingleHardImpact(this, hardImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
@@ -51,14 +51,14 @@ final class BendableLongScoreContext extends ScoreContext<BendableLongScore, Ben
         var hardImpacts = new long[hardScoreLevelCount];
         var softImpacts = new long[softScoreLevelCount];
         for (var hardScoreLevel = 0; hardScoreLevel < hardScoreLevelCount; hardScoreLevel++) {
-            var hardImpact = constraintWeight.hardScore(hardScoreLevel) * matchWeight;
+            var hardImpact = Math.multiplyExact(constraintWeight.hardScore(hardScoreLevel), matchWeight);
             hardImpacts[hardScoreLevel] = hardImpact;
-            inliner.hardScores[hardScoreLevel] += hardImpact;
+            inliner.hardScores[hardScoreLevel] = Math.addExact(inliner.hardScores[hardScoreLevel], hardImpact);
         }
         for (var softScoreLevel = 0; softScoreLevel < softScoreLevelCount; softScoreLevel++) {
-            var softImpact = constraintWeight.softScore(softScoreLevel) * matchWeight;
+            var softImpact = Math.multiplyExact(constraintWeight.softScore(softScoreLevel), matchWeight);
             softImpacts[softScoreLevel] = softImpact;
-            inliner.softScores[softScoreLevel] += softImpact;
+            inliner.softScores[softScoreLevel] = Math.addExact(inliner.softScores[softScoreLevel], softImpact);
         }
         var scoreImpact = new ComplexImpact(this, hardImpacts, softImpacts);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
@@ -70,7 +70,7 @@ final class BendableLongScoreContext extends ScoreContext<BendableLongScore, Ben
 
         @Override
         public void undo() {
-            ctx.inliner.softScores[ctx.scoreLevel] -= impact;
+            ctx.inliner.softScores[ctx.scoreLevel] = Math.subtractExact(ctx.inliner.softScores[ctx.scoreLevel], impact);
         }
 
         @Override
@@ -85,7 +85,7 @@ final class BendableLongScoreContext extends ScoreContext<BendableLongScore, Ben
 
         @Override
         public void undo() {
-            ctx.inliner.hardScores[ctx.scoreLevel] -= impact;
+            ctx.inliner.hardScores[ctx.scoreLevel] = Math.subtractExact(ctx.inliner.hardScores[ctx.scoreLevel], impact);
         }
 
         @Override
@@ -102,10 +102,12 @@ final class BendableLongScoreContext extends ScoreContext<BendableLongScore, Ben
         public void undo() {
             var inliner = ctx.inliner;
             for (var hardScoreLevel = 0; hardScoreLevel < ctx.hardScoreLevelCount; hardScoreLevel++) {
-                inliner.hardScores[hardScoreLevel] -= hardImpacts[hardScoreLevel];
+                inliner.hardScores[hardScoreLevel] =
+                        Math.subtractExact(inliner.hardScores[hardScoreLevel], hardImpacts[hardScoreLevel]);
             }
             for (var softScoreLevel = 0; softScoreLevel < ctx.softScoreLevelCount; softScoreLevel++) {
-                inliner.softScores[softScoreLevel] -= softImpacts[softScoreLevel];
+                inliner.softScores[softScoreLevel] =
+                        Math.subtractExact(inliner.softScores[softScoreLevel], softImpacts[softScoreLevel]);
             }
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreContext.java
@@ -32,16 +32,16 @@ final class BendableScoreContext extends ScoreContext<BendableScore, BendableSco
 
     public ScoreImpact<BendableScore> changeSoftScoreBy(int matchWeight,
             ConstraintMatchSupplier<BendableScore> constraintMatchSupplier) {
-        var softImpact = scoreLevelWeight * matchWeight;
-        inliner.softScores[scoreLevel] += softImpact;
+        var softImpact = Math.multiplyExact(scoreLevelWeight, matchWeight);
+        inliner.softScores[scoreLevel] = Math.addExact(inliner.softScores[scoreLevel], softImpact);
         var scoreImpact = new SingleSoftImpact(this, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<BendableScore> changeHardScoreBy(int matchWeight,
             ConstraintMatchSupplier<BendableScore> constraintMatchSupplier) {
-        var hardImpact = scoreLevelWeight * matchWeight;
-        inliner.hardScores[scoreLevel] += hardImpact;
+        var hardImpact = Math.multiplyExact(scoreLevelWeight, matchWeight);
+        inliner.hardScores[scoreLevel] = Math.addExact(inliner.hardScores[scoreLevel], hardImpact);
         var scoreImpact = new SingleHardImpact(this, hardImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
@@ -51,14 +51,14 @@ final class BendableScoreContext extends ScoreContext<BendableScore, BendableSco
         var hardImpacts = new int[hardScoreLevelCount];
         var softImpacts = new int[softScoreLevelCount];
         for (var hardScoreLevel = 0; hardScoreLevel < hardScoreLevelCount; hardScoreLevel++) {
-            var hardImpact = constraintWeight.hardScore(hardScoreLevel) * matchWeight;
+            var hardImpact = Math.multiplyExact(constraintWeight.hardScore(hardScoreLevel), matchWeight);
             hardImpacts[hardScoreLevel] = hardImpact;
-            inliner.hardScores[hardScoreLevel] += hardImpact;
+            inliner.hardScores[hardScoreLevel] = Math.addExact(inliner.hardScores[hardScoreLevel], hardImpact);
         }
         for (var softScoreLevel = 0; softScoreLevel < softScoreLevelCount; softScoreLevel++) {
-            var softImpact = constraintWeight.softScore(softScoreLevel) * matchWeight;
+            var softImpact = Math.multiplyExact(constraintWeight.softScore(softScoreLevel), matchWeight);
             softImpacts[softScoreLevel] = softImpact;
-            inliner.softScores[softScoreLevel] += softImpact;
+            inliner.softScores[softScoreLevel] = Math.addExact(inliner.softScores[softScoreLevel], softImpact);
         }
         var scoreImpact = new ComplexImpact(this, hardImpacts, softImpacts);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
@@ -69,7 +69,7 @@ final class BendableScoreContext extends ScoreContext<BendableScore, BendableSco
 
         @Override
         public void undo() {
-            ctx.inliner.softScores[ctx.scoreLevel] -= impact;
+            ctx.inliner.softScores[ctx.scoreLevel] = Math.subtractExact(ctx.inliner.softScores[ctx.scoreLevel], impact);
         }
 
         @Override
@@ -83,7 +83,7 @@ final class BendableScoreContext extends ScoreContext<BendableScore, BendableSco
 
         @Override
         public void undo() {
-            ctx.inliner.hardScores[ctx.scoreLevel] -= impact;
+            ctx.inliner.hardScores[ctx.scoreLevel] = Math.subtractExact(ctx.inliner.hardScores[ctx.scoreLevel], impact);
         }
 
         @Override
@@ -100,10 +100,12 @@ final class BendableScoreContext extends ScoreContext<BendableScore, BendableSco
         public void undo() {
             var inliner = ctx.inliner;
             for (var hardScoreLevel = 0; hardScoreLevel < ctx.hardScoreLevelCount; hardScoreLevel++) {
-                inliner.hardScores[hardScoreLevel] -= hardImpacts[hardScoreLevel];
+                inliner.hardScores[hardScoreLevel] =
+                        Math.subtractExact(inliner.hardScores[hardScoreLevel], hardImpacts[hardScoreLevel]);
             }
             for (var softScoreLevel = 0; softScoreLevel < ctx.softScoreLevelCount; softScoreLevel++) {
-                inliner.softScores[softScoreLevel] -= softImpacts[softScoreLevel];
+                inliner.softScores[softScoreLevel] =
+                        Math.subtractExact(inliner.softScores[softScoreLevel], softImpacts[softScoreLevel]);
             }
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreContext.java
@@ -5,7 +5,8 @@ import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 import org.jspecify.annotations.NullMarked;
 
-final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLongScore, HardMediumSoftLongScoreInliner> {
+final class HardMediumSoftLongScoreContext
+        extends ScoreContext<HardMediumSoftLongScore, HardMediumSoftLongScoreInliner> {
 
     public HardMediumSoftLongScoreContext(HardMediumSoftLongScoreInliner parent, AbstractConstraint<?, ?, ?> constraint,
             HardMediumSoftLongScore constraintWeight) {
@@ -14,36 +15,36 @@ final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLo
 
     public ScoreImpact<HardMediumSoftLongScore> changeSoftScoreBy(long matchWeight,
             ConstraintMatchSupplier<HardMediumSoftLongScore> constraintMatchSupplier) {
-        var softImpact = constraintWeight.softScore() * matchWeight;
-        inliner.softScore += softImpact;
+        var softImpact = Math.multiplyExact(constraintWeight.softScore(), matchWeight);
+        inliner.softScore = Math.addExact(inliner.softScore, softImpact);
         var scoreImpact = new SoftImpact(inliner, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardMediumSoftLongScore> changeMediumScoreBy(long matchWeight,
             ConstraintMatchSupplier<HardMediumSoftLongScore> constraintMatchSupplier) {
-        var mediumImpact = constraintWeight.mediumScore() * matchWeight;
-        inliner.mediumScore += mediumImpact;
+        var mediumImpact = Math.multiplyExact(constraintWeight.mediumScore(), matchWeight);
+        inliner.mediumScore = Math.addExact(inliner.mediumScore, mediumImpact);
         var scoreImpact = new MediumImpact(inliner, mediumImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardMediumSoftLongScore> changeHardScoreBy(long matchWeight,
             ConstraintMatchSupplier<HardMediumSoftLongScore> constraintMatchSupplier) {
-        var hardImpact = constraintWeight.hardScore() * matchWeight;
-        inliner.hardScore += hardImpact;
+        var hardImpact = Math.multiplyExact(constraintWeight.hardScore(), matchWeight);
+        inliner.hardScore = Math.addExact(inliner.hardScore, hardImpact);
         var scoreImpact = new HardImpact(inliner, hardImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardMediumSoftLongScore> changeScoreBy(long matchWeight,
             ConstraintMatchSupplier<HardMediumSoftLongScore> constraintMatchSupplier) {
-        var hardImpact = constraintWeight.hardScore() * matchWeight;
-        var mediumImpact = constraintWeight.mediumScore() * matchWeight;
-        var softImpact = constraintWeight.softScore() * matchWeight;
-        inliner.hardScore += hardImpact;
-        inliner.mediumScore += mediumImpact;
-        inliner.softScore += softImpact;
+        var hardImpact = Math.multiplyExact(constraintWeight.hardScore(), matchWeight);
+        var mediumImpact = Math.multiplyExact(constraintWeight.mediumScore(), matchWeight);
+        var softImpact = Math.multiplyExact(constraintWeight.softScore(), matchWeight);
+        inliner.hardScore = Math.addExact(inliner.hardScore, hardImpact);
+        inliner.mediumScore = Math.addExact(inliner.mediumScore, mediumImpact);
+        inliner.softScore = Math.addExact(inliner.softScore, softImpact);
         var scoreImpact = new ComplexImpact(inliner, hardImpact, mediumImpact, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
@@ -54,7 +55,7 @@ final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLo
 
         @Override
         public void undo() {
-            inliner.softScore -= softImpact;
+            inliner.softScore = Math.subtractExact(inliner.softScore, softImpact);
         }
 
         @Override
@@ -70,7 +71,7 @@ final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLo
 
         @Override
         public void undo() {
-            inliner.mediumScore -= mediumImpact;
+            inliner.mediumScore = Math.subtractExact(inliner.mediumScore, mediumImpact);
         }
 
         @Override
@@ -86,7 +87,7 @@ final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLo
 
         @Override
         public void undo() {
-            inliner.hardScore -= hardImpact;
+            inliner.hardScore = Math.subtractExact(inliner.hardScore, hardImpact);
         }
 
         @Override
@@ -102,9 +103,9 @@ final class HardMediumSoftLongScoreContext extends ScoreContext<HardMediumSoftLo
 
         @Override
         public void undo() {
-            inliner.hardScore -= hardImpact;
-            inliner.mediumScore -= mediumImpact;
-            inliner.softScore -= softImpact;
+            inliner.hardScore = Math.subtractExact(inliner.hardScore, hardImpact);
+            inliner.mediumScore = Math.subtractExact(inliner.mediumScore, mediumImpact);
+            inliner.softScore = Math.subtractExact(inliner.softScore, softImpact);
         }
 
         @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreContext.java
@@ -14,36 +14,36 @@ final class HardMediumSoftScoreContext extends ScoreContext<HardMediumSoftScore,
 
     public ScoreImpact<HardMediumSoftScore> changeSoftScoreBy(int matchWeight,
             ConstraintMatchSupplier<HardMediumSoftScore> constraintMatchSupplier) {
-        var softImpact = constraintWeight.softScore() * matchWeight;
-        inliner.softScore += softImpact;
+        var softImpact = Math.multiplyExact(constraintWeight.softScore(), matchWeight);
+        inliner.softScore = Math.addExact(inliner.softScore, softImpact);
         var scoreImpact = new SoftImpact(inliner, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardMediumSoftScore> changeMediumScoreBy(int matchWeight,
             ConstraintMatchSupplier<HardMediumSoftScore> constraintMatchSupplier) {
-        var mediumImpact = constraintWeight.mediumScore() * matchWeight;
-        inliner.mediumScore += mediumImpact;
+        var mediumImpact = Math.multiplyExact(constraintWeight.mediumScore(), matchWeight);
+        inliner.mediumScore = Math.addExact(inliner.mediumScore, mediumImpact);
         var scoreImpact = new MediumImpact(inliner, mediumImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardMediumSoftScore> changeHardScoreBy(int matchWeight,
             ConstraintMatchSupplier<HardMediumSoftScore> constraintMatchSupplier) {
-        var hardImpact = constraintWeight.hardScore() * matchWeight;
-        inliner.hardScore += hardImpact;
+        var hardImpact = Math.multiplyExact(constraintWeight.hardScore(), matchWeight);
+        inliner.hardScore = Math.addExact(inliner.hardScore, hardImpact);
         var scoreImpact = new HardImpact(inliner, hardImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardMediumSoftScore> changeScoreBy(int matchWeight,
             ConstraintMatchSupplier<HardMediumSoftScore> constraintMatchSupplier) {
-        var hardImpact = constraintWeight.hardScore() * matchWeight;
-        var mediumImpact = constraintWeight.mediumScore() * matchWeight;
-        var softImpact = constraintWeight.softScore() * matchWeight;
-        inliner.hardScore += hardImpact;
-        inliner.mediumScore += mediumImpact;
-        inliner.softScore += softImpact;
+        var hardImpact = Math.multiplyExact(constraintWeight.hardScore(), matchWeight);
+        var mediumImpact = Math.multiplyExact(constraintWeight.mediumScore(), matchWeight);
+        var softImpact = Math.multiplyExact(constraintWeight.softScore(), matchWeight);
+        inliner.hardScore = Math.addExact(inliner.hardScore, hardImpact);
+        inliner.mediumScore = Math.addExact(inliner.mediumScore, mediumImpact);
+        inliner.softScore = Math.addExact(inliner.softScore, softImpact);
         var scoreImpact = new ComplexImpact(inliner, hardImpact, mediumImpact, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
@@ -54,7 +54,7 @@ final class HardMediumSoftScoreContext extends ScoreContext<HardMediumSoftScore,
 
         @Override
         public void undo() {
-            inliner.softScore -= softImpact;
+            inliner.softScore = Math.subtractExact(inliner.softScore, softImpact);
         }
 
         @Override
@@ -70,7 +70,7 @@ final class HardMediumSoftScoreContext extends ScoreContext<HardMediumSoftScore,
 
         @Override
         public void undo() {
-            inliner.mediumScore -= mediumImpact;
+            inliner.mediumScore = Math.subtractExact(inliner.mediumScore, mediumImpact);
         }
 
         @Override
@@ -86,7 +86,7 @@ final class HardMediumSoftScoreContext extends ScoreContext<HardMediumSoftScore,
 
         @Override
         public void undo() {
-            inliner.hardScore -= hardImpact;
+            inliner.hardScore = Math.subtractExact(inliner.hardScore, hardImpact);
         }
 
         @Override
@@ -102,9 +102,9 @@ final class HardMediumSoftScoreContext extends ScoreContext<HardMediumSoftScore,
 
         @Override
         public void undo() {
-            inliner.hardScore -= hardImpact;
-            inliner.mediumScore -= mediumImpact;
-            inliner.softScore -= softImpact;
+            inliner.hardScore = Math.subtractExact(inliner.hardScore, hardImpact);
+            inliner.mediumScore = Math.subtractExact(inliner.mediumScore, mediumImpact);
+            inliner.softScore = Math.subtractExact(inliner.softScore, softImpact);
         }
 
         @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreContext.java
@@ -7,7 +7,8 @@ import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
 import org.jspecify.annotations.NullMarked;
 
-final class HardSoftBigDecimalScoreContext extends ScoreContext<HardSoftBigDecimalScore, HardSoftBigDecimalScoreInliner> {
+final class HardSoftBigDecimalScoreContext
+        extends ScoreContext<HardSoftBigDecimalScore, HardSoftBigDecimalScoreInliner> {
 
     public HardSoftBigDecimalScoreContext(HardSoftBigDecimalScoreInliner parent, AbstractConstraint<?, ?, ?> constraint,
             HardSoftBigDecimalScore constraintWeight) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreContext.java
@@ -14,26 +14,26 @@ final class HardSoftLongScoreContext extends ScoreContext<HardSoftLongScore, Har
 
     public ScoreImpact<HardSoftLongScore> changeSoftScoreBy(long matchWeight,
             ConstraintMatchSupplier<HardSoftLongScore> constraintMatchSupplier) {
-        var softImpact = constraintWeight.softScore() * matchWeight;
-        inliner.softScore += softImpact;
+        var softImpact = Math.multiplyExact(constraintWeight.softScore(), matchWeight);
+        inliner.softScore = Math.addExact(inliner.softScore, softImpact);
         var scoreImpact = new SoftImpact(inliner, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardSoftLongScore> changeHardScoreBy(long matchWeight,
             ConstraintMatchSupplier<HardSoftLongScore> constraintMatchSupplier) {
-        var hardImpact = constraintWeight.hardScore() * matchWeight;
-        inliner.hardScore += hardImpact;
+        var hardImpact = Math.multiplyExact(constraintWeight.hardScore(), matchWeight);
+        inliner.hardScore = Math.addExact(inliner.hardScore, hardImpact);
         var scoreImpact = new HardImpact(inliner, hardImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardSoftLongScore> changeScoreBy(long matchWeight,
             ConstraintMatchSupplier<HardSoftLongScore> constraintMatchSupplier) {
-        var hardImpact = constraintWeight.hardScore() * matchWeight;
-        var softImpact = constraintWeight.softScore() * matchWeight;
-        inliner.hardScore += hardImpact;
-        inliner.softScore += softImpact;
+        var hardImpact = Math.multiplyExact(constraintWeight.hardScore(), matchWeight);
+        var softImpact = Math.multiplyExact(constraintWeight.softScore(), matchWeight);
+        inliner.hardScore = Math.addExact(inliner.hardScore, hardImpact);
+        inliner.softScore = Math.addExact(inliner.softScore, softImpact);
         var scoreImpact = new ComplexImpact(inliner, hardImpact, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
@@ -44,7 +44,7 @@ final class HardSoftLongScoreContext extends ScoreContext<HardSoftLongScore, Har
 
         @Override
         public void undo() {
-            inliner.softScore -= softImpact;
+            inliner.softScore = Math.subtractExact(inliner.softScore, softImpact);
         }
 
         @Override
@@ -60,7 +60,7 @@ final class HardSoftLongScoreContext extends ScoreContext<HardSoftLongScore, Har
 
         @Override
         public void undo() {
-            inliner.hardScore -= hardImpact;
+            inliner.hardScore = Math.subtractExact(inliner.hardScore, hardImpact);
         }
 
         @Override
@@ -76,8 +76,8 @@ final class HardSoftLongScoreContext extends ScoreContext<HardSoftLongScore, Har
 
         @Override
         public void undo() {
-            inliner.hardScore -= hardImpact;
-            inliner.softScore -= softImpact;
+            inliner.hardScore = Math.subtractExact(inliner.hardScore, hardImpact);
+            inliner.softScore = Math.subtractExact(inliner.softScore, softImpact);
         }
 
         @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreContext.java
@@ -14,26 +14,26 @@ final class HardSoftScoreContext extends ScoreContext<HardSoftScore, HardSoftSco
 
     public ScoreImpact<HardSoftScore> changeSoftScoreBy(int matchWeight,
             ConstraintMatchSupplier<HardSoftScore> constraintMatchSupplier) {
-        var softImpact = constraintWeight.softScore() * matchWeight;
-        inliner.softScore += softImpact;
+        var softImpact = Math.multiplyExact(constraintWeight.softScore(), matchWeight);
+        inliner.softScore = Math.addExact(inliner.softScore, softImpact);
         var scoreImpact = new SoftImpact(inliner, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardSoftScore> changeHardScoreBy(int matchWeight,
             ConstraintMatchSupplier<HardSoftScore> constraintMatchSupplier) {
-        var hardImpact = constraintWeight.hardScore() * matchWeight;
-        inliner.hardScore += hardImpact;
+        var hardImpact = Math.multiplyExact(constraintWeight.hardScore(), matchWeight);
+        inliner.hardScore = Math.addExact(inliner.hardScore, hardImpact);
         var scoreImpact = new HardImpact(inliner, hardImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
 
     public ScoreImpact<HardSoftScore> changeScoreBy(int matchWeight,
             ConstraintMatchSupplier<HardSoftScore> constraintMatchSupplier) {
-        var hardImpact = constraintWeight.hardScore() * matchWeight;
-        var softImpact = constraintWeight.softScore() * matchWeight;
-        inliner.hardScore += hardImpact;
-        inliner.softScore += softImpact;
+        var hardImpact = Math.multiplyExact(constraintWeight.hardScore(), matchWeight);
+        var softImpact = Math.multiplyExact(constraintWeight.softScore(), matchWeight);
+        inliner.hardScore = Math.addExact(inliner.hardScore, hardImpact);
+        inliner.softScore = Math.addExact(inliner.softScore, softImpact);
         var scoreImpact = new ComplexImpact(inliner, hardImpact, softImpact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
@@ -43,7 +43,7 @@ final class HardSoftScoreContext extends ScoreContext<HardSoftScore, HardSoftSco
 
         @Override
         public void undo() {
-            inliner.softScore -= softImpact;
+            inliner.softScore = Math.subtractExact(inliner.softScore, softImpact);
         }
 
         @Override
@@ -58,7 +58,7 @@ final class HardSoftScoreContext extends ScoreContext<HardSoftScore, HardSoftSco
 
         @Override
         public void undo() {
-            inliner.hardScore -= hardImpact;
+            inliner.hardScore = Math.subtractExact(inliner.hardScore, hardImpact);
         }
 
         @Override
@@ -74,8 +74,8 @@ final class HardSoftScoreContext extends ScoreContext<HardSoftScore, HardSoftSco
 
         @Override
         public void undo() {
-            inliner.hardScore -= hardImpact;
-            inliner.softScore -= softImpact;
+            inliner.hardScore = Math.subtractExact(inliner.hardScore, hardImpact);
+            inliner.softScore = Math.subtractExact(inliner.softScore, softImpact);
         }
 
         @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreContext.java
@@ -14,8 +14,8 @@ final class SimpleLongScoreContext extends ScoreContext<SimpleLongScore, SimpleL
 
     public ScoreImpact<SimpleLongScore> changeScoreBy(long matchWeight,
             ConstraintMatchSupplier<SimpleLongScore> constraintMatchSupplier) {
-        var impact = constraintWeight.score() * matchWeight;
-        inliner.score += impact;
+        var impact = Math.multiplyExact(constraintWeight.score(), matchWeight);
+        inliner.score = Math.addExact(inliner.score, impact);
         var scoreImpact = new Impact(inliner, impact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
@@ -25,7 +25,7 @@ final class SimpleLongScoreContext extends ScoreContext<SimpleLongScore, SimpleL
 
         @Override
         public void undo() {
-            inliner.score -= impact;
+            inliner.score = Math.subtractExact(inliner.score, impact);
         }
 
         @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreContext.java
@@ -13,8 +13,8 @@ final class SimpleScoreContext extends ScoreContext<SimpleScore, SimpleScoreInli
 
     public ScoreImpact<SimpleScore> changeScoreBy(int matchWeight,
             ConstraintMatchSupplier<SimpleScore> constraintMatchSupplier) {
-        var impact = constraintWeight.score() * matchWeight;
-        inliner.score += impact;
+        var impact = Math.multiplyExact(constraintWeight.score(), matchWeight);
+        inliner.score = Math.addExact(inliner.score, impact);
         var scoreImpact = new Impact(inliner, impact);
         return possiblyAddConstraintMatch(scoreImpact, constraintMatchSupplier);
     }
@@ -24,7 +24,7 @@ final class SimpleScoreContext extends ScoreContext<SimpleScore, SimpleScoreInli
 
         @Override
         public void undo() {
-            inliner.score -= impact;
+            inliner.score = Math.subtractExact(inliner.score, impact);
         }
 
         @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/WeightedScoreImpacter.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/WeightedScoreImpacter.java
@@ -27,17 +27,20 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public interface WeightedScoreImpacter<Score_ extends Score<Score_>, Context_ extends ScoreContext<Score_, ?>> {
 
-    static <Score_ extends Score<Score_>, Context_ extends ScoreContext<Score_, ?>> WeightedScoreImpacter<Score_, Context_>
+    static <Score_ extends Score<Score_>, Context_ extends ScoreContext<Score_, ?>>
+            WeightedScoreImpacter<Score_, Context_>
             of(Context_ context, IntImpactFunction<Score_, Context_> impactFunction) {
         return new IntWeightedScoreImpacter<>(impactFunction, context);
     }
 
-    static <Score_ extends Score<Score_>, Context_ extends ScoreContext<Score_, ?>> WeightedScoreImpacter<Score_, Context_>
+    static <Score_ extends Score<Score_>, Context_ extends ScoreContext<Score_, ?>>
+            WeightedScoreImpacter<Score_, Context_>
             of(Context_ context, LongImpactFunction<Score_, Context_> impactFunction) {
         return new LongWeightedScoreImpacter<>(impactFunction, context);
     }
 
-    static <Score_ extends Score<Score_>, Context_ extends ScoreContext<Score_, ?>> WeightedScoreImpacter<Score_, Context_>
+    static <Score_ extends Score<Score_>, Context_ extends ScoreContext<Score_, ?>>
+            WeightedScoreImpacter<Score_, Context_>
             of(Context_ context, BigDecimalImpactFunction<Score_, Context_> impactFunction) {
         return new BigDecimalWeightedScoreImpacter<>(impactFunction, context);
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableLongScoreInlinerTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.common.inliner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Map;
@@ -111,6 +112,23 @@ class BendableLongScoreInlinerTest extends AbstractScoreInlinerTest<TestdataBend
         impact1.undo();
         assertThat(scoreInliner.extractScore())
                 .isEqualTo(buildScore(0, 0, 0));
+    }
+
+    @Test
+    void impactAllMatchWeightOverflow() {
+        var constraintWeight = buildScore(100, 1_000, 10_000);
+        var impacter = buildScoreImpacter(constraintWeight);
+        assertThatThrownBy(() -> impacter.impactScore(Long.MAX_VALUE, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void impactAllTotalOverflow() {
+        var constraintWeight = buildScore(Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE);
+        var impacter = buildScoreImpacter(constraintWeight);
+        impacter.impactScore(1, ConstraintMatchSupplier.empty()); // This will send the total right to the limit.
+        assertThatThrownBy(() -> impacter.impactScore(1, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableScoreInlinerTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.common.inliner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Map;
@@ -111,6 +112,23 @@ class BendableScoreInlinerTest extends AbstractScoreInlinerTest<TestdataBendable
         impact1.undo();
         assertThat(scoreInliner.extractScore())
                 .isEqualTo(buildScore(0, 0, 0));
+    }
+
+    @Test
+    void impactAllMatchWeightOverflow() {
+        var constraintWeight = buildScore(100, 1_000, 10_000);
+        var impacter = buildScoreImpacter(constraintWeight);
+        assertThatThrownBy(() -> impacter.impactScore(Integer.MAX_VALUE, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void impactAllTotalOverflow() {
+        var constraintWeight = buildScore(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        var impacter = buildScoreImpacter(constraintWeight);
+        impacter.impactScore(1, ConstraintMatchSupplier.empty()); // This will send the total right to the limit.
+        assertThatThrownBy(() -> impacter.impactScore(1, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftLongScoreInlinerTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.common.inliner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Map;
@@ -112,6 +113,23 @@ class HardMediumSoftLongScoreInlinerTest
         impact1.undo();
         assertThat(scoreInliner.extractScore())
                 .isEqualTo(HardMediumSoftLongScore.of(0, 0, 0));
+    }
+
+    @Test
+    void impactAllMatchWeightOverflow() {
+        var constraintWeight = HardMediumSoftLongScore.of(10, 100, 1_000);
+        var impacter = buildScoreImpacter(constraintWeight);
+        assertThatThrownBy(() -> impacter.impactScore(Long.MAX_VALUE, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void impactAllTotalOverflow() {
+        var constraintWeight = HardMediumSoftLongScore.of(Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE);
+        var impacter = buildScoreImpacter(constraintWeight);
+        impacter.impactScore(1, ConstraintMatchSupplier.empty()); // This will send the total right to the limit.
+        assertThatThrownBy(() -> impacter.impactScore(1, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftScoreInlinerTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.common.inliner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Map;
@@ -112,6 +113,23 @@ class HardMediumSoftScoreInlinerTest
         impact1.undo();
         assertThat(scoreInliner.extractScore())
                 .isEqualTo(HardMediumSoftScore.of(0, 0, 0));
+    }
+
+    @Test
+    void impactAllMatchWeightOverflow() {
+        var constraintWeight = HardMediumSoftScore.of(10, 100, 1_000);
+        var impacter = buildScoreImpacter(constraintWeight);
+        assertThatThrownBy(() -> impacter.impactScore(Integer.MAX_VALUE, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void impactAllTotalOverflow() {
+        var constraintWeight = HardMediumSoftScore.of(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        var impacter = buildScoreImpacter(constraintWeight);
+        impacter.impactScore(1, ConstraintMatchSupplier.empty()); // This will send the total right to the limit.
+        assertThatThrownBy(() -> impacter.impactScore(1, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftLongScoreInlinerTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.common.inliner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Map;
@@ -88,6 +89,23 @@ class HardSoftLongScoreInlinerTest extends AbstractScoreInlinerTest<TestdataHard
         impact1.undo();
         assertThat(scoreInliner.extractScore())
                 .isEqualTo(HardSoftLongScore.of(0, 0));
+    }
+
+    @Test
+    void impactAllMatchWeightOverflow() {
+        var constraintWeight = HardSoftLongScore.of(10, 100);
+        var impacter = buildScoreImpacter(constraintWeight);
+        assertThatThrownBy(() -> impacter.impactScore(Long.MAX_VALUE, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void impactAllTotalOverflow() {
+        var constraintWeight = HardSoftLongScore.of(Long.MAX_VALUE, Long.MAX_VALUE);
+        var impacter = buildScoreImpacter(constraintWeight);
+        impacter.impactScore(1, ConstraintMatchSupplier.empty()); // This will send the total right to the limit.
+        assertThatThrownBy(() -> impacter.impactScore(1, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftScoreInlinerTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.common.inliner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Map;
@@ -88,6 +89,23 @@ class HardSoftScoreInlinerTest extends AbstractScoreInlinerTest<TestdataHardSoft
         impact1.undo();
         assertThat(scoreInliner.extractScore())
                 .isEqualTo(HardSoftScore.of(0, 0));
+    }
+
+    @Test
+    void impactAllMatchWeightOverflow() {
+        var constraintWeight = HardSoftScore.of(10, 100);
+        var impacter = buildScoreImpacter(constraintWeight);
+        assertThatThrownBy(() -> impacter.impactScore(Integer.MAX_VALUE, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void impactAllTotalOverflow() {
+        var constraintWeight = HardSoftScore.of(Integer.MAX_VALUE, Integer.MAX_VALUE);
+        var impacter = buildScoreImpacter(constraintWeight);
+        impacter.impactScore(1, ConstraintMatchSupplier.empty()); // This will send the total right to the limit.
+        assertThatThrownBy(() -> impacter.impactScore(1, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleLongScoreInlinerTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.common.inliner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Map;
@@ -42,6 +43,23 @@ class SimpleLongScoreInlinerTest extends AbstractScoreInlinerTest<TestdataSimple
         impact1.undo();
         assertThat(scoreInliner.extractScore())
                 .isEqualTo(SimpleLongScore.of(0));
+    }
+
+    @Test
+    void impactMatchWeightOverflow() {
+        var constraintWeight = SimpleLongScore.of(10);
+        var impacter = buildScoreImpacter(constraintWeight);
+        assertThatThrownBy(() -> impacter.impactScore(Long.MAX_VALUE, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void impactTotalOverflow() {
+        var constraintWeight = SimpleLongScore.of(Long.MAX_VALUE);
+        var impacter = buildScoreImpacter(constraintWeight);
+        impacter.impactScore(1, ConstraintMatchSupplier.empty()); // This will send the total right to the limit.
+        assertThatThrownBy(() -> impacter.impactScore(1, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreInlinerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/inliner/SimpleScoreInlinerTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.common.inliner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Map;
@@ -42,6 +43,23 @@ class SimpleScoreInlinerTest extends AbstractScoreInlinerTest<TestdataSolution, 
         impact1.undo();
         assertThat(scoreInliner.extractScore())
                 .isEqualTo(SimpleScore.of(0));
+    }
+
+    @Test
+    void impactMatchWeightOverflow() {
+        var constraintWeight = SimpleScore.of(10);
+        var impacter = buildScoreImpacter(constraintWeight);
+        assertThatThrownBy(() -> impacter.impactScore(Integer.MAX_VALUE, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void impactTotalOverflow() {
+        var constraintWeight = SimpleScore.of(Integer.MAX_VALUE);
+        var impacter = buildScoreImpacter(constraintWeight);
+        impacter.impactScore(1, ConstraintMatchSupplier.empty()); // This will send the total right to the limit.
+        assertThatThrownBy(() -> impacter.impactScore(1, ConstraintMatchSupplier.empty()))
+                .isInstanceOf(ArithmeticException.class);
     }
 
     @Override


### PR DESCRIPTION
The score director performance regression tests point towards an overall slowdown, but all of it within the margin of error, therefore the actual difference will be very small. When the overhead of the rest of the solver (and not just score director) comes into play, the impact of this will become effectively zero.