### PR TITLE
docs: add context7 json

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/timefoldai/timefold-solver",
+  "public_key": "pk_Z4ILWouuqpAmZTqIOaeAt"
+}


### PR DESCRIPTION
Context7 is one of the best known MCP servers. It indexes documentation from different sources and provides them as a MCP server. 

Adding this file to our repository allows us to claim the "timefold-solver" library on their platform, giving us insights and allowing us to force an update of their index. 

Try it: https://context7.com/timefoldai/timefold-solver?tab=chat

<img width="1116" height="642" alt="Screenshot 2026-01-30 at 10 17 42" src="https://github.com/user-attachments/assets/5eff6a63-eb5a-44e0-a12a-4d2e120a3646" />

If we agree to do this, i'll do the same for our Docs and Quickstarts
