### PR TITLE
fix: Use field getters/setters when available, enforce getters/setters are public

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>io.quarkus.gizmo</groupId>
       <artifactId>gizmo2</artifactId>
-      <optional>true</optional>
+      <!--      <optional>true</optional>-->
     </dependency>
 
     <!-- External dependencies -->

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/common/ReflectionHelper.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/common/ReflectionHelper.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -276,6 +277,10 @@ public final class ReflectionHelper {
     }
 
     public static void assertGetterMethod(Method getterMethod) {
+        if (!Modifier.isPublic(getterMethod.getModifiers())) {
+            throw new IllegalStateException("The getterMethod (%s) must be public."
+                    .formatted(getterMethod));
+        }
         if (getterMethod.getParameterTypes().length != 0) {
             throw new IllegalStateException("The getterMethod (%s) must not have any parameters (%s)."
                     .formatted(getterMethod, Arrays.toString(getterMethod.getParameterTypes())));
@@ -304,8 +309,12 @@ public final class ReflectionHelper {
     }
 
     public static void assertGetterMethod(Method getterMethod, Class<? extends Annotation> annotationClass) {
+        if (!Modifier.isPublic(getterMethod.getModifiers())) {
+            throw new IllegalStateException("The getterMethod (%s) with a @%s annotation must be public."
+                    .formatted(getterMethod, annotationClass.getSimpleName()));
+        }
         if (getterMethod.getParameterTypes().length != 0) {
-            throw new IllegalStateException("The getterMethod (%s) with a %s annotation must not have any parameters (%s)."
+            throw new IllegalStateException("The getterMethod (%s) with a @%s annotation must not have any parameters (%s)."
                     .formatted(getterMethod, annotationClass.getSimpleName(),
                             Arrays.toString(getterMethod.getParameterTypes())));
         }
@@ -313,13 +322,13 @@ public final class ReflectionHelper {
         if (methodName.startsWith(PROPERTY_ACCESSOR_PREFIX_GET)) {
             if (getterMethod.getReturnType() == void.class) {
                 throw new IllegalStateException(
-                        "The getterMethod (%s) with a %s annotation must have a non-void return type (%s)."
+                        "The getterMethod (%s) with a @%s annotation must have a non-void return type (%s)."
                                 .formatted(getterMethod, annotationClass.getSimpleName(), getterMethod.getReturnType()));
             }
         } else if (methodName.startsWith(PROPERTY_ACCESSOR_PREFIX_IS)) {
             if (getterMethod.getReturnType() != boolean.class) {
                 throw new IllegalStateException("""
-                        The getterMethod (%s) with a %s annotation must have a primitive boolean return type (%s) \
+                        The getterMethod (%s) with a @%s annotation must have a primitive boolean return type (%s) \
                         or use another prefix in its methodName (%s).
                         Maybe use '%s' instead of '%s'?"""
                         .formatted(getterMethod, annotationClass.getSimpleName(), getterMethod.getReturnType(), methodName,
@@ -327,13 +336,17 @@ public final class ReflectionHelper {
             }
         } else {
             throw new IllegalStateException(
-                    "The getterMethod (%s) with a %s annotation has a methodName (%s) that does not start with a valid prefix (%s)."
+                    "The getterMethod (%s) with a @%s annotation has a methodName (%s) that does not start with a valid prefix (%s)."
                             .formatted(getterMethod, annotationClass.getSimpleName(), methodName,
                                     Arrays.toString(PROPERTY_ACCESSOR_PREFIXES)));
         }
     }
 
     public static void assertReadMethod(Method readMethod, boolean readMethodWithParameter) {
+        if (!Modifier.isPublic(readMethod.getModifiers())) {
+            throw new IllegalStateException("The readMethod (%s) must be public."
+                    .formatted(readMethod));
+        }
         if (!readMethodWithParameter && readMethod.getParameterCount() != 0) {
             throw new IllegalStateException("The readMethod (%s) must not have any parameters (%s)."
                     .formatted(readMethod, Arrays.toString(readMethod.getParameterTypes())));
@@ -350,16 +363,20 @@ public final class ReflectionHelper {
 
     public static void assertReadMethod(Method readMethod, boolean readMethodWithParameter,
             Class<? extends Annotation> annotationClass) {
+        if (!Modifier.isPublic(readMethod.getModifiers())) {
+            throw new IllegalStateException("The readMethod (%s) with a @%s annotation must be public."
+                    .formatted(readMethod, annotationClass.getSimpleName()));
+        }
         if (!readMethodWithParameter && readMethod.getParameterCount() != 0) {
-            throw new IllegalStateException("The readMethod (%s) with a %s annotation must not have any parameters (%s)."
+            throw new IllegalStateException("The readMethod (%s) with a @%s annotation must not have any parameters (%s)."
                     .formatted(readMethod, annotationClass.getSimpleName(), Arrays.toString(readMethod.getParameterTypes())));
         }
         if (readMethodWithParameter && readMethod.getParameterCount() > 1) {
-            throw new IllegalStateException("The readMethod (%s) with a %s annotation must have only one parameter (%s)."
+            throw new IllegalStateException("The readMethod (%s) with a @%s annotation must have only one parameter (%s)."
                     .formatted(readMethod, annotationClass.getSimpleName(), Arrays.toString(readMethod.getParameterTypes())));
         }
         if (readMethod.getReturnType() == void.class) {
-            throw new IllegalStateException("The readMethod (%s) with a %s annotation must have a non-void return type (%s)."
+            throw new IllegalStateException("The readMethod (%s) with a @%s annotation must have a non-void return type (%s)."
                     .formatted(readMethod, annotationClass.getSimpleName(), readMethod.getReturnType()));
         }
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/ReflectionMethodMemberAccessor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/ReflectionMethodMemberAccessor.java
@@ -28,7 +28,6 @@ public sealed class ReflectionMethodMemberAccessor extends AbstractMemberAccesso
         this.returnType = readMethod.getReturnType();
         this.methodName = readMethod.getName();
         try {
-            readMethod.setAccessible(true);
             this.methodHandle = MethodHandles.lookup()
                     .unreflect(readMethod)
                     .asFixedArity();

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoFieldHandler.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoFieldHandler.java
@@ -1,23 +1,54 @@
 package ai.timefold.solver.core.impl.domain.common.accessor.gizmo;
 
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.function.Consumer;
+
+import ai.timefold.solver.core.impl.domain.common.ReflectionHelper;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.desc.FieldDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
+@NullMarked
 final class GizmoFieldHandler implements GizmoMemberHandler {
 
     private final Class<?> declaringClass;
     private final FieldDesc fieldDescriptor;
+    private final @Nullable MethodDesc getterDescriptor;
+    private final @Nullable MethodDesc setterDescriptor;
     private final boolean canBeWritten;
 
     GizmoFieldHandler(Class<?> declaringClass, FieldDesc fieldDescriptor, boolean canBeWritten) {
         this.declaringClass = declaringClass;
         this.fieldDescriptor = fieldDescriptor;
-        this.canBeWritten = canBeWritten;
+        var getterMethod = ReflectionHelper.getGetterMethod(declaringClass, fieldDescriptor.name());
+        var setterMethod = ReflectionHelper.getSetterMethod(declaringClass, fieldDescriptor.name());
+
+        if (getterMethod == null) {
+            if (setterMethod != null) {
+                throw new IllegalArgumentException("Field (%s) in class (%s) is a write-only field."
+                        .formatted(fieldDescriptor.name(), declaringClass.getName()));
+            }
+            getterDescriptor = null;
+            setterDescriptor = null;
+            this.canBeWritten = canBeWritten;
+        } else {
+            ReflectionHelper.assertGetterMethod(getterMethod);
+            getterDescriptor = MethodDesc.of(getterMethod);
+
+            if (setterMethod != null && Modifier.isPublic(setterMethod.getModifiers())) {
+                setterDescriptor = MethodDesc.of(setterMethod);
+                this.canBeWritten = true;
+            } else {
+                setterDescriptor = null;
+                this.canBeWritten = false;
+            }
+        }
     }
 
     @Override
@@ -32,6 +63,9 @@ final class GizmoFieldHandler implements GizmoMemberHandler {
 
     @Override
     public Expr readMemberValue(BlockCreator bytecodeCreator, Expr thisObj) {
+        if (getterDescriptor != null) {
+            return bytecodeCreator.invokeVirtual(getterDescriptor, thisObj);
+        }
         return thisObj.field(fieldDescriptor);
     }
 
@@ -44,6 +78,10 @@ final class GizmoFieldHandler implements GizmoMemberHandler {
     public boolean writeMemberValue(MethodDesc setter, BlockCreator bytecodeCreator, Expr thisObj,
             Expr newValue) {
         if (canBeWritten) {
+            if (setterDescriptor != null) {
+                bytecodeCreator.invokeVirtual(setterDescriptor, thisObj, newValue);
+                return true;
+            }
             bytecodeCreator.set(thisObj.field(fieldDescriptor), newValue);
             return true;
         } else {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorImplementor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorImplementor.java
@@ -420,7 +420,7 @@ public final class GizmoMemberAccessorImplementor {
     /**
      * Generates the following code:
      * <p>
-     * For a field
+     * For a field without a getter
      *
      * <pre>
      * Object executeGetter(Object bean) {
@@ -428,7 +428,7 @@ public final class GizmoMemberAccessorImplementor {
      * }
      * </pre>
      *
-     * For a method with returning type
+     * For a field with a getter or a method with returning type
      *
      * <pre>
      * Object executeGetter(Object bean) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
@@ -12,6 +12,9 @@ import java.util.function.Consumer;
 import ai.timefold.solver.core.api.domain.common.DomainAccessType;
 import ai.timefold.solver.core.impl.domain.common.ReflectionHelper;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.desc.FieldDesc;
@@ -20,6 +23,7 @@ import io.quarkus.gizmo2.desc.MethodDesc;
 /**
  * Describe and provide simplified/unified access for {@link Member}.
  */
+@NullMarked
 public final class GizmoMemberDescriptor {
 
     /**
@@ -34,6 +38,7 @@ public final class GizmoMemberDescriptor {
     /**
      * The type of the read method parameter. Null if the method does not accept a parameter.
      */
+    @Nullable
     private final Type methodParameterType;
 
     private final GizmoMemberHandler memberHandler;
@@ -46,6 +51,7 @@ public final class GizmoMemberDescriptor {
     /**
      * The MethodDescriptor of the corresponding setter. Empty if not present.
      */
+    @Nullable
     private final MethodDesc setter;
 
     public GizmoMemberDescriptor(Member member) {
@@ -91,7 +97,7 @@ public final class GizmoMemberDescriptor {
     }
 
     public GizmoMemberDescriptor(String name, MethodDesc memberDescriptor, MethodDesc metadataDescriptor,
-            Type methodParameterType, Class<?> declaringClass, MethodDesc setterDescriptor) {
+            Type methodParameterType, Class<?> declaringClass, @Nullable MethodDesc setterDescriptor) {
         this.name = name;
         this.memberHandler = GizmoMemberHandler.of(declaringClass, (Class<?>) methodParameterType, memberDescriptor);
         this.metadataHandler = memberDescriptor == metadataDescriptor ? this.memberHandler
@@ -101,7 +107,7 @@ public final class GizmoMemberDescriptor {
     }
 
     public GizmoMemberDescriptor(String name, MethodDesc memberDescriptor, Type methodParameterType, Class<?> declaringClass,
-            MethodDesc setterDescriptor) {
+            @Nullable MethodDesc setterDescriptor) {
         this.name = name;
         this.memberHandler = GizmoMemberHandler.of(declaringClass, (Class<?>) methodParameterType, memberDescriptor);
         this.metadataHandler = this.memberHandler;
@@ -110,7 +116,7 @@ public final class GizmoMemberDescriptor {
     }
 
     public GizmoMemberDescriptor(String name, MethodDesc memberDescriptor, FieldDesc metadataDescriptor,
-            Type methodParameterType, Class<?> declaringClass, MethodDesc setterDescriptor) {
+            @Nullable Type methodParameterType, Class<?> declaringClass, @Nullable MethodDesc setterDescriptor) {
         this.name = name;
         this.memberHandler = GizmoMemberHandler.of(declaringClass, (Class<?>) methodParameterType, memberDescriptor);
         this.metadataHandler = GizmoMemberHandler.of(declaringClass, name, metadataDescriptor, true);
@@ -118,6 +124,7 @@ public final class GizmoMemberDescriptor {
         this.setter = setterDescriptor;
     }
 
+    @Nullable
     public static Type getMethodParameterType(Method method, boolean methodWithParameter) {
         var parameterCount = method.getParameterCount();
         Type methodParameterType = null;
@@ -244,6 +251,7 @@ public final class GizmoMemberDescriptor {
         return metadataHandler.getType();
     }
 
+    @Nullable
     public Type getMethodParameterType() {
         return methodParameterType;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import ai.timefold.solver.core.api.domain.common.DomainAccessType;
 import ai.timefold.solver.core.impl.domain.common.ReflectionHelper;
 
 import org.jspecify.annotations.NullMarked;
@@ -60,15 +59,6 @@ public final class GizmoMemberDescriptor {
 
     public GizmoMemberDescriptor(Member member, boolean methodWithParameter) {
         Class<?> declaringClass = member.getDeclaringClass();
-        if (!Modifier.isPublic(member.getModifiers())) {
-            throw new IllegalStateException("""
-                    Member (%s) of class (%s) is not public and domainAccessType is %s.
-                    %sMaybe use domainAccessType %s instead of %s."""
-                    .formatted(member.getName(), member.getDeclaringClass().getName(), DomainAccessType.GIZMO,
-                            ((member instanceof Field) ? "Maybe put the annotations onto the public getter of the field.\n"
-                                    : ""),
-                            DomainAccessType.REFLECTION, DomainAccessType.GIZMO));
-        }
         if (member instanceof Field field) {
             var fieldDescriptor = FieldDesc.of(field);
             this.name = member.getName();
@@ -76,6 +66,11 @@ public final class GizmoMemberDescriptor {
             this.setter = null;
             this.methodParameterType = null;
         } else if (member instanceof Method method) {
+            if (!Modifier.isPublic(method.getModifiers())) {
+                throw new IllegalStateException("""
+                        Member (%s) of class (%s) is not public."""
+                        .formatted(method.getName(), declaringClass.getName()));
+            }
             var methodDescriptor = MethodDesc.of(method);
             this.name = ReflectionHelper.isGetterMethod(method) ? ReflectionHelper.getGetterPropertyName(member)
                     : member.getName();

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberHandler.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberHandler.java
@@ -28,9 +28,10 @@ interface GizmoMemberHandler {
         try {
             Field field = declaringClass.getField(name);
             return new GizmoFieldHandler(declaringClass, fieldDescriptor,
-                    ignoreFinalChecks || !Modifier.isFinal(field.getModifiers()));
+                    ignoreFinalChecks, ignoreFinalChecks || !Modifier.isFinal(field.getModifiers()),
+                    Modifier.isPublic(field.getModifiers()));
         } catch (NoSuchFieldException e) { // The field is only used for its metadata and never actually called.
-            return new GizmoFieldHandler(declaringClass, fieldDescriptor, false);
+            return new GizmoFieldHandler(declaringClass, fieldDescriptor, ignoreFinalChecks, false, false);
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/score/descriptor/ScoreDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/score/descriptor/ScoreDescriptor.java
@@ -45,6 +45,7 @@ public final class ScoreDescriptor<Score_ extends Score<Score_>> {
         // A solution class cannot have more than one score field or bean property (name check), and the @PlanningScore
         // annotation cannot appear on both the score field and its getter (member accessor class check).
         if (!scoreMemberAccessor.getName().equals(memberAccessor.getName())
+                || !scoreMemberAccessor.equals(memberAccessor)
                 || !scoreMemberAccessor.getClass().equals(memberAccessor.getClass())) {
             throw new IllegalStateException("The solutionClass (" + solutionClass
                     + ") has a @" + PlanningScore.class.getSimpleName()

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
@@ -1857,7 +1857,7 @@ public class SolutionManagerTest {
         var c1 = new TestdataPinnedWithIndexListValue("c1");
         var c = new TestdataPinnedWithIndexListEntity("c", c0, c1);
         c.setPinned(false);
-        c.setPlanningPinToIndex(1); // Destination c[0] will be unavailable.
+        c.setPinIndex(1); // Destination c[0] will be unavailable.
         var solution = new TestdataPinnedWithIndexListSolution();
         var uninitializedValue = new TestdataPinnedWithIndexListValue("uninitialized");
         solution.setEntityList(Arrays.asList(a, b, c));
@@ -1918,7 +1918,7 @@ public class SolutionManagerTest {
         var c1 = new TestdataPinnedWithIndexListValue("c1");
         var c = new TestdataPinnedWithIndexListEntity("c", c0, c1);
         c.setPinned(false);
-        c.setPlanningPinToIndex(1); // Destination c[0] will be unavailable.
+        c.setPinIndex(1); // Destination c[0] will be unavailable.
         var solution = new TestdataPinnedWithIndexListSolution();
         var uninitializedValue = new TestdataPinnedWithIndexListValue("uninitialized");
         solution.setEntityList(Arrays.asList(a, b, c));
@@ -1980,7 +1980,7 @@ public class SolutionManagerTest {
         var evaluatedValue = new TestdataPinnedWithIndexListValue("c1");
         var c = new TestdataPinnedWithIndexListEntity("c", c0, evaluatedValue);
         c.setPinned(false);
-        c.setPlanningPinToIndex(1); // Destination c[0] will be unavailable.
+        c.setPinIndex(1); // Destination c[0] will be unavailable.
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(Arrays.asList(a, b, c));
         solution.setValueList(Arrays.asList(b0, c0, evaluatedValue));
@@ -2030,7 +2030,7 @@ public class SolutionManagerTest {
         var c = new TestdataPinnedWithIndexListEntity("c", c0, c1);
         var d = new TestdataPinnedWithIndexListEntity("d");
         c.setPinned(false);
-        c.setPlanningPinToIndex(1); // Destination c[0] will be unavailable.
+        c.setPinIndex(1); // Destination c[0] will be unavailable.
         var solution = new TestdataPinnedWithIndexListSolution();
         var uninitializedValue = new TestdataPinnedWithIndexListValue("uninitialized");
         solution.setEntityList(Arrays.asList(a, b, c, d));
@@ -2054,7 +2054,7 @@ public class SolutionManagerTest {
         var c = new TestdataPinnedWithIndexListEntity("c", c0, c1);
         var d = new TestdataPinnedWithIndexListEntity("d");
         c.setPinned(false);
-        c.setPlanningPinToIndex(1); // Destination c[0] will be unavailable.
+        c.setPinIndex(1); // Destination c[0] will be unavailable.
         var solution = new TestdataPinnedWithIndexListSolution();
         var uninitializedValue = new TestdataPinnedWithIndexListValue("uninitialized");
         solution.setEntityList(Arrays.asList(a, b, c, d));

--- a/core/src/test/java/ai/timefold/solver/core/config/solver/SolverConfigTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/config/solver/SolverConfigTest.java
@@ -306,6 +306,21 @@ class SolverConfigTest {
         @PlanningScore
         SimpleScore score;
 
+        public List<DummyRecordEntity> getEntities() {
+            return entities;
+        }
+
+        public void setEntities(List<DummyRecordEntity> entities) {
+            this.entities = entities;
+        }
+
+        public SimpleScore getScore() {
+            return score;
+        }
+
+        public void setScore(SimpleScore score) {
+            this.score = score;
+        }
     }
 
     @PlanningEntity
@@ -357,6 +372,40 @@ class SolverConfigTest {
         @PlanningScore
         SimpleScore score;
 
+        public List<DummyEntityWithTwoListVariables> getEntities() {
+            return entities;
+        }
+
+        public void setEntities(
+                List<DummyEntityWithTwoListVariables> entities) {
+            this.entities = entities;
+        }
+
+        public ValueRange<DummyEntityForListVariable> getFirstListValueRange() {
+            return firstListValueRange;
+        }
+
+        public void setFirstListValueRange(
+                ValueRange<DummyEntityForListVariable> firstListValueRange) {
+            this.firstListValueRange = firstListValueRange;
+        }
+
+        public ValueRange<DummyEntityForListVariable> getSecondListValueRange() {
+            return secondListValueRange;
+        }
+
+        public void setSecondListValueRange(
+                ValueRange<DummyEntityForListVariable> secondListValueRange) {
+            this.secondListValueRange = secondListValueRange;
+        }
+
+        public SimpleScore getScore() {
+            return score;
+        }
+
+        public void setScore(SimpleScore score) {
+            this.score = score;
+        }
     }
 
     @PlanningEntity
@@ -368,6 +417,23 @@ class SolverConfigTest {
         @PlanningListVariable(valueRangeProviderRefs = "secondListValueRange")
         private List<DummyEntityForListVariable> secondListVariable;
 
+        public List<DummyEntityForListVariable> getFirstListVariable() {
+            return firstListVariable;
+        }
+
+        public void setFirstListVariable(
+                List<DummyEntityForListVariable> firstListVariable) {
+            this.firstListVariable = firstListVariable;
+        }
+
+        public List<DummyEntityForListVariable> getSecondListVariable() {
+            return secondListVariable;
+        }
+
+        public void setSecondListVariable(
+                List<DummyEntityForListVariable> secondListVariable) {
+            this.secondListVariable = secondListVariable;
+        }
     }
 
     @PlanningEntity

--- a/core/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowEntity.java
@@ -24,6 +24,14 @@ public class CorruptedUndoShadowEntity {
         this.id = id;
     }
 
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public CorruptedUndoShadowValue getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/config/solver/testutil/corruptedundoshadow/CorruptedUndoShadowSolution.java
@@ -27,4 +27,30 @@ public class CorruptedUndoShadowSolution {
         this.entityList = entityList;
         this.valueList = valueList;
     }
+
+    public List<CorruptedUndoShadowEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(
+            List<CorruptedUndoShadowEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public List<CorruptedUndoShadowValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(
+            List<CorruptedUndoShadowValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/common/accessor/ReflectionBeanPropertyMemberAccessorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/common/accessor/ReflectionBeanPropertyMemberAccessorTest.java
@@ -41,10 +41,9 @@ class ReflectionBeanPropertyMemberAccessorTest {
         assertThatCode(() -> new ReflectionBeanPropertyMemberAccessor(
                 TestdataDifferentGetterSetterVisibilityEntity.class.getDeclaredMethod("getValue2")))
                 .hasMessageContainingAll("getterMethod (getValue2)",
-                        "has access modifier (package-private)",
-                        "not match the setterMethod (setValue2)",
-                        "access modifier (protected)",
-                        "on class (ai.timefold.solver.core.testdomain.invalid.gettersetter.TestdataDifferentGetterSetterVisibilityEntity)");
+                        "on class (%s)".formatted(TestdataDifferentGetterSetterVisibilityEntity.class.getCanonicalName()),
+                        "is not public",
+                        "having access modifier (package-private) instead.");
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/common/accessor/ReflectionMethodExtendedMemberAccessorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/common/accessor/ReflectionMethodExtendedMemberAccessorTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import java.util.List;
 
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.testdomain.TestdataSolution;
 import ai.timefold.solver.core.testdomain.TestdataValue;
 import ai.timefold.solver.core.testdomain.valuerange.entityproviding.parameter.TestdataEntityProvidingWithParameterEntity;
 import ai.timefold.solver.core.testdomain.valuerange.entityproviding.parameter.TestdataEntityProvidingWithParameterSolution;
@@ -14,6 +15,7 @@ import ai.timefold.solver.core.testdomain.valuerange.entityproviding.parameter.i
 import ai.timefold.solver.core.testdomain.valuerange.entityproviding.parameter.inheritance.TestdataEntityProvidingOnlyBaseAnnotatedSolution;
 import ai.timefold.solver.core.testdomain.valuerange.entityproviding.parameter.invalid.TestdataInvalidCountEntityProvidingWithParameterEntity;
 import ai.timefold.solver.core.testdomain.valuerange.entityproviding.parameter.invalid.TestdataInvalidTypeEntityProvidingWithParameterEntity;
+import ai.timefold.solver.core.testdomain.valuerange.entityproviding.parameter.invalid.TestdataInvalidTypeEntityProvidingWithParameterSolution;
 import ai.timefold.solver.core.testdomain.valuerange.parameter.invalid.TestdataInvalidParameterSolution;
 
 import org.junit.jupiter.api.Test;
@@ -73,21 +75,27 @@ class ReflectionMethodExtendedMemberAccessorTest {
     @Test
     void invalidEntityReadMethodWithParameter() {
         assertThatCode(TestdataInvalidTypeEntityProvidingWithParameterEntity::buildVariableDescriptorForValueRange)
-                .hasMessageContaining("The parameter type (ai.timefold.solver.core.testdomain.TestdataSolution)")
+                .hasMessageContaining("The parameter type (%s)".formatted(TestdataSolution.class.getCanonicalName()))
                 .hasMessageContaining(
-                        "of the method (getValueRange) must match the solution (ai.timefold.solver.core.testdomain.valuerange.entityproviding.parameter.invalid.TestdataInvalidTypeEntityProvidingWithParameterSolution).");
+                        "of the method (getValueRange) must match the solution (%s)."
+                                .formatted(TestdataInvalidTypeEntityProvidingWithParameterSolution.class.getCanonicalName()));
         assertThatCode(TestdataInvalidCountEntityProvidingWithParameterEntity::buildVariableDescriptorForValueRange)
                 .hasMessageContaining("The readMethod")
-                .hasMessageContaining("with a ValueRangeProvider annotation must have only one parameter");
+                .hasMessageContaining("with a @%s annotation must have only one parameter"
+                        .formatted(ValueRangeProvider.class.getSimpleName()));
     }
 
     @Test
     void invalidSolutionReadMethodWithParameter() {
         assertThatCode(TestdataInvalidParameterSolution::buildSolutionDescriptor)
                 .hasMessageContainingAll(
-                        "The readMethod (public java.util.List ai.timefold.solver.core.testdomain.valuerange.parameter.invalid.TestdataInvalidParameterSolution.getValueList(ai.timefold.solver.core.testdomain.valuerange.parameter.invalid.TestdataInvalidParameterSolution))")
+                        "The readMethod (public java.util.List %s.getValueList(%s))"
+                                .formatted(TestdataInvalidParameterSolution.class.getCanonicalName(),
+                                        TestdataInvalidParameterSolution.class.getCanonicalName()))
                 .hasMessageContainingAll(
-                        " with a ValueRangeProvider annotation must not have any parameters ([class ai.timefold.solver.core.testdomain.valuerange.parameter.invalid.TestdataInvalidParameterSolution]).");
+                        " with a @%s annotation must not have any parameters ([class %s])."
+                                .formatted(ValueRangeProvider.class.getSimpleName(),
+                                        TestdataInvalidParameterSolution.class.getCanonicalName()));
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptorTest.java
@@ -24,19 +24,19 @@ import io.quarkus.gizmo2.desc.MethodDesc;
 class GizmoMemberDescriptorTest {
 
     @Test
-    void testThatCreatingDescriptorForPrivateMembersFail() {
-        assertThatCode(() -> new GizmoMemberDescriptor(TestdataFieldAnnotatedEntity.class.getDeclaredField("value")))
-                .hasMessage("Member (" + "value" + ") of class (" +
-                        TestdataFieldAnnotatedEntity.class.getName() + ") is not public and domainAccessType is GIZMO.\n" +
-                        "Maybe put the annotations onto the public getter of the field.\n" +
-                        "Maybe use domainAccessType REFLECTION instead of GIZMO.");
+    void testCreatingDescriptorForPrivateFieldWithPublicAccessorsWork() throws NoSuchFieldException {
+        var descriptor = new GizmoMemberDescriptor(TestdataFieldAnnotatedEntity.class.getDeclaredField("value"));
+        assertThat(descriptor.getDeclaringClassName()).isEqualTo(TestdataFieldAnnotatedEntity.class.getName());
+        assertThat(descriptor.getName()).isEqualTo("value");
+    }
 
+    @Test
+    void testThatCreatingDescriptorForPrivateMembersFail() {
         assertThatCode(() -> new GizmoMemberDescriptor(
                 TestdataVisibilityModifierSolution.class.getDeclaredMethod("getPrivateProperty")))
                 .hasMessage("Member (" + "getPrivateProperty" + ") of class (" +
                         TestdataVisibilityModifierSolution.class.getName()
-                        + ") is not public and domainAccessType is GIZMO.\n" +
-                        "Maybe use domainAccessType REFLECTION instead of GIZMO.");
+                        + ") is not public.");
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AlwaysLoopedShadowVariableTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/AlwaysLoopedShadowVariableTest.java
@@ -31,7 +31,7 @@ class AlwaysLoopedShadowVariableTest {
         assertThatCode(() -> solver.solve(problem)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContainingAll(
                         "There are fixed dependency loops in the graph for variables",
-                        "isOdd",
-                        "isEven");
+                        "odd",
+                        "even");
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSourceTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/RootVariableSourceTest.java
@@ -729,18 +729,18 @@ class RootVariableSourceTest {
                 planningSolutionMetaModel,
                 TestdataInvalidDeclarativeValue.class,
                 "shadow",
-                "isInconsistent",
+                "inconsistent",
                 DEFAULT_MEMBER_ACCESSOR_FACTORY,
                 DEFAULT_DESCRIPTOR_POLICY))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContainingAll(
-                        "The source path (isInconsistent) starting from root class (%s) accesses a @%s property (isInconsistent)"
+                        "The source path (inconsistent) starting from root class (%s) accesses a @%s property (inconsistent)"
                                 .formatted(TestdataInvalidDeclarativeValue.class.getCanonicalName(),
                                         ShadowVariablesInconsistent.class.getSimpleName()),
                         "Supplier methods are only called when all of their dependencies are consistent",
                         "reading @%s properties are not needed since they are guaranteed to be false"
                                 .formatted(ShadowVariablesInconsistent.class.getSimpleName()),
-                        "Maybe remove the source path (isInconsistent) from the @%s?"
+                        "Maybe remove the source path (inconsistent) from the @%s?"
                                 .formatted(ShadowSources.class.getSimpleName()));
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
@@ -294,7 +294,7 @@ class DefaultExhaustiveSearchPhaseTest {
         var e2 = new TestdataListPinnedEntityProvidingEntity("e2", List.of(v1, v4, v5));
         e2.setValueList(List.of(v5, v4));
         // Pin the two first elements
-        e2.setPlanningPinToIndex(2);
+        e2.setPinIndex(2);
         var e3 = new TestdataListPinnedEntityProvidingEntity("e3", List.of(v3, v4, v5));
         solution.setEntityList(List.of(e1, e2, e3));
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
@@ -431,7 +431,7 @@ class ElementDestinationSelectorTest {
         var a = new TestdataPinnedWithIndexListEntity("A", v1, v2);
         var b = new TestdataPinnedWithIndexListEntity("B");
         var c = new TestdataPinnedWithIndexListEntity("C", v3);
-        a.setPlanningPinToIndex(2);
+        a.setPinIndex(2);
         c.setPinned(true);
 
         var solution = new TestdataPinnedWithIndexListSolution();
@@ -528,7 +528,7 @@ class ElementDestinationSelectorTest {
         var a = new TestdataPinnedWithIndexListEntity("A");
         var b = new TestdataPinnedWithIndexListEntity("B", new TestdataPinnedWithIndexListValue("B0"),
                 new TestdataPinnedWithIndexListValue("B1"));
-        b.setPlanningPinToIndex(1); // B0 will be ignored.
+        b.setPinIndex(1); // B0 will be ignored.
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(List.of(a, b));
         solution.setValueList(List.of(b.getValueList().get(0), b.getValueList().get(1)));

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/RandomSubListSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/RandomSubListSelectorTest.java
@@ -85,7 +85,7 @@ class RandomSubListSelectorTest {
         var v3 = new TestdataPinnedWithIndexListValue("3");
         var v4 = new TestdataPinnedWithIndexListValue("4");
         var a = new TestdataPinnedWithIndexListEntity("A", v1, v2, v3, v4);
-        a.setPlanningPinToIndex(1); // Ignore v1.
+        a.setPinIndex(1); // Ignore v1.
         var b = new TestdataPinnedWithIndexListEntity("B");
         var solution = new TestdataPinnedWithIndexListSolution();
         solution.setEntityList(List.of(a, b));

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorTest.java
@@ -154,7 +154,7 @@ class ListChangeMoveSelectorTest {
         var v3 = new TestdataPinnedWithIndexListValue("3");
         var v4 = new TestdataPinnedWithIndexListValue("4");
         var a = new TestdataPinnedWithIndexListEntity("A", v2, v1);
-        a.setPlanningPinToIndex(1); // Ignore v2.
+        a.setPinIndex(1); // Ignore v2.
         var b = new TestdataPinnedWithIndexListEntity("B", v4);
         b.setPinned(true); // Ignore entirely.
         var c = new TestdataPinnedWithIndexListEntity("C", v3);
@@ -208,7 +208,7 @@ class ListChangeMoveSelectorTest {
         var v4 = new TestdataValue("4");
         var a = new TestdataListPinnedEntityProvidingEntity("A", List.of(v1, v2, v3));
         a.setValueList(List.of(v2, v1));
-        a.setPlanningPinToIndex(1); // Ignore v2.
+        a.setPinIndex(1); // Ignore v2.
         var b = new TestdataListPinnedEntityProvidingEntity("B", List.of(v2, v4));
         b.setPinned(true); // Ignore entirely.
         b.setValueList(List.of(v4));
@@ -463,7 +463,7 @@ class ListChangeMoveSelectorTest {
         var v3 = new TestdataPinnedWithIndexListValue("3");
         var v4 = new TestdataPinnedWithIndexListValue("4");
         var a = new TestdataPinnedWithIndexListEntity("A", v1, v2);
-        a.setPlanningPinToIndex(1); // Ignore v1.
+        a.setPinIndex(1); // Ignore v1.
         var b = new TestdataPinnedWithIndexListEntity("B", v4);
         b.setPinned(true); // Ignore entirely.
         var c = new TestdataPinnedWithIndexListEntity("C", v3);
@@ -512,7 +512,7 @@ class ListChangeMoveSelectorTest {
         var v4 = new TestdataValue("4");
         var a = new TestdataListPinnedEntityProvidingEntity("A", List.of(v1, v2, v3));
         a.setValueList(List.of(v2, v1));
-        a.setPlanningPinToIndex(1); // Ignore v2.
+        a.setPinIndex(1); // Ignore v2.
         var b = new TestdataListPinnedEntityProvidingEntity("B", List.of(v2, v4));
         b.setPinned(true); // Ignore entirely.
         b.setValueList(List.of(v4));

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorTest.java
@@ -126,7 +126,7 @@ class ListSwapMoveSelectorTest {
         var v2 = new TestdataPinnedWithIndexListValue("v2");
         var v3 = new TestdataPinnedWithIndexListValue("v3");
         var a = new TestdataPinnedWithIndexListEntity("A", v2, v1);
-        a.setPlanningPinToIndex(1); // Ignore v2
+        a.setPinIndex(1); // Ignore v2
         var b = new TestdataPinnedWithIndexListEntity("B");
         b.setPinned(true); // Ignore entirely.
         var c = new TestdataPinnedWithIndexListEntity("C", v3);
@@ -169,7 +169,7 @@ class ListSwapMoveSelectorTest {
         var v4 = new TestdataValue("4");
         var a = new TestdataListPinnedEntityProvidingEntity("A", List.of(v1, v2, v3));
         a.setValueList(List.of(v2, v1));
-        a.setPlanningPinToIndex(1); // Ignore v2.
+        a.setPinIndex(1); // Ignore v2.
         var b = new TestdataListPinnedEntityProvidingEntity("B", List.of(v2, v4));
         b.setPinned(true); // Ignore entirely.
         b.setValueList(List.of(v4));
@@ -410,7 +410,7 @@ class ListSwapMoveSelectorTest {
         var v2 = new TestdataPinnedWithIndexListValue("2");
         var v3 = new TestdataPinnedWithIndexListValue("3");
         var a = new TestdataPinnedWithIndexListEntity("A", v1, v2);
-        a.setPlanningPinToIndex(1); // Ignore v1
+        a.setPinIndex(1); // Ignore v1
         var b = new TestdataPinnedWithIndexListEntity("B");
         b.setPinned(true); // Ignore entirely.
         var c = new TestdataPinnedWithIndexListEntity("C", v3);
@@ -448,7 +448,7 @@ class ListSwapMoveSelectorTest {
         var v4 = new TestdataValue("4");
         var a = new TestdataListPinnedEntityProvidingEntity("A", List.of(v1, v2, v3));
         a.setValueList(List.of(v2, v1));
-        a.setPlanningPinToIndex(1); // Ignore v2.
+        a.setPinIndex(1); // Ignore v2.
         var b = new TestdataListPinnedEntityProvidingEntity("B", List.of(v2, v4));
         b.setPinned(true); // Ignore entirely.
         b.setValueList(List.of(v4));

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorSemanticsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirectorSemanticsTest.java
@@ -200,7 +200,7 @@ public abstract class AbstractScoreDirectorSemanticsTest {
         firstEntity.setPinned(true);
         var secondEntity = solution.getEntityList().get(1);
         secondEntity.setValueList(List.of(solution.getValueList().get(1)));
-        secondEntity.setPlanningPinToIndex(1);
+        secondEntity.setPinIndex(1);
 
         try (var scoreDirector = scoreDirectorFactory.buildScoreDirector()) {
             scoreDirector.setWorkingSolution(solution);

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -897,7 +897,7 @@ class DefaultSolverTest {
         var partiallyPinnedValue2 = solution.getValueList().get(2);
         partiallyPinnedList.add(partiallyPinnedValue1);
         partiallyPinnedList.add(partiallyPinnedValue2);
-        partiallyPinnedEntity.setPlanningPinToIndex(1); // The first value is pinned.
+        partiallyPinnedEntity.setPinIndex(1); // The first value is pinned.
         partiallyPinnedEntity.setPinned(false); // The list isn't pinned overall.
 
         var solverConfig = PlannerTestUtils
@@ -938,7 +938,7 @@ class DefaultSolverTest {
         var partiallyPinnedValue2 = solution.getValueList().get(2);
         partiallyPinnedList.add(partiallyPinnedValue1);
         partiallyPinnedList.add(partiallyPinnedValue2);
-        partiallyPinnedEntity.setPlanningPinToIndex(1); // The first value is pinned.
+        partiallyPinnedEntity.setPinIndex(1); // The first value is pinned.
         partiallyPinnedEntity.setPinned(false); // The list isn't pinned overall.
 
         var solverConfig = PlannerTestUtils

--- a/core/src/test/java/ai/timefold/solver/core/preview/api/neighborhood/stream/enumerating/UniEnumeratingStreamTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/preview/api/neighborhood/stream/enumerating/UniEnumeratingStreamTest.java
@@ -197,11 +197,11 @@ class UniEnumeratingStreamTest {
         fullyPinnedEntity.setPinned(true);
         // 2 values, 1 pinned.
         var partiallyPinnedEntity = solution.getEntityList().get(1);
-        partiallyPinnedEntity.setPlanningPinToIndex(1);
+        partiallyPinnedEntity.setPinIndex(1);
         // 1 value, not pinned.
         var unpinnedEntity = solution.getEntityList().get(2);
         unpinnedEntity.setPinned(false);
-        unpinnedEntity.setPlanningPinToIndex(0);
+        unpinnedEntity.setPinIndex(0);
 
         var datasetSession = createSession(enumeratingStreamFactory, solution);
         var uniDatasetInstance = getDatasetInstance(datasetSession, uniDataset);
@@ -241,11 +241,11 @@ class UniEnumeratingStreamTest {
         fullyPinnedEntity.setPinned(true);
         // 2 values, 1 pinned.
         var partiallyPinnedEntity = solution.getEntityList().get(1);
-        partiallyPinnedEntity.setPlanningPinToIndex(1);
+        partiallyPinnedEntity.setPinIndex(1);
         // 1 value, not pinned.
         var unpinnedEntity = solution.getEntityList().get(2);
         unpinnedEntity.setPinned(false);
-        unpinnedEntity.setPlanningPinToIndex(0);
+        unpinnedEntity.setPinIndex(0);
 
         var datasetSession = createSession(enumeratingStreamFactory, solution);
         var uniDatasetInstance = getDatasetInstance(datasetSession, uniDataset);
@@ -286,11 +286,11 @@ class UniEnumeratingStreamTest {
         // 2 values, 1 pinned.
         var partiallyPinnedEntity = solution.getEntityList().get(1);
         partiallyPinnedEntity.setPinned(false);
-        partiallyPinnedEntity.setPlanningPinToIndex(1);
+        partiallyPinnedEntity.setPinIndex(1);
         // 1 value, not pinned.
         var unpinnedEntity = solution.getEntityList().get(2);
         unpinnedEntity.setPinned(false);
-        unpinnedEntity.setPlanningPinToIndex(0);
+        unpinnedEntity.setPinIndex(0);
 
         var datasetSession = createSession(enumeratingStreamFactory, solution);
         var uniDatasetInstance = getDatasetInstance(datasetSession, uniDataset);
@@ -331,11 +331,11 @@ class UniEnumeratingStreamTest {
         // 2 values, 1 pinned.
         var partiallyPinnedEntity = solution.getEntityList().get(1);
         partiallyPinnedEntity.setPinned(false);
-        partiallyPinnedEntity.setPlanningPinToIndex(1);
+        partiallyPinnedEntity.setPinIndex(1);
         // 1 value, not pinned.
         var unpinnedEntity = solution.getEntityList().get(2);
         unpinnedEntity.setPinned(false);
-        unpinnedEntity.setPlanningPinToIndex(0);
+        unpinnedEntity.setPinIndex(0);
 
         var datasetSession = createSession(enumeratingStreamFactory, solution);
         var uniDatasetInstance = getDatasetInstance(datasetSession, uniDataset);
@@ -381,12 +381,12 @@ class UniEnumeratingStreamTest {
         fullyPinnedEntity.setValueList(List.of(value1));
         // 2 values, 1 pinned.
         var partiallyPinnedEntity = solution.getEntityList().get(1);
-        partiallyPinnedEntity.setPlanningPinToIndex(1);
+        partiallyPinnedEntity.setPinIndex(1);
         partiallyPinnedEntity.setValueList(List.of(value2, value3));
         // 1 value, not pinned.
         var unpinnedEntity = solution.getEntityList().get(2);
         unpinnedEntity.setPinned(false);
-        unpinnedEntity.setPlanningPinToIndex(0);
+        unpinnedEntity.setPinIndex(0);
         unpinnedEntity.setValueList(List.of(value4));
         // Properly set shadow variables based on the changes above.
         SolutionManager.updateShadowVariables(solution);
@@ -423,12 +423,12 @@ class UniEnumeratingStreamTest {
         fullyPinnedEntity.setValueList(List.of(value1));
         // 2 values, 1 pinned.
         var partiallyPinnedEntity = solution.getEntityList().get(1);
-        partiallyPinnedEntity.setPlanningPinToIndex(1);
+        partiallyPinnedEntity.setPinIndex(1);
         partiallyPinnedEntity.setValueList(List.of(value2, value3));
         // 1 value, not pinned.
         var unpinnedEntity = solution.getEntityList().get(2);
         unpinnedEntity.setPinned(false);
-        unpinnedEntity.setPlanningPinToIndex(0);
+        unpinnedEntity.setPinIndex(0);
         unpinnedEntity.setValueList(List.of(value4));
         // Properly set shadow variables based on the changes above.
         SolutionManager.updateShadowVariables(solution);
@@ -464,12 +464,12 @@ class UniEnumeratingStreamTest {
         fullyPinnedEntity.setValueList(List.of(value0));
         // 2 values, 1 pinned.
         var partiallyPinnedEntity = solution.getEntityList().get(1);
-        partiallyPinnedEntity.setPlanningPinToIndex(1);
+        partiallyPinnedEntity.setPinIndex(1);
         partiallyPinnedEntity.setValueList(List.of(value1, value2));
         // 1 value, not pinned.
         var unpinnedEntity = solution.getEntityList().get(2);
         unpinnedEntity.setPinned(false);
-        unpinnedEntity.setPlanningPinToIndex(0);
+        unpinnedEntity.setPinIndex(0);
         unpinnedEntity.setValueList(List.of(value3));
         // Fully pinned, but not initially present in the solution.
         var entityAddedLater = new TestdataPinnedWithIndexListEntity("entity4", value4);
@@ -508,12 +508,12 @@ class UniEnumeratingStreamTest {
         fullyPinnedEntity.setValueList(List.of(value0));
         // 2 values, 1 pinned.
         var partiallyPinnedEntity = solution.getEntityList().get(1);
-        partiallyPinnedEntity.setPlanningPinToIndex(1);
+        partiallyPinnedEntity.setPinIndex(1);
         // 1 value, not pinned.
         partiallyPinnedEntity.setValueList(List.of(value1, value2));
         var unpinnedEntity = solution.getEntityList().get(2);
         unpinnedEntity.setPinned(false);
-        unpinnedEntity.setPlanningPinToIndex(0);
+        unpinnedEntity.setPinIndex(0);
         unpinnedEntity.setValueList(List.of(value3));
         // Fully pinned, but not initially present in the solution.
         var entityAddedLater = new TestdataPinnedWithIndexListEntity("entity4", value4);

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/clone/customcloner/TestdataCorrectlyClonedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/clone/customcloner/TestdataCorrectlyClonedSolution.java
@@ -47,4 +47,24 @@ public class TestdataCorrectlyClonedSolution implements SolutionCloner<TestdataC
         return clonedByCustomCloner;
     }
 
+    public void setClonedByCustomCloner(boolean clonedByCustomCloner) {
+        this.clonedByCustomCloner = clonedByCustomCloner;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    public TestdataEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataEntity entity) {
+        this.entity = entity;
+    }
+
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/clone/customcloner/TestdataEntitiesNotClonedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/clone/customcloner/TestdataEntitiesNotClonedSolution.java
@@ -23,6 +23,22 @@ public class TestdataEntitiesNotClonedSolution implements SolutionCloner<Testdat
     @PlanningEntityProperty
     private TestdataEntity entity = new TestdataEntity("A");
 
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    public TestdataEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataEntity entity) {
+        this.entity = entity;
+    }
+
     @ValueRangeProvider(id = "valueRange")
     @ProblemFactCollectionProperty
     public List<TestdataValue> valueRange() {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/clone/customcloner/TestdataScoreNotClonedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/clone/customcloner/TestdataScoreNotClonedSolution.java
@@ -23,6 +23,22 @@ public class TestdataScoreNotClonedSolution implements SolutionCloner<TestdataSc
     @PlanningEntityProperty
     private TestdataEntity entity = new TestdataEntity("A");
 
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    public TestdataEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataEntity entity) {
+        this.entity = entity;
+    }
+
     @ValueRangeProvider(id = "valueRange")
     @ProblemFactCollectionProperty
     public List<TestdataValue> valueRange() {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/clone/customcloner/TestdataScoreNotEqualSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/clone/customcloner/TestdataScoreNotEqualSolution.java
@@ -44,4 +44,19 @@ public class TestdataScoreNotEqualSolution implements SolutionCloner<TestdataSco
         return clone;
     }
 
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    public TestdataEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataEntity entity) {
+        this.entity = entity;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/equals/list/TestdataEqualsByCodeListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/equals/list/TestdataEqualsByCodeListEntity.java
@@ -39,6 +39,10 @@ public class TestdataEqualsByCodeListEntity extends TestdataEqualsByCodeListObje
         return valueList;
     }
 
+    public void setValueList(List<TestdataEqualsByCodeListValue> valueList) {
+        this.valueList = valueList;
+    }
+
     public void addValue(TestdataEqualsByCodeListValue value) {
         addValueAt(valueList.size(), value);
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/multiple/baseannotated/classes/childnot/TestdataMultipleChildNotAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/multiple/baseannotated/classes/childnot/TestdataMultipleChildNotAnnotatedBaseEntity.java
@@ -24,6 +24,10 @@ public class TestdataMultipleChildNotAnnotatedBaseEntity {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/multiple/baseannotated/classes/childnot/TestdataMultipleChildNotAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/multiple/baseannotated/classes/childnot/TestdataMultipleChildNotAnnotatedBaseEntity.java
@@ -24,10 +24,6 @@ public class TestdataMultipleChildNotAnnotatedBaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/multiple/baseannotated/classes/childtoo/TestdataMultipleBothAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/multiple/baseannotated/classes/childtoo/TestdataMultipleBothAnnotatedBaseEntity.java
@@ -24,6 +24,10 @@ public class TestdataMultipleBothAnnotatedBaseEntity {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/multiple/baseannotated/classes/childtoo/TestdataMultipleBothAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/multiple/baseannotated/classes/childtoo/TestdataMultipleBothAnnotatedBaseEntity.java
@@ -24,10 +24,6 @@ public class TestdataMultipleBothAnnotatedBaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/baseannotated/classes/addvar/TestdataAddVarBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/baseannotated/classes/addvar/TestdataAddVarBaseEntity.java
@@ -24,6 +24,10 @@ public class TestdataAddVarBaseEntity {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/baseannotated/classes/addvar/TestdataAddVarBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/baseannotated/classes/addvar/TestdataAddVarBaseEntity.java
@@ -24,10 +24,6 @@ public class TestdataAddVarBaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/baseannotated/classes/childnot/TestdataChildNotAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/baseannotated/classes/childnot/TestdataChildNotAnnotatedBaseEntity.java
@@ -24,10 +24,6 @@ public class TestdataChildNotAnnotatedBaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/baseannotated/classes/childnot/TestdataChildNotAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/baseannotated/classes/childnot/TestdataChildNotAnnotatedBaseEntity.java
@@ -24,6 +24,10 @@ public class TestdataChildNotAnnotatedBaseEntity {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/basenot/classes/TestdataBaseNotAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/basenot/classes/TestdataBaseNotAnnotatedBaseEntity.java
@@ -22,10 +22,6 @@ public class TestdataBaseNotAnnotatedBaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/basenot/classes/TestdataBaseNotAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/entity/single/basenot/classes/TestdataBaseNotAnnotatedBaseEntity.java
@@ -22,6 +22,10 @@ public class TestdataBaseNotAnnotatedBaseEntity {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseannotated/childtooabstract/TestdataBothAnnotatedAbstractBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseannotated/childtooabstract/TestdataBothAnnotatedAbstractBaseEntity.java
@@ -24,6 +24,10 @@ public class TestdataBothAnnotatedAbstractBaseEntity {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseannotated/childtooabstract/TestdataBothAnnotatedAbstractBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseannotated/childtooabstract/TestdataBothAnnotatedAbstractBaseEntity.java
@@ -24,10 +24,6 @@ public class TestdataBothAnnotatedAbstractBaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseanot/TestdataOnlyAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseanot/TestdataOnlyAnnotatedBaseEntity.java
@@ -24,10 +24,6 @@ public class TestdataOnlyAnnotatedBaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseanot/TestdataOnlyAnnotatedBaseEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseanot/TestdataOnlyAnnotatedBaseEntity.java
@@ -24,6 +24,10 @@ public class TestdataOnlyAnnotatedBaseEntity {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseanot/TestdataOnlyChildAnnotatedExtendedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/inheritance/solution/baseanot/TestdataOnlyChildAnnotatedExtendedSolution.java
@@ -49,4 +49,8 @@ public class TestdataOnlyChildAnnotatedExtendedSolution extends TestdataOnlyChil
     public List<TestdataOnlyChildAnnotatedChildEntity> getEntityList() {
         return (List<TestdataOnlyChildAnnotatedChildEntity>) super.getEntityList();
     }
+
+    public void getEntityList(List<TestdataOnlyChildAnnotatedChildEntity> entityList) {
+        super.setEntityList(entityList);
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/composite/TestdataListCompositeEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/composite/TestdataListCompositeEntity.java
@@ -43,4 +43,8 @@ public class TestdataListCompositeEntity extends TestdataObject {
     public List<TestdataListValue> getValueList() {
         return valueList;
     }
+
+    public void setValueList(List<TestdataListValue> valueList) {
+        this.valueList = valueList;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/index/TestdataPinnedWithIndexListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/pinned/index/TestdataPinnedWithIndexListEntity.java
@@ -70,7 +70,7 @@ public class TestdataPinnedWithIndexListEntity extends TestdataObject {
         return pinIndex;
     }
 
-    public void setPlanningPinToIndex(int pinIndex) {
+    public void setPinIndex(int pinIndex) {
         this.pinIndex = pinIndex;
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/shadowhistory/TestdataListEntityWithShadowHistory.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/shadowhistory/TestdataListEntityWithShadowHistory.java
@@ -41,4 +41,9 @@ public class TestdataListEntityWithShadowHistory extends TestdataObject {
     public List<TestdataListValueWithShadowHistory> getValueList() {
         return valueList;
     }
+
+    public void setValueList(
+            List<TestdataListValueWithShadowHistory> valueList) {
+        this.valueList = valueList;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/unassignedvar/composite/TestdataAllowsUnassignedCompositeListEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/unassignedvar/composite/TestdataAllowsUnassignedCompositeListEntity.java
@@ -43,4 +43,8 @@ public class TestdataAllowsUnassignedCompositeListEntity extends TestdataObject 
     public List<TestdataListValue> getValueList() {
         return valueList;
     }
+
+    public void setValueList(List<TestdataListValue> valueList) {
+        this.valueList = valueList;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/TestdataListEntityWithArrayValueRange.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/TestdataListEntityWithArrayValueRange.java
@@ -24,7 +24,7 @@ public class TestdataListEntityWithArrayValueRange extends TestdataObject {
     }
 
     @PlanningListVariable(valueRangeProviderRefs = "arrayValueRange")
-    private final List<TestdataValue> valueList;
+    private List<TestdataValue> valueList;
 
     public TestdataListEntityWithArrayValueRange(String code, List<TestdataValue> valueList) {
         super(code);
@@ -37,5 +37,9 @@ public class TestdataListEntityWithArrayValueRange extends TestdataObject {
 
     public List<TestdataValue> getValueList() {
         return valueList;
+    }
+
+    public void setValueList(List<TestdataValue> valueList) {
+        this.valueList = valueList;
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/composite/TestdataListCompositeEntityProvidingEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/composite/TestdataListCompositeEntityProvidingEntity.java
@@ -49,6 +49,10 @@ public class TestdataListCompositeEntityProvidingEntity extends TestdataObject {
         return valueRange1;
     }
 
+    public List<TestdataListEntityProvidingValue> getValueRange2() {
+        return valueRange2;
+    }
+
     public List<TestdataListEntityProvidingValue> getValueList() {
         return valueList;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/pinned/TestdataListPinnedEntityProvidingEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/pinned/TestdataListPinnedEntityProvidingEntity.java
@@ -59,7 +59,7 @@ public class TestdataListPinnedEntityProvidingEntity extends TestdataObject {
         return pinIndex;
     }
 
-    public void setPlanningPinToIndex(int pinIndex) {
+    public void setPinIndex(int pinIndex) {
         this.pinIndex = pinIndex;
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/reflect/field/TestdataFieldAnnotatedEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/reflect/field/TestdataFieldAnnotatedEntity.java
@@ -38,6 +38,10 @@ public class TestdataFieldAnnotatedEntity extends TestdataObject {
         return value;
     }
 
+    public void setValue(TestdataValue value) {
+        this.value = value;
+    }
+
     // ************************************************************************
     // Complex methods
     // ************************************************************************

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/reflect/field/TestdataFieldAnnotatedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/reflect/field/TestdataFieldAnnotatedSolution.java
@@ -47,8 +47,16 @@ public class TestdataFieldAnnotatedSolution extends TestdataObject {
         return valueList;
     }
 
+    public void setValueList(List<TestdataValue> valueList) {
+        this.valueList = valueList;
+    }
+
     public List<TestdataFieldAnnotatedEntity> getEntityList() {
         return entityList;
+    }
+
+    public void setEntityList(List<TestdataFieldAnnotatedEntity> entityList) {
+        this.entityList = entityList;
     }
 
     public SimpleScore getScore() {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/always_looped/TestdataAlwaysLoopedEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/always_looped/TestdataAlwaysLoopedEntity.java
@@ -12,10 +12,10 @@ public class TestdataAlwaysLoopedEntity extends TestdataObject {
     Integer value;
 
     @ShadowVariable(supplierName = "isEvenSupplier")
-    Boolean isEven;
+    Boolean even;
 
     @ShadowVariable(supplierName = "isOddSupplier")
-    Boolean isOdd;
+    Boolean odd;
 
     public TestdataAlwaysLoopedEntity() {
     }
@@ -38,32 +38,40 @@ public class TestdataAlwaysLoopedEntity extends TestdataObject {
     }
 
     public Boolean getEven() {
-        return isEven;
+        return even;
     }
 
     public Boolean getOdd() {
-        return isOdd;
+        return odd;
+    }
+
+    public void setEven(Boolean even) {
+        this.even = even;
+    }
+
+    public void setOdd(Boolean odd) {
+        this.odd = odd;
     }
 
     // Complex methods
-    @ShadowSources({ "value", "isOdd" })
+    @ShadowSources({ "value", "odd" })
     public Boolean isEvenSupplier() {
         if (value == null) {
             return null;
         }
-        if (isOdd != null) {
-            return !isOdd;
+        if (odd != null) {
+            return !odd;
         }
         return value % 2 == 0;
     }
 
-    @ShadowSources({ "value", "isEven" })
+    @ShadowSources({ "value", "even" })
     public Boolean isOddSupplier() {
         if (value == null) {
             return null;
         }
-        if (isEven != null) {
-            return !isEven;
+        if (even != null) {
+            return !even;
         }
         return value % 2 == 1;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/basic/TestdataBasicVarEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/basic/TestdataBasicVarEntity.java
@@ -48,6 +48,10 @@ public class TestdataBasicVarEntity {
         return durationInDays;
     }
 
+    public void setDurationInDays(long durationInDays) {
+        this.durationInDays = durationInDays;
+    }
+
     @Override
     public String toString() {
         return "TestdataBasicVarEntity{" +

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/basic/TestdataBasicVarValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/basic/TestdataBasicVarValue.java
@@ -25,7 +25,7 @@ public class TestdataBasicVarValue {
     LocalDateTime endTime;
 
     @ShadowVariablesInconsistent
-    boolean isInvalid;
+    boolean invalid;
 
     @InverseRelationShadowVariable(sourceVariableName = "value")
     List<TestdataBasicVarEntity> entityList = new ArrayList<>();
@@ -90,11 +90,11 @@ public class TestdataBasicVarValue {
     }
 
     public boolean isInvalid() {
-        return isInvalid;
+        return invalid;
     }
 
     public void setInvalid(boolean invalid) {
-        isInvalid = invalid;
+        this.invalid = invalid;
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/chained/TestdataChainedVarEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/chained/TestdataChainedVarEntity.java
@@ -49,6 +49,10 @@ public class TestdataChainedVarEntity extends TestdataChainedVarValue {
         return durationInDays;
     }
 
+    public void setDurationInDays(long durationInDays) {
+        this.durationInDays = durationInDays;
+    }
+
     @Override
     public String toString() {
         return "TestdataBasicVarEntity{" +

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/chained/TestdataChainedVarEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/chained/TestdataChainedVarEntity.java
@@ -25,10 +25,6 @@ public class TestdataChainedVarEntity extends TestdataChainedVarValue {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public TestdataChainedVarValue getPrevious() {
         return previous;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/chained/TestdataChainedVarValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/chained/TestdataChainedVarValue.java
@@ -23,7 +23,7 @@ public class TestdataChainedVarValue {
     LocalDateTime endTime;
 
     @ShadowVariablesInconsistent
-    boolean isInvalid;
+    boolean invalid;
 
     @InverseRelationShadowVariable(sourceVariableName = "previous")
     TestdataChainedVarEntity next;
@@ -88,11 +88,11 @@ public class TestdataChainedVarValue {
     }
 
     public boolean isInvalid() {
-        return isInvalid;
+        return invalid;
     }
 
     public void setInvalid(boolean invalid) {
-        isInvalid = invalid;
+        this.invalid = invalid;
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/concurrent/TestdataConcurrentEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/concurrent/TestdataConcurrentEntity.java
@@ -28,10 +28,6 @@ public class TestdataConcurrentEntity {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public List<TestdataConcurrentValue> getValues() {
         return values;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/concurrent/TestdataConcurrentValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/concurrent/TestdataConcurrentValue.java
@@ -66,10 +66,6 @@ public class TestdataConcurrentValue {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public TestdataConcurrentEntity getEntity() {
         return entity;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/concurrent/TestdataConcurrentValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/concurrent/TestdataConcurrentValue.java
@@ -53,7 +53,7 @@ public class TestdataConcurrentValue {
     List<TestdataConcurrentValue> concurrentValueGroup;
 
     @ShadowVariablesInconsistent
-    Boolean isInconsistent;
+    boolean inconsistent;
 
     public TestdataConcurrentValue() {
     }
@@ -110,6 +110,38 @@ public class TestdataConcurrentValue {
         this.serviceStartTime = serviceStartTime;
     }
 
+    public LocalDateTime getServiceReadyTime() {
+        return serviceReadyTime;
+    }
+
+    public void setServiceReadyTime(LocalDateTime serviceReadyTime) {
+        this.serviceReadyTime = serviceReadyTime;
+    }
+
+    public LocalDateTime getServiceFinishTime() {
+        return serviceFinishTime;
+    }
+
+    public void setServiceFinishTime(LocalDateTime serviceFinishTime) {
+        this.serviceFinishTime = serviceFinishTime;
+    }
+
+    public List<TestdataConcurrentValue> getConcurrentValueGroup() {
+        return concurrentValueGroup;
+    }
+
+    public void setConcurrentValueGroup(List<TestdataConcurrentValue> concurrentValueGroup) {
+        this.concurrentValueGroup = concurrentValueGroup;
+    }
+
+    public boolean isInconsistent() {
+        return inconsistent;
+    }
+
+    public void setInconsistent(boolean inconsistent) {
+        this.inconsistent = inconsistent;
+    }
+
     public LocalDateTime getCascadingTime() {
         return cascadingTime;
     }
@@ -133,7 +165,7 @@ public class TestdataConcurrentValue {
             value = { "serviceReadyTime", "concurrentValueGroup[].serviceReadyTime" },
             alignmentKey = "concurrentValueGroup")
     public LocalDateTime serviceStartTimeUpdater() {
-        if (isInconsistent) {
+        if (inconsistent) {
             throw new IllegalStateException(
                     "Value (%s) is inconsistent when serviceStartTimeUpdater is called.".formatted(this));
         }
@@ -143,7 +175,7 @@ public class TestdataConcurrentValue {
         var startTime = serviceReadyTime;
         if (concurrentValueGroup != null) {
             for (var visit : concurrentValueGroup) {
-                if (visit.isInconsistent) {
+                if (visit.inconsistent) {
                     throw new IllegalStateException(
                             "Value (%s) is inconsistent when serviceStartTimeUpdater is called.".formatted(visit));
                 }
@@ -169,30 +201,6 @@ public class TestdataConcurrentValue {
         } else {
             cascadingTime = BASE_START_TIME.plusDays(index);
         }
-    }
-
-    public LocalDateTime getServiceFinishTime() {
-        return serviceFinishTime;
-    }
-
-    public void setServiceFinishTime(LocalDateTime serviceFinishTime) {
-        this.serviceFinishTime = serviceFinishTime;
-    }
-
-    public List<TestdataConcurrentValue> getConcurrentValueGroup() {
-        return concurrentValueGroup;
-    }
-
-    public void setConcurrentValueGroup(List<TestdataConcurrentValue> concurrentValueGroup) {
-        this.concurrentValueGroup = concurrentValueGroup;
-    }
-
-    public Boolean isInconsistent() {
-        return isInconsistent;
-    }
-
-    public void setInconsistent(Boolean inconsistent) {
-        isInconsistent = inconsistent;
     }
 
     public boolean getExpectedInconsistent() {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/follower/TestdataFollowerEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/follower/TestdataFollowerEntity.java
@@ -26,6 +26,10 @@ public class TestdataFollowerEntity extends TestdataObject implements TestdataHa
         return value;
     }
 
+    public void setValue(TestdataValue value) {
+        this.value = value;
+    }
+
     @ShadowSources(value = "leader.value", alignmentKey = "leader")
     public TestdataValue valueSupplier() {
         return leader.value;

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/follower_set/TestdataFollowerSetEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/follower_set/TestdataFollowerSetEntity.java
@@ -30,6 +30,18 @@ public class TestdataFollowerSetEntity extends TestdataObject implements Testdat
         return value;
     }
 
+    public void setValue(TestdataValue value) {
+        this.value = value;
+    }
+
+    public List<TestdataLeaderEntity> getLeaders() {
+        return leaders;
+    }
+
+    public void setLeaders(List<TestdataLeaderEntity> leaders) {
+        this.leaders = leaders;
+    }
+
     @ShadowSources("leaders[].value")
     public TestdataValue valueSupplier() {
         var min = leaders.get(0).getValue();

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/full/TestdataShadowedFullEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/full/TestdataShadowedFullEntity.java
@@ -15,7 +15,7 @@ public class TestdataShadowedFullEntity extends TestdataObject {
 
     @ShadowVariable(variableListenerClass = TestdataShadowedFullConsistencyListVariableListener.class,
             sourceVariableName = "valueList")
-    Boolean isConsistent;
+    Boolean consistent;
 
     public TestdataShadowedFullEntity() {
         this.valueList = new ArrayList<>();
@@ -28,5 +28,17 @@ public class TestdataShadowedFullEntity extends TestdataObject {
 
     public List<TestdataShadowedFullValue> getValueList() {
         return valueList;
+    }
+
+    public void setValueList(List<TestdataShadowedFullValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    public Boolean getConsistent() {
+        return consistent;
+    }
+
+    public void setConsistent(Boolean consistent) {
+        this.consistent = consistent;
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/full/TestdataShadowedFullValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/full/TestdataShadowedFullValue.java
@@ -30,7 +30,7 @@ public class TestdataShadowedFullValue extends TestdataObject {
             sourceVariableName = "nextValue")
     @ShadowVariable(variableListenerClass = TestdataShadowedFullConsistencyListener.class,
             sourceVariableName = "index")
-    Boolean isConsistent;
+    Boolean consistent;
 
     public TestdataShadowedFullValue() {
 
@@ -38,6 +38,46 @@ public class TestdataShadowedFullValue extends TestdataObject {
 
     public TestdataShadowedFullValue(String code) {
         super(code);
+    }
+
+    public TestdataShadowedFullEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataShadowedFullEntity entity) {
+        this.entity = entity;
+    }
+
+    public TestdataShadowedFullValue getPreviousValue() {
+        return previousValue;
+    }
+
+    public void setPreviousValue(TestdataShadowedFullValue previousValue) {
+        this.previousValue = previousValue;
+    }
+
+    public TestdataShadowedFullValue getNextValue() {
+        return nextValue;
+    }
+
+    public void setNextValue(TestdataShadowedFullValue nextValue) {
+        this.nextValue = nextValue;
+    }
+
+    public Integer getIndex() {
+        return index;
+    }
+
+    public void setIndex(Integer index) {
+        this.index = index;
+    }
+
+    public Boolean getConsistent() {
+        return consistent;
+    }
+
+    public void setConsistent(Boolean consistent) {
+        this.consistent = consistent;
     }
 
     public void updateShadows(TestdataShadowedFullEntity entity, int index) {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/TestdataInvalidDeclarativeEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/TestdataInvalidDeclarativeEntity.java
@@ -27,4 +27,20 @@ public class TestdataInvalidDeclarativeEntity extends TestdataObject {
     public Integer shadowSupplier() {
         return values.size();
     }
+
+    public List<TestdataInvalidDeclarativeValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataInvalidDeclarativeValue> values) {
+        this.values = values;
+    }
+
+    public Integer getShadow() {
+        return shadow;
+    }
+
+    public void setShadow(Integer shadow) {
+        this.shadow = shadow;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/TestdataInvalidDeclarativeSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/TestdataInvalidDeclarativeSolution.java
@@ -28,4 +28,28 @@ public class TestdataInvalidDeclarativeSolution extends TestdataObject {
     public TestdataInvalidDeclarativeSolution(String code) {
         super(code);
     }
+
+    public List<TestdataInvalidDeclarativeEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(List<TestdataInvalidDeclarativeEntity> entities) {
+        this.entities = entities;
+    }
+
+    public List<TestdataInvalidDeclarativeValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataInvalidDeclarativeValue> values) {
+        this.values = values;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/TestdataInvalidDeclarativeValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/TestdataInvalidDeclarativeValue.java
@@ -25,7 +25,7 @@ public class TestdataInvalidDeclarativeValue extends TestdataObject {
     TestdataInvalidDeclarativeValue shadow;
 
     @ShadowVariablesInconsistent
-    boolean isInconsistent;
+    boolean inconsistent;
 
     public TestdataInvalidDeclarativeValue() {
     }
@@ -75,11 +75,11 @@ public class TestdataInvalidDeclarativeValue extends TestdataObject {
     }
 
     public boolean isInconsistent() {
-        return isInconsistent;
+        return inconsistent;
     }
 
     public void setInconsistent(boolean inconsistent) {
-        isInconsistent = inconsistent;
+        this.inconsistent = inconsistent;
     }
 
     @ShadowSources("previous")

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/parameter/TestdataInvalidDeclarativeParameterEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/parameter/TestdataInvalidDeclarativeParameterEntity.java
@@ -18,4 +18,12 @@ public class TestdataInvalidDeclarativeParameterEntity extends TestdataObject {
         super(code);
     }
 
+    public List<TestdataInvalidDeclarativeParameterValue> getValues() {
+        return values;
+    }
+
+    public void setValues(
+            List<TestdataInvalidDeclarativeParameterValue> values) {
+        this.values = values;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/parameter/TestdataInvalidDeclarativeParameterSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/parameter/TestdataInvalidDeclarativeParameterSolution.java
@@ -28,4 +28,30 @@ public class TestdataInvalidDeclarativeParameterSolution extends TestdataObject 
     public TestdataInvalidDeclarativeParameterSolution(String code) {
         super(code);
     }
+
+    public List<TestdataInvalidDeclarativeParameterEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(
+            List<TestdataInvalidDeclarativeParameterEntity> entities) {
+        this.entities = entities;
+    }
+
+    public List<TestdataInvalidDeclarativeParameterValue> getValues() {
+        return values;
+    }
+
+    public void setValues(
+            List<TestdataInvalidDeclarativeParameterValue> values) {
+        this.values = values;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/parameter/TestdataInvalidDeclarativeParameterValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/invalid/parameter/TestdataInvalidDeclarativeParameterValue.java
@@ -22,7 +22,7 @@ public class TestdataInvalidDeclarativeParameterValue extends TestdataObject {
     TestdataInvalidDeclarativeParameterValue invalidParameter;
 
     @ShadowVariablesInconsistent
-    boolean isInconsistent;
+    boolean inconsistent;
 
     public TestdataInvalidDeclarativeParameterValue() {
     }
@@ -64,11 +64,11 @@ public class TestdataInvalidDeclarativeParameterValue extends TestdataObject {
     }
 
     public boolean isInconsistent() {
-        return isInconsistent;
+        return inconsistent;
     }
 
     public void setInconsistent(boolean inconsistent) {
-        isInconsistent = inconsistent;
+        this.inconsistent = inconsistent;
     }
 
     @ShadowSources("previous")

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/missing/TestdataDeclarativeMissingSupplierEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/missing/TestdataDeclarativeMissingSupplierEntity.java
@@ -47,6 +47,10 @@ public class TestdataDeclarativeMissingSupplierEntity {
         return durationInDays;
     }
 
+    public void setDurationInDays(long durationInDays) {
+        this.durationInDays = durationInDays;
+    }
+
     @Override
     public String toString() {
         return "TestdataDeclarativeMissingSupplierEntity{" +

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/missing/TestdataDeclarativeMissingSupplierEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/missing/TestdataDeclarativeMissingSupplierEntity.java
@@ -23,10 +23,6 @@ public class TestdataDeclarativeMissingSupplierEntity {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public TestdataDeclarativeMissingSupplierValue getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/missing/TestdataDeclarativeMissingSupplierValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/missing/TestdataDeclarativeMissingSupplierValue.java
@@ -25,7 +25,7 @@ public class TestdataDeclarativeMissingSupplierValue {
     LocalDateTime endTime;
 
     @ShadowVariablesInconsistent
-    boolean isInvalid;
+    boolean invalid;
 
     @InverseRelationShadowVariable(sourceVariableName = "value")
     List<TestdataDeclarativeMissingSupplierEntity> entityList = new ArrayList<>();
@@ -82,11 +82,11 @@ public class TestdataDeclarativeMissingSupplierValue {
     }
 
     public boolean isInvalid() {
-        return isInvalid;
+        return invalid;
     }
 
     public void setInvalid(boolean invalid) {
-        isInvalid = invalid;
+        this.invalid = invalid;
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedSolution.java
@@ -27,6 +27,14 @@ public class TestdataMixedSolution {
         // required for cloning
     }
 
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
     public List<TestdataMixedEntity> getMixedEntityList() {
         return mixedEntityList;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/mixed/TestdataMixedValue.java
@@ -34,7 +34,7 @@ public class TestdataMixedValue extends TestdataObject {
             "previous",
             "previous.delay"
     })
-    private Integer previousDelaySupplier() {
+    public Integer previousDelaySupplier() {
         if (previous == null) {
             return null;
         } else {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_directional_parent/TestdataMultiDirectionConcurrentEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_directional_parent/TestdataMultiDirectionConcurrentEntity.java
@@ -26,10 +26,6 @@ public class TestdataMultiDirectionConcurrentEntity {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public List<TestdataMultiDirectionConcurrentValue> getValues() {
         return values;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_directional_parent/TestdataMultiDirectionConcurrentValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_directional_parent/TestdataMultiDirectionConcurrentValue.java
@@ -43,7 +43,7 @@ public class TestdataMultiDirectionConcurrentValue {
     List<TestdataMultiDirectionConcurrentValue> concurrentValueGroup;
 
     @ShadowVariablesInconsistent
-    boolean isInvalid;
+    boolean invalid;
 
     public TestdataMultiDirectionConcurrentValue() {
     }
@@ -100,6 +100,14 @@ public class TestdataMultiDirectionConcurrentValue {
         this.serviceStartTime = serviceStartTime;
     }
 
+    public LocalDateTime getServiceReadyTime() {
+        return serviceReadyTime;
+    }
+
+    public void setServiceReadyTime(LocalDateTime serviceReadyTime) {
+        this.serviceReadyTime = serviceReadyTime;
+    }
+
     @ShadowSources({ "previousValue.serviceFinishTime", "entity" })
     public LocalDateTime serviceReadyTimeUpdater() {
         if (previousValue != null) {
@@ -152,11 +160,11 @@ public class TestdataMultiDirectionConcurrentValue {
     }
 
     public boolean isInvalid() {
-        return isInvalid;
+        return invalid;
     }
 
     public void setInvalid(boolean invalid) {
-        isInvalid = invalid;
+        this.invalid = invalid;
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_directional_parent/TestdataMultiDirectionConcurrentValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_directional_parent/TestdataMultiDirectionConcurrentValue.java
@@ -56,10 +56,6 @@ public class TestdataMultiDirectionConcurrentValue {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public TestdataMultiDirectionConcurrentEntity getEntity() {
         return entity;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_entity/TestdataMultiEntityDependencyEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_entity/TestdataMultiEntityDependencyEntity.java
@@ -57,6 +57,14 @@ public class TestdataMultiEntityDependencyEntity {
         this.readyTime = readyTime;
     }
 
+    public TestdataMultiEntityDependencyDelay getDelay() {
+        return delay;
+    }
+
+    public void setDelay(TestdataMultiEntityDependencyDelay delay) {
+        this.delay = delay;
+    }
+
     @ShadowSources("delay")
     public LocalDateTime readyTimeSupplier() {
         if (delay == null) {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_entity/TestdataMultiEntityDependencyValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_entity/TestdataMultiEntityDependencyValue.java
@@ -53,10 +53,6 @@ public class TestdataMultiEntityDependencyValue {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public List<TestdataMultiEntityDependencyValue> getDependencies() {
         return dependencies;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_entity/TestdataMultiEntityDependencyValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multi_entity/TestdataMultiEntityDependencyValue.java
@@ -28,7 +28,7 @@ public class TestdataMultiEntityDependencyValue {
     LocalDateTime endTime;
 
     @ShadowVariablesInconsistent
-    boolean isInvalid;
+    boolean invalid;
 
     @InverseRelationShadowVariable(sourceVariableName = "values")
     TestdataMultiEntityDependencyEntity entity;
@@ -49,6 +49,14 @@ public class TestdataMultiEntityDependencyValue {
         this.dependencies = dependencies;
     }
 
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public List<TestdataMultiEntityDependencyValue> getDependencies() {
         return dependencies;
     }
@@ -64,6 +72,14 @@ public class TestdataMultiEntityDependencyValue {
 
     public void setStartTime(LocalDateTime startTime) {
         this.startTime = startTime;
+    }
+
+    public TestdataMultiEntityDependencyValue getPreviousValue() {
+        return previousValue;
+    }
+
+    public void setPreviousValue(TestdataMultiEntityDependencyValue previousValue) {
+        this.previousValue = previousValue;
     }
 
     @ShadowSources({ "dependencies[].endTime", "previousValue.endTime", "entity.readyTime" })
@@ -116,11 +132,11 @@ public class TestdataMultiEntityDependencyValue {
     }
 
     public boolean isInvalid() {
-        return isInvalid;
+        return invalid;
     }
 
     public void setInvalid(boolean invalid) {
-        isInvalid = invalid;
+        this.invalid = invalid;
     }
 
     public TestdataMultiEntityDependencyEntity getEntity() {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multiplelistener/TestdataListMultipleShadowVariableValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/multiplelistener/TestdataListMultipleShadowVariableValue.java
@@ -89,6 +89,10 @@ public class TestdataListMultipleShadowVariableValue extends TestdataObject {
         return cascadeValue;
     }
 
+    public void setCascadeValue(Integer cascadeValue) {
+        this.cascadeValue = cascadeValue;
+    }
+
     public void updateCascadeValue() {
         this.cascadeValue = index + 10;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/order/TestdataShadowVariableOrderEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/order/TestdataShadowVariableOrderEntity.java
@@ -67,6 +67,62 @@ public class TestdataShadowVariableOrderEntity extends TestdataObject {
         super(code);
     }
 
+    public String getX0G() {
+        return x0G;
+    }
+
+    public void setX0G(String x0G) {
+        this.x0G = x0G;
+    }
+
+    public String getX1D() {
+        return x1D;
+    }
+
+    public void setX1D(String x1D) {
+        this.x1D = x1D;
+    }
+
+    public String getX2E() {
+        return x2E;
+    }
+
+    public void setX2E(String x2E) {
+        this.x2E = x2E;
+    }
+
+    public String getX3C() {
+        return x3C;
+    }
+
+    public void setX3C(String x3C) {
+        this.x3C = x3C;
+    }
+
+    public String getX4F() {
+        return x4F;
+    }
+
+    public void setX4F(String x4F) {
+        this.x4F = x4F;
+    }
+
+    public TestdataValue getX5B() {
+        return x5B;
+    }
+
+    public void setX5B(TestdataValue x5B) {
+        this.x5B = x5B;
+    }
+
+    public TestdataValue getX6A() {
+        return x6A;
+    }
+
+    public void setX6A(TestdataValue x6A) {
+        this.x6A = x6A;
+    }
+
     // ************************************************************************
     // Static inner classes
     // ************************************************************************

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/parameter/TestdataBasicVarParameterEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/parameter/TestdataBasicVarParameterEntity.java
@@ -48,6 +48,10 @@ public class TestdataBasicVarParameterEntity {
         return durationInDays;
     }
 
+    public void setDurationInDays(long durationInDays) {
+        this.durationInDays = durationInDays;
+    }
+
     @Override
     public String toString() {
         return "TestdataBasicVarParameterEntity{" +

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/parameter/TestdataBasicVarParameterEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/parameter/TestdataBasicVarParameterEntity.java
@@ -24,10 +24,6 @@ public class TestdataBasicVarParameterEntity {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public TestdataBasicVarParameterValue getValue() {
         return value;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/parameter/TestdataBasicVarParameterValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/parameter/TestdataBasicVarParameterValue.java
@@ -25,7 +25,7 @@ public class TestdataBasicVarParameterValue {
     LocalDateTime endTime;
 
     @ShadowVariablesInconsistent
-    boolean isInvalid;
+    boolean invalid;
 
     @InverseRelationShadowVariable(sourceVariableName = "value")
     List<TestdataBasicVarParameterEntity> entityList = new ArrayList<>();
@@ -96,11 +96,11 @@ public class TestdataBasicVarParameterValue {
     }
 
     public boolean isInvalid() {
-        return isInvalid;
+        return invalid;
     }
 
     public void setInvalid(boolean invalid) {
-        isInvalid = invalid;
+        this.invalid = invalid;
     }
 
     @Override

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/simple_chained/TestdataChainedSimpleVarEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/simple_chained/TestdataChainedSimpleVarEntity.java
@@ -24,10 +24,6 @@ public class TestdataChainedSimpleVarEntity extends TestdataChainedSimpleVarValu
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public TestdataChainedSimpleVarValue getPrevious() {
         return previous;
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/simple_chained/TestdataChainedSimpleVarValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/simple_chained/TestdataChainedSimpleVarValue.java
@@ -48,6 +48,10 @@ public class TestdataChainedSimpleVarValue {
         return cumulativeDurationInDays;
     }
 
+    public void setCumulativeDurationInDays(int cumulativeDurationInDays) {
+        this.cumulativeDurationInDays = cumulativeDurationInDays;
+    }
+
     @ShadowSources("next.cumulativeDurationInDays")
     public int updateCumulativeDurationInDays() {
         if (next == null) {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/wrongcascade/TestdataCascadingInvalidField.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/wrongcascade/TestdataCascadingInvalidField.java
@@ -70,6 +70,10 @@ public class TestdataCascadingInvalidField {
         return cascadeValue;
     }
 
+    public void setCascadeValue(Integer cascadeValue) {
+        this.cascadeValue = cascadeValue;
+    }
+
     //---Complex methods---//
     public void updateCascadeValue() {
         if (value != null) {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/wrongcascade/TestdataCascadingInvalidPiggyback.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/wrongcascade/TestdataCascadingInvalidPiggyback.java
@@ -73,6 +73,18 @@ public class TestdataCascadingInvalidPiggyback {
         return cascadeValue;
     }
 
+    public void setCascadeValue(Integer cascadeValue) {
+        this.cascadeValue = cascadeValue;
+    }
+
+    public Integer getCascadeValue2() {
+        return cascadeValue2;
+    }
+
+    public void setCascadeValue2(Integer cascadeValue2) {
+        this.cascadeValue2 = cascadeValue2;
+    }
+
     //---Complex methods---//
     public void updateCascadeValue() {
         if (value != null) {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/wrongcascade/TestdataCascadingInvalidSource.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/wrongcascade/TestdataCascadingInvalidSource.java
@@ -74,6 +74,18 @@ public class TestdataCascadingInvalidSource {
         return cascadeValue;
     }
 
+    public void setCascadeValue(Integer cascadeValue) {
+        this.cascadeValue = cascadeValue;
+    }
+
+    public Integer getCascadeValue2() {
+        return cascadeValue2;
+    }
+
+    public void setCascadeValue2(Integer cascadeValue2) {
+        this.cascadeValue2 = cascadeValue2;
+    }
+
     //---Complex methods---//
     public void updateCascadeValue() {
         if (value != null) {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/wrongcascade/TestdataCascadingWrongMethod.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/wrongcascade/TestdataCascadingWrongMethod.java
@@ -72,8 +72,16 @@ public class TestdataCascadingWrongMethod {
         return cascadeValue;
     }
 
+    public void setCascadeValue(Integer cascadeValue) {
+        this.cascadeValue = cascadeValue;
+    }
+
     public Integer getCascadeValueReturnType() {
         return cascadeValueReturnType;
+    }
+
+    public void setCascadeValueReturnType(Integer cascadeValueReturnType) {
+        this.cascadeValueReturnType = cascadeValueReturnType;
     }
 
     //---Complex methods---//

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/solutionproperties/autodiscover/TestdataAutoDiscoverFieldOverrideSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/solutionproperties/autodiscover/TestdataAutoDiscoverFieldOverrideSolution.java
@@ -57,4 +57,43 @@ public class TestdataAutoDiscoverFieldOverrideSolution extends TestdataObject {
         this.score = score;
     }
 
+    public TestdataObject getSingleProblemFact() {
+        return singleProblemFact;
+    }
+
+    public void setSingleProblemFact(TestdataObject singleProblemFact) {
+        this.singleProblemFact = singleProblemFact;
+    }
+
+    public List<TestdataValue> getProblemFactList() {
+        return problemFactList;
+    }
+
+    public void setProblemFactList(List<TestdataValue> problemFactList) {
+        this.problemFactList = problemFactList;
+    }
+
+    public List<String> getListProblemFact() {
+        return listProblemFact;
+    }
+
+    public void setListProblemFact(List<String> listProblemFact) {
+        this.listProblemFact = listProblemFact;
+    }
+
+    public List<TestdataEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public TestdataEntity getOtherEntity() {
+        return otherEntity;
+    }
+
+    public void setOtherEntity(TestdataEntity otherEntity) {
+        this.otherEntity = otherEntity;
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/solutionproperties/autodiscover/TestdataAutoDiscoverFieldSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/solutionproperties/autodiscover/TestdataAutoDiscoverFieldSolution.java
@@ -54,4 +54,44 @@ public class TestdataAutoDiscoverFieldSolution extends TestdataObject {
         this.score = score;
     }
 
+    public TestdataConstraintConfiguration getConstraintConfiguration() {
+        return constraintConfiguration;
+    }
+
+    public void setConstraintConfiguration(
+            TestdataConstraintConfiguration constraintConfiguration) {
+        this.constraintConfiguration = constraintConfiguration;
+    }
+
+    public TestdataObject getSingleProblemFact() {
+        return singleProblemFact;
+    }
+
+    public void setSingleProblemFact(TestdataObject singleProblemFact) {
+        this.singleProblemFact = singleProblemFact;
+    }
+
+    public List<TestdataValue> getProblemFactList() {
+        return problemFactList;
+    }
+
+    public void setProblemFactList(List<TestdataValue> problemFactList) {
+        this.problemFactList = problemFactList;
+    }
+
+    public List<TestdataEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public TestdataEntity getOtherEntity() {
+        return otherEntity;
+    }
+
+    public void setOtherEntity(TestdataEntity otherEntity) {
+        this.otherEntity = otherEntity;
+    }
 }

--- a/quarkus-integration/quarkus-benchmark/integration-test/src/main/java/ai/timefold/solver/quarkus/benchmark/it/domain/TestdataStringLengthShadowEntity.java
+++ b/quarkus-integration/quarkus-benchmark/integration-test/src/main/java/ai/timefold/solver/quarkus/benchmark/it/domain/TestdataStringLengthShadowEntity.java
@@ -32,6 +32,10 @@ public class TestdataStringLengthShadowEntity {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public List<TestdataListValueShadowEntity> getValues() {
         return values;
     }

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -105,7 +105,7 @@ final class GizmoMemberAccessorEntityEnhancer {
         var declaringClass = Class.forName(fieldInfo.declaringClass().name().toString(), false,
                 Thread.currentThread().getContextClassLoader());
         var fieldMember = declaringClass.getDeclaredField(fieldInfo.name());
-        var member = createMemberDescriptorForField(fieldMember, transformers);
+        var member = createMemberDescriptorForField(fieldMember, transformers, true);
         var memberInfo = new GizmoMemberInfo(member, true, false, (Class<? extends Annotation>) Class
                 .forName(annotationInstance.name().toString(), false, Thread.currentThread().getContextClassLoader()));
         var generatedClassName = GizmoMemberAccessorFactory.getGeneratedClassName(fieldMember);
@@ -113,7 +113,7 @@ final class GizmoMemberAccessorEntityEnhancer {
         return generatedClassName;
     }
 
-    private void addVirtualFieldGetter(Class<?> classInfo, Field fieldInfo,
+    private void addVirtualFieldGetterAndSetter(Class<?> classInfo, Field fieldInfo,
             BuildProducer<BytecodeTransformerBuildItem> transformers) {
         if (!visitedFields.contains(fieldInfo)) {
             transformers.produce(new BytecodeTransformerBuildItem(classInfo.getName(),
@@ -362,7 +362,8 @@ final class GizmoMemberAccessorEntityEnhancer {
                 if (Modifier.isStatic(field.getModifiers())) {
                     continue;
                 }
-                solutionFieldToMemberDescriptor.put(field, createMemberDescriptorForField(field, transformers));
+                // Do not enforce a setter; this is for cloning, not an annotation
+                solutionFieldToMemberDescriptor.put(field, createMemberDescriptorForField(field, transformers, false));
             }
             currentClass = currentClass.getSuperclass();
         }
@@ -372,8 +373,10 @@ final class GizmoMemberAccessorEntityEnhancer {
     }
 
     private GizmoMemberDescriptor createMemberDescriptorForField(Field field,
-            BuildProducer<BytecodeTransformerBuildItem> transformers) {
-        if (Modifier.isFinal(field.getModifiers())) {
+            BuildProducer<BytecodeTransformerBuildItem> transformers,
+            boolean enforceSetter) {
+        var isFinal = Modifier.isFinal(field.getModifiers());
+        if (isFinal) {
             makeFieldNonFinal(field, transformers);
         }
 
@@ -382,10 +385,47 @@ final class GizmoMemberAccessorEntityEnhancer {
         var name = field.getName();
 
         // Not being recorded, so can use Type and annotated element directly
-        if (Modifier.isPublic(field.getModifiers())) {
+        if (ReflectionHelper.hasGetterMethod(declaringClass, name)) {
+            var getterMethod = ReflectionHelper.getGetterMethod(declaringClass, name);
+            ReflectionHelper.assertGetterMethod(getterMethod);
+
+            String setterName;
+            if (isFinal) {
+                // It a final field, so no setter exists normally.
+                // In the transformed bytecode, the field is no longer final,
+                // so we can add a setter to delegate field cloning to.
+                addVirtualFieldGetterAndSetter(declaringClass, field, transformers);
+                setterName = getVirtualSetterName(true, name);
+            } else {
+                var setterMethod = ReflectionHelper.getSetterMethod(declaringClass, name);
+                if (setterMethod == null) {
+                    if (enforceSetter) {
+                        throw new IllegalArgumentException(
+                                "The non-final field (%s) on class (%s) has a public getter (%s) but no public setter."
+                                        .formatted(field.getName(), declaringClass.getCanonicalName(), getterMethod));
+                    } else {
+                        addVirtualFieldGetterAndSetter(declaringClass, field, transformers);
+                        setterName = getVirtualSetterName(true, name);
+                    }
+                } else {
+                    if (!Modifier.isPublic(setterMethod.getModifiers())) {
+                        throw new IllegalArgumentException(
+                                "The non-final field (%s) on class (%s) has a public getter (%s) but its setter (%s) is not public."
+                                        .formatted(field.getName(), declaringClass.getCanonicalName(), getterMethod,
+                                                setterMethod));
+                    }
+                    setterName = setterMethod.getName();
+                }
+            }
+            var getterDescriptor = MethodDesc.of(getterMethod);
+            var setterDescriptor =
+                    ClassMethodDesc.of(ClassDesc.ofDescriptor(declaringClass.descriptorString()), setterName, void.class,
+                            field.getType());
+            return new GizmoMemberDescriptor(name, getterDescriptor, memberDescriptor, null, declaringClass, setterDescriptor);
+        } else if (Modifier.isPublic(field.getModifiers())) {
             return new GizmoMemberDescriptor(name, memberDescriptor, declaringClass);
         } else {
-            addVirtualFieldGetter(declaringClass, field, transformers);
+            addVirtualFieldGetterAndSetter(declaringClass, field, transformers);
             var getterName = getVirtualGetterName(true, name);
             var getterDescriptor =
                     ClassMethodDesc.of(ClassDesc.ofDescriptor(declaringClass.descriptorString()), getterName, field.getType());

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorUseGettersSettersTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorUseGettersSettersTest.java
@@ -1,0 +1,56 @@
+package ai.timefold.solver.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import jakarta.inject.Inject;
+
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.quarkus.testdomain.usegettersetter.TestdataQuarkusUseGetterSetterConstraintProvider;
+import ai.timefold.solver.quarkus.testdomain.usegettersetter.TestdataQuarkusUseGetterSetterEntity;
+import ai.timefold.solver.quarkus.testdomain.usegettersetter.TestdataQuarkusUseGetterSetterSolution;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class TimefoldProcessorUseGettersSettersTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.timefold.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusUseGetterSetterEntity.class,
+                            TestdataQuarkusUseGetterSetterSolution.class,
+                            TestdataQuarkusUseGetterSetterConstraintProvider.class));
+
+    @Inject
+    SolverManager<TestdataQuarkusUseGetterSetterSolution, Long> solverManager;
+
+    @Test
+    void solve() throws ExecutionException, InterruptedException {
+        var problem = new TestdataQuarkusUseGetterSetterSolution();
+        problem.setValueList(IntStream.range(1, 3)
+                .mapToObj(i -> "v" + i)
+                .collect(Collectors.toList()));
+        problem.setEntityList(IntStream.range(1, 3)
+                .mapToObj(i -> new TestdataQuarkusUseGetterSetterEntity())
+                .collect(Collectors.toList()));
+        var solverJob = solverManager.solve(1L, problem);
+        var solution = solverJob.getFinalBestSolution();
+        assertNotNull(solution);
+        assertTrue(solution.getScore().score() >= 0);
+        for (var entity : solution.getEntityList()) {
+            assertTrue(entity.getGetterCallCount() > 0);
+            assertTrue(entity.getSetterCallCount() > 0);
+        }
+    }
+
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/declarative/list/TestdataQuarkusDeclarativeShadowVariableListEntity.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/declarative/list/TestdataQuarkusDeclarativeShadowVariableListEntity.java
@@ -22,6 +22,15 @@ public class TestdataQuarkusDeclarativeShadowVariableListEntity {
         this.values = new ArrayList<>();
     }
 
+    public List<TestdataQuarkusDeclarativeShadowVariableListValue> getValues() {
+        return values;
+    }
+
+    public void setValues(
+            List<TestdataQuarkusDeclarativeShadowVariableListValue> values) {
+        this.values = values;
+    }
+
     @Override
     public String toString() {
         return name + " " + values;

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/declarative/list/TestdataQuarkusDeclarativeShadowVariableListValue.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/declarative/list/TestdataQuarkusDeclarativeShadowVariableListValue.java
@@ -21,7 +21,7 @@ public class TestdataQuarkusDeclarativeShadowVariableListValue {
     private Integer startTime;
 
     @ShadowVariablesInconsistent
-    private boolean isInconsistent;
+    private boolean inconsistent;
 
     public TestdataQuarkusDeclarativeShadowVariableListValue() {
     }
@@ -45,15 +45,41 @@ public class TestdataQuarkusDeclarativeShadowVariableListValue {
     }
 
     public boolean isInconsistent() {
-        return isInconsistent;
+        return inconsistent;
     }
 
     public void setInconsistent(boolean inconsistent) {
-        this.isInconsistent = inconsistent;
+        this.inconsistent = inconsistent;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<TestdataQuarkusDeclarativeShadowVariableListValue> getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(
+            List<TestdataQuarkusDeclarativeShadowVariableListValue> dependencies) {
+        this.dependencies = dependencies;
+    }
+
+    public TestdataQuarkusDeclarativeShadowVariableListValue getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(
+            TestdataQuarkusDeclarativeShadowVariableListValue previous) {
+        this.previous = previous;
     }
 
     @ShadowSources({ "previous.startTime", "dependencies[].startTime" })
-    private Integer startTimeSupplier() {
+    public Integer startTimeSupplier() {
         if (previous == null) {
             return 0;
         }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/OnlyMultiArgsConstructorEntity.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/OnlyMultiArgsConstructorEntity.java
@@ -11,4 +11,12 @@ public class OnlyMultiArgsConstructorEntity extends PrivateNoArgsConstructorEnti
     public OnlyMultiArgsConstructorEntity(String id) {
         super(id);
     }
+
+    public String getAnotherValue() {
+        return anotherValue;
+    }
+
+    public void setAnotherValue(String anotherValue) {
+        this.anotherValue = anotherValue;
+    }
 }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/PrivateNoArgsConstructorEntity.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/PrivateNoArgsConstructorEntity.java
@@ -19,4 +19,16 @@ public class PrivateNoArgsConstructorEntity {
     public PrivateNoArgsConstructorEntity(String id) {
         this.id = id;
     }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
 }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/PrivateNoArgsConstructorSolution.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/PrivateNoArgsConstructorSolution.java
@@ -32,4 +32,25 @@ public class PrivateNoArgsConstructorSolution {
     public List<String> valueRange() {
         return Arrays.asList("1", "2", "3");
     }
+
+    public List<PrivateNoArgsConstructorEntity> getPlanningEntityList() {
+        return planningEntityList;
+    }
+
+    public void setPlanningEntityList(
+            List<PrivateNoArgsConstructorEntity> planningEntityList) {
+        this.planningEntityList = planningEntityList;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    public int getSomeField() {
+        return someField;
+    }
 }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/TestDataKitchenSinkEntity.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/TestDataKitchenSinkEntity.java
@@ -42,7 +42,7 @@ public class TestDataKitchenSinkEntity {
     private String declarativeShadowVariable;
 
     @ShadowVariablesInconsistent
-    private boolean isInconsistent;
+    private boolean inconsistent;
 
     @PiggybackShadowVariable(shadowVariableName = "shadow2")
     private String piggybackShadow;
@@ -50,7 +50,7 @@ public class TestDataKitchenSinkEntity {
     @PlanningVariable(valueRangeProviderRefs = { "names" })
     private String stringVariable;
 
-    private boolean isPinned;
+    private boolean pinned;
 
     @PlanningVariable(valueRangeProviderRefs = { "ints" })
     public Integer getIntVariable() {
@@ -69,18 +69,78 @@ public class TestDataKitchenSinkEntity {
         return stringVariable;
     }
 
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getShadow1() {
+        return shadow1;
+    }
+
+    public void setShadow1(String shadow1) {
+        this.shadow1 = shadow1;
+    }
+
+    public String getShadow2() {
+        return shadow2;
+    }
+
+    public void setShadow2(String shadow2) {
+        this.shadow2 = shadow2;
+    }
+
+    public String getDeclarativeShadowVariable() {
+        return declarativeShadowVariable;
+    }
+
+    public void setDeclarativeShadowVariable(String declarativeShadowVariable) {
+        this.declarativeShadowVariable = declarativeShadowVariable;
+    }
+
+    public boolean isInconsistent() {
+        return inconsistent;
+    }
+
+    public void setInconsistent(boolean inconsistent) {
+        this.inconsistent = inconsistent;
+    }
+
+    public String getPiggybackShadow() {
+        return piggybackShadow;
+    }
+
+    public void setPiggybackShadow(String piggybackShadow) {
+        this.piggybackShadow = piggybackShadow;
+    }
+
+    public String getStringVariable() {
+        return stringVariable;
+    }
+
+    public void setStringVariable(String stringVariable) {
+        this.stringVariable = stringVariable;
+    }
+
+    public void setPinned(boolean pinned) {
+        this.pinned = pinned;
+    }
+
     @ShadowSources(value = "stringVariable", alignmentKey = "groupId")
-    private String copyStringVariable() {
+    public String copyStringVariable() {
         return stringVariable;
     }
 
     @PlanningPin
-    private boolean isPinned() {
-        return isPinned;
+    public boolean isPinned() {
+        return pinned;
     }
 
     @ValueRangeProvider(id = "ints")
-    private List<Integer> myIntValueRange() {
+    public List<Integer> myIntValueRange() {
         return Collections.singletonList(1);
     }
 

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/TestDataKitchenSinkSolution.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/gizmo/TestDataKitchenSinkSolution.java
@@ -45,4 +45,41 @@ public class TestDataKitchenSinkSolution {
     public TestDataKitchenSinkEntity getPlanningEntityProperty() {
         return planningEntityProperty;
     }
+
+    public void setPlanningEntityProperty(TestDataKitchenSinkEntity planningEntityProperty) {
+        this.planningEntityProperty = planningEntityProperty;
+    }
+
+    public List<TestDataKitchenSinkEntity> getPlanningEntityListProperty() {
+        return planningEntityListProperty;
+    }
+
+    public void setPlanningEntityListProperty(
+            List<TestDataKitchenSinkEntity> planningEntityListProperty) {
+        this.planningEntityListProperty = planningEntityListProperty;
+    }
+
+    public String getProblemFactProperty() {
+        return problemFactProperty;
+    }
+
+    public void setProblemFactProperty(String problemFactProperty) {
+        this.problemFactProperty = problemFactProperty;
+    }
+
+    public List<String> getProblemFactListProperty() {
+        return problemFactListProperty;
+    }
+
+    public void setProblemFactListProperty(List<String> problemFactListProperty) {
+        this.problemFactListProperty = problemFactListProperty;
+    }
+
+    public HardSoftLongScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftLongScore score) {
+        this.score = score;
+    }
 }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/inheritance/solution/TestdataExtendedQuarkusSolution.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/inheritance/solution/TestdataExtendedQuarkusSolution.java
@@ -15,4 +15,8 @@ public class TestdataExtendedQuarkusSolution extends TestdataQuarkusSolution {
     public String getExtraData() {
         return extraData;
     }
+
+    public void setExtraData(String extraData) {
+        this.extraData = extraData;
+    }
 }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/superclass/TestdataAbstractIdentifiable.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/superclass/TestdataAbstractIdentifiable.java
@@ -17,4 +17,8 @@ abstract class TestdataAbstractIdentifiable {
     public Long getId() {
         return id;
     }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
 }

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/usegettersetter/TestdataQuarkusUseGetterSetterConstraintProvider.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/usegettersetter/TestdataQuarkusUseGetterSetterConstraintProvider.java
@@ -1,0 +1,25 @@
+package ai.timefold.solver.quarkus.testdomain.usegettersetter;
+
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.api.score.stream.Joiners;
+
+import org.jspecify.annotations.NonNull;
+
+public class TestdataQuarkusUseGetterSetterConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.forEach(TestdataQuarkusUseGetterSetterEntity.class)
+                        .join(TestdataQuarkusUseGetterSetterEntity.class,
+                                Joiners.equal(TestdataQuarkusUseGetterSetterEntity::getValue))
+                        .filter((a, b) -> a != b)
+                        .penalize(SimpleScore.ONE)
+                        .asConstraint("Don't assign 2 entities the same value.")
+        };
+    }
+
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/usegettersetter/TestdataQuarkusUseGetterSetterEntity.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/usegettersetter/TestdataQuarkusUseGetterSetterEntity.java
@@ -1,0 +1,31 @@
+package ai.timefold.solver.quarkus.testdomain.usegettersetter;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class TestdataQuarkusUseGetterSetterEntity {
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    private String value;
+    private long getterCallCount;
+    private long setterCallCount;
+
+    public String getValue() {
+        getterCallCount++;
+        return value;
+    }
+
+    public void setValue(String value) {
+        setterCallCount++;
+        this.value = value;
+    }
+
+    public long getGetterCallCount() {
+        return getterCallCount;
+    }
+
+    public long getSetterCallCount() {
+        return setterCallCount;
+    }
+}

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/usegettersetter/TestdataQuarkusUseGetterSetterSolution.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/testdomain/usegettersetter/TestdataQuarkusUseGetterSetterSolution.java
@@ -1,0 +1,48 @@
+package ai.timefold.solver.quarkus.testdomain.usegettersetter;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataQuarkusUseGetterSetterSolution {
+
+    private List<String> valueList;
+    private List<TestdataQuarkusUseGetterSetterEntity> entityList;
+
+    private SimpleScore score;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataQuarkusUseGetterSetterEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataQuarkusUseGetterSetterEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}

--- a/quarkus-integration/quarkus/integration-test/src/main/java/ai/timefold/solver/quarkus/it/domain/TestdataStringLengthShadowEntity.java
+++ b/quarkus-integration/quarkus/integration-test/src/main/java/ai/timefold/solver/quarkus/it/domain/TestdataStringLengthShadowEntity.java
@@ -62,6 +62,14 @@ public class TestdataStringLengthShadowEntity implements TestdataStringLengthSha
         return shadowVarWithoutParam;
     }
 
+    public void setShadowVarWithParam(Integer shadowVarWithParam) {
+        this.shadowVarWithParam = shadowVarWithParam;
+    }
+
+    public void setShadowVarWithoutParam(Integer shadowVarWithoutParam) {
+        this.shadowVarWithoutParam = shadowVarWithoutParam;
+    }
+
     @ShadowSources("value")
     public int processShadowVarWithParam(TestdataStringLengthShadowSolution solution) {
         if (solution == null) {

--- a/spring-integration/spring-boot-integration-test/src/main/java/ai/timefold/solver/spring/boot/it/domain/IntegrationTestEntity.java
+++ b/spring-integration/spring-boot-integration-test/src/main/java/ai/timefold/solver/spring/boot/it/domain/IntegrationTestEntity.java
@@ -70,6 +70,14 @@ public class IntegrationTestEntity {
         return shadowVarWithoutParam;
     }
 
+    public void setShadowVarWithParam(Integer shadowVarWithParam) {
+        this.shadowVarWithParam = shadowVarWithParam;
+    }
+
+    public void setShadowVarWithoutParam(Integer shadowVarWithoutParam) {
+        this.shadowVarWithoutParam = shadowVarWithoutParam;
+    }
+
     @ShadowSources("value")
     public int processShadowVarWithParam(IntegrationTestSolution solution) {
         if (solution == null) {

--- a/test/src/test/java/ai/timefold/solver/test/api/testdomain/TestdataConstraintVerifierSecondEntity.java
+++ b/test/src/test/java/ai/timefold/solver/test/api/testdomain/TestdataConstraintVerifierSecondEntity.java
@@ -17,6 +17,14 @@ public final class TestdataConstraintVerifierSecondEntity {
         this.value = value;
     }
 
+    public String getPlanningId() {
+        return planningId;
+    }
+
+    public void setPlanningId(String planningId) {
+        this.planningId = planningId;
+    }
+
     public String getValue() {
         return value;
     }


### PR DESCRIPTION
Before, this is how domain accessors were created:

- Annotation on the field? Make that field accessible and read/write directly to it.
- Annotation on a getter method? Make that method accessible, and pair it with the corresponding setter (if available) and read/write using the method pair.

Now, domain accessors are created like this:

- Annotation on the field? If the field has a getter, enforce that getter is public. If there is a setter but no getter, fail-fast. Use the field getter/setter for the MemberAccessor; only directly read/write the field if the field is public and there are no getters or setters for the field. Fail-fast otherwise.
- Annotation on a getter method? Enforce the getter is public, and pair it with the corresponding setter (if available, fail if there a setter and not public), and read/write using the method pair.

Quarkus generated MemberAccessors will also follow these same rules and use getters/setters if available.

This is a breaking change. Do not merge until 2.0 is branched.

Fixes #1862 and #1710.