### PR TITLE
fix: make ComparableValue fallback to comparing identity hashcode when compareTo returns 0 (instead of when index are identity equal)

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ComparableValue.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ComparableValue.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.score.stream.collector.consecutive;
 
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
@@ -30,12 +31,11 @@ record ComparableValue<Value_, Point_ extends Comparable<Point_>>(Value_ value, 
         if (this == other) {
             return 0;
         }
-        var point1 = index;
-        var point2 = other.index;
-        if (point1 == point2) {
+        var out = index.compareTo(other.index);
+        if (out == 0) {
             return compareWithIdentityHashCode(value, other.value);
         }
-        return point1.compareTo(point2);
+        return out;
     }
 
     private int compareWithIdentityHashCode(Value_ o1, Value_ o2) {
@@ -49,4 +49,16 @@ record ComparableValue<Value_, Point_ extends Comparable<Point_>>(Value_ value, 
         return Integer.compare(identityHashCode1, identityHashCode2);
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof ComparableValue<?, ?> that)) {
+            return false;
+        }
+        return value == that.value && Objects.equals(index, that.index);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(System.identityHashCode(value), index);
+    }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ComparableValue.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ComparableValue.java
@@ -1,6 +1,5 @@
 package ai.timefold.solver.core.impl.score.stream.collector.consecutive;
 
-import java.util.Objects;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
@@ -54,11 +53,11 @@ record ComparableValue<Value_, Point_ extends Comparable<Point_>>(Value_ value, 
         if (!(object instanceof ComparableValue<?, ?> that)) {
             return false;
         }
-        return value == that.value && Objects.equals(index, that.index);
+        return value == that.value && index.equals(that.index);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(System.identityHashCode(value), index);
+        return 31 * System.identityHashCode(value) + index.hashCode();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTree.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTree.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.collector.consecutive;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
@@ -35,7 +35,7 @@ public final class ConsecutiveSetTree<Value_, Point_ extends Comparable<Point_>,
     final BiFunction<Point_, Point_, Difference_> sequenceLengthFunction;
     private final Difference_ maxDifference;
     private final Difference_ zeroDifference;
-    private final Map<Value_, ValueCount<ComparableValue<Value_, Point_>>> valueCountMap = new HashMap<>();
+    private final Map<Value_, ValueCount<ComparableValue<Value_, Point_>>> valueCountMap = new IdentityHashMap<>();
     private final NavigableMap<ComparableValue<Value_, Point_>, Value_> itemMap = new TreeMap<>();
     private final NavigableMap<ComparableValue<Value_, Point_>, SequenceImpl<Value_, Point_, Difference_>> startItemToSequence =
             new TreeMap<>();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTree.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTree.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.collector.consecutive;
 
 import java.util.Collection;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
@@ -35,7 +35,7 @@ public final class ConsecutiveSetTree<Value_, Point_ extends Comparable<Point_>,
     final BiFunction<Point_, Point_, Difference_> sequenceLengthFunction;
     private final Difference_ maxDifference;
     private final Difference_ zeroDifference;
-    private final Map<Value_, ValueCount<ComparableValue<Value_, Point_>>> valueCountMap = new IdentityHashMap<>();
+    private final Map<Value_, ValueCount<ComparableValue<Value_, Point_>>> valueCountMap = new HashMap<>();
     private final NavigableMap<ComparableValue<Value_, Point_>, Value_> itemMap = new TreeMap<>();
     private final NavigableMap<ComparableValue<Value_, Point_>, SequenceImpl<Value_, Point_, Difference_>> startItemToSequence =
             new TreeMap<>();
@@ -392,6 +392,13 @@ public final class ConsecutiveSetTree<Value_, Point_ extends Comparable<Point_>,
             count = 1;
         }
 
+        @Override
+        public String toString() {
+            return "ValueCount{" +
+                    "value=" + value +
+                    ", count=" + count +
+                    '}';
+        }
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTree.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTree.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.collector.consecutive;
 
 import java.util.Collection;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
@@ -35,7 +35,7 @@ public final class ConsecutiveSetTree<Value_, Point_ extends Comparable<Point_>,
     final BiFunction<Point_, Point_, Difference_> sequenceLengthFunction;
     private final Difference_ maxDifference;
     private final Difference_ zeroDifference;
-    private final Map<Value_, ValueCount<ComparableValue<Value_, Point_>>> valueCountMap = new IdentityHashMap<>();
+    private final Map<Value_, ValueCount<ComparableValue<Value_, Point_>>> valueCountMap = new HashMap<>();
     private final NavigableMap<ComparableValue<Value_, Point_>, Value_> itemMap = new TreeMap<>();
     private final NavigableMap<ComparableValue<Value_, Point_>, SequenceImpl<Value_, Point_, Difference_>> startItemToSequence =
             new TreeMap<>();

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
@@ -185,7 +185,7 @@ class ConsecutiveSetTreeTest {
         assertThat(breakList).isEmpty();
 
         tree.remove(c);
-        assertThat(sequenceList).hasSize(0);
+        assertThat(sequenceList).isEmpty();
         assertThat(tree.getBreaks()).isEmpty();
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
@@ -8,16 +8,15 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import ai.timefold.solver.core.api.score.stream.common.Break;
 import ai.timefold.solver.core.api.score.stream.common.Sequence;
 import ai.timefold.solver.core.api.score.stream.common.SequenceChain;
+import ai.timefold.solver.core.impl.util.MutableInt;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -29,9 +28,9 @@ class ConsecutiveSetTreeTest {
     @Test
     void testNonconsecutiveNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var start1 = atomic(3);
-        var middle3 = atomic(5);
-        var end7 = atomic(5);
+        var start1 = mutable(3);
+        var middle3 = mutable(5);
+        var end7 = mutable(5);
 
         tree.add(start1, 1);
         tree.add(middle3, 3);
@@ -64,22 +63,22 @@ class ConsecutiveSetTreeTest {
 
     @Test
     void testConsecutiveNumbers() {
-        ConsecutiveSetTree<AtomicInteger, Integer, Integer> tree = getIntegerConsecutiveSetTree();
-        AtomicInteger breakStart3 = atomic(3);
-        AtomicInteger breakEnd5 = atomic(5);
+        var tree = getIntegerConsecutiveSetTree();
+        var breakStart3 = mutable(3);
+        var breakEnd5 = mutable(5);
 
-        tree.add(atomic(1), 1);
-        tree.add(atomic(2), 2);
+        tree.add(mutable(1), 1);
+        tree.add(mutable(2), 2);
         tree.add(breakStart3, 3);
 
         tree.add(breakEnd5, 5);
-        tree.add(atomic(6), 6);
-        tree.add(atomic(7), 7);
-        tree.add(atomic(8), 8);
+        tree.add(mutable(6), 6);
+        tree.add(mutable(7), 7);
+        tree.add(mutable(8), 8);
 
-        IterableList<Sequence<AtomicInteger, Integer>> sequenceList = new IterableList<>(tree.getConsecutiveSequences());
+        var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
         assertThat(sequenceList).hasSize(2);
-        IterableList<Break<AtomicInteger, Integer>> breakList = new IterableList<>(tree.getBreaks());
+        var breakList = new IterableList<>(tree.getBreaks());
         assertThat(breakList).hasSize(1);
 
         assertThat(sequenceList.get(0).getCount()).isEqualTo(3);
@@ -90,9 +89,9 @@ class ConsecutiveSetTreeTest {
     @Test
     void testDuplicateNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var duplicateValue = atomic(3);
-        tree.add(atomic(1), 1);
-        tree.add(atomic(2), 2);
+        var duplicateValue = mutable(3);
+        tree.add(mutable(1), 1);
+        tree.add(mutable(2), 2);
         tree.add(duplicateValue, 3);
         tree.add(duplicateValue, 3);
         tree.add(duplicateValue, 3);
@@ -119,7 +118,7 @@ class ConsecutiveSetTreeTest {
             softly.assertThat(tree.getLastBreak()).isNull();
         });
 
-        duplicateValue.set(0); // mimic the constraint collector changing a planning variable
+        duplicateValue.setValue(0); // mimic the constraint collector changing a planning variable
 
         tree.remove(duplicateValue);
         assertThat(sequenceList).hasSize(1);
@@ -139,22 +138,22 @@ class ConsecutiveSetTreeTest {
 
     @Test
     void testConsecutiveReverseNumbers() {
-        ConsecutiveSetTree<AtomicInteger, Integer, Integer> tree = getIntegerConsecutiveSetTree();
-        AtomicInteger breakStart3 = atomic(3);
-        AtomicInteger breakEnd5 = atomic(5);
+        var tree = getIntegerConsecutiveSetTree();
+        var breakStart3 = mutable(3);
+        var breakEnd5 = mutable(5);
 
         tree.add(breakStart3, 3);
-        tree.add(atomic(2), 2);
-        tree.add(atomic(1), 1);
+        tree.add(mutable(2), 2);
+        tree.add(mutable(1), 1);
 
-        tree.add(atomic(8), 8);
-        tree.add(atomic(7), 7);
-        tree.add(atomic(6), 6);
+        tree.add(mutable(8), 8);
+        tree.add(mutable(7), 7);
+        tree.add(mutable(6), 6);
         tree.add(breakEnd5, 5);
 
-        IterableList<Sequence<AtomicInteger, Integer>> sequenceList = new IterableList<>(tree.getConsecutiveSequences());
+        var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
         assertThat(sequenceList).hasSize(2);
-        IterableList<Break<AtomicInteger, Integer>> breakList = new IterableList<>(tree.getBreaks());
+        var breakList = new IterableList<>(tree.getBreaks());
         assertThat(breakList).hasSize(1);
 
         assertThat(sequenceList.get(0).getCount()).isEqualTo(3);
@@ -164,19 +163,19 @@ class ConsecutiveSetTreeTest {
 
     @Test
     void testJoinOfTwoChains() {
-        ConsecutiveSetTree<AtomicInteger, Integer, Integer> tree = getIntegerConsecutiveSetTree();
-        tree.add(atomic(1), 1);
-        tree.add(atomic(2), 2);
-        tree.add(atomic(3), 3);
+        var tree = getIntegerConsecutiveSetTree();
+        tree.add(mutable(1), 1);
+        tree.add(mutable(2), 2);
+        tree.add(mutable(3), 3);
 
-        tree.add(atomic(5), 5);
-        tree.add(atomic(6), 6);
-        tree.add(atomic(7), 7);
-        tree.add(atomic(8), 8);
+        tree.add(mutable(5), 5);
+        tree.add(mutable(6), 6);
+        tree.add(mutable(7), 7);
+        tree.add(mutable(8), 8);
 
-        tree.add(atomic(4), 4);
+        tree.add(mutable(4), 4);
 
-        IterableList<Sequence<AtomicInteger, Integer>> sequenceList = new IterableList<>(tree.getConsecutiveSequences());
+        var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
 
         assertThat(sequenceList).hasSize(1);
         assertThat(sequenceList.get(0).getCount()).isEqualTo(8);
@@ -185,25 +184,25 @@ class ConsecutiveSetTreeTest {
 
     @Test
     void testBreakOfChain() {
-        ConsecutiveSetTree<AtomicInteger, Integer, Integer> tree = getIntegerConsecutiveSetTree();
-        AtomicInteger removed4 = atomic(4);
-        AtomicInteger breakStart3 = atomic(3);
-        AtomicInteger breakEnd5 = atomic(5);
+        var tree = getIntegerConsecutiveSetTree();
+        var removed4 = mutable(4);
+        var breakStart3 = mutable(3);
+        var breakEnd5 = mutable(5);
 
-        tree.add(atomic(1), 1);
-        tree.add(atomic(2), 2);
+        tree.add(mutable(1), 1);
+        tree.add(mutable(2), 2);
         tree.add(breakStart3, 3);
         tree.add(removed4, 4);
         tree.add(breakEnd5, 5);
-        tree.add(atomic(6), 6);
-        tree.add(atomic(7), 7);
+        tree.add(mutable(6), 6);
+        tree.add(mutable(7), 7);
 
-        removed4.set(8); // mimic changing a planning variable
+        removed4.setValue(8); // mimic changing a planning variable
         tree.remove(removed4);
 
-        IterableList<Sequence<AtomicInteger, Integer>> sequenceList = new IterableList<>(tree.getConsecutiveSequences());
+        var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
         assertThat(sequenceList).hasSize(2);
-        IterableList<Break<AtomicInteger, Integer>> breakList = new IterableList<>(tree.getBreaks());
+        var breakList = new IterableList<>(tree.getBreaks());
         assertThat(breakList).hasSize(1);
 
         assertThat(sequenceList).hasSize(2);
@@ -215,29 +214,29 @@ class ConsecutiveSetTreeTest {
 
     @Test
     void testChainRemoval() {
-        ConsecutiveSetTree<AtomicInteger, Integer, Integer> tree = getIntegerConsecutiveSetTree();
-        AtomicInteger removed1 = atomic(1);
-        AtomicInteger removed2 = atomic(2);
-        AtomicInteger removed3 = atomic(3);
+        var tree = getIntegerConsecutiveSetTree();
+        var removed1 = mutable(1);
+        var removed2 = mutable(2);
+        var removed3 = mutable(3);
 
         tree.add(removed1, 1);
         tree.add(removed2, 2);
         tree.add(removed3, 3);
 
-        tree.add(atomic(5), 5);
-        tree.add(atomic(6), 6);
-        tree.add(atomic(7), 7);
+        tree.add(mutable(5), 5);
+        tree.add(mutable(6), 6);
+        tree.add(mutable(7), 7);
 
         // mimic changing planning variables
-        removed1.set(3);
-        removed2.set(10);
-        removed3.set(-1);
+        removed1.setValue(3);
+        removed2.setValue(10);
+        removed3.setValue(-1);
 
         tree.remove(removed2);
         tree.remove(removed1);
         tree.remove(removed3);
 
-        IterableList<Sequence<AtomicInteger, Integer>> sequenceList = new IterableList<>(tree.getConsecutiveSequences());
+        var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
         assertThat(sequenceList).hasSize(1);
 
         assertThat(sequenceList.get(0).getCount()).isEqualTo(3);
@@ -246,31 +245,31 @@ class ConsecutiveSetTreeTest {
 
     @Test
     void testShorteningOfChain() {
-        ConsecutiveSetTree<AtomicInteger, Integer, Integer> tree = getIntegerConsecutiveSetTree();
-        AtomicInteger start = atomic(1);
-        AtomicInteger end = atomic(7);
+        var tree = getIntegerConsecutiveSetTree();
+        var start = mutable(1);
+        var end = mutable(7);
 
         tree.add(start, 1);
-        tree.add(atomic(2), 2);
-        tree.add(atomic(3), 3);
-        tree.add(atomic(4), 4);
-        tree.add(atomic(5), 5);
-        tree.add(atomic(6), 6);
+        tree.add(mutable(2), 2);
+        tree.add(mutable(3), 3);
+        tree.add(mutable(4), 4);
+        tree.add(mutable(5), 5);
+        tree.add(mutable(6), 6);
         tree.add(end, 7);
 
         // mimic changing planning variable
-        end.set(3);
+        end.setValue(3);
 
         tree.remove(end);
 
-        IterableList<Sequence<AtomicInteger, Integer>> sequenceList = new IterableList<>(tree.getConsecutiveSequences());
+        var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
 
         assertThat(sequenceList).hasSize(1);
         assertThat(sequenceList.get(0).getCount()).isEqualTo(6);
         assertThat(tree.getBreaks()).isEmpty();
 
         // mimic changing planning variable
-        start.set(3);
+        start.setValue(3);
 
         tree.remove(start);
         assertThat(sequenceList).hasSize(1);
@@ -280,15 +279,14 @@ class ConsecutiveSetTreeTest {
 
     @Test
     void testRandomSequences() {
-        Random random = new Random(1);
-        TreeMap<Integer, Integer> valueToCountMap = new TreeMap<>();
+        var random = new Random(1);
+        var valueToCountMap = new TreeMap<Integer, Integer>();
 
         // Tree we are testing is at most difference 2
-        ConsecutiveSetTree<Integer, Integer, Integer> tree =
-                new ConsecutiveSetTree<>((a, b) -> b - a, Integer::sum, 2, 0);
+        var tree = new ConsecutiveSetTree<Integer, Integer, Integer>((a, b) -> b - a, Integer::sum, 2, 0);
 
-        for (int i = 0; i < 1000; i++) {
-            int value = random.nextInt(64);
+        for (var i = 0; i < 1000; i++) {
+            var value = random.nextInt(64);
             String op;
             if (valueToCountMap.containsKey(value) && random.nextDouble() < 0.75) {
                 op = valueToCountMap.keySet().stream().map(Object::toString)
@@ -302,9 +300,9 @@ class ConsecutiveSetTreeTest {
                 tree.add(value, value);
             }
 
-            ConsecutiveSetTree<Integer, Integer, Integer> freshTree =
-                    new ConsecutiveSetTree<>((a, b) -> b - a, Integer::sum, 2, 0);
-            for (Map.Entry<Integer, Integer> entry : valueToCountMap.entrySet()) {
+            var freshTree =
+                    new ConsecutiveSetTree<Integer, Integer, Integer>((a, b) -> b - a, Integer::sum, 2, 0);
+            for (var entry : valueToCountMap.entrySet()) {
                 IntStream.range(0, entry.getValue()).map(index -> entry.getKey()).forEach(key -> freshTree.add(key, key));
             }
 
@@ -320,16 +318,16 @@ class ConsecutiveSetTreeTest {
 
     @Test
     void testRandomSequencesWithDuplicates() {
-        Random random = new Random(1);
-        TreeMap<Integer, Integer> valueToCountMap =
-                new TreeMap<>(Comparator.<Integer, Integer> comparing(Math::abs).thenComparing(System::identityHashCode));
+        var random = new Random(1);
+        var valueToCountMap =
+                new TreeMap<Integer, Integer>(
+                        Comparator.<Integer, Integer> comparing(Math::abs).thenComparing(System::identityHashCode));
 
         // Tree we are absolute value consecutive
-        ConsecutiveSetTree<Integer, Integer, Integer> tree =
-                new ConsecutiveSetTree<>((a, b) -> b - a, Integer::sum, 2, 0);
+        var tree = new ConsecutiveSetTree<Integer, Integer, Integer>((a, b) -> b - a, Integer::sum, 2, 0);
 
-        for (int i = 0; i < 1000; i++) {
-            int value = random.nextInt(64) - 32;
+        for (var i = 0; i < 1000; i++) {
+            var value = random.nextInt(64) - 32;
             String op;
             if (valueToCountMap.containsKey(value) && random.nextDouble() < 0.75) {
                 op = valueToCountMap.keySet().stream().map(Object::toString)
@@ -343,9 +341,8 @@ class ConsecutiveSetTreeTest {
                 tree.add(value, Math.abs(value));
             }
 
-            ConsecutiveSetTree<Integer, Integer, Integer> freshTree =
-                    new ConsecutiveSetTree<>((a, b) -> b - a, Integer::sum, 2, 0);
-            for (Map.Entry<Integer, Integer> entry : valueToCountMap.entrySet()) {
+            var freshTree = new ConsecutiveSetTree<Integer, Integer, Integer>((a, b) -> b - a, Integer::sum, 2, 0);
+            for (var entry : valueToCountMap.entrySet()) {
                 IntStream.range(0, entry.getValue()).map(index -> entry.getKey())
                         .forEach(key -> freshTree.add(key, Math.abs(key)));
             }
@@ -395,7 +392,7 @@ class ConsecutiveSetTreeTest {
                 .isEqualTo(getBreak(tree, t2, t3));
     }
 
-    private ConsecutiveSetTree<AtomicInteger, Integer, Integer> getIntegerConsecutiveSetTree() {
+    private ConsecutiveSetTree<MutableInt, Integer, Integer> getIntegerConsecutiveSetTree() {
         return new ConsecutiveSetTree<>((a, b) -> b - a, Integer::sum, 1, 0);
     }
 
@@ -410,8 +407,8 @@ class ConsecutiveSetTreeTest {
                 + consecutiveData.getConsecutiveSequences() + ")");
     }
 
-    private static AtomicInteger atomic(int value) {
-        return new AtomicInteger(value);
+    private static MutableInt mutable(int value) {
+        return new MutableInt(value);
     }
 
     private record Timeslot(OffsetDateTime from, OffsetDateTime to) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
@@ -31,7 +31,7 @@ class ConsecutiveSetTreeTest {
         var tree = getIntegerConsecutiveSetTree();
         var start1 = mutable(3);
         var middle3 = mutable(5);
-        var end7 = mutable(5);
+        var end7 = mutable(6);
 
         tree.add(start1, 1);
         tree.add(middle3, 3);
@@ -119,22 +119,14 @@ class ConsecutiveSetTreeTest {
             softly.assertThat(tree.getLastBreak()).isNull();
         });
 
+        tree.remove(duplicateValue);
+        tree.remove(duplicateValue);
+        tree.remove(duplicateValue);
         duplicateValue.setValue(0); // mimic the constraint collector changing a planning variable
 
-        tree.remove(duplicateValue);
-        assertThat(sequenceList).hasSize(1);
-        assertThat(sequenceList.get(0).getCount()).isEqualTo(3);
-        assertThat(breakList).isEmpty();
-
-        tree.remove(duplicateValue);
-        assertThat(sequenceList).hasSize(1);
-        assertThat(sequenceList.get(0).getCount()).isEqualTo(3);
-        assertThat(breakList).isEmpty();
-
-        tree.remove(duplicateValue);
         assertThat(sequenceList).hasSize(1);
         assertThat(sequenceList.get(0).getCount()).isEqualTo(2);
-        assertThat(tree.getBreaks()).isEmpty();
+        assertThat(breakList).isEmpty();
     }
 
     @Test
@@ -250,8 +242,8 @@ class ConsecutiveSetTreeTest {
         tree.add(mutable(6), 6);
         tree.add(mutable(7), 7);
 
-        removed4.setValue(8); // mimic changing a planning variable
         tree.remove(removed4);
+        removed4.setValue(8); // mimic changing a planning variable
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
         assertThat(sequenceList).hasSize(2);
@@ -281,13 +273,13 @@ class ConsecutiveSetTreeTest {
         tree.add(mutable(7), 7);
 
         // mimic changing planning variables
-        removed1.setValue(3);
-        removed2.setValue(10);
-        removed3.setValue(-1);
-
         tree.remove(removed2);
         tree.remove(removed1);
         tree.remove(removed3);
+
+        removed1.setValue(3);
+        removed2.setValue(10);
+        removed3.setValue(-1);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
         assertThat(sequenceList).hasSize(1);
@@ -311,9 +303,8 @@ class ConsecutiveSetTreeTest {
         tree.add(end, 7);
 
         // mimic changing planning variable
-        end.setValue(3);
-
         tree.remove(end);
+        end.setValue(3);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
 
@@ -322,9 +313,9 @@ class ConsecutiveSetTreeTest {
         assertThat(tree.getBreaks()).isEmpty();
 
         // mimic changing planning variable
+        tree.remove(start);
         start.setValue(3);
 
-        tree.remove(start);
         assertThat(sequenceList).hasSize(1);
         assertThat(sequenceList.get(0).getCount()).isEqualTo(5);
         assertThat(tree.getBreaks()).isEmpty();

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
@@ -29,9 +29,9 @@ class ConsecutiveSetTreeTest {
     @Test
     void testNonconsecutiveNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var start1 = atomic(3);
-        var middle3 = atomic(5);
-        var end7 = atomic(5);
+        var start1 = mutable(3);
+        var middle3 = mutable(5);
+        var end7 = mutable(5);
 
         tree.add(start1, 1);
         tree.add(middle3, 3);
@@ -65,17 +65,17 @@ class ConsecutiveSetTreeTest {
     @Test
     void testConsecutiveNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var breakStart3 = atomic(3);
-        var breakEnd5 = atomic(5);
+        var breakStart3 = mutable(3);
+        var breakEnd5 = mutable(5);
 
-        tree.add(atomic(1), 1);
-        tree.add(atomic(2), 2);
+        tree.add(mutable(1), 1);
+        tree.add(mutable(2), 2);
         tree.add(breakStart3, 3);
 
         tree.add(breakEnd5, 5);
-        tree.add(atomic(6), 6);
-        tree.add(atomic(7), 7);
-        tree.add(atomic(8), 8);
+        tree.add(mutable(6), 6);
+        tree.add(mutable(7), 7);
+        tree.add(mutable(8), 8);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
         assertThat(sequenceList).hasSize(2);
@@ -90,9 +90,9 @@ class ConsecutiveSetTreeTest {
     @Test
     void testDuplicateNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var duplicateValue = atomic(3);
-        tree.add(atomic(1), 1);
-        tree.add(atomic(2), 2);
+        var duplicateValue = mutable(3);
+        tree.add(mutable(1), 1);
+        tree.add(mutable(2), 2);
         tree.add(duplicateValue, 3);
         tree.add(duplicateValue, 3);
         tree.add(duplicateValue, 3);
@@ -119,7 +119,7 @@ class ConsecutiveSetTreeTest {
             softly.assertThat(tree.getLastBreak()).isNull();
         });
 
-        duplicateValue.set(0); // mimic the constraint collector changing a planning variable
+        duplicateValue.setValue(0); // mimic the constraint collector changing a planning variable
 
         tree.remove(duplicateValue);
         assertThat(sequenceList).hasSize(1);
@@ -192,16 +192,16 @@ class ConsecutiveSetTreeTest {
     @Test
     void testConsecutiveReverseNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var breakStart3 = atomic(3);
-        var breakEnd5 = atomic(5);
+        var breakStart3 = mutable(3);
+        var breakEnd5 = mutable(5);
 
         tree.add(breakStart3, 3);
-        tree.add(atomic(2), 2);
-        tree.add(atomic(1), 1);
+        tree.add(mutable(2), 2);
+        tree.add(mutable(1), 1);
 
-        tree.add(atomic(8), 8);
-        tree.add(atomic(7), 7);
-        tree.add(atomic(6), 6);
+        tree.add(mutable(8), 8);
+        tree.add(mutable(7), 7);
+        tree.add(mutable(6), 6);
         tree.add(breakEnd5, 5);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
@@ -217,16 +217,16 @@ class ConsecutiveSetTreeTest {
     @Test
     void testJoinOfTwoChains() {
         var tree = getIntegerConsecutiveSetTree();
-        tree.add(atomic(1), 1);
-        tree.add(atomic(2), 2);
-        tree.add(atomic(3), 3);
+        tree.add(mutable(1), 1);
+        tree.add(mutable(2), 2);
+        tree.add(mutable(3), 3);
 
-        tree.add(atomic(5), 5);
-        tree.add(atomic(6), 6);
-        tree.add(atomic(7), 7);
-        tree.add(atomic(8), 8);
+        tree.add(mutable(5), 5);
+        tree.add(mutable(6), 6);
+        tree.add(mutable(7), 7);
+        tree.add(mutable(8), 8);
 
-        tree.add(atomic(4), 4);
+        tree.add(mutable(4), 4);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
 
@@ -238,19 +238,19 @@ class ConsecutiveSetTreeTest {
     @Test
     void testBreakOfChain() {
         var tree = getIntegerConsecutiveSetTree();
-        var removed4 = atomic(4);
-        var breakStart3 = atomic(3);
-        var breakEnd5 = atomic(5);
+        var removed4 = mutable(4);
+        var breakStart3 = mutable(3);
+        var breakEnd5 = mutable(5);
 
-        tree.add(atomic(1), 1);
-        tree.add(atomic(2), 2);
+        tree.add(mutable(1), 1);
+        tree.add(mutable(2), 2);
         tree.add(breakStart3, 3);
         tree.add(removed4, 4);
         tree.add(breakEnd5, 5);
-        tree.add(atomic(6), 6);
-        tree.add(atomic(7), 7);
+        tree.add(mutable(6), 6);
+        tree.add(mutable(7), 7);
 
-        removed4.set(8); // mimic changing a planning variable
+        removed4.setValue(8); // mimic changing a planning variable
         tree.remove(removed4);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
@@ -268,22 +268,22 @@ class ConsecutiveSetTreeTest {
     @Test
     void testChainRemoval() {
         var tree = getIntegerConsecutiveSetTree();
-        var removed1 = atomic(1);
-        var removed2 = atomic(2);
-        var removed3 = atomic(3);
+        var removed1 = mutable(1);
+        var removed2 = mutable(2);
+        var removed3 = mutable(3);
 
         tree.add(removed1, 1);
         tree.add(removed2, 2);
         tree.add(removed3, 3);
 
-        tree.add(atomic(5), 5);
-        tree.add(atomic(6), 6);
-        tree.add(atomic(7), 7);
+        tree.add(mutable(5), 5);
+        tree.add(mutable(6), 6);
+        tree.add(mutable(7), 7);
 
         // mimic changing planning variables
-        removed1.set(3);
-        removed2.set(10);
-        removed3.set(-1);
+        removed1.setValue(3);
+        removed2.setValue(10);
+        removed3.setValue(-1);
 
         tree.remove(removed2);
         tree.remove(removed1);
@@ -299,19 +299,19 @@ class ConsecutiveSetTreeTest {
     @Test
     void testShorteningOfChain() {
         var tree = getIntegerConsecutiveSetTree();
-        var start = atomic(1);
-        var end = atomic(7);
+        var start = mutable(1);
+        var end = mutable(7);
 
         tree.add(start, 1);
-        tree.add(atomic(2), 2);
-        tree.add(atomic(3), 3);
-        tree.add(atomic(4), 4);
-        tree.add(atomic(5), 5);
-        tree.add(atomic(6), 6);
+        tree.add(mutable(2), 2);
+        tree.add(mutable(3), 3);
+        tree.add(mutable(4), 4);
+        tree.add(mutable(5), 5);
+        tree.add(mutable(6), 6);
         tree.add(end, 7);
 
         // mimic changing planning variable
-        end.set(3);
+        end.setValue(3);
 
         tree.remove(end);
 
@@ -322,7 +322,7 @@ class ConsecutiveSetTreeTest {
         assertThat(tree.getBreaks()).isEmpty();
 
         // mimic changing planning variable
-        start.set(3);
+        start.setValue(3);
 
         tree.remove(start);
         assertThat(sequenceList).hasSize(1);
@@ -445,7 +445,7 @@ class ConsecutiveSetTreeTest {
                 .isEqualTo(getBreak(tree, t2, t3));
     }
 
-    private ConsecutiveSetTree<AtomicInteger, Integer, Integer> getIntegerConsecutiveSetTree() {
+    private ConsecutiveSetTree<MutableInt, Integer, Integer> getIntegerConsecutiveSetTree() {
         return new ConsecutiveSetTree<>((a, b) -> b - a, Integer::sum, 1, 0);
     }
 
@@ -467,8 +467,8 @@ class ConsecutiveSetTreeTest {
                 + consecutiveData.getConsecutiveSequences() + ")");
     }
 
-    private static AtomicInteger atomic(int value) {
-        return new AtomicInteger(value);
+    private static MutableInt mutable(int value) {
+        return new MutableInt(value);
     }
 
     private record Timeslot(OffsetDateTime from, OffsetDateTime to) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/collector/consecutive/ConsecutiveSetTreeTest.java
@@ -10,6 +10,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Random;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -28,9 +29,9 @@ class ConsecutiveSetTreeTest {
     @Test
     void testNonconsecutiveNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var start1 = mutable(3);
-        var middle3 = mutable(5);
-        var end7 = mutable(5);
+        var start1 = atomic(3);
+        var middle3 = atomic(5);
+        var end7 = atomic(5);
 
         tree.add(start1, 1);
         tree.add(middle3, 3);
@@ -64,17 +65,17 @@ class ConsecutiveSetTreeTest {
     @Test
     void testConsecutiveNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var breakStart3 = mutable(3);
-        var breakEnd5 = mutable(5);
+        var breakStart3 = atomic(3);
+        var breakEnd5 = atomic(5);
 
-        tree.add(mutable(1), 1);
-        tree.add(mutable(2), 2);
+        tree.add(atomic(1), 1);
+        tree.add(atomic(2), 2);
         tree.add(breakStart3, 3);
 
         tree.add(breakEnd5, 5);
-        tree.add(mutable(6), 6);
-        tree.add(mutable(7), 7);
-        tree.add(mutable(8), 8);
+        tree.add(atomic(6), 6);
+        tree.add(atomic(7), 7);
+        tree.add(atomic(8), 8);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
         assertThat(sequenceList).hasSize(2);
@@ -89,9 +90,9 @@ class ConsecutiveSetTreeTest {
     @Test
     void testDuplicateNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var duplicateValue = mutable(3);
-        tree.add(mutable(1), 1);
-        tree.add(mutable(2), 2);
+        var duplicateValue = atomic(3);
+        tree.add(atomic(1), 1);
+        tree.add(atomic(2), 2);
         tree.add(duplicateValue, 3);
         tree.add(duplicateValue, 3);
         tree.add(duplicateValue, 3);
@@ -118,7 +119,7 @@ class ConsecutiveSetTreeTest {
             softly.assertThat(tree.getLastBreak()).isNull();
         });
 
-        duplicateValue.setValue(0); // mimic the constraint collector changing a planning variable
+        duplicateValue.set(0); // mimic the constraint collector changing a planning variable
 
         tree.remove(duplicateValue);
         assertThat(sequenceList).hasSize(1);
@@ -137,18 +138,70 @@ class ConsecutiveSetTreeTest {
     }
 
     @Test
+    void testDuplicateIndexes() {
+        var THREE_1 = new MutableInt(3);
+        var THREE_2 = new MutableInt(3);
+        var THREE_3 = new MutableInt(3);
+
+        var a = new AtomicInteger(0);
+        var b = new AtomicInteger(1);
+        var c = new AtomicInteger(2);
+
+        var tree = getMutableIntConsecutiveSetTree();
+        tree.add(a, THREE_1);
+        tree.add(b, THREE_2);
+        tree.add(c, THREE_3);
+
+        var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
+        assertSoftly(softly -> {
+            softly.assertThat(sequenceList).hasSize(1);
+            softly.assertThat(tree.getFirstSequence())
+                    .usingRecursiveComparison()
+                    .isEqualTo(sequenceList.get(0));
+            softly.assertThat(tree.getLastSequence())
+                    .usingRecursiveComparison()
+                    .isEqualTo(sequenceList.get(0));
+            softly.assertThat(sequenceList)
+                    .first()
+                    .matches(sequence -> sequence.getCount() == 3);
+        });
+
+        var breakList = new IterableList<>(tree.getBreaks());
+        assertSoftly(softly -> {
+            softly.assertThat(breakList).isEmpty();
+            softly.assertThat(tree.getBreaks()).isEmpty();
+            softly.assertThat(tree.getFirstBreak()).isNull();
+            softly.assertThat(tree.getLastBreak()).isNull();
+        });
+
+        tree.remove(a);
+        assertThat(sequenceList).hasSize(1);
+        assertThat(sequenceList.get(0).getCount()).isEqualTo(2);
+        assertThat(breakList).isEmpty();
+
+        tree.remove(b);
+        assertThat(sequenceList).hasSize(1);
+        assertThat(sequenceList.get(0).getCount()).isEqualTo(1);
+        assertThat(breakList).isEmpty();
+
+        tree.remove(c);
+        assertThat(sequenceList).hasSize(0);
+        assertThat(tree.getBreaks()).isEmpty();
+    }
+
+    @Test
     void testConsecutiveReverseNumbers() {
         var tree = getIntegerConsecutiveSetTree();
-        var breakStart3 = mutable(3);
-        var breakEnd5 = mutable(5);
+        var breakStart3 = atomic(3);
+        var breakEnd5 = atomic(5);
 
         tree.add(breakStart3, 3);
-        tree.add(mutable(2), 2);
-        tree.add(mutable(1), 1);
+        tree.add(atomic(2), 2);
+        tree.add(atomic(1), 1);
 
-        tree.add(mutable(8), 8);
-        tree.add(mutable(7), 7);
-        tree.add(mutable(6), 6);
+        tree.add(atomic(8), 8);
+        tree.add(atomic(7), 7);
+        tree.add(atomic(6), 6);
         tree.add(breakEnd5, 5);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
@@ -164,16 +217,16 @@ class ConsecutiveSetTreeTest {
     @Test
     void testJoinOfTwoChains() {
         var tree = getIntegerConsecutiveSetTree();
-        tree.add(mutable(1), 1);
-        tree.add(mutable(2), 2);
-        tree.add(mutable(3), 3);
+        tree.add(atomic(1), 1);
+        tree.add(atomic(2), 2);
+        tree.add(atomic(3), 3);
 
-        tree.add(mutable(5), 5);
-        tree.add(mutable(6), 6);
-        tree.add(mutable(7), 7);
-        tree.add(mutable(8), 8);
+        tree.add(atomic(5), 5);
+        tree.add(atomic(6), 6);
+        tree.add(atomic(7), 7);
+        tree.add(atomic(8), 8);
 
-        tree.add(mutable(4), 4);
+        tree.add(atomic(4), 4);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
 
@@ -185,19 +238,19 @@ class ConsecutiveSetTreeTest {
     @Test
     void testBreakOfChain() {
         var tree = getIntegerConsecutiveSetTree();
-        var removed4 = mutable(4);
-        var breakStart3 = mutable(3);
-        var breakEnd5 = mutable(5);
+        var removed4 = atomic(4);
+        var breakStart3 = atomic(3);
+        var breakEnd5 = atomic(5);
 
-        tree.add(mutable(1), 1);
-        tree.add(mutable(2), 2);
+        tree.add(atomic(1), 1);
+        tree.add(atomic(2), 2);
         tree.add(breakStart3, 3);
         tree.add(removed4, 4);
         tree.add(breakEnd5, 5);
-        tree.add(mutable(6), 6);
-        tree.add(mutable(7), 7);
+        tree.add(atomic(6), 6);
+        tree.add(atomic(7), 7);
 
-        removed4.setValue(8); // mimic changing a planning variable
+        removed4.set(8); // mimic changing a planning variable
         tree.remove(removed4);
 
         var sequenceList = new IterableList<>(tree.getConsecutiveSequences());
@@ -215,22 +268,22 @@ class ConsecutiveSetTreeTest {
     @Test
     void testChainRemoval() {
         var tree = getIntegerConsecutiveSetTree();
-        var removed1 = mutable(1);
-        var removed2 = mutable(2);
-        var removed3 = mutable(3);
+        var removed1 = atomic(1);
+        var removed2 = atomic(2);
+        var removed3 = atomic(3);
 
         tree.add(removed1, 1);
         tree.add(removed2, 2);
         tree.add(removed3, 3);
 
-        tree.add(mutable(5), 5);
-        tree.add(mutable(6), 6);
-        tree.add(mutable(7), 7);
+        tree.add(atomic(5), 5);
+        tree.add(atomic(6), 6);
+        tree.add(atomic(7), 7);
 
         // mimic changing planning variables
-        removed1.setValue(3);
-        removed2.setValue(10);
-        removed3.setValue(-1);
+        removed1.set(3);
+        removed2.set(10);
+        removed3.set(-1);
 
         tree.remove(removed2);
         tree.remove(removed1);
@@ -246,19 +299,19 @@ class ConsecutiveSetTreeTest {
     @Test
     void testShorteningOfChain() {
         var tree = getIntegerConsecutiveSetTree();
-        var start = mutable(1);
-        var end = mutable(7);
+        var start = atomic(1);
+        var end = atomic(7);
 
         tree.add(start, 1);
-        tree.add(mutable(2), 2);
-        tree.add(mutable(3), 3);
-        tree.add(mutable(4), 4);
-        tree.add(mutable(5), 5);
-        tree.add(mutable(6), 6);
+        tree.add(atomic(2), 2);
+        tree.add(atomic(3), 3);
+        tree.add(atomic(4), 4);
+        tree.add(atomic(5), 5);
+        tree.add(atomic(6), 6);
         tree.add(end, 7);
 
         // mimic changing planning variable
-        end.setValue(3);
+        end.set(3);
 
         tree.remove(end);
 
@@ -269,7 +322,7 @@ class ConsecutiveSetTreeTest {
         assertThat(tree.getBreaks()).isEmpty();
 
         // mimic changing planning variable
-        start.setValue(3);
+        start.set(3);
 
         tree.remove(start);
         assertThat(sequenceList).hasSize(1);
@@ -392,8 +445,15 @@ class ConsecutiveSetTreeTest {
                 .isEqualTo(getBreak(tree, t2, t3));
     }
 
-    private ConsecutiveSetTree<MutableInt, Integer, Integer> getIntegerConsecutiveSetTree() {
+    private ConsecutiveSetTree<AtomicInteger, Integer, Integer> getIntegerConsecutiveSetTree() {
         return new ConsecutiveSetTree<>((a, b) -> b - a, Integer::sum, 1, 0);
+    }
+
+    private ConsecutiveSetTree<AtomicInteger, MutableInt, MutableInt> getMutableIntConsecutiveSetTree() {
+        return new ConsecutiveSetTree<>(
+                (a, b) -> new MutableInt(b.intValue() - a.intValue()),
+                (a, b) -> new MutableInt(a.intValue() + b.intValue()),
+                new MutableInt(1), new MutableInt(0));
     }
 
     private <ValueType_, DifferenceType_ extends Comparable<DifferenceType_>> Break<ValueType_, DifferenceType_>
@@ -407,8 +467,8 @@ class ConsecutiveSetTreeTest {
                 + consecutiveData.getConsecutiveSequences() + ")");
     }
 
-    private static MutableInt mutable(int value) {
-        return new MutableInt(value);
+    private static AtomicInteger atomic(int value) {
+        return new AtomicInteger(value);
     }
 
     private record Timeslot(OffsetDateTime from, OffsetDateTime to) {


### PR DESCRIPTION
Previous, the code assumed  a.compareTo(b) == 0 if and only if
a == b; this is false; in particular, when LocalDate or other
reference type is used as the point. This cause the fallback identity hashcode
compare to not happen, and thus erases an entry in the `TreeMap`.