### PR TITLE
chore: improve MutableSolutionView API around list variables

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/move/DefaultMoveRunner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/move/DefaultMoveRunner.java
@@ -40,4 +40,9 @@ public final class DefaultMoveRunner<Solution_> implements MoveRunner<Solution_>
         return new DefaultMoveRunContext<>(scoreDirector);
     }
 
+    @Override
+    public PlanningSolutionMetaModel<Solution_> getSolutionMetaModel() {
+        return scoreDirectorFactory.getSolutionDescriptor().getMetaModel();
+    }
+
 }

--- a/core/src/main/java/ai/timefold/solver/core/preview/api/move/MoveRunner.java
+++ b/core/src/main/java/ai/timefold/solver/core/preview/api/move/MoveRunner.java
@@ -4,7 +4,9 @@ import java.util.Objects;
 
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.move.DefaultMoveRunner;
+import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningEntityMetaModel;
 import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningSolutionMetaModel;
+import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningVariableMetaModel;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -20,9 +22,14 @@ import org.jspecify.annotations.NullMarked;
  * 
  * <pre>{@code
  *     var runner = MoveRunner.build(MySolution.class, MyEntity.class);
- *     var context = runner.using(solution);
+ *     var basicVariable = runner.getSolutionMetaModel()
+ *          .genuineEntity(MyEntity.class)
+ *          .basicVariable();
+ *
+ *     var move = Moves.change(basicVariable, ..., ...);
  *
  *     // Permanent execution
+ *     var context = runner.using(solution);
  *     context.execute(move);
  *
  *     // Temporary execution with automatic undo
@@ -48,6 +55,10 @@ public interface MoveRunner<Solution_> {
      * These are heavy operations performed once and cached for reuse.
      * <p>
      * Shadow variables are initialized later when a solution is bound via {@link #using(Object)}.
+     * <p>
+     * Using this method will create a new {@link PlanningSolutionMetaModel} internally,
+     * which can be accessed later via {@link #getSolutionMetaModel()}
+     * and should be used to construct moves for this runner.
      *
      * @param solutionClass the planning solution class; must not be null
      * @param entityClasses the planning entity classes; must not be empty
@@ -64,7 +75,8 @@ public interface MoveRunner<Solution_> {
     }
 
     /**
-     * As defined by {@link #build(Class, Class[])}, but using the meta-model to extract classes.
+     * As defined by {@link #build(Class, Class[])}, but using the given meta-model to extract classes.
+     * This meta-model instance can be accessed later via {@link #getSolutionMetaModel()}
      */
     static <Solution_> MoveRunner<Solution_> build(PlanningSolutionMetaModel<Solution_> solutionMetaModel) {
         return new DefaultMoveRunner<>(solutionMetaModel, null);
@@ -84,5 +96,14 @@ public interface MoveRunner<Solution_> {
      * @return a new execution context bound to the given solution with initialized shadow variables
      */
     MoveRunContext<Solution_> using(Solution_ solution);
+
+    /**
+     * Gets the planning solution meta-model associated with this {@link MoveRunner}.
+     * All moves executed by this runner must use
+     * the {@link PlanningEntityMetaModel} and {@link PlanningVariableMetaModel} instances provided by this model.
+     *
+     * @return the planning solution meta-model
+     */
+    PlanningSolutionMetaModel<Solution_> getSolutionMetaModel();
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/preview/api/move/builtin/ListAssignMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/preview/api/move/builtin/ListAssignMove.java
@@ -33,7 +33,7 @@ public class ListAssignMove<Solution_, Entity_, Value_> extends AbstractMove<Sol
 
     @Override
     public void execute(MutableSolutionView<Solution_> mutableSolutionView) {
-        mutableSolutionView.assignValue(variableMetaModel, planningValue, destinationEntity, destinationIndex);
+        mutableSolutionView.assignValueAndInsert(variableMetaModel, planningValue, destinationEntity, destinationIndex);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/preview/api/move/builtin/ListChangeMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/preview/api/move/builtin/ListChangeMove.java
@@ -126,8 +126,10 @@ public class ListChangeMove<Solution_, Entity_, Value_> extends AbstractMove<Sol
 
     @Override
     public void execute(MutableSolutionView<Solution_> solutionView) {
-        planningValue = solutionView.moveValueBetweenLists(variableMetaModel, sourceEntity, sourceIndex, destinationEntity,
-                destinationIndex);
+        planningValue = (sourceEntity == destinationEntity)
+                ? solutionView.moveValueInList(variableMetaModel, sourceEntity, sourceIndex, destinationIndex)
+                : solutionView.moveValueBetweenLists(variableMetaModel, sourceEntity, sourceIndex, destinationEntity,
+                        destinationIndex);
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ChangeMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ChangeMoveTest.java
@@ -23,7 +23,9 @@ class ChangeMoveTest {
 
         var changeMove = Moves.change(variableMetaModel, entity, newValue);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class).using(solution).execute(changeMove);
+        MoveRunner.build(solutionMetaModel)
+                .using(solution)
+                .execute(changeMove);
 
         assertThat(entity.getValue()).isEqualTo(newValue);
     }
@@ -39,7 +41,9 @@ class ChangeMoveTest {
 
         var changeMove = Moves.change(variableMetaModel, entity, null);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class).using(solution).execute(changeMove);
+        MoveRunner.build(solutionMetaModel)
+                .using(solution)
+                .execute(changeMove);
 
         assertThat(entity.getValue()).isNull();
     }
@@ -61,7 +65,8 @@ class ChangeMoveTest {
         var move2 = Moves.change(variableMetaModel, entity2, value1);
         var move3 = Moves.change(variableMetaModel, entity3, value2);
 
-        var context = MoveRunner.build(TestdataSolution.class, TestdataEntity.class).using(solution);
+        var context = MoveRunner.build(solutionMetaModel)
+                .using(solution);
         context.execute(move1);
         context.execute(move2);
         context.execute(move3);
@@ -84,7 +89,7 @@ class ChangeMoveTest {
 
         var changeMove = Moves.change(variableMetaModel, entity, newValue);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .executeTemporarily(changeMove, view -> {
                     // During temporary execution, value should be changed
@@ -116,7 +121,7 @@ class ChangeMoveTest {
         var move3 = Moves.change(variableMetaModel, entity3, value2);
         var compositeMove = Moves.compose(move1, move2, move3);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .executeTemporarily(compositeMove, view -> {
                     // All changes should be applied

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/CompositeMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/CompositeMoveTest.java
@@ -30,7 +30,7 @@ class CompositeMoveTest {
         var move3 = Moves.change(variableMetaModel, entity3, value2);
         var compositeMove = Moves.compose(move1, move2, move3);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(compositeMove);
 
@@ -58,7 +58,7 @@ class CompositeMoveTest {
         var changeMove = Moves.change(variableMetaModel, entity3, value3);
         var compositeMove = Moves.compose(swapMove, changeMove);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(compositeMove);
 
@@ -81,7 +81,7 @@ class CompositeMoveTest {
         var changeMove = Moves.change(variableMetaModel, entity, newValue);
         var compositeMove = Moves.compose(changeMove);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(compositeMove);
 
@@ -115,7 +115,7 @@ class CompositeMoveTest {
 
         var nestedComposite = Moves.compose(composite1, composite2);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(nestedComposite);
 
@@ -148,7 +148,7 @@ class CompositeMoveTest {
         var move3 = Moves.change(variableMetaModel, entity3, value2);
         var compositeMove = Moves.compose(move1, move2, move3);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .executeTemporarily(compositeMove, view -> {
                     // All changes should be applied
@@ -193,7 +193,7 @@ class CompositeMoveTest {
 
         var nestedComposite = Moves.compose(composite1, composite2);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .executeTemporarily(nestedComposite, view -> {
                     // All 4 changes should be applied

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListAssignMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListAssignMoveTest.java
@@ -23,7 +23,7 @@ class ListAssignMoveTest {
 
         var assignMove = Moves.assign(variableMetaModel, value, entity, 0);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class).using(solution)
+        MoveRunner.build(solutionMetaModel).using(solution)
                 .execute(assignMove);
 
         assertThat(entity.getValueList()).hasSize(1);
@@ -46,8 +46,8 @@ class ListAssignMoveTest {
         var move2 = Moves.assign(variableMetaModel, value2, entity, 1);
         var move3 = Moves.assign(variableMetaModel, value3, entity, 1); // Insert at position 1
 
-        var runner = MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class);
-        var context = runner.using(solution);
+        var context = MoveRunner.build(solutionMetaModel)
+                .using(solution);
         context.execute(move1);
         context.execute(move2);
         context.execute(move3);
@@ -77,8 +77,8 @@ class ListAssignMoveTest {
         var move2 = Moves.assign(variableMetaModel, value2, entity2, 0);
         var move3 = Moves.assign(variableMetaModel, value3, entity3, 0);
 
-        var runner = MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class);
-        var context = runner.using(solution);
+        var context = MoveRunner.build(solutionMetaModel)
+                .using(solution);
         context.execute(move1);
         context.execute(move2);
         context.execute(move3);
@@ -100,7 +100,8 @@ class ListAssignMoveTest {
 
         var assignMove = Moves.assign(variableMetaModel, value, entity, 0);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class).using(solution)
+        MoveRunner.build(solutionMetaModel)
+                .using(solution)
                 .executeTemporarily(assignMove, view -> {
                     // During temporary execution, value should be assigned
                     assertThat(entity.getValueList()).hasSize(1);
@@ -128,7 +129,8 @@ class ListAssignMoveTest {
         var move3 = Moves.assign(variableMetaModel, value3, entity, 1);
         var compositeMove = Moves.compose(move1, move2, move3);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class).using(solution)
+        MoveRunner.build(solutionMetaModel)
+                .using(solution)
                 .executeTemporarily(compositeMove, view -> {
                     // All assignments should be applied
                     assertThat(entity.getValueList()).hasSize(3);

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListChangeMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListChangeMoveTest.java
@@ -25,7 +25,7 @@ class ListChangeMoveTest {
 
         var changeMove = Moves.change(variableMetaModel, entity, 0, entity, 2);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(changeMove);
 
@@ -52,7 +52,7 @@ class ListChangeMoveTest {
 
         var changeMove = Moves.change(variableMetaModel, entity1, 0, entity2, 0);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(changeMove);
 
@@ -78,7 +78,7 @@ class ListChangeMoveTest {
 
         var valueToMove = entity1.getValueList().get(0);
 
-        var context = MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        var context = MoveRunner.build(solutionMetaModel)
                 .using(solution);
         context.execute(move1);
         context.execute(move2);
@@ -99,7 +99,7 @@ class ListChangeMoveTest {
 
         var changeMove = Moves.change(variableMetaModel, entity, 0, entity, 2);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .executeTemporarily(changeMove, view -> {
                     // During temporary execution, order should be changed
@@ -127,7 +127,7 @@ class ListChangeMoveTest {
 
         var changeMove = Moves.change(variableMetaModel, entity1, 0, entity2, 0);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .executeTemporarily(changeMove, view -> {
                     // Value should be moved from entity1 to entity2

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListSwapMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/ListSwapMoveTest.java
@@ -25,7 +25,7 @@ class ListSwapMoveTest {
 
         var swapMove = Moves.swap(variableMetaModel, entity, 0, entity, 2);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(swapMove);
 
@@ -51,7 +51,7 @@ class ListSwapMoveTest {
 
         var swapMove = Moves.swap(variableMetaModel, entity1, 0, entity2, 0);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(swapMove);
 
@@ -75,7 +75,7 @@ class ListSwapMoveTest {
         // Swap adjacent positions 1 and 2
         var swapMove = Moves.swap(variableMetaModel, entity, 1, entity, 2);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(swapMove);
 
@@ -102,7 +102,7 @@ class ListSwapMoveTest {
         var e2v0 = entity2.getValueList().get(0);
         var e2v1 = entity2.getValueList().get(1);
 
-        var context = MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        var context = MoveRunner.build(solutionMetaModel)
                 .using(solution);
         context.execute(move1);
         context.execute(move2);
@@ -126,7 +126,7 @@ class ListSwapMoveTest {
 
         var swapMove = Moves.swap(variableMetaModel, entity, 0, entity, 2);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .executeTemporarily(swapMove, view -> {
                     // During temporary execution, positions should be swapped
@@ -153,7 +153,7 @@ class ListSwapMoveTest {
 
         var swapMove = Moves.swap(variableMetaModel, entity1, 0, entity2, 0);
 
-        MoveRunner.build(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .executeTemporarily(swapMove, view -> {
                     // Values should be swapped

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/SwapMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/move/builtin/SwapMoveTest.java
@@ -25,7 +25,7 @@ class SwapMoveTest {
 
         var swapMove = Moves.swap(variableMetaModel, entity1, entity2);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(swapMove);
 
@@ -50,7 +50,7 @@ class SwapMoveTest {
 
         var swapMove = Moves.swap(variableMetaModel, entity1, entity2);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .execute(swapMove);
 
@@ -76,7 +76,7 @@ class SwapMoveTest {
         var swap1 = Moves.swap(variableMetaModel, entity1, entity2);
         var swap2 = Moves.swap(variableMetaModel, entity2, entity3);
 
-        var context = MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        var context = MoveRunner.build(solutionMetaModel)
                 .using(solution);
         context.execute(swap1);
         context.execute(swap2);
@@ -102,7 +102,7 @@ class SwapMoveTest {
 
         var swapMove = Moves.swap(variableMetaModel, entity1, entity2);
 
-        MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        MoveRunner.build(solutionMetaModel)
                 .using(solution)
                 .executeTemporarily(swapMove, view -> {
                     // During temporary execution, values should be swapped
@@ -132,7 +132,7 @@ class SwapMoveTest {
         var swap1 = Moves.swap(variableMetaModel, entity1, entity2);
         var swap2 = Moves.swap(variableMetaModel, entity2, entity3);
 
-        var context = MoveRunner.build(TestdataSolution.class, TestdataEntity.class)
+        var context = MoveRunner.build(solutionMetaModel)
                 .using(solution);
 
         // Execute swap1 temporarily and verify


### PR DESCRIPTION
Updates Javadocs of several `MutableSolutionView` methods to better reflect the actual behavior.
Also introduces new `assignValue` options to support some corner cases.
Adds plenty of test coverage for each.