### PR TITLE
fix: remove a faulty fail-fast

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
@@ -119,28 +119,18 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
                 termination);
     }
 
+    @SuppressWarnings("unchecked")
     private NeighborhoodsBasedMoveRepository<Solution_> buildNeighborhoodsBasedMoveRepository(
             HeuristicConfigPolicy<Solution_> configPolicy,
             Class<? extends NeighborhoodProvider<Solution_>> neighborhoodProviderClass) {
-        var solutionDescriptor = configPolicy.getSolutionDescriptor();
-        var solutionMetaModel = solutionDescriptor.getMetaModel();
-        if (solutionMetaModel.genuineEntities().size() > 1) {
-            throw new UnsupportedOperationException(
-                    "Neighborhoods API currently only supports solutions with a single entity class, not multiple.");
-        }
-        var entityMetaModel = solutionMetaModel.genuineEntities().get(0);
-        if (entityMetaModel.genuineVariables().size() > 1) {
-            throw new UnsupportedOperationException(
-                    "Neighborhoods API currently only supports solutions with a single variable class, not multiple.");
-        }
-
         if (!NeighborhoodProvider.class.isAssignableFrom(neighborhoodProviderClass)) {
             throw new IllegalArgumentException("The neighborhoodProviderClass (%s) does not implement %s."
                     .formatted(neighborhoodProviderClass, NeighborhoodProvider.class.getSimpleName()));
         }
         var neighborhoodProvider = ConfigUtils.newInstance(LocalSearchPhaseConfig.class::getSimpleName,
                 "neighborhoodProviderClass", neighborhoodProviderClass);
-        var neighborhoodBuilder = new DefaultNeighborhoodBuilder<>(solutionMetaModel);
+        var solutionDescriptor = configPolicy.getSolutionDescriptor();
+        var neighborhoodBuilder = new DefaultNeighborhoodBuilder<>(solutionDescriptor.getMetaModel());
         var moveStreamFactory = new DefaultMoveStreamFactory<>(solutionDescriptor, configPolicy.getEnvironmentMode());
         return new NeighborhoodsBasedMoveRepository<>(moveStreamFactory,
                 ((DefaultNeighborhood<Solution_>) neighborhoodProvider.defineNeighborhood(neighborhoodBuilder))

--- a/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseTest.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
 import ai.timefold.solver.core.config.constructionheuristic.ConstructionHeuristicType;
 import ai.timefold.solver.core.config.constructionheuristic.decider.forager.ConstructionHeuristicForagerConfig;
@@ -311,11 +312,12 @@ class DefaultConstructionHeuristicPhaseTest {
         var value2 = new TestdataAllowsUnassignedValuesListValue("v2");
         var value3 = new TestdataAllowsUnassignedValuesListValue("v3");
         var value4 = new TestdataAllowsUnassignedValuesListValue("v4");
-        var entity = TestdataAllowsUnassignedValuesListEntity.createWithValues("e1", value1, value2);
+        var entity = new TestdataAllowsUnassignedValuesListEntity("e1", value1, value2);
 
         var solution = new TestdataAllowsUnassignedValuesListSolution();
         solution.setEntityList(List.of(entity));
         solution.setValueList(Arrays.asList(value1, value2, value3, value4));
+        SolutionManager.updateShadowVariables(solution);
 
         var bestSolution = PlannerTestUtils.solve(solverConfig, solution, true);
         assertSoftly(softly -> {

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/ListVariableListenerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/ListVariableListenerTest.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.stream.Collectors;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.selector.move.generic.list.ListAssignMove;
 import ai.timefold.solver.core.impl.heuristic.selector.move.generic.list.ListChangeMove;
@@ -38,6 +39,7 @@ class ListVariableListenerTest {
         var solution = new TestdataListSolutionWithShadowHistory();
         solution.setEntityList(Arrays.asList(entities));
         solution.setValueList(values);
+        SolutionManager.updateShadowVariables(solution);
         return solution;
     }
 
@@ -176,9 +178,10 @@ class ListVariableListenerTest {
         var b = new TestdataListValueWithShadowHistory("B");
         var c = new TestdataListValueWithShadowHistory("C");
         var x = new TestdataListValueWithShadowHistory("X");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c);
         var solution = buildSolution(ann);
         solution.getValueList().add(x);
+        SolutionManager.updateShadowVariables(solution);
 
         scoreDirector.setWorkingSolution(solution);
         assertThat(scoreDirector.calculateScore()).isEqualTo(InnerScore.withUnassignedCount(SimpleScore.ZERO, 1));
@@ -240,7 +243,7 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var d = new TestdataListValueWithShadowHistory("D");
         var e = new TestdataListValueWithShadowHistory("E");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d, e);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c, d, e);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -281,7 +284,7 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var d = new TestdataListValueWithShadowHistory("D");
         var e = new TestdataListValueWithShadowHistory("E");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d, e);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c, d, e);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -322,8 +325,8 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var x = new TestdataListValueWithShadowHistory("X");
         var y = new TestdataListValueWithShadowHistory("Y");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c);
-        var bob = TestdataListEntityWithShadowHistory.createWithValues("Bob", x, y);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c);
+        var bob = new TestdataListEntityWithShadowHistory("Bob", x, y);
 
         scoreDirector.setWorkingSolution(buildSolution(ann, bob));
 
@@ -365,8 +368,8 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var x = new TestdataListValueWithShadowHistory("X");
         var y = new TestdataListValueWithShadowHistory("Y");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c);
-        var bob = TestdataListEntityWithShadowHistory.createWithValues("Bob", x, y);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c);
+        var bob = new TestdataListEntityWithShadowHistory("Bob", x, y);
 
         scoreDirector.setWorkingSolution(buildSolution(ann, bob));
 
@@ -406,7 +409,7 @@ class ListVariableListenerTest {
         var a = new TestdataListValueWithShadowHistory("A");
         var b = new TestdataListValueWithShadowHistory("B");
         var c = new TestdataListValueWithShadowHistory("C");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -437,7 +440,7 @@ class ListVariableListenerTest {
         var a = new TestdataListValueWithShadowHistory("A");
         var b = new TestdataListValueWithShadowHistory("B");
         var c = new TestdataListValueWithShadowHistory("C");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -470,7 +473,7 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var d = new TestdataListValueWithShadowHistory("D");
         var e = new TestdataListValueWithShadowHistory("E");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d, e);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c, d, e);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -511,8 +514,8 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var x = new TestdataListValueWithShadowHistory("X");
         var y = new TestdataListValueWithShadowHistory("Y");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c);
-        var bob = TestdataListEntityWithShadowHistory.createWithValues("Bob", x, y);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c);
+        var bob = new TestdataListEntityWithShadowHistory("Bob", x, y);
 
         scoreDirector.setWorkingSolution(buildSolution(ann, bob));
 
@@ -554,8 +557,8 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var x = new TestdataListValueWithShadowHistory("X");
         var y = new TestdataListValueWithShadowHistory("Y");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c);
-        var bob = TestdataListEntityWithShadowHistory.createWithValues("Bob", x, y);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c);
+        var bob = new TestdataListEntityWithShadowHistory("Bob", x, y);
 
         scoreDirector.setWorkingSolution(buildSolution(ann, bob));
 
@@ -601,7 +604,7 @@ class ListVariableListenerTest {
         var b = new TestdataListValueWithShadowHistory("B");
         var c = new TestdataListValueWithShadowHistory("C");
         var d = new TestdataListValueWithShadowHistory("D");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c, d);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -638,7 +641,7 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var d = new TestdataListValueWithShadowHistory("D");
         var e = new TestdataListValueWithShadowHistory("E");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d, e);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c, d, e);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -679,7 +682,7 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var d = new TestdataListValueWithShadowHistory("D");
         var e = new TestdataListValueWithShadowHistory("E");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d, e);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c, d, e);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -723,8 +726,8 @@ class ListVariableListenerTest {
         var x = new TestdataListValueWithShadowHistory("X");
         var y = new TestdataListValueWithShadowHistory("Y");
         var z = new TestdataListValueWithShadowHistory("Z");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d, e);
-        var bob = TestdataListEntityWithShadowHistory.createWithValues("Bob", x, y, z);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c, d, e);
+        var bob = new TestdataListEntityWithShadowHistory("Bob", x, y, z);
 
         scoreDirector.setWorkingSolution(buildSolution(ann, bob));
 
@@ -777,8 +780,8 @@ class ListVariableListenerTest {
         var b = new TestdataListValueWithShadowHistory("B");
         var c = new TestdataListValueWithShadowHistory("C");
         var x = new TestdataListValueWithShadowHistory("X");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c);
-        var bob = TestdataListEntityWithShadowHistory.createWithValues("Bob", x);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c);
+        var bob = new TestdataListEntityWithShadowHistory("Bob", x);
 
         scoreDirector.setWorkingSolution(buildSolution(ann, bob));
 
@@ -812,8 +815,8 @@ class ListVariableListenerTest {
         var a = new TestdataListValueWithShadowHistory("A");
         var b = new TestdataListValueWithShadowHistory("B");
         var c = new TestdataListValueWithShadowHistory("C");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c);
-        var bob = TestdataListEntityWithShadowHistory.createWithValues("Bob");
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c);
+        var bob = new TestdataListEntityWithShadowHistory("Bob");
 
         scoreDirector.setWorkingSolution(buildSolution(ann, bob));
 
@@ -851,7 +854,7 @@ class ListVariableListenerTest {
         var g = new TestdataListValueWithShadowHistory("G");
         var h = new TestdataListValueWithShadowHistory("H");
         var ann =
-                TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d, e, f, g, h);
+                new TestdataListEntityWithShadowHistory("Ann", a, b, c, d, e, f, g, h);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -908,7 +911,7 @@ class ListVariableListenerTest {
         var g = new TestdataListValueWithShadowHistory("G");
         var h = new TestdataListValueWithShadowHistory("H");
         var ann =
-                TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d, e, f, g, h);
+                new TestdataListEntityWithShadowHistory("Ann", a, b, c, d, e, f, g, h);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 
@@ -961,7 +964,7 @@ class ListVariableListenerTest {
         var c = new TestdataListValueWithShadowHistory("C");
         var d = new TestdataListValueWithShadowHistory("D");
         var e = new TestdataListValueWithShadowHistory("E");
-        var ann = TestdataListEntityWithShadowHistory.createWithValues("Ann", a, b, c, d, e);
+        var ann = new TestdataListEntityWithShadowHistory("Ann", a, b, c, d, e);
 
         scoreDirector.setWorkingSolution(buildSolution(ann));
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.impl.heuristic.selector.entity.FromSolutionEntitySelector;
 import ai.timefold.solver.core.impl.heuristic.selector.entity.decorator.FilteringEntityByValueSelector;
@@ -60,12 +61,13 @@ class ElementDestinationSelectorTest {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
-        var a = TestdataListEntity.createWithValues("A", v2, v1);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v3);
+        var a = new TestdataListEntity("A", v2, v1);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -99,12 +101,13 @@ class ElementDestinationSelectorTest {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
-        var a = TestdataListEntity.createWithValues("A", v1, v2);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v3);
+        var a = new TestdataListEntity("A", v1, v2);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -312,10 +315,10 @@ class ElementDestinationSelectorTest {
         var v5 = new TestdataPinnedUnassignedValuesListValue("5");
         var v6 = new TestdataPinnedUnassignedValuesListValue("5");
         var unassignedValue = new TestdataPinnedUnassignedValuesListValue("7");
-        var a = TestdataPinnedUnassignedValuesListEntity.createWithValues("A", v1, v2);
-        var b = TestdataPinnedUnassignedValuesListEntity.createWithValues("B");
-        var c = TestdataPinnedUnassignedValuesListEntity.createWithValues("C", v3);
-        var d = TestdataPinnedUnassignedValuesListEntity.createWithValues("D", v4, v5, v6);
+        var a = new TestdataPinnedUnassignedValuesListEntity("A", v1, v2);
+        var b = new TestdataPinnedUnassignedValuesListEntity("B");
+        var c = new TestdataPinnedUnassignedValuesListEntity("C", v3);
+        var d = new TestdataPinnedUnassignedValuesListEntity("D", v4, v5, v6);
         a.setPlanningPinToIndex(1);
         c.setPlanningPinToIndex(1);
         d.setPlanningPinToIndex(2);
@@ -323,6 +326,7 @@ class ElementDestinationSelectorTest {
         var solution = new TestdataPinnedUnassignedValuesListSolution();
         solution.setEntityList(List.of(a, b, c, d));
         solution.setValueList(List.of(v1, v2, v3, v3, v4, v5, unassignedValue));
+        SolutionManager.updateShadowVariables(solution);
 
         var random = new TestRandom(
                 0, // Unassigned element goes first.
@@ -379,11 +383,12 @@ class ElementDestinationSelectorTest {
     @Test
     void randomUnassignedSingleEntity() {
         var unassignedValue = new TestdataAllowsUnassignedValuesListValue("3");
-        var a = TestdataAllowsUnassignedValuesListEntity.createWithValues("A");
+        var a = new TestdataAllowsUnassignedValuesListEntity("A");
 
         var solution = new TestdataAllowsUnassignedValuesListSolution();
         solution.setEntityList(List.of(a));
         solution.setValueList(List.of(unassignedValue));
+        SolutionManager.updateShadowVariables(solution);
 
         var solutionDescriptor = TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor();
         var scoreDirector = mockScoreDirector(solutionDescriptor);
@@ -417,15 +422,16 @@ class ElementDestinationSelectorTest {
         var v1 = new TestdataPinnedWithIndexListValue("1");
         var v2 = new TestdataPinnedWithIndexListValue("2");
         var v3 = new TestdataPinnedWithIndexListValue("3");
-        var a = TestdataPinnedWithIndexListEntity.createWithValues("A", v1, v2);
-        var b = TestdataPinnedWithIndexListEntity.createWithValues("B");
-        var c = TestdataPinnedWithIndexListEntity.createWithValues("C", v3);
+        var a = new TestdataPinnedWithIndexListEntity("A", v1, v2);
+        var b = new TestdataPinnedWithIndexListEntity("B");
+        var c = new TestdataPinnedWithIndexListEntity("C", v3);
         a.setPlanningPinToIndex(2);
         c.setPinned(true);
 
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataPinnedWithIndexListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -486,12 +492,13 @@ class ElementDestinationSelectorTest {
 
     @Test
     void notEmptyIfThereAreEntities() {
-        var a = TestdataListEntity.createWithValues("A");
-        var b = TestdataListEntity.createWithValues("B");
+        var a = new TestdataListEntity("A");
+        var b = new TestdataListEntity("B");
         var v1 = new TestdataListValue("1");
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -512,13 +519,14 @@ class ElementDestinationSelectorTest {
 
     @Test
     void notEmptyIfThereAreEntitiesWithPinning() {
-        var a = TestdataPinnedWithIndexListEntity.createWithValues("A");
-        var b = TestdataPinnedWithIndexListEntity.createWithValues("B",
-                new TestdataPinnedWithIndexListValue("B0"), new TestdataPinnedWithIndexListValue("B1"));
+        var a = new TestdataPinnedWithIndexListEntity("A");
+        var b = new TestdataPinnedWithIndexListEntity("B", new TestdataPinnedWithIndexListValue("B0"),
+                new TestdataPinnedWithIndexListValue("B1"));
         b.setPlanningPinToIndex(1); // B0 will be ignored.
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(b.getValueList().get(0), b.getValueList().get(1)));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataPinnedWithIndexListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/RandomSubListSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/RandomSubListSelectorTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.util.List;
 
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.testdomain.list.TestdataListEntity;
 import ai.timefold.solver.core.testdomain.list.TestdataListSolution;
 import ai.timefold.solver.core.testdomain.list.TestdataListUtils;
@@ -41,11 +42,12 @@ class RandomSubListSelectorTest {
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4);
-        var b = TestdataListEntity.createWithValues("B");
+        var a = new TestdataListEntity("A", v1, v2, v3, v4);
+        var b = new TestdataListEntity("B");
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -82,9 +84,9 @@ class RandomSubListSelectorTest {
         var v2 = new TestdataPinnedWithIndexListValue("2");
         var v3 = new TestdataPinnedWithIndexListValue("3");
         var v4 = new TestdataPinnedWithIndexListValue("4");
-        var a = TestdataPinnedWithIndexListEntity.createWithValues("A", v1, v2, v3, v4);
+        var a = new TestdataPinnedWithIndexListEntity("A", v1, v2, v3, v4);
         a.setPlanningPinToIndex(1); // Ignore v1.
-        var b = TestdataPinnedWithIndexListEntity.createWithValues("B");
+        var b = new TestdataPinnedWithIndexListEntity("B");
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4));
@@ -124,11 +126,12 @@ class RandomSubListSelectorTest {
         var v2 = new TestdataAllowsUnassignedValuesListValue("2");
         var v3 = new TestdataAllowsUnassignedValuesListValue("3");
         var v4 = new TestdataAllowsUnassignedValuesListValue("4");
-        var a = TestdataAllowsUnassignedValuesListEntity.createWithValues("A", v1, v2, v3);
-        var b = TestdataAllowsUnassignedValuesListEntity.createWithValues("B");
+        var a = new TestdataAllowsUnassignedValuesListEntity("A", v1, v2, v3);
+        var b = new TestdataAllowsUnassignedValuesListEntity("B");
         var solution = new TestdataAllowsUnassignedValuesListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -167,11 +170,12 @@ class RandomSubListSelectorTest {
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
         var v5 = new TestdataListValue("5");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4, v5);
-        var b = TestdataListEntity.createWithValues("B");
+        var a = new TestdataListEntity("A", v1, v2, v3, v4, v5);
+        var b = new TestdataListEntity("B");
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4, v5));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -202,7 +206,7 @@ class RandomSubListSelectorTest {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3);
+        var a = new TestdataListEntity("A", v1, v2, v3);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Random;
 
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import ai.timefold.solver.core.preview.api.domain.metamodel.ElementPosition;
 import ai.timefold.solver.core.testdomain.TestdataValue;
@@ -56,12 +57,13 @@ class ListChangeMoveSelectorTest {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
-        var a = TestdataListEntity.createWithValues("A", v2, v1);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v3);
+        var a = new TestdataListEntity("A", v2, v1);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -151,14 +153,15 @@ class ListChangeMoveSelectorTest {
         var v2 = new TestdataPinnedWithIndexListValue("2");
         var v3 = new TestdataPinnedWithIndexListValue("3");
         var v4 = new TestdataPinnedWithIndexListValue("4");
-        var a = TestdataPinnedWithIndexListEntity.createWithValues("A", v2, v1);
+        var a = new TestdataPinnedWithIndexListEntity("A", v2, v1);
         a.setPlanningPinToIndex(1); // Ignore v2.
-        var b = TestdataPinnedWithIndexListEntity.createWithValues("B", v4);
+        var b = new TestdataPinnedWithIndexListEntity("B", v4);
         b.setPinned(true); // Ignore entirely.
-        var c = TestdataPinnedWithIndexListEntity.createWithValues("C", v3);
+        var c = new TestdataPinnedWithIndexListEntity("C", v3);
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataPinnedWithIndexListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -242,12 +245,13 @@ class ListChangeMoveSelectorTest {
         var v2 = new TestdataAllowsUnassignedValuesListValue("2");
         var v3 = new TestdataAllowsUnassignedValuesListValue("3");
         var v4 = new TestdataAllowsUnassignedValuesListValue("4");
-        var a = TestdataAllowsUnassignedValuesListEntity.createWithValues("A", v2, v1);
-        var b = TestdataAllowsUnassignedValuesListEntity.createWithValues("B");
-        var c = TestdataAllowsUnassignedValuesListEntity.createWithValues("C", v3);
+        var a = new TestdataAllowsUnassignedValuesListEntity("A", v2, v1);
+        var b = new TestdataAllowsUnassignedValuesListEntity("B");
+        var c = new TestdataAllowsUnassignedValuesListEntity("C", v3);
         var solution = new TestdataAllowsUnassignedValuesListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -346,12 +350,13 @@ class ListChangeMoveSelectorTest {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
-        var a = TestdataListEntity.createWithValues("A", v1, v2);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v3);
+        var a = new TestdataListEntity("A", v1, v2);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -457,14 +462,15 @@ class ListChangeMoveSelectorTest {
         var v2 = new TestdataPinnedWithIndexListValue("2");
         var v3 = new TestdataPinnedWithIndexListValue("3");
         var v4 = new TestdataPinnedWithIndexListValue("4");
-        var a = TestdataPinnedWithIndexListEntity.createWithValues("A", v1, v2);
+        var a = new TestdataPinnedWithIndexListEntity("A", v1, v2);
         a.setPlanningPinToIndex(1); // Ignore v1.
-        var b = TestdataPinnedWithIndexListEntity.createWithValues("B", v4);
+        var b = new TestdataPinnedWithIndexListEntity("B", v4);
         b.setPinned(true); // Ignore entirely.
-        var c = TestdataPinnedWithIndexListEntity.createWithValues("C", v3);
+        var c = new TestdataPinnedWithIndexListEntity("C", v3);
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataPinnedWithIndexListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -544,12 +550,13 @@ class ListChangeMoveSelectorTest {
         var v2 = new TestdataAllowsUnassignedValuesListValue("2");
         var v3 = new TestdataAllowsUnassignedValuesListValue("3");
         var v4 = new TestdataAllowsUnassignedValuesListValue("4");
-        var a = TestdataAllowsUnassignedValuesListEntity.createWithValues("A", v1, v2);
-        var b = TestdataAllowsUnassignedValuesListEntity.createWithValues("B");
-        var c = TestdataAllowsUnassignedValuesListEntity.createWithValues("C", v3);
+        var a = new TestdataAllowsUnassignedValuesListEntity("A", v1, v2);
+        var b = new TestdataAllowsUnassignedValuesListEntity("B");
+        var c = new TestdataAllowsUnassignedValuesListEntity("C", v3);
         var solution = new TestdataAllowsUnassignedValuesListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Random;
 
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.heuristic.move.NoChangeMove;
 import ai.timefold.solver.core.testdomain.TestdataValue;
 import ai.timefold.solver.core.testdomain.list.TestdataListEntity;
@@ -48,12 +49,13 @@ class ListSwapMoveSelectorTest {
         var v1 = new TestdataListValue("v1");
         var v2 = new TestdataListValue("v2");
         var v3 = new TestdataListValue("v3");
-        var e1 = TestdataListEntity.createWithValues("A", v2, v1);
-        var e2 = TestdataListEntity.createWithValues("B");
-        var e3 = TestdataListEntity.createWithValues("C", v3);
+        var e1 = new TestdataListEntity("A", v2, v1);
+        var e2 = new TestdataListEntity("B");
+        var e3 = new TestdataListEntity("C", v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1, e2, e3));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -123,14 +125,15 @@ class ListSwapMoveSelectorTest {
         var v1 = new TestdataPinnedWithIndexListValue("v1");
         var v2 = new TestdataPinnedWithIndexListValue("v2");
         var v3 = new TestdataPinnedWithIndexListValue("v3");
-        var a = TestdataPinnedWithIndexListEntity.createWithValues("A", v2, v1);
+        var a = new TestdataPinnedWithIndexListEntity("A", v2, v1);
         a.setPlanningPinToIndex(1); // Ignore v2
-        var b = TestdataPinnedWithIndexListEntity.createWithValues("B");
+        var b = new TestdataPinnedWithIndexListEntity("B");
         b.setPinned(true); // Ignore entirely.
-        var c = TestdataPinnedWithIndexListEntity.createWithValues("C", v3);
+        var c = new TestdataPinnedWithIndexListEntity("C", v3);
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataPinnedWithIndexListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -200,11 +203,12 @@ class ListSwapMoveSelectorTest {
         var v2 = new TestdataAllowsUnassignedValuesListValue("v2");
         var v3 = new TestdataAllowsUnassignedValuesListValue("v3");
         var v4 = new TestdataAllowsUnassignedValuesListValue("v4");
-        var a = TestdataAllowsUnassignedValuesListEntity.createWithValues("A", v2, v1);
-        var b = TestdataAllowsUnassignedValuesListEntity.createWithValues("B", v3);
+        var a = new TestdataAllowsUnassignedValuesListEntity("A", v2, v1);
+        var b = new TestdataAllowsUnassignedValuesListEntity("B", v3);
         var solution = new TestdataAllowsUnassignedValuesListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -274,12 +278,13 @@ class ListSwapMoveSelectorTest {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
-        var e1 = TestdataListEntity.createWithValues("A", v1, v2);
-        var e2 = TestdataListEntity.createWithValues("B");
-        var e3 = TestdataListEntity.createWithValues("C", v3);
+        var e1 = new TestdataListEntity("A", v1, v2);
+        var e2 = new TestdataListEntity("B");
+        var e3 = new TestdataListEntity("C", v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1, e2, e3));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -404,14 +409,15 @@ class ListSwapMoveSelectorTest {
         var v1 = new TestdataPinnedWithIndexListValue("1");
         var v2 = new TestdataPinnedWithIndexListValue("2");
         var v3 = new TestdataPinnedWithIndexListValue("3");
-        var a = TestdataPinnedWithIndexListEntity.createWithValues("A", v1, v2);
+        var a = new TestdataPinnedWithIndexListEntity("A", v1, v2);
         a.setPlanningPinToIndex(1); // Ignore v1
-        var b = TestdataPinnedWithIndexListEntity.createWithValues("B");
+        var b = new TestdataPinnedWithIndexListEntity("B");
         b.setPinned(true); // Ignore entirely.
-        var c = TestdataPinnedWithIndexListEntity.createWithValues("C", v3);
+        var c = new TestdataPinnedWithIndexListEntity("C", v3);
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataPinnedWithIndexListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -477,11 +483,12 @@ class ListSwapMoveSelectorTest {
         var v2 = new TestdataAllowsUnassignedValuesListValue("2");
         var v3 = new TestdataAllowsUnassignedValuesListValue("3");
         var v4 = new TestdataAllowsUnassignedValuesListValue("4");
-        var e1 = TestdataAllowsUnassignedValuesListEntity.createWithValues("A", v2, v1);
-        var e2 = TestdataAllowsUnassignedValuesListEntity.createWithValues("B", v3);
+        var e1 = new TestdataAllowsUnassignedValuesListEntity("A", v2, v1);
+        var e2 = new TestdataAllowsUnassignedValuesListEntity("B", v3);
         var solution = new TestdataAllowsUnassignedValuesListSolution();
         solution.setEntityList(List.of(e1, e2));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListUnassignMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListUnassignMoveTest.java
@@ -75,7 +75,7 @@ class ListUnassignMoveTest {
     @Test
     void toStringTest() {
         var v1 = new TestdataListValue("1");
-        var e1 = TestdataListEntity.createWithValues("E1", v1);
+        var e1 = new TestdataListEntity("E1", v1);
 
         var variableDescriptor =
                 TestdataListEntity.buildVariableDescriptorForValueList();

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomListChangeIteratorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomListChangeIteratorTest.java
@@ -9,6 +9,7 @@ import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockScoreDirecto
 
 import java.util.List;
 
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.heuristic.selector.list.ElementDestinationSelector;
 import ai.timefold.solver.core.testdomain.list.TestdataListEntity;
 import ai.timefold.solver.core.testdomain.list.TestdataListSolution;
@@ -24,12 +25,13 @@ class RandomListChangeIteratorTest {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
-        var a = TestdataListEntity.createWithValues("A", v1, v2);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v3);
+        var a = new TestdataListEntity("A", v1, v2);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomListSwapIteratorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomListSwapIteratorTest.java
@@ -8,6 +8,7 @@ import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockScoreDirecto
 import java.util.List;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.testdomain.list.TestdataListEntity;
@@ -23,12 +24,13 @@ class RandomListSwapIteratorTest {
         TestdataListValue v1 = new TestdataListValue("1");
         TestdataListValue v2 = new TestdataListValue("2");
         TestdataListValue v3 = new TestdataListValue("3");
-        var e1 = TestdataListEntity.createWithValues("A", v1, v2);
-        var e2 = TestdataListEntity.createWithValues("B");
-        var e3 = TestdataListEntity.createWithValues("C", v3);
+        var e1 = new TestdataListEntity("A", v1, v2);
+        var e2 = new TestdataListEntity("B");
+        var e3 = new TestdataListEntity("C", v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1, e2, e3));
         solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
                 mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelectorTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.heuristic.selector.list.RandomSubListSelector;
 import ai.timefold.solver.core.preview.api.domain.metamodel.ElementPosition;
 import ai.timefold.solver.core.testdomain.list.TestdataListEntity;
@@ -38,11 +39,12 @@ class RandomSubListChangeMoveSelectorTest {
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4);
-        var b = TestdataListEntity.createWithValues("B");
+        var a = new TestdataListEntity("A", v1, v2, v3, v4);
+        var b = new TestdataListEntity("B");
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -90,11 +92,12 @@ class RandomSubListChangeMoveSelectorTest {
         var v2 = new TestdataAllowsUnassignedValuesListValue("2");
         var v3 = new TestdataAllowsUnassignedValuesListValue("3");
         var v4 = new TestdataAllowsUnassignedValuesListValue("4");
-        var a = TestdataAllowsUnassignedValuesListEntity.createWithValues("A", v1, v2);
-        var b = TestdataAllowsUnassignedValuesListEntity.createWithValues("B", v3);
+        var a = new TestdataAllowsUnassignedValuesListEntity("A", v1, v2);
+        var b = new TestdataAllowsUnassignedValuesListEntity("B", v3);
         var solution = new TestdataAllowsUnassignedValuesListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -174,11 +177,12 @@ class RandomSubListChangeMoveSelectorTest {
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4);
-        var b = TestdataListEntity.createWithValues("B");
+        var a = new TestdataListEntity("A", v1, v2, v3, v4);
+        var b = new TestdataListEntity("B");
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -236,11 +240,12 @@ class RandomSubListChangeMoveSelectorTest {
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4);
-        var b = TestdataListEntity.createWithValues("B");
+        var a = new TestdataListEntity("A", v1, v2, v3, v4);
+        var b = new TestdataListEntity("B");
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -279,7 +284,7 @@ class RandomSubListChangeMoveSelectorTest {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3);
+        var a = new TestdataListEntity("A", v1, v2, v3);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
@@ -306,12 +311,13 @@ class RandomSubListChangeMoveSelectorTest {
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v4);
+        var a = new TestdataListEntity("A", v1, v2, v3);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v4);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -350,12 +356,13 @@ class RandomSubListChangeMoveSelectorTest {
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
         var v5 = new TestdataListValue("5");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v4, v5);
+        var a = new TestdataListEntity("A", v1, v2, v3);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v4, v5);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3, v4, v5));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -400,13 +407,14 @@ class RandomSubListChangeMoveSelectorTest {
         var v22 = new TestdataListValue("22");
         var v23 = new TestdataListValue("23");
         var v24 = new TestdataListValue("24");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4, v5, v6, v7);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v11, v12, v13);
-        var d = TestdataListEntity.createWithValues("D", v21, v22, v23, v24);
+        var a = new TestdataListEntity("A", v1, v2, v3, v4, v5, v6, v7);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v11, v12, v13);
+        var d = new TestdataListEntity("D", v21, v22, v23, v24);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v11, v12, v13, v21, v22, v23, v24));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelectorTest.java
@@ -15,6 +15,7 @@ import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockScoreDirecto
 
 import java.util.List;
 
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.heuristic.selector.list.RandomSubListSelector;
 import ai.timefold.solver.core.testdomain.list.TestdataListEntity;
 import ai.timefold.solver.core.testdomain.list.TestdataListSolution;
@@ -35,10 +36,11 @@ class RandomSubListSwapMoveSelectorTest {
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4);
+        var a = new TestdataListEntity("A", v1, v2, v3, v4);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -120,11 +122,12 @@ class RandomSubListSwapMoveSelectorTest {
         var v3 = new TestdataListValue("3");
         var v5 = new TestdataListValue("5");
         var v6 = new TestdataListValue("6");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3);
-        var b = TestdataListEntity.createWithValues("B", v5, v6);
+        var a = new TestdataListEntity("A", v1, v2, v3);
+        var b = new TestdataListEntity("B", v5, v6);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v5, v6));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -176,10 +179,11 @@ class RandomSubListSwapMoveSelectorTest {
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4);
+        var a = new TestdataListEntity("A", v1, v2, v3, v4);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -239,7 +243,7 @@ class RandomSubListSwapMoveSelectorTest {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3);
+        var a = new TestdataListEntity("A", v1, v2, v3);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
@@ -273,12 +277,13 @@ class RandomSubListSwapMoveSelectorTest {
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v4);
+        var a = new TestdataListEntity("A", v1, v2, v3);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v4);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -330,11 +335,12 @@ class RandomSubListSwapMoveSelectorTest {
         var v2 = new TestdataAllowsUnassignedValuesListValue("2");
         var v3 = new TestdataAllowsUnassignedValuesListValue("3");
         var v4 = new TestdataAllowsUnassignedValuesListValue("4");
-        var a = TestdataAllowsUnassignedValuesListEntity.createWithValues("A", v1, v2);
-        var b = TestdataAllowsUnassignedValuesListEntity.createWithValues("B", v3);
+        var a = new TestdataAllowsUnassignedValuesListEntity("A", v1, v2);
+        var b = new TestdataAllowsUnassignedValuesListEntity("B", v3);
         var solution = new TestdataAllowsUnassignedValuesListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -396,12 +402,13 @@ class RandomSubListSwapMoveSelectorTest {
         var v2 = new TestdataListValue("2");
         var v3 = new TestdataListValue("3");
         var v4 = new TestdataListValue("4");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v4);
+        var a = new TestdataListEntity("A", v1, v2, v3);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v4);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c));
         solution.setValueList(List.of(v1, v2, v3, v4));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
@@ -450,13 +457,14 @@ class RandomSubListSwapMoveSelectorTest {
         var v22 = new TestdataListValue("22");
         var v23 = new TestdataListValue("23");
         var v24 = new TestdataListValue("24");
-        var a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4, v5, v6, v7);
-        var b = TestdataListEntity.createWithValues("B");
-        var c = TestdataListEntity.createWithValues("C", v11, v12, v13);
-        var d = TestdataListEntity.createWithValues("D", v21, v22, v23, v24);
+        var a = new TestdataListEntity("A", v1, v2, v3, v4, v5, v6, v7);
+        var b = new TestdataListEntity("B");
+        var c = new TestdataListEntity("C", v11, v12, v13);
+        var d = new TestdataListEntity("D", v21, v22, v23, v24);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(a, b, c, d));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v11, v12, v13, v21, v22, v23, v24));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.function.Function;
 
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.list.kopt.KOptListMoveSelectorConfig;
 import ai.timefold.solver.core.impl.domain.variable.ListVariableStateDemand;
 import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
@@ -80,10 +81,11 @@ class KOptListMoveTest {
 
     @Test
     void test3Opt() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -104,10 +106,11 @@ class KOptListMoveTest {
 
     @Test
     void test3OptPinned() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var variableDescriptorSpy = spy(variableDescriptor);
@@ -137,12 +140,13 @@ class KOptListMoveTest {
 
     @Test
     void test3OptRebase() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6);
-        var destinationE1 = TestdataListEntity.createWithValues("e1", destinationV1, destinationV2,
-                destinationV3, destinationV4, destinationV5, destinationV6);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6);
+        var destinationE1 = new TestdataListEntity("e1", destinationV1, destinationV2, destinationV3, destinationV4,
+                destinationV5, destinationV6);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -182,16 +186,17 @@ class KOptListMoveTest {
 
     @Test
     void testMultiEntity3OptRebase() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v6);
-        var e2 = TestdataListEntity.createWithValues("e2", v4, v5);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v6);
+        var e2 = new TestdataListEntity("e2", v4, v5);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1, e2));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var destinationE1 =
-                TestdataListEntity.createWithValues("e1", destinationV1, destinationV2, destinationV3, destinationV6);
-        var destinationE2 = TestdataListEntity.createWithValues("e2", destinationV4, destinationV5);
+                new TestdataListEntity("e1", destinationV1, destinationV2, destinationV3, destinationV6);
+        var destinationE2 = new TestdataListEntity("e2", destinationV4, destinationV5);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
                 variableDescriptor,
@@ -235,11 +240,12 @@ class KOptListMoveTest {
 
     @Test
     void testMultiEntity2Opt() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4);
-        var e2 = TestdataListEntity.createWithValues("e2", v5, v6, v7, v8);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4);
+        var e2 = new TestdataListEntity("e2", v5, v6, v7, v8);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1, e2));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v8));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -261,11 +267,12 @@ class KOptListMoveTest {
 
     @Test
     void testMultiEntity3Opt() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v6);
-        var e2 = TestdataListEntity.createWithValues("e2", v4, v5);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v6);
+        var e2 = new TestdataListEntity("e2", v4, v5);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1, e2));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -289,11 +296,12 @@ class KOptListMoveTest {
 
     @Test
     void testMultiEntity3OptPinned() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v6, v7);
-        var e2 = TestdataListEntity.createWithValues("e2", v4, v5);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v6, v7);
+        var e2 = new TestdataListEntity("e2", v4, v5);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1, e2));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var variableDescriptorSpy = spy(variableDescriptor);
@@ -327,12 +335,13 @@ class KOptListMoveTest {
 
     @Test
     void testMultiEntity4Opt() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4);
-        var e2 = TestdataListEntity.createWithValues("e2", v5, v6, v7, v8);
-        var e3 = TestdataListEntity.createWithValues("e3", v9, v10, v11, v12);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4);
+        var e2 = new TestdataListEntity("e2", v5, v6, v7, v8);
+        var e3 = new TestdataListEntity("e3", v9, v10, v11, v12);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1, e2, e3));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -361,10 +370,11 @@ class KOptListMoveTest {
 
     @Test
     void test3OptLong() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -385,10 +395,11 @@ class KOptListMoveTest {
 
     @Test
     void test4Opt() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v8));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -414,10 +425,11 @@ class KOptListMoveTest {
 
     @Test
     void test4OptLong() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -442,10 +454,11 @@ class KOptListMoveTest {
 
     @Test
     void testInverted4OptLong() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         // Note: using only endpoints work (removing v4, v7, v8, v11) from the above list works
@@ -472,10 +485,11 @@ class KOptListMoveTest {
 
     @Test
     void testDoubleBridge4Opt() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v8));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -500,10 +514,11 @@ class KOptListMoveTest {
 
     @Test
     void testDoubleBridge4OptLong() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
@@ -529,10 +544,11 @@ class KOptListMoveTest {
 
     @Test
     void testIsFeasible() {
-        var e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8);
+        var e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v3, v4, v5, v6, v7, v8));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var kOptListMove = fromRemovedAndAddedEdges(scoreDirector,

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/TwoOptListMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/TwoOptListMoveTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.ValueRangeManager;
@@ -53,10 +54,11 @@ class TwoOptListMoveTest {
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
-        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v5, v4, v3, v6, v7, v8);
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v5, v4, v3, v6, v7, v8);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v5, v4, v3, v6, v7, v8));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         // 2-Opt((v2, v5), (v3, v6))
@@ -80,7 +82,7 @@ class TwoOptListMoveTest {
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
-        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v5, v4, v3, v6, v7, v8);
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v5, v4, v3, v6, v7, v8);
 
         // 2-Opt((v2, v5), (v3, v6))
         TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor,
@@ -144,8 +146,8 @@ class TwoOptListMoveTest {
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
         TestdataListValue v9 = new TestdataListValue("9");
-        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4);
-        TestdataListEntity e2 = TestdataListEntity.createWithValues("e2", v5, v6, v7, v8, v9);
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4);
+        TestdataListEntity e2 = new TestdataListEntity("e2", v5, v6, v7, v8, v9);
 
         // 2-Opt((v2, v3), (v6, v7))
         TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor,
@@ -172,11 +174,12 @@ class TwoOptListMoveTest {
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
         TestdataListValue v9 = new TestdataListValue("9");
-        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4);
-        TestdataListEntity e2 = TestdataListEntity.createWithValues("e2", v5, v6, v7, v8, v9);
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4);
+        TestdataListEntity e2 = new TestdataListEntity("e2", v5, v6, v7, v8, v9);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1, e2));
         solution.setValueList(List.of(v1, v2, v5, v4, v3, v6, v7, v8, v9));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         // 2-Opt((v2, v3), (v6, v7))
@@ -203,10 +206,11 @@ class TwoOptListMoveTest {
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
-        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v8, v7, v3, v4, v5, v6, v2, v1);
+        TestdataListEntity e1 = new TestdataListEntity("e1", v8, v7, v3, v4, v5, v6, v2, v1);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v5, v4, v3, v6, v7, v8));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         // 2-Opt((v6, v2), (v7, v3))
@@ -229,10 +233,11 @@ class TwoOptListMoveTest {
         TestdataListValue v5 = new TestdataListValue("5");
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
-        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v5, v2, v3, v4, v1, v7, v6);
+        TestdataListEntity e1 = new TestdataListEntity("e1", v5, v2, v3, v4, v1, v7, v6);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v5, v4, v3, v6, v7));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         // 2-Opt((v4, v1), (v5, v2))
@@ -255,10 +260,11 @@ class TwoOptListMoveTest {
         TestdataListValue v5 = new TestdataListValue("5");
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
-        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v2, v1, v7, v4, v5, v6, v3);
+        TestdataListEntity e1 = new TestdataListEntity("e1", v2, v1, v7, v4, v5, v6, v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v5, v4, v3, v6, v7));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         // 2-Opt((v4, v1), (v5, v2))
@@ -282,10 +288,11 @@ class TwoOptListMoveTest {
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
-        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v8, v7, v3, v4, v5, v6, v2, v1);
+        TestdataListEntity e1 = new TestdataListEntity("e1", v8, v7, v3, v4, v5, v6, v2, v1);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(e1));
         solution.setValueList(List.of(v1, v2, v5, v4, v3, v6, v7, v8));
+        SolutionManager.updateShadowVariables(solution);
         scoreDirector.setWorkingSolution(solution);
 
         var variableDescriptorSpy = Mockito.spy(variableDescriptor);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/UnassignedListValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/UnassignedListValueSelectorTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.heuristic.selector.value.IterableValueSelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
@@ -33,10 +34,11 @@ class UnassignedListValueSelectorTest {
         var v4 = new TestdataListValue("4");
         var v5 = new TestdataListValue("5");
         // 1 and 3 are assigned, the rest (2, 4, 5) are unassigned.
-        var entity = TestdataListEntity.createWithValues("A", v1, v3);
+        var entity = new TestdataListEntity("A", v1, v3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(entity));
         solution.setValueList(List.of(v1, v2, v3, v4, v5));
+        SolutionManager.updateShadowVariables(solution);
 
         var scoreDirector = mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);

--- a/core/src/test/java/ai/timefold/solver/core/impl/move/MoveDirectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/move/MoveDirectorTest.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.DefaultPlanningListVariableMetaModel;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.DefaultPlanningVariableMetaModel;
@@ -108,7 +109,7 @@ class MoveDirectorTest {
         var expectedValue1 = new TestdataListValue("value1");
         var expectedValue2 = new TestdataListValue("value2");
 
-        var entity = TestdataListEntity.createWithValues("A", expectedValue1, expectedValue2);
+        var entity = new TestdataListEntity("A", expectedValue1, expectedValue2);
         var actualValue1 = moveDirector.getValueAtIndex(variableMetaModel, entity, 0);
         assertThat(actualValue1).isEqualTo(expectedValue1);
 
@@ -132,7 +133,7 @@ class MoveDirectorTest {
         var expectedValue1 = new TestdataListValue("value1");
         var expectedValue2 = new TestdataListValue("value2");
         var expectedValue3 = new TestdataListValue("value3");
-        var entity = TestdataListEntity.createWithValues("A", expectedValue1, expectedValue2, expectedValue3);
+        var entity = new TestdataListEntity("A", expectedValue1, expectedValue2, expectedValue3);
 
         // Move value from last to first position.
         var mockScoreDirector = (InnerScoreDirector<TestdataListSolution, ?>) mock(InnerScoreDirector.class);
@@ -177,11 +178,11 @@ class MoveDirectorTest {
         var expectedValueA1 = new TestdataListValue("valueA1");
         var expectedValueA2 = new TestdataListValue("valueA2");
         var expectedValueA3 = new TestdataListValue("valueA3");
-        var entityA = TestdataListEntity.createWithValues("A", expectedValueA1, expectedValueA2, expectedValueA3);
+        var entityA = new TestdataListEntity("A", expectedValueA1, expectedValueA2, expectedValueA3);
         var expectedValueB1 = new TestdataListValue("valueB1");
         var expectedValueB2 = new TestdataListValue("valueB2");
         var expectedValueB3 = new TestdataListValue("valueB3");
-        var entityB = TestdataListEntity.createWithValues("B", expectedValueB1, expectedValueB2, expectedValueB3);
+        var entityB = new TestdataListEntity("B", expectedValueB1, expectedValueB2, expectedValueB3);
 
         // Move between second and last position.
         var mockScoreDirector = (InnerScoreDirector<TestdataListSolution, ?>) mock(InnerScoreDirector.class);
@@ -217,7 +218,7 @@ class MoveDirectorTest {
         var expectedValue1 = new TestdataListValue("value1");
         var expectedValue2 = new TestdataListValue("value2");
         var expectedValue3 = new TestdataListValue("value3");
-        var entity = TestdataListEntity.createWithValues("A", expectedValue1, expectedValue2, expectedValue3);
+        var entity = new TestdataListEntity("A", expectedValue1, expectedValue2, expectedValue3);
 
         // Swap between first and last position.
         var mockScoreDirector = (InnerScoreDirector<TestdataListSolution, ?>) mock(InnerScoreDirector.class);
@@ -261,11 +262,11 @@ class MoveDirectorTest {
         var expectedValueA1 = new TestdataListValue("valueA1");
         var expectedValueA2 = new TestdataListValue("valueA2");
         var expectedValueA3 = new TestdataListValue("valueA3");
-        var entityA = TestdataListEntity.createWithValues("A", expectedValueA1, expectedValueA2, expectedValueA3);
+        var entityA = new TestdataListEntity("A", expectedValueA1, expectedValueA2, expectedValueA3);
         var expectedValueB1 = new TestdataListValue("valueB1");
         var expectedValueB2 = new TestdataListValue("valueB2");
         var expectedValueB3 = new TestdataListValue("valueB3");
-        var entityB = TestdataListEntity.createWithValues("B", expectedValueB1, expectedValueB2, expectedValueB3);
+        var entityB = new TestdataListEntity("B", expectedValueB1, expectedValueB2, expectedValueB3);
 
         // Swap between second and last position.
         var mockScoreDirector = (InnerScoreDirector<TestdataListSolution, ?>) mock(InnerScoreDirector.class);
@@ -501,10 +502,11 @@ class MoveDirectorTest {
         var expectedValueA1 = new TestdataListValue("valueA1");
         var expectedValueA2 = new TestdataListValue("valueA2");
         var expectedValueA3 = new TestdataListValue("valueA3");
-        var entityA = TestdataListEntity.createWithValues("A", expectedValueA1, expectedValueA2, expectedValueA3);
+        var entityA = new TestdataListEntity("A", expectedValueA1, expectedValueA2, expectedValueA3);
         var solution = new TestdataListSolution();
         solution.setEntityList(List.of(entityA));
         solution.setValueList(List.of(expectedValueA1, expectedValueA2, expectedValueA3));
+        SolutionManager.updateShadowVariables(solution);
 
         var f = new BavetConstraintStreamScoreDirectorFactory<>(solutionDescriptor,
                 constraintFactory -> new Constraint[] { constraintFactory.forEach(TestdataListEntity.class)

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListChangeMoveProviderTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListChangeMoveProviderTest.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.neighborhood.stream.DefaultMoveStreamFactory;
@@ -46,7 +47,7 @@ class ListChangeMoveProviderTest {
         var unassignedValue = solution.getValueList().get(0);
         var initiallyAssignedValue = solution.getValueList().get(1);
         e2.getValueList().add(initiallyAssignedValue);
-        solution.getEntityList().forEach(TestdataListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(solution);
 
         var moveIterable = createMoveIterable(new ListChangeMoveProvider<>(variableMetaModel), solutionDescriptor, solution);
         assertThat(moveIterable).hasSize(4);
@@ -118,7 +119,7 @@ class ListChangeMoveProviderTest {
         var e2 = solution.getEntityList().get(1);
         var initiallyAssignedValue = e2.getValueRange().get(0);
         e2.getValueList().add(initiallyAssignedValue);
-        solution.getEntityList().forEach(TestdataListEntityProvidingEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(solution);
 
         var moveIterable = createMoveIterable(new ListChangeMoveProvider<>(variableMetaModel), solutionDescriptor, solution);
         assertThat(moveIterable).hasSize(4);
@@ -268,7 +269,7 @@ class ListChangeMoveProviderTest {
         var v1 = solution.getValueList().get(0);
         var v2 = solution.getValueList().get(1);
         e2.getValueList().add(v1);
-        solution.getEntityList().forEach(TestdataAllowsUnassignedValuesListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(solution);
 
         var moveIterable = createMoveIterable(new ListChangeMoveProvider<>(variableMetaModel), solutionDescriptor, solution);
         assertThat(moveIterable).hasSize(5);

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListSwapMoveProviderTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListSwapMoveProviderTest.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.neighborhood.stream.DefaultMoveStreamFactory;
@@ -45,7 +46,7 @@ class ListSwapMoveProviderTest {
         e1.getValueList().add(assignedValue1);
         e2.getValueList().add(assignedValue2);
         e2.getValueList().add(assignedValue3);
-        solution.getEntityList().forEach(TestdataListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(solution);
 
         var moveIterable = createMoveIterable(new ListSwapMoveProvider<>(variableMetaModel), solutionDescriptor, solution);
         var moveList = StreamSupport.stream(moveIterable.spliterator(), false)
@@ -122,7 +123,7 @@ class ListSwapMoveProviderTest {
         e1.getValueList().clear();
         var initiallyAssignedValue = e2.getValueRange().get(0);
         e2.getValueList().add(initiallyAssignedValue);
-        solution.getEntityList().forEach(TestdataListEntityProvidingEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(solution);
 
         var moveIterable = createMoveIterable(new ListSwapMoveProvider<>(variableMetaModel), solutionDescriptor, solution);
         var moveList = StreamSupport.stream(moveIterable.spliterator(), false)

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/neighborhood/stream/enumerating/UniEnumeratingStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/neighborhood/stream/enumerating/UniEnumeratingStreamTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
 import ai.timefold.solver.core.impl.neighborhood.stream.enumerating.DatasetSession;
@@ -387,7 +388,7 @@ class UniEnumeratingStreamTest {
         unpinnedEntity.setPlanningPinToIndex(0);
         unpinnedEntity.setValueList(List.of(value4));
         // Properly set shadow variables based on the changes above.
-        solution.getEntityList().forEach(TestdataPinnedWithIndexListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(solution);
 
         var datasetSession = createSession(enumeratingStreamFactory, solution);
         var uniDatasetInstance = getDatasetInstance(datasetSession, uniDataset);
@@ -429,7 +430,7 @@ class UniEnumeratingStreamTest {
         unpinnedEntity.setPlanningPinToIndex(0);
         unpinnedEntity.setValueList(List.of(value4));
         // Properly set shadow variables based on the changes above.
-        solution.getEntityList().forEach(TestdataPinnedWithIndexListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(solution);
 
         var datasetSession = createSession(enumeratingStreamFactory, solution);
         var uniDatasetInstance = getDatasetInstance(datasetSession, uniDataset);
@@ -473,7 +474,7 @@ class UniEnumeratingStreamTest {
         var entityAddedLater = new TestdataPinnedWithIndexListEntity("entity4", value4);
         entityAddedLater.setPinned(true);
         // Properly set shadow variables based on the changes above.
-        solution.getEntityList().forEach(TestdataPinnedWithIndexListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(solution);
 
         var datasetSession = createSession(enumeratingStreamFactory, solution);
         var uniDatasetInstance = getDatasetInstance(datasetSession, uniDataset);
@@ -517,7 +518,7 @@ class UniEnumeratingStreamTest {
         var entityAddedLater = new TestdataPinnedWithIndexListEntity("entity4", value4);
         entityAddedLater.setPinned(true);
         // Properly set shadow variables based on the changes above.
-        solution.getEntityList().forEach(TestdataPinnedWithIndexListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(solution);
 
         var datasetSession = createSession(enumeratingStreamFactory, solution);
         var uniDatasetInstance = getDatasetInstance(datasetSession, uniDataset);

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/cascade/distinct/TestdataDifferentCascadingEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/cascade/distinct/TestdataDifferentCascadingEntity.java
@@ -1,7 +1,5 @@
 package ai.timefold.solver.core.testdomain.cascade.distinct;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -22,33 +20,6 @@ public class TestdataDifferentCascadingEntity extends TestdataObject {
     public static ListVariableDescriptor<TestdataDifferentCascadingSolution> buildVariableDescriptorForValueList() {
         return (ListVariableDescriptor<TestdataDifferentCascadingSolution>) buildEntityDescriptor()
                 .getGenuineVariableDescriptor("valueList");
-    }
-
-    public static TestdataDifferentCascadingEntity createWithValues(String code, TestdataDifferentCascadingValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataDifferentCascadingEntity(code, new ArrayList<>(Arrays.asList(values))).setUpShadowVariables();
-    }
-
-    TestdataDifferentCascadingEntity setUpShadowVariables() {
-        if (valueList != null && !valueList.isEmpty()) {
-            int i = 0;
-            var previous = valueList.get(i);
-            var current = valueList.get(i);
-            while (current != null) {
-                current.setEntity(this);
-                current.setPrevious(previous);
-                if (previous != null) {
-                    previous.setNext(current);
-                }
-                previous = current;
-                current = ++i < valueList.size() ? valueList.get(i) : null;
-            }
-            for (var v : valueList) {
-                v.updateCascadeValue();
-                v.updateSecondCascadeValue();
-            }
-        }
-        return this;
     }
 
     @PlanningListVariable(valueRangeProviderRefs = "valueRange")

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/cascade/multiple/TestdataMultipleCascadingEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/cascade/multiple/TestdataMultipleCascadingEntity.java
@@ -1,7 +1,5 @@
 package ai.timefold.solver.core.testdomain.cascade.multiple;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -22,32 +20,6 @@ public class TestdataMultipleCascadingEntity extends TestdataObject {
     public static ListVariableDescriptor<TestdataMultipleCascadingSolution> buildVariableDescriptorForValueList() {
         return (ListVariableDescriptor<TestdataMultipleCascadingSolution>) buildEntityDescriptor()
                 .getGenuineVariableDescriptor("valueList");
-    }
-
-    public static TestdataMultipleCascadingEntity createWithValues(String code, TestdataMultipleCascadingValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataMultipleCascadingEntity(code, new ArrayList<>(Arrays.asList(values))).setUpShadowVariables();
-    }
-
-    TestdataMultipleCascadingEntity setUpShadowVariables() {
-        if (valueList != null && !valueList.isEmpty()) {
-            int i = 0;
-            var previous = valueList.get(i);
-            var current = valueList.get(i);
-            while (current != null) {
-                current.setEntity(this);
-                current.setPrevious(previous);
-                if (previous != null) {
-                    previous.setNext(current);
-                }
-                previous = current;
-                current = ++i < valueList.size() ? valueList.get(i) : null;
-            }
-            for (var v : valueList) {
-                v.updateCascadeValue();
-            }
-        }
-        return this;
     }
 
     @PlanningListVariable(valueRangeProviderRefs = "valueRange")

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/cascade/single/TestdataSingleCascadingEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/cascade/single/TestdataSingleCascadingEntity.java
@@ -1,7 +1,5 @@
 package ai.timefold.solver.core.testdomain.cascade.single;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -22,32 +20,6 @@ public class TestdataSingleCascadingEntity extends TestdataObject {
     public static ListVariableDescriptor<TestdataSingleCascadingSolution> buildVariableDescriptorForValueList() {
         return (ListVariableDescriptor<TestdataSingleCascadingSolution>) buildEntityDescriptor()
                 .getGenuineVariableDescriptor("valueList");
-    }
-
-    public static TestdataSingleCascadingEntity createWithValues(String code, TestdataSingleCascadingValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataSingleCascadingEntity(code, new ArrayList<>(Arrays.asList(values))).setUpShadowVariables();
-    }
-
-    TestdataSingleCascadingEntity setUpShadowVariables() {
-        if (valueList != null && !valueList.isEmpty()) {
-            int i = 0;
-            var previous = valueList.get(i);
-            var current = valueList.get(i);
-            while (current != null) {
-                current.setEntity(this);
-                current.setPrevious(previous);
-                if (previous != null) {
-                    previous.setNext(current);
-                }
-                previous = current;
-                current = ++i < valueList.size() ? valueList.get(i) : null;
-            }
-            for (var v : valueList) {
-                v.updateCascadeValue();
-            }
-        }
-        return this;
     }
 
     @PlanningListVariable(valueRangeProviderRefs = "valueRange")

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/equals/list/TestdataEqualsByCodeListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/equals/list/TestdataEqualsByCodeListEntity.java
@@ -23,19 +23,6 @@ public class TestdataEqualsByCodeListEntity extends TestdataEqualsByCodeListObje
                 .getGenuineVariableDescriptor("valueList");
     }
 
-    public static TestdataEqualsByCodeListEntity createWithValues(String code, TestdataEqualsByCodeListValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataEqualsByCodeListEntity(code, values).setUpShadowVariables();
-    }
-
-    TestdataEqualsByCodeListEntity setUpShadowVariables() {
-        valueList.forEach(testdataEqualsByCodeListValue -> {
-            testdataEqualsByCodeListValue.setEntity(this);
-            testdataEqualsByCodeListValue.setIndex(valueList.indexOf(testdataEqualsByCodeListValue));
-        });
-        return this;
-    }
-
     @PlanningListVariable(valueRangeProviderRefs = "valueRange")
     private List<TestdataEqualsByCodeListValue> valueList;
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/equals/list/TestdataEqualsByCodeListSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/equals/list/TestdataEqualsByCodeListSolution.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 
 @PlanningSolution
@@ -50,7 +51,7 @@ public class TestdataEqualsByCodeListSolution extends TestdataEqualsByCodeListOb
         for (int i = 0; i < valueList.size(); i++) {
             entityList.get(i % entityList.size()).getValueList().add(valueList.get(i));
         }
-        entityList.forEach(TestdataEqualsByCodeListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(this);
         return this;
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListEntity.java
@@ -22,19 +22,6 @@ public class TestdataListEntity extends TestdataObject {
         return (ListVariableDescriptor<TestdataListSolution>) buildEntityDescriptor().getGenuineVariableDescriptor("valueList");
     }
 
-    public static TestdataListEntity createWithValues(String code, TestdataListValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataListEntity(code, values).setUpShadowVariables();
-    }
-
-    public TestdataListEntity setUpShadowVariables() {
-        valueList.forEach(testdataListValue -> {
-            testdataListValue.setEntity(this);
-            testdataListValue.setIndex(valueList.indexOf(testdataListValue));
-        });
-        return this;
-    }
-
     @PlanningListVariable(valueRangeProviderRefs = "valueRange")
     private List<TestdataListValue> valueList;
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListSolution.java
@@ -8,6 +8,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningSolutionMetaModel;
 
@@ -54,7 +55,7 @@ public class TestdataListSolution {
         for (int i = 0; i < valueList.size(); i++) {
             entityList.get(i % entityList.size()).getValueList().add(valueList.get(i));
         }
-        entityList.forEach(TestdataListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(this);
         return this;
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/TestdataPinnedListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/TestdataPinnedListEntity.java
@@ -24,19 +24,6 @@ public class TestdataPinnedListEntity extends TestdataObject {
                 .getGenuineVariableDescriptor("valueList");
     }
 
-    public static TestdataPinnedListEntity createWithValues(String code, TestdataPinnedListValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataPinnedListEntity(code, values).setUpShadowVariables();
-    }
-
-    TestdataPinnedListEntity setUpShadowVariables() {
-        valueList.forEach(testdataListValue -> {
-            testdataListValue.setEntity(this);
-            testdataListValue.setIndex(valueList.indexOf(testdataListValue));
-        });
-        return this;
-    }
-
     private List<TestdataPinnedListValue> valueList;
 
     @PlanningPin

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/TestdataPinnedListSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/TestdataPinnedListSolution.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 
 @PlanningSolution
@@ -50,7 +51,7 @@ public class TestdataPinnedListSolution {
         for (int i = 0; i < valueList.size(); i++) {
             entityList.get(i % entityList.size()).getValueList().add(valueList.get(i));
         }
-        entityList.forEach(TestdataPinnedListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(this);
         return this;
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/index/TestdataPinnedWithIndexListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/index/TestdataPinnedWithIndexListEntity.java
@@ -26,18 +26,6 @@ public class TestdataPinnedWithIndexListEntity extends TestdataObject {
                 .getGenuineVariableDescriptor("valueList");
     }
 
-    public static TestdataPinnedWithIndexListEntity createWithValues(String code, TestdataPinnedWithIndexListValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataPinnedWithIndexListEntity(code, values).setUpShadowVariables();
-    }
-
-    public TestdataPinnedWithIndexListEntity setUpShadowVariables() {
-        valueList.forEach(testdataListValue -> {
-            testdataListValue.setEntity(this);
-        });
-        return this;
-    }
-
     private List<TestdataPinnedWithIndexListValue> valueList;
 
     @PlanningPin

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/index/TestdataPinnedWithIndexListSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/index/TestdataPinnedWithIndexListSolution.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 
 @PlanningSolution
@@ -50,7 +51,7 @@ public class TestdataPinnedWithIndexListSolution {
         for (int i = 0; i < valueList.size(); i++) {
             entityList.get(i % entityList.size()).getValueList().add(valueList.get(i));
         }
-        entityList.forEach(TestdataPinnedWithIndexListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(this);
         return this;
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/noshadows/TestdataPinnedNoShadowsListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/noshadows/TestdataPinnedNoShadowsListEntity.java
@@ -25,18 +25,6 @@ public class TestdataPinnedNoShadowsListEntity extends TestdataObject {
                 .getGenuineVariableDescriptor("valueList");
     }
 
-    public static TestdataPinnedNoShadowsListEntity createWithValues(String code, TestdataPinnedNoShadowsListValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataPinnedNoShadowsListEntity(code, values).setUpShadowVariables();
-    }
-
-    TestdataPinnedNoShadowsListEntity setUpShadowVariables() {
-        valueList.forEach(testdataListValue -> {
-            testdataListValue.setIndex(valueList.indexOf(testdataListValue));
-        });
-        return this;
-    }
-
     private List<TestdataPinnedNoShadowsListValue> valueList;
 
     @PlanningPin

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/noshadows/TestdataPinnedNoShadowsListSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/noshadows/TestdataPinnedNoShadowsListSolution.java
@@ -9,6 +9,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 
 @PlanningSolution
@@ -50,7 +51,7 @@ public class TestdataPinnedNoShadowsListSolution {
         for (int i = 0; i < valueList.size(); i++) {
             entityList.get(i % entityList.size()).getValueList().add(valueList.get(i));
         }
-        entityList.forEach(TestdataPinnedNoShadowsListEntity::setUpShadowVariables);
+        SolutionManager.updateShadowVariables(this);
         return this;
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/shadowhistory/TestdataListEntityWithShadowHistory.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/shadowhistory/TestdataListEntityWithShadowHistory.java
@@ -23,27 +23,6 @@ public class TestdataListEntityWithShadowHistory extends TestdataObject {
                 .getGenuineVariableDescriptor("valueList");
     }
 
-    public static TestdataListEntityWithShadowHistory createWithValues(String code,
-            TestdataListValueWithShadowHistory... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataListEntityWithShadowHistory(code, values).setUpShadowVariables();
-    }
-
-    TestdataListEntityWithShadowHistory setUpShadowVariables() {
-        for (int i = 0; i < valueList.size(); i++) {
-            TestdataListValueWithShadowHistory value = valueList.get(i);
-            value.setEntity(this);
-            value.setIndex(i);
-            if (i > 0) {
-                value.setPrevious(valueList.get(i - 1));
-            }
-            if (i < valueList.size() - 1) {
-                value.setNext(valueList.get(i + 1));
-            }
-        }
-        return this;
-    }
-
     @PlanningListVariable(valueRangeProviderRefs = "valueRange")
     private List<TestdataListValueWithShadowHistory> valueList;
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/unassignedvar/TestdataAllowsUnassignedValuesListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/unassignedvar/TestdataAllowsUnassignedValuesListEntity.java
@@ -23,27 +23,6 @@ public class TestdataAllowsUnassignedValuesListEntity extends TestdataObject {
                 .getGenuineVariableDescriptor("valueList");
     }
 
-    public static TestdataAllowsUnassignedValuesListEntity createWithValues(String code,
-            TestdataAllowsUnassignedValuesListValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataAllowsUnassignedValuesListEntity(code, values).setUpShadowVariables();
-    }
-
-    public TestdataAllowsUnassignedValuesListEntity setUpShadowVariables() {
-        for (int i = 0; i < valueList.size(); i++) {
-            var testdataListValue = valueList.get(i);
-            testdataListValue.setEntity(this);
-            testdataListValue.setIndex(valueList.indexOf(testdataListValue));
-            if (i != 0) {
-                testdataListValue.setPrevious(valueList.get(i - 1));
-            }
-            if (i != valueList.size() - 1) {
-                testdataListValue.setNext(valueList.get(i + 1));
-            }
-        }
-        return this;
-    }
-
     private List<TestdataAllowsUnassignedValuesListValue> valueList;
 
     public TestdataAllowsUnassignedValuesListEntity() {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/unassignedvar/pinned/TestdataPinnedUnassignedValuesListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/unassignedvar/pinned/TestdataPinnedUnassignedValuesListEntity.java
@@ -25,27 +25,6 @@ public class TestdataPinnedUnassignedValuesListEntity extends TestdataObject {
                 .getGenuineVariableDescriptor("valueList");
     }
 
-    public static TestdataPinnedUnassignedValuesListEntity createWithValues(String code,
-            TestdataPinnedUnassignedValuesListValue... values) {
-        // Set up shadow variables to preserve consistency.
-        return new TestdataPinnedUnassignedValuesListEntity(code, values).setUpShadowVariables();
-    }
-
-    TestdataPinnedUnassignedValuesListEntity setUpShadowVariables() {
-        for (int i = 0; i < valueList.size(); i++) {
-            var testdataListValue = valueList.get(i);
-            testdataListValue.setEntity(this);
-            testdataListValue.setIndex(valueList.indexOf(testdataListValue));
-            if (i != 0) {
-                testdataListValue.setPrevious(valueList.get(i - 1));
-            }
-            if (i != valueList.size() - 1) {
-                testdataListValue.setNext(valueList.get(i + 1));
-            }
-        }
-        return this;
-    }
-
     private List<TestdataPinnedUnassignedValuesListValue> valueList;
     @PlanningPinToIndex
     private int planningPinToIndex = 0;

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/TestdataListEntityProvidingEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/TestdataListEntityProvidingEntity.java
@@ -52,14 +52,6 @@ public class TestdataListEntityProvidingEntity extends TestdataObject {
         }
     }
 
-    public TestdataListEntityProvidingEntity setUpShadowVariables() {
-        valueList.forEach(testdataListValue -> {
-            testdataListValue.setEntity(this);
-            testdataListValue.setIndex(valueList.indexOf(testdataListValue));
-        });
-        return this;
-    }
-
     public List<TestdataListEntityProvidingValue> getValueRange() {
         return valueRange;
     }


### PR DESCRIPTION
The fail-fast is not necessary since the latest improvements to Neighborhoods.
I added a lot of test coverage to `DefaultSolverTest` to prove that.
I also removed much of shadow var updating code, replacing it with a custom-made tool which we also recently introduced.