### PR TITLE
feat: Change usage of Random to RandomGenerator

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/api/domain/valuerange/ValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/valuerange/ValueRange.java
@@ -3,8 +3,8 @@ package ai.timefold.solver.core.api.domain.valuerange;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
@@ -54,9 +54,9 @@ public interface ValueRange<T> {
      * Each element might be selected multiple times.
      * Scales well because it does not require caching.
      *
-     * @param workingRandom the {@link Random} to use when any random number is needed,
+     * @param workingRandom the {@link RandomGenerator} to use when any random number is needed,
      *        so runs are reproducible.
      */
-    Iterator<T> createRandomIterator(Random workingRandom);
+    Iterator<T> createRandomIterator(RandomGenerator workingRandom);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/NearbyAutoConfigurationEnabled.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/NearbyAutoConfigurationEnabled.java
@@ -1,6 +1,6 @@
 package ai.timefold.solver.core.config.heuristic.selector.move;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 
@@ -20,6 +20,7 @@ public interface NearbyAutoConfigurationEnabled<Config_ extends MoveSelectorConf
      * @return new instance with the Nearby Selection settings properly configured
      */
     @NonNull
-    Config_ enableNearbySelection(@NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull Random random);
+    Config_ enableNearbySelection(@NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
+            @NonNull RandomGenerator random);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/NearbyUtil.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/NearbyUtil.java
@@ -1,6 +1,6 @@
 package ai.timefold.solver.core.config.heuristic.selector.move;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
@@ -20,7 +20,7 @@ import org.jspecify.annotations.NonNull;
 public final class NearbyUtil {
 
     public static @NonNull ChangeMoveSelectorConfig enable(@NonNull ChangeMoveSelectorConfig changeMoveSelectorConfig,
-            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull Random random) {
+            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull RandomGenerator random) {
         var nearbyConfig = changeMoveSelectorConfig.copyConfig();
         var entityConfig = configureEntitySelector(nearbyConfig.getEntitySelectorConfig(), random);
         var valueConfig = configureValueSelector(nearbyConfig.getValueSelectorConfig(), entityConfig.getId(), distanceMeter);
@@ -28,7 +28,8 @@ public final class NearbyUtil {
                 .withValueSelectorConfig(valueConfig);
     }
 
-    private static EntitySelectorConfig configureEntitySelector(EntitySelectorConfig entitySelectorConfig, Random random) {
+    private static EntitySelectorConfig configureEntitySelector(EntitySelectorConfig entitySelectorConfig,
+            RandomGenerator random) {
         if (entitySelectorConfig == null) {
             entitySelectorConfig = new EntitySelectorConfig();
         }
@@ -65,7 +66,7 @@ public final class NearbyUtil {
     }
 
     public static @NonNull SwapMoveSelectorConfig enable(@NonNull SwapMoveSelectorConfig swapMoveSelectorConfig,
-            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull Random random) {
+            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull RandomGenerator random) {
         var nearbyConfig = swapMoveSelectorConfig.copyConfig();
         var entityConfig = configureEntitySelector(nearbyConfig.getEntitySelectorConfig(), random);
         var secondaryConfig = nearbyConfig.getSecondaryEntitySelectorConfig();
@@ -79,7 +80,7 @@ public final class NearbyUtil {
 
     public static @NonNull TailChainSwapMoveSelectorConfig enable(
             @NonNull TailChainSwapMoveSelectorConfig tailChainSwapMoveSelectorConfig,
-            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull Random random) {
+            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull RandomGenerator random) {
         var nearbyConfig = tailChainSwapMoveSelectorConfig.copyConfig();
         var entityConfig = configureEntitySelector(nearbyConfig.getEntitySelectorConfig(), random);
         var valueConfig = configureValueSelector(nearbyConfig.getValueSelectorConfig(), entityConfig.getId(), distanceMeter);
@@ -89,7 +90,7 @@ public final class NearbyUtil {
 
     public static @NonNull ListChangeMoveSelectorConfig enable(
             @NonNull ListChangeMoveSelectorConfig listChangeMoveSelectorConfig,
-            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull Random random) {
+            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull RandomGenerator random) {
         var nearbyConfig = listChangeMoveSelectorConfig.copyConfig();
         var valueConfig = configureValueSelector(nearbyConfig.getValueSelectorConfig(), random);
         var destinationConfig = nearbyConfig.getDestinationSelectorConfig();
@@ -125,7 +126,7 @@ public final class NearbyUtil {
                 .withDestinationSelectorConfig(destinationConfig);
     }
 
-    private static ValueSelectorConfig configureValueSelector(ValueSelectorConfig valueSelectorConfig, Random random) {
+    private static ValueSelectorConfig configureValueSelector(ValueSelectorConfig valueSelectorConfig, RandomGenerator random) {
         if (valueSelectorConfig == null) {
             valueSelectorConfig = new ValueSelectorConfig();
         }
@@ -135,7 +136,7 @@ public final class NearbyUtil {
     }
 
     public static @NonNull ListSwapMoveSelectorConfig enable(@NonNull ListSwapMoveSelectorConfig listSwapMoveSelectorConfig,
-            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull Random random) {
+            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull RandomGenerator random) {
         var nearbyConfig = listSwapMoveSelectorConfig.copyConfig();
         var valueConfig = configureValueSelector(nearbyConfig.getValueSelectorConfig(), random);
         var secondaryConfig =
@@ -155,7 +156,7 @@ public final class NearbyUtil {
     }
 
     public static @NonNull KOptListMoveSelectorConfig enable(@NonNull KOptListMoveSelectorConfig kOptListMoveSelectorConfig,
-            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull Random random) {
+            @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter, @NonNull RandomGenerator random) {
         var nearbyConfig = kOptListMoveSelectorConfig.copyConfig();
         var originConfig = configureValueSelector(nearbyConfig.getOriginSelectorConfig(), random);
         var valueConfig = configureSecondaryValueSelector(nearbyConfig.getValueSelectorConfig(), originConfig, distanceMeter);

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
@@ -3,8 +3,8 @@ package ai.timefold.solver.core.config.heuristic.selector.move.composite;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Random;
 import java.util.function.Consumer;
+import java.util.random.RandomGenerator;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElements;
@@ -187,7 +187,7 @@ public class UnionMoveSelectorConfig
     @Override
     public @NonNull UnionMoveSelectorConfig enableNearbySelection(
             @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
-            @NonNull Random random) {
+            @NonNull RandomGenerator random) {
         UnionMoveSelectorConfig nearbyConfig = copyConfig();
         var updatedMoveSelectorList = new LinkedList<MoveSelectorConfig>();
         for (var selectorConfig : moveSelectorConfigList) {

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.config.heuristic.selector.move.generic;
 
-import java.util.Random;
 import java.util.function.Consumer;
+import java.util.random.RandomGenerator;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -94,7 +94,7 @@ public class ChangeMoveSelectorConfig
     @Override
     public @NonNull ChangeMoveSelectorConfig enableNearbySelection(
             @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
-            @NonNull Random random) {
+            @NonNull RandomGenerator random) {
         return NearbyUtil.enable(this, distanceMeter, random);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
@@ -2,8 +2,8 @@ package ai.timefold.solver.core.config.heuristic.selector.move.generic;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.function.Consumer;
+import java.util.random.RandomGenerator;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
@@ -117,7 +117,7 @@ public class SwapMoveSelectorConfig
     @Override
     public @NonNull SwapMoveSelectorConfig enableNearbySelection(
             @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
-            @NonNull Random random) {
+            @NonNull RandomGenerator random) {
         return NearbyUtil.enable(this, distanceMeter, random);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorConfig.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.config.heuristic.selector.move.generic.chained;
 
-import java.util.Random;
 import java.util.function.Consumer;
+import java.util.random.RandomGenerator;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -102,7 +102,7 @@ public class TailChainSwapMoveSelectorConfig
     @Override
     public @NonNull TailChainSwapMoveSelectorConfig enableNearbySelection(
             @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
-            @NonNull Random random) {
+            @NonNull RandomGenerator random) {
         return NearbyUtil.enable(this, distanceMeter, random);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.config.heuristic.selector.move.generic.list;
 
-import java.util.Random;
 import java.util.function.Consumer;
+import java.util.random.RandomGenerator;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -96,7 +96,7 @@ public class ListChangeMoveSelectorConfig
     @Override
     public @NonNull ListChangeMoveSelectorConfig enableNearbySelection(
             @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
-            @NonNull Random random) {
+            @NonNull RandomGenerator random) {
         return NearbyUtil.enable(this, distanceMeter, random);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.config.heuristic.selector.move.generic.list;
 
-import java.util.Random;
 import java.util.function.Consumer;
+import java.util.random.RandomGenerator;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -94,7 +94,7 @@ public class ListSwapMoveSelectorConfig
     @Override
     public @NonNull ListSwapMoveSelectorConfig enableNearbySelection(
             @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
-            @NonNull Random random) {
+            @NonNull RandomGenerator random) {
         return NearbyUtil.enable(this, distanceMeter, random);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.config.heuristic.selector.move.generic.list.kopt;
 
-import java.util.Random;
 import java.util.function.Consumer;
+import java.util.random.RandomGenerator;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -128,7 +128,7 @@ public class KOptListMoveSelectorConfig
     @Override
     public @NonNull KOptListMoveSelectorConfig enableNearbySelection(
             @NonNull Class<? extends NearbyDistanceMeter<?, ?>> distanceMeter,
-            @NonNull Random random) {
+            @NonNull RandomGenerator random) {
         return NearbyUtil.enable(this, distanceMeter, random);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/util/ConfigUtils.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -607,7 +607,7 @@ public class ConfigUtils {
         return abbreviate(list, 3);
     }
 
-    public static String addRandomSuffix(String name, Random random) {
+    public static String addRandomSuffix(String name, RandomGenerator random) {
         var value = new StringBuilder(name);
         value.append("-");
         random.ints(97, 122) // ['a', 'z']

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
@@ -7,12 +7,12 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Random;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.bavet.common.joiner.JoinerType;
 import ai.timefold.solver.core.impl.util.ListEntry;
@@ -173,11 +173,12 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom) {
         return createRandomIterator(queryCompositeKey, workingRandom, null);
     }
 
-    private Iterator<T> createRandomIterator(Object queryCompositeKey, Random workingRandom, @Nullable Predicate<T> filter) {
+    private Iterator<T> createRandomIterator(Object queryCompositeKey, RandomGenerator workingRandom,
+            @Nullable Predicate<T> filter) {
         return switch (comparisonMap.size()) {
             case 0 -> Collections.emptyIterator();
             case 1 -> {
@@ -206,7 +207,7 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom, Predicate<T> filter) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter) {
         return createRandomIterator(queryCompositeKey, workingRandom, filter);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ContainedInIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ContainedInIndexer.java
@@ -7,10 +7,10 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.score.stream.UnfinishedJoiners;
 import ai.timefold.solver.core.impl.util.ListEntry;
@@ -104,11 +104,12 @@ final class ContainedInIndexer<T, Key_, KeyCollection_ extends Collection<Key_>>
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom) {
         return createRandomIterator(queryCompositeKey, workingRandom, null);
     }
 
-    private Iterator<T> createRandomIterator(Object queryCompositeKey, Random workingRandom, @Nullable Predicate<T> filter) {
+    private Iterator<T> createRandomIterator(Object queryCompositeKey, RandomGenerator workingRandom,
+            @Nullable Predicate<T> filter) {
         var indexKeyCollection = queryKeyUnpacker.apply(queryCompositeKey);
         if (indexKeyCollection.isEmpty()) {
             return Collections.emptyIterator();
@@ -124,7 +125,7 @@ final class ContainedInIndexer<T, Key_, KeyCollection_ extends Collection<Key_>>
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom, Predicate<T> filter) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter) {
         return createRandomIterator(queryCompositeKey, workingRandom, filter);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ContainingAnyOfIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ContainingAnyOfIndexer.java
@@ -9,12 +9,12 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Random;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.score.stream.UnfinishedJoiners;
 import ai.timefold.solver.core.impl.util.CompositeListEntry;
@@ -186,12 +186,12 @@ final class ContainingAnyOfIndexer<T, Key_, KeyCollection_ extends Collection<Ke
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom) {
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom, Predicate<T> filter) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter) {
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ContainingIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ContainingIndexer.java
@@ -7,11 +7,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.score.stream.UnfinishedJoiners;
 import ai.timefold.solver.core.impl.util.CompositeListEntry;
@@ -141,11 +141,12 @@ final class ContainingIndexer<T, Key_, KeyCollection_ extends Collection<Key_>> 
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom) {
         return createRandomIterator(queryCompositeKey, workingRandom, null);
     }
 
-    private Iterator<T> createRandomIterator(Object queryCompositeKey, Random workingRandom, @Nullable Predicate<T> filter) {
+    private Iterator<T> createRandomIterator(Object queryCompositeKey, RandomGenerator workingRandom,
+            @Nullable Predicate<T> filter) {
         if (downstreamIndexerMap.isEmpty()) {
             return Collections.emptyIterator();
         }
@@ -164,7 +165,7 @@ final class ContainingIndexer<T, Key_, KeyCollection_ extends Collection<Key_>> 
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom, Predicate<T> filter) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter) {
         return createRandomIterator(queryCompositeKey, workingRandom, filter);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/DefaultUniqueRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/DefaultUniqueRandomIterator.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.BitSet;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.util.ElementAwareArrayList;
 
@@ -21,7 +21,7 @@ final class DefaultUniqueRandomIterator<T> implements UniqueRandomIterator<T> {
 
     private final ElementAwareArrayList<T> source;
     private final int length;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
     private final BitSet removed;
 
     private int removedCount;
@@ -32,7 +32,7 @@ final class DefaultUniqueRandomIterator<T> implements UniqueRandomIterator<T> {
     private @Nullable T next = null;
     private int indexToOptionallyRemove = -1;
 
-    DefaultUniqueRandomIterator(ElementAwareArrayList<T> source, Random workingRandom) {
+    DefaultUniqueRandomIterator(ElementAwareArrayList<T> source, RandomGenerator workingRandom) {
         this.source = source;
         this.length = source.size();
         this.removed = new BitSet(); // Do not size upfront, we may only remove a few elements.
@@ -64,7 +64,7 @@ final class DefaultUniqueRandomIterator<T> implements UniqueRandomIterator<T> {
         return true;
     }
 
-    private int pickIndex(Random workingRandom, int index) {
+    private int pickIndex(RandomGenerator workingRandom, int index) {
         if (removed.get(index)) {
             // use the closest index to avoid skewing the probability
             index = determineActiveIndex(workingRandom, index);
@@ -75,7 +75,7 @@ final class DefaultUniqueRandomIterator<T> implements UniqueRandomIterator<T> {
         return index;
     }
 
-    private int determineActiveIndex(Random workingRandom, int randomIndex) {
+    private int determineActiveIndex(RandomGenerator workingRandom, int randomIndex) {
         var nextClearIndex = removed.nextClearBit(randomIndex);
         var previousClearIndex = removed.previousClearBit(randomIndex);
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/EqualIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/EqualIndexer.java
@@ -5,10 +5,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.util.ListEntry;
 
@@ -122,11 +122,12 @@ final class EqualIndexer<T, Key_> implements Indexer<T> {
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom) {
         return createRandomIterator(queryCompositeKey, workingRandom, null);
     }
 
-    private Iterator<T> createRandomIterator(Object queryCompositeKey, Random workingRandom, @Nullable Predicate<T> filter) {
+    private Iterator<T> createRandomIterator(Object queryCompositeKey, RandomGenerator workingRandom,
+            @Nullable Predicate<T> filter) {
         if (downstreamIndexerMap.isEmpty()) {
             return Collections.emptyIterator();
         }
@@ -145,7 +146,7 @@ final class EqualIndexer<T, Key_> implements Indexer<T> {
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom, Predicate<T> filter) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter) {
         return createRandomIterator(queryCompositeKey, workingRandom, filter);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/FilteredUniqueRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/FilteredUniqueRandomIterator.java
@@ -2,8 +2,8 @@ package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Predicate;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.util.ElementAwareArrayList;
 
@@ -27,7 +27,7 @@ public final class FilteredUniqueRandomIterator<T> implements UniqueRandomIterat
     private boolean hasNext = false;
     private @Nullable T next = null;
 
-    FilteredUniqueRandomIterator(ElementAwareArrayList<T> source, Random workingRandom, Predicate<T> filter) {
+    FilteredUniqueRandomIterator(ElementAwareArrayList<T> source, RandomGenerator workingRandom, Predicate<T> filter) {
         this.filter = Objects.requireNonNull(filter);
         this.delegate = new DefaultUniqueRandomIterator<>(source, workingRandom);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/Indexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/Indexer.java
@@ -1,9 +1,9 @@
 package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.Iterator;
-import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleState;
 import ai.timefold.solver.core.impl.util.ListEntry;
@@ -103,12 +103,12 @@ public sealed interface Indexer<T>
      * @param workingRandom used to pick random elements
      * @return iterator for the given composite key, possibly empty
      */
-    Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom);
+    Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom);
 
     /**
-     * As defined by {@link #randomIterator(Object, Random)},
+     * As defined by {@link #randomIterator(Object, RandomGenerator)},
      * but only returning elements matching the given filter.
      */
-    Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom, Predicate<T> filter);
+    Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/LinkedListIndexerBackend.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/LinkedListIndexerBackend.java
@@ -1,9 +1,9 @@
 package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.Iterator;
-import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.util.ElementAwareLinkedList;
 import ai.timefold.solver.core.impl.util.ListEntry;
@@ -46,12 +46,12 @@ public final class LinkedListIndexerBackend<T> implements IndexerBackend<T> {
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom) { // Neighborhoods will not get here.
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom) { // Neighborhoods will not get here.
         throw new UnsupportedOperationException("Impossible state: This backend does not support random access.");
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom, Predicate<T> filter) { // Neighborhoods will not get here.
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter) { // Neighborhoods will not get here.
         throw new UnsupportedOperationException("Impossible state: This backend does not support random access.");
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/RandomAccessIndexerBackend.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/RandomAccessIndexerBackend.java
@@ -1,9 +1,9 @@
 package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.Iterator;
-import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.util.ElementAwareArrayList;
 import ai.timefold.solver.core.impl.util.ListEntry;
@@ -48,12 +48,12 @@ public final class RandomAccessIndexerBackend<T> implements IndexerBackend<T> {
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom) {
         return new DefaultUniqueRandomIterator<>(tupleList, workingRandom);
     }
 
     @Override
-    public Iterator<T> randomIterator(Object queryCompositeKey, Random workingRandom, Predicate<T> filter) {
+    public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter) {
         return new FilteredUniqueRandomIterator<>(tupleList, workingRandom, filter);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/UniqueRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/UniqueRandomIterator.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.Iterator;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.util.ElementAwareArrayList;
 
@@ -26,7 +26,7 @@ public sealed interface UniqueRandomIterator<T>
         extends Iterator<T>
         permits DefaultUniqueRandomIterator, FilteredUniqueRandomIterator {
 
-    static <T> Iterator<T> of(ElementAwareArrayList<T> list, Random random) {
+    static <T> Iterator<T> of(ElementAwareArrayList<T> list, RandomGenerator random) {
         return new DefaultUniqueRandomIterator<>(list, random);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/ValueRangeCache.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/ValueRangeCache.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.valuerange.sort.ValueRangeSorter;
 import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.CachedListRandomIterator;
@@ -78,7 +78,7 @@ public final class ValueRangeCache<Value_>
     /**
      * Iterates in random order, does not terminate.
      */
-    public Iterator<Value_> iterator(Random workingRandom) {
+    public Iterator<Value_> iterator(RandomGenerator workingRandom) {
         return new CachedListRandomIterator<>(valuesWithFastRandomAccess, workingRandom);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/EmptyValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/EmptyValueRange.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.valuerange.buildin;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractCountableValueRange;
@@ -57,7 +57,7 @@ public final class EmptyValueRange<T> extends AbstractCountableValueRange<T> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Iterator<T> createRandomIterator(Random workingRandom) {
+    public Iterator<T> createRandomIterator(RandomGenerator workingRandom) {
         return (Iterator<T>) EmptyIterator.INSTANCE;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/bigdecimal/BigDecimalValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/bigdecimal/BigDecimalValueRange.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractCountableValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.util.ValueRangeIterator;
@@ -118,16 +118,16 @@ public final class BigDecimalValueRange extends AbstractCountableValueRange<BigD
     }
 
     @Override
-    public Iterator<BigDecimal> createRandomIterator(Random workingRandom) {
+    public Iterator<BigDecimal> createRandomIterator(RandomGenerator workingRandom) {
         return new RandomBigDecimalValueRangeIterator(workingRandom);
     }
 
     private class RandomBigDecimalValueRangeIterator extends ValueRangeIterator<BigDecimal> {
 
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
         private final long size = getSize();
 
-        public RandomBigDecimalValueRangeIterator(Random workingRandom) {
+        public RandomBigDecimalValueRangeIterator(RandomGenerator workingRandom) {
             this.workingRandom = workingRandom;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/biginteger/BigIntegerValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/biginteger/BigIntegerValueRange.java
@@ -3,7 +3,7 @@ package ai.timefold.solver.core.impl.domain.valuerange.buildin.biginteger;
 import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractCountableValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.util.ValueRangeIterator;
@@ -101,16 +101,16 @@ public final class BigIntegerValueRange extends AbstractCountableValueRange<BigI
     }
 
     @Override
-    public Iterator<BigInteger> createRandomIterator(Random workingRandom) {
+    public Iterator<BigInteger> createRandomIterator(RandomGenerator workingRandom) {
         return new RandomBigIntegerValueRangeIterator(workingRandom);
     }
 
     private class RandomBigIntegerValueRangeIterator extends ValueRangeIterator<BigInteger> {
 
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
         private final long size = getSize();
 
-        public RandomBigIntegerValueRangeIterator(Random workingRandom) {
+        public RandomBigIntegerValueRangeIterator(RandomGenerator workingRandom) {
             this.workingRandom = workingRandom;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/collection/ListValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/collection/ListValueRange.java
@@ -3,7 +3,7 @@ package ai.timefold.solver.core.impl.domain.valuerange.buildin.collection;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractCountableValueRange;
@@ -72,7 +72,7 @@ public final class ListValueRange<T> extends AbstractCountableValueRange<T> {
     }
 
     @Override
-    public Iterator<T> createRandomIterator(Random workingRandom) {
+    public Iterator<T> createRandomIterator(RandomGenerator workingRandom) {
         return new CachedListRandomIterator<>(list, workingRandom);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/collection/SetValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/collection/SetValueRange.java
@@ -1,8 +1,8 @@
 package ai.timefold.solver.core.impl.domain.valuerange.buildin.collection;
 
 import java.util.Iterator;
-import java.util.Random;
 import java.util.Set;
+import java.util.random.RandomGenerator;
 import java.util.stream.Collectors;
 
 import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
@@ -73,7 +73,7 @@ public final class SetValueRange<T> extends AbstractCountableValueRange<T> {
     }
 
     @Override
-    public Iterator<T> createRandomIterator(Random workingRandom) {
+    public Iterator<T> createRandomIterator(RandomGenerator workingRandom) {
         return getCache().iterator(workingRandom);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/composite/CompositeCountableValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/composite/CompositeCountableValueRange.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.valuerange.buildin.composite;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractCountableValueRange;
@@ -86,7 +86,7 @@ public final class CompositeCountableValueRange<T> extends AbstractCountableValu
     }
 
     @Override
-    public Iterator<T> createRandomIterator(Random workingRandom) {
+    public Iterator<T> createRandomIterator(RandomGenerator workingRandom) {
         return cache.iterator(workingRandom);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/composite/NullAllowingCountableValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/composite/NullAllowingCountableValueRange.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.domain.valuerange.buildin.composite;
 
 import java.util.Iterator;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
@@ -89,15 +89,15 @@ public final class NullAllowingCountableValueRange<T> extends AbstractCountableV
     }
 
     @Override
-    public @NonNull Iterator<T> createRandomIterator(@NonNull Random workingRandom) {
+    public @NonNull Iterator<T> createRandomIterator(@NonNull RandomGenerator workingRandom) {
         return new RandomNullValueRangeIterator(workingRandom);
     }
 
     private class RandomNullValueRangeIterator extends ValueRangeIterator<T> {
 
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
 
-        public RandomNullValueRangeIterator(Random workingRandom) {
+        public RandomNullValueRangeIterator(RandomGenerator workingRandom) {
             this.workingRandom = workingRandom;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primboolean/BooleanValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primboolean/BooleanValueRange.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.valuerange.buildin.primboolean;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractCountableValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.util.ValueRangeIterator;
@@ -63,15 +63,15 @@ public final class BooleanValueRange extends AbstractCountableValueRange<Boolean
     }
 
     @Override
-    public Iterator<Boolean> createRandomIterator(Random workingRandom) {
+    public Iterator<Boolean> createRandomIterator(RandomGenerator workingRandom) {
         return new RandomBooleanValueRangeIterator(workingRandom);
     }
 
     private static final class RandomBooleanValueRangeIterator extends ValueRangeIterator<Boolean> {
 
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
 
-        public RandomBooleanValueRangeIterator(Random workingRandom) {
+        public RandomBooleanValueRangeIterator(RandomGenerator workingRandom) {
             this.workingRandom = workingRandom;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primdouble/DoubleValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primdouble/DoubleValueRange.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.valuerange.buildin.primdouble;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractUncountableValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.buildin.bigdecimal.BigDecimalValueRange;
@@ -53,15 +53,15 @@ public class DoubleValueRange extends AbstractUncountableValueRange<Double> {
     // But in practice, no one could use it.
 
     @Override
-    public @NonNull Iterator<Double> createRandomIterator(@NonNull Random workingRandom) {
+    public @NonNull Iterator<Double> createRandomIterator(@NonNull RandomGenerator workingRandom) {
         return new RandomDoubleValueRangeIterator(workingRandom);
     }
 
     private class RandomDoubleValueRangeIterator extends ValueRangeIterator<Double> {
 
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
 
-        public RandomDoubleValueRangeIterator(Random workingRandom) {
+        public RandomDoubleValueRangeIterator(RandomGenerator workingRandom) {
             this.workingRandom = workingRandom;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primint/IntValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primint/IntValueRange.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.valuerange.buildin.primint;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractCountableValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.util.ValueRangeIterator;
@@ -102,16 +102,16 @@ public final class IntValueRange extends AbstractCountableValueRange<Integer> {
     }
 
     @Override
-    public Iterator<Integer> createRandomIterator(Random workingRandom) {
+    public Iterator<Integer> createRandomIterator(RandomGenerator workingRandom) {
         return new RandomIntValueRangeIterator(workingRandom);
     }
 
     private class RandomIntValueRangeIterator extends ValueRangeIterator<Integer> {
 
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
         private final long size = getSize();
 
-        public RandomIntValueRangeIterator(Random workingRandom) {
+        public RandomIntValueRangeIterator(RandomGenerator workingRandom) {
             this.workingRandom = workingRandom;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primlong/LongValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/primlong/LongValueRange.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.valuerange.buildin.primlong;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractCountableValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.util.ValueRangeIterator;
@@ -107,16 +107,16 @@ public final class LongValueRange extends AbstractCountableValueRange<Long> {
     }
 
     @Override
-    public Iterator<Long> createRandomIterator(Random workingRandom) {
+    public Iterator<Long> createRandomIterator(RandomGenerator workingRandom) {
         return new RandomLongValueRangeIterator(workingRandom);
     }
 
     private class RandomLongValueRangeIterator extends ValueRangeIterator<Long> {
 
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
         private final long size = getSize();
 
-        public RandomLongValueRangeIterator(Random workingRandom) {
+        public RandomLongValueRangeIterator(RandomGenerator workingRandom) {
             this.workingRandom = workingRandom;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/temporal/TemporalValueRange.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/buildin/temporal/TemporalValueRange.java
@@ -6,7 +6,7 @@ import java.time.temporal.TemporalAmount;
 import java.time.temporal.TemporalUnit;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.valuerange.AbstractCountableValueRange;
 import ai.timefold.solver.core.impl.domain.valuerange.util.ValueRangeIterator;
@@ -153,15 +153,15 @@ public final class TemporalValueRange<Temporal_ extends Temporal & Comparable<? 
     }
 
     @Override
-    public Iterator<Temporal_> createRandomIterator(Random workingRandom) {
+    public Iterator<Temporal_> createRandomIterator(RandomGenerator workingRandom) {
         return new RandomTemporalValueRangeIterator(workingRandom);
     }
 
     private class RandomTemporalValueRangeIterator extends ValueRangeIterator<Temporal_> {
 
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
 
-        public RandomTemporalValueRangeIterator(Random workingRandom) {
+        public RandomTemporalValueRangeIterator(RandomGenerator workingRandom) {
             this.workingRandom = workingRandom;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
@@ -2,8 +2,8 @@ package ai.timefold.solver.core.impl.domain.variable.descriptor;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.BiPredicate;
+import java.util.random.RandomGenerator;
 import java.util.stream.Collectors;
 
 import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
@@ -165,7 +165,7 @@ public final class ListVariableDescriptor<Solution_> extends GenuineVariableDesc
         }
     }
 
-    public Object getRandomUnpinnedElement(Object entity, Random workingRandom) {
+    public Object getRandomUnpinnedElement(Object entity, RandomGenerator workingRandom) {
         var listVariable = getValue(entity);
         var firstUnpinnedIndex = getFirstUnpinnedIndex(entity);
         return listVariable.get(workingRandom.nextInt(listVariable.size() - firstUnpinnedIndex) + firstUnpinnedIndex);

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/HeuristicConfigPolicy.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/HeuristicConfigPolicy.java
@@ -3,9 +3,9 @@ package ai.timefold.solver.core.impl.heuristic;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadFactory;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySorterManner;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSorterManner;
@@ -43,7 +43,7 @@ public class HeuristicConfigPolicy<Solution_> {
     private final boolean initializedChainedValueFilterEnabled;
     private final boolean unassignedValuesAllowed;
     private final Class<? extends NearbyDistanceMeter<?, ?>> nearbyDistanceMeterClass;
-    private final Random random;
+    private final RandomGenerator random;
 
     private final Map<String, EntityMimicRecorder<Solution_>> entityMimicRecorderMap = new HashMap<>();
     private final Map<String, SubListMimicRecorder<Solution_>> subListMimicRecorderMap = new HashMap<>();
@@ -124,7 +124,7 @@ public class HeuristicConfigPolicy<Solution_> {
         return nearbyDistanceMeterClass;
     }
 
-    public Random getRandom() {
+    public RandomGenerator getRandom() {
         return random;
     }
 
@@ -283,7 +283,7 @@ public class HeuristicConfigPolicy<Solution_> {
         private boolean unassignedValuesAllowed = false;
 
         private Class<? extends NearbyDistanceMeter<?, ?>> nearbyDistanceMeterClass;
-        private Random random;
+        private RandomGenerator random;
 
         public Builder<Solution_> withPreviewFeatureSet(Set<PreviewFeature> previewFeatureSet) {
             this.previewFeatureSet = previewFeatureSet;
@@ -316,7 +316,7 @@ public class HeuristicConfigPolicy<Solution_> {
             return this;
         }
 
-        public Builder<Solution_> withRandom(Random random) {
+        public Builder<Solution_> withRandom(RandomGenerator random) {
             this.random = random;
             return this;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/AbstractSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/AbstractSelector.java
@@ -1,6 +1,6 @@
 package ai.timefold.solver.core.impl.heuristic.selector;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleSupport;
@@ -22,7 +22,7 @@ public abstract class AbstractSelector<Solution_> implements Selector<Solution_>
 
     protected PhaseLifecycleSupport<Solution_> phaseLifecycleSupport = new PhaseLifecycleSupport<>();
 
-    protected Random workingRandom = null;
+    protected RandomGenerator workingRandom = null;
 
     @Override
     public void solvingStarted(SolverScope<Solution_> solverScope) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/CachedListRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/CachedListRandomIterator.java
@@ -3,7 +3,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.common.iterator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.heuristic.move.Move;
 
@@ -15,10 +15,10 @@ import ai.timefold.solver.core.impl.heuristic.move.Move;
 public class CachedListRandomIterator<S> extends SelectionIterator<S> {
 
     protected final List<S> cachedList;
-    protected final Random workingRandom;
+    protected final RandomGenerator workingRandom;
     protected final boolean empty;
 
-    public CachedListRandomIterator(List<S> cachedList, Random workingRandom) {
+    public CachedListRandomIterator(List<S> cachedList, RandomGenerator workingRandom) {
         this.cachedList = cachedList;
         this.workingRandom = workingRandom;
         empty = cachedList.isEmpty();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntityByEntitySelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntityByEntitySelector.java
@@ -5,8 +5,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
@@ -424,7 +424,7 @@ public final class FilteringEntityByEntitySelector<Solution_> extends AbstractDe
         private final Iterator<Entity_> allEntitiesIterator;
         private final BasicVariableDescriptor<Solution_> basicVariableDescriptor;
         private final ReachableValues<Entity_, Value_> reachableValues;
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
         private final int maxBailoutSize;
         private Entity_ currentReplayedEntity = null;
         private Iterator<Entity_> entityIterator;
@@ -434,7 +434,7 @@ public final class FilteringEntityByEntitySelector<Solution_> extends AbstractDe
         private SingleVariableRandomFilteringValueRangeIterator(Supplier<Entity_> upcomingEntitySupplier,
                 Iterator<Entity_> allEntitiesIterator, BasicVariableDescriptor<Solution_>[] basicVariableDescriptors,
                 ValueRangeManager<Solution_> valueRangeManager, ReachableValues<Entity_, Value_> reachableValues,
-                Random workingRandom, int maxBailoutSize) {
+                RandomGenerator workingRandom, int maxBailoutSize) {
             super(upcomingEntitySupplier, basicVariableDescriptors, valueRangeManager);
             this.allEntitiesIterator = allEntitiesIterator;
             if (basicVariableDescriptors.length > 1) {
@@ -552,9 +552,9 @@ public final class FilteringEntityByEntitySelector<Solution_> extends AbstractDe
     private static class RandomListIterator<Value_> implements Iterator<Value_> {
 
         private final List<Value_> values;
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
 
-        private RandomListIterator(List<Value_> values, Random workingRandom) {
+        private RandomListIterator(List<Value_> values, RandomGenerator workingRandom) {
             this.values = values;
             this.workingRandom = workingRandom;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntityByValueSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntityByValueSelector.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.constructionheuristic.placer.EntityPlacerFactory;
 import ai.timefold.solver.core.impl.constructionheuristic.placer.QueuedValuePlacer;
@@ -363,12 +363,12 @@ public final class FilteringEntityByValueSelector<Solution_> extends AbstractDem
 
         private final Supplier<Value_> upcomingValueSupplier;
         private final ReachableValues<Entity_, Value_> reachableValues;
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
         private Value_ currentUpcomingValue;
         private List<Entity_> entityList;
 
         private RandomFilteringValueRangeIterator(Supplier<Value_> upcomingValueSupplier,
-                ReachableValues<Entity_, Value_> reachableValues, Random workingRandom) {
+                ReachableValues<Entity_, Value_> reachableValues, RandomGenerator workingRandom) {
             this.upcomingValueSupplier = upcomingValueSupplier;
             this.reachableValues = Objects.requireNonNull(reachableValues);
             this.workingRandom = workingRandom;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/ShufflingEntitySelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/ShufflingEntitySelector.java
@@ -1,11 +1,11 @@
 package ai.timefold.solver.core.impl.heuristic.selector.entity.decorator;
 
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.ListIterator;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.impl.heuristic.selector.entity.EntitySelector;
+import ai.timefold.solver.core.impl.solver.random.RandomUtils;
 
 public final class ShufflingEntitySelector<Solution_> extends AbstractCachingEntitySelector<Solution_> {
 
@@ -24,7 +24,7 @@ public final class ShufflingEntitySelector<Solution_> extends AbstractCachingEnt
 
     @Override
     public Iterator<Object> iterator() {
-        Collections.shuffle(cachedEntityList, workingRandom);
+        RandomUtils.shuffle(cachedEntityList, workingRandom);
         logger.trace("    Shuffled cachedEntityList with size ({}) in entitySelector({}).",
                 cachedEntityList.size(), this);
         return cachedEntityList.iterator();
@@ -32,7 +32,7 @@ public final class ShufflingEntitySelector<Solution_> extends AbstractCachingEnt
 
     @Override
     public ListIterator<Object> listIterator() {
-        Collections.shuffle(cachedEntityList, workingRandom);
+        RandomUtils.shuffle(cachedEntityList, workingRandom);
         logger.trace("    Shuffled cachedEntityList with size ({}) in entitySelector({}).",
                 cachedEntityList.size(), this);
         return cachedEntityList.listIterator();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.list;
 
 import java.util.Iterator;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
@@ -20,7 +20,7 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
     private final Iterator<Object> replayingValueIterator;
     private final IterableValueSelector<Solution_> valueSelector;
     private final Iterator<Object> entityIterator;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
     private final long totalSize;
     private final boolean allowsUnassignedValues;
     private Iterator<Object> valueIterator;
@@ -29,7 +29,7 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
 
     public ElementPositionRandomIterator(ListVariableStateSupply<Solution_, Object, Object> listVariableStateSupply,
             EntitySelector<Solution_> entitySelector, Iterator<Object> replayingValueIterator,
-            IterableValueSelector<Solution_> valueSelector, Random workingRandom, long totalSize,
+            IterableValueSelector<Solution_> valueSelector, RandomGenerator workingRandom, long totalSize,
             boolean allowsUnassignedValues) {
         this.listVariableStateSupply = listVariableStateSupply;
         this.listVariableDescriptor = listVariableStateSupply.getSourceVariableDescriptor();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/TriangleElementFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/TriangleElementFactory.java
@@ -3,15 +3,15 @@ package ai.timefold.solver.core.impl.heuristic.selector.list;
 import static ai.timefold.solver.core.impl.heuristic.selector.list.TriangularNumbers.nthTriangle;
 import static ai.timefold.solver.core.impl.heuristic.selector.list.TriangularNumbers.triangularRoot;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 final class TriangleElementFactory {
 
     private final int minimumSubListSize;
     private final int maximumSubListSize;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
 
-    TriangleElementFactory(int minimumSubListSize, int maximumSubListSize, Random workingRandom) {
+    TriangleElementFactory(int minimumSubListSize, int maximumSubListSize, RandomGenerator workingRandom) {
         if (minimumSubListSize > maximumSubListSize) {
             throw new IllegalArgumentException("The minimumSubListSize (" + minimumSubListSize
                     + ") must be less than or equal to the maximumSubListSize (" + maximumSubListSize + ").");

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/BiasedRandomUnionMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/BiasedRandomUnionMoveIterator.java
@@ -5,9 +5,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Random;
 import java.util.TreeMap;
 import java.util.function.ToDoubleFunction;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.SelectionIterator;
@@ -18,13 +18,13 @@ final class BiasedRandomUnionMoveIterator<Solution_> extends SelectionIterator<M
 
     private final Map<Iterator<Move<Solution_>>, ProbabilityItem<Solution_>> probabilityItemMap;
     private final NavigableMap<Double, Iterator<Move<Solution_>>> moveIteratorMap;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
     private double probabilityWeightTotal;
     private boolean stale;
 
     public BiasedRandomUnionMoveIterator(List<MoveSelector<Solution_>> childMoveSelectorList,
             ToDoubleFunction<MoveSelector<Solution_>> probabilityWeightFunction,
-            Random workingRandom) {
+            RandomGenerator workingRandom) {
         this.probabilityItemMap = new LinkedHashMap<>(childMoveSelectorList.size());
         for (MoveSelector<Solution_> moveSelector : childMoveSelectorList) {
             Iterator<Move<Solution_>> moveIterator = moveSelector.iterator();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UniformRandomUnionMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UniformRandomUnionMoveIterator.java
@@ -3,7 +3,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.composite;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.SelectionIterator;
@@ -24,9 +24,9 @@ final class UniformRandomUnionMoveIterator<Solution_> extends SelectionIterator<
     }
 
     private final List<Iterator<Move<Solution_>>> moveIteratorList;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
 
-    public UniformRandomUnionMoveIterator(List<MoveSelector<Solution_>> childMoveSelectorList, Random workingRandom) {
+    public UniformRandomUnionMoveIterator(List<MoveSelector<Solution_>> childMoveSelectorList, RandomGenerator workingRandom) {
         this.moveIteratorList = toMoveIteratorList(childMoveSelectorList);
         this.workingRandom = workingRandom;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/ShufflingMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/ShufflingMoveSelector.java
@@ -1,11 +1,11 @@
 package ai.timefold.solver.core.impl.heuristic.selector.move.decorator;
 
-import java.util.Collections;
 import java.util.Iterator;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector;
+import ai.timefold.solver.core.impl.solver.random.RandomUtils;
 
 public class ShufflingMoveSelector<Solution_> extends AbstractCachingMoveSelector<Solution_> {
 
@@ -24,7 +24,7 @@ public class ShufflingMoveSelector<Solution_> extends AbstractCachingMoveSelecto
 
     @Override
     public Iterator<Move<Solution_>> iterator() {
-        Collections.shuffle(cachedMoveList, workingRandom);
+        RandomUtils.shuffle(cachedMoveList, workingRandom);
         logger.trace("    Shuffled cachedMoveList with size ({}) in moveSelector({}).",
                 cachedMoveList.size(), this);
         return cachedMoveList.iterator();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/factory/MoveIteratorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/factory/MoveIteratorFactory.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.move.factory;
 
 import java.util.Iterator;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
@@ -49,7 +49,7 @@ public interface MoveIteratorFactory<Solution_, Move_ extends Move<Solution_>> {
      * @param scoreDirector never null, the {@link ScoreDirector}
      *        which has the {@link ScoreDirector#getWorkingSolution()} of which the {@link Move}s need to be generated
      * @return never null, an {@link Iterator} that will end sooner or later
-     * @throws UnsupportedOperationException if only {@link #createRandomMoveIterator(ScoreDirector, Random)} is
+     * @throws UnsupportedOperationException if only {@link #createRandomMoveIterator(ScoreDirector, RandomGenerator)} is
      *         supported
      */
     Iterator<Move_> createOriginalMoveIterator(ScoreDirector<Solution_> scoreDirector);
@@ -59,11 +59,11 @@ public interface MoveIteratorFactory<Solution_, Move_ extends Move<Solution_>> {
      *
      * @param scoreDirector never null, the {@link ScoreDirector}
      *        which has the {@link ScoreDirector#getWorkingSolution()} of which the {@link Move}s need to be generated
-     * @param workingRandom never null, the {@link Random} to use when any random number is needed,
+     * @param workingRandom never null, the {@link RandomGenerator} to use when any random number is needed,
      *        so {@link EnvironmentMode#PHASE_ASSERT} works correctly
      * @return never null, an {@link Iterator} that is allowed (or even presumed) to be never ending
      * @throws UnsupportedOperationException if only {@link #createOriginalMoveIterator(ScoreDirector)} is supported
      */
-    Iterator<Move_> createRandomMoveIterator(ScoreDirector<Solution_> scoreDirector, Random workingRandom);
+    Iterator<Move_> createRandomMoveIterator(ScoreDirector<Solution_> scoreDirector, RandomGenerator workingRandom);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveIterator.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.generic;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.move.Move;
@@ -20,12 +20,12 @@ final class RuinRecreateMoveIterator<Solution_> extends UpcomingSelectionIterato
     private final SolverScope<Solution_> solverScope;
     private final int minimumRuinedCount;
     private final int maximumRuinedCount;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
 
     public RuinRecreateMoveIterator(EntitySelector<Solution_> entitySelector,
             GenuineVariableDescriptor<Solution_> variableDescriptor,
             RuinRecreateConstructionHeuristicPhaseBuilder<Solution_> constructionHeuristicPhaseBuilder,
-            SolverScope<Solution_> solverScope, int minimumRuinedCount, int maximumRuinedCount, Random workingRandom) {
+            SolverScope<Solution_> solverScope, int minimumRuinedCount, int maximumRuinedCount, RandomGenerator workingRandom) {
         this.entitySelector = entitySelector;
         this.variableDescriptor = variableDescriptor;
         this.constructionHeuristicPhaseBuilder = constructionHeuristicPhaseBuilder;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveIterator.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.move.generic.list;
 
 import java.util.Iterator;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.move.Move;
@@ -17,13 +17,13 @@ class RandomSubListChangeMoveIterator<Solution_> extends UpcomingSelectionIterat
     private final Iterator<SubList> subListIterator;
     private final Iterator<ElementPosition> destinationIterator;
     private final ListVariableDescriptor<Solution_> listVariableDescriptor;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
     private final boolean selectReversingMoveToo;
 
     RandomSubListChangeMoveIterator(
             SubListSelector<Solution_> subListSelector,
             DestinationSelector<Solution_> destinationSelector,
-            Random workingRandom,
+            RandomGenerator workingRandom,
             boolean selectReversingMoveToo) {
         this.subListIterator = subListSelector.iterator();
         this.destinationIterator = destinationSelector.iterator();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveIterator.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.generic.list.kopt;
 
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
@@ -17,7 +17,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 final class KOptListMoveIterator<Solution_, Node_> extends UpcomingSelectionIterator<Move<Solution_>> {
 
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
     private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final ListVariableStateSupply<Solution_, Object, Object> listVariableStateSupply;
     private final IterableValueSelector<Node_> originSelector;
@@ -27,7 +27,7 @@ final class KOptListMoveIterator<Solution_, Node_> extends UpcomingSelectionIter
     private final int pickedKDistributionSum;
     private final int maxCyclesPatchedInInfeasibleMove;
 
-    public KOptListMoveIterator(Random workingRandom, ListVariableDescriptor<Solution_> listVariableDescriptor,
+    public KOptListMoveIterator(RandomGenerator workingRandom, ListVariableDescriptor<Solution_> listVariableDescriptor,
             ListVariableStateSupply<Solution_, Object, Object> listVariableStateSupply,
             IterableValueSelector<Node_> originSelector,
             IterableValueSelector<Node_> valueSelector, int minK, int maxK, int[] pickedKDistribution) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveIterator.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.generic.list.ruin;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
 import ai.timefold.solver.core.impl.heuristic.move.Move;
@@ -21,14 +21,14 @@ final class ListRuinRecreateMoveIterator<Solution_> extends UpcomingSelectionIte
     private final ListVariableStateSupply<Solution_, Object, Object> listVariableStateSupply;
     private final int minimumRuinedCount;
     private final int maximumRuinedCount;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
 
     public ListRuinRecreateMoveIterator(IterableValueSelector<Solution_> valueSelector,
             RuinRecreateConstructionHeuristicPhaseBuilder<Solution_> constructionHeuristicPhaseBuilder,
             SolverScope<Solution_> solverScope,
             ListVariableStateSupply<Solution_, Object, Object> listVariableStateSupply, int minimumRuinedCount,
             int maximumRuinedCount,
-            Random workingRandom) {
+            RandomGenerator workingRandom) {
         this.valueSelector = valueSelector;
         this.constructionHeuristicPhaseBuilder = constructionHeuristicPhaseBuilder;
         this.solverScope = solverScope;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueRangeSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueRangeSelector.java
@@ -5,8 +5,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
@@ -379,14 +379,14 @@ public final class FilteringValueRangeSelector<Solution_> extends AbstractDemand
     private class RandomFilteringValueRangeIterator<Entity_, Value_>
             extends AbstractFilteringValueRangeIterator<Entity_, Value_> {
 
-        private final Random workingRandom;
+        private final RandomGenerator workingRandom;
         private int maxBailoutSize;
         private Value_ replayedValue;
         private List<Value_> reachableValueList = null;
 
         private RandomFilteringValueRangeIterator(Supplier<Value_> upcomingValueSupplier,
                 ReachableValues<Entity_, Value_> reachableValues,
-                ListVariableStateSupply<Solution_, Entity_, Value_> listVariableStateSupply, Random workingRandom,
+                ListVariableStateSupply<Solution_, Entity_, Value_> listVariableStateSupply, RandomGenerator workingRandom,
                 boolean checkSourceAndDestination) {
             super(upcomingValueSupplier, reachableValues, listVariableStateSupply, checkSourceAndDestination);
             this.workingRandom = workingRandom;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/ShufflingValueSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/ShufflingValueSelector.java
@@ -1,10 +1,10 @@
 package ai.timefold.solver.core.impl.heuristic.selector.value.decorator;
 
-import java.util.Collections;
 import java.util.Iterator;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.impl.heuristic.selector.value.IterableValueSelector;
+import ai.timefold.solver.core.impl.solver.random.RandomUtils;
 
 public final class ShufflingValueSelector<Solution_>
         extends AbstractCachingValueSelector<Solution_>
@@ -31,7 +31,7 @@ public final class ShufflingValueSelector<Solution_>
 
     @Override
     public Iterator<Object> iterator() {
-        Collections.shuffle(cachedValueList, workingRandom);
+        RandomUtils.shuffle(cachedValueList, workingRandom);
         logger.trace("    Shuffled cachedValueList with size ({}) in valueSelector({}).",
                 cachedValueList.size(), this);
         return cachedValueList.iterator();

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsBasedMoveRepository.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsBasedMoveRepository.java
@@ -3,7 +3,7 @@ package ai.timefold.solver.core.impl.neighborhood;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.neighborhood.stream.DefaultMoveStreamFactory;
 import ai.timefold.solver.core.impl.neighborhood.stream.DefaultNeighborhoodSession;
@@ -28,7 +28,7 @@ public final class NeighborhoodsBasedMoveRepository<Solution_> implements MoveRe
 
     private @Nullable DefaultNeighborhoodSession<Solution_> neighborhoodSession;
     private @Nullable List<MoveIterable<Solution_>> moveIterableList;
-    private @Nullable Random workingRandom;
+    private @Nullable RandomGenerator workingRandom;
 
     public NeighborhoodsBasedMoveRepository(DefaultMoveStreamFactory<Solution_> moveStreamFactory,
             List<MoveProvider<Solution_>> neighborhood, boolean random) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/RandomOrderNeighborhoodIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/RandomOrderNeighborhoodIterator.java
@@ -3,7 +3,7 @@ package ai.timefold.solver.core.impl.neighborhood;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.stream.Collectors;
 
 import ai.timefold.solver.core.impl.neighborhood.stream.MoveIterable;
@@ -16,11 +16,11 @@ import org.jspecify.annotations.Nullable;
 final class RandomOrderNeighborhoodIterator<Solution_> implements Iterator<Move<Solution_>> {
 
     private final List<Iterator<Move<Solution_>>> unexhaustedMoveIteratorList;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
 
     private @Nullable Iterator<Move<Solution_>> currentMoveIterator;
 
-    public RandomOrderNeighborhoodIterator(List<MoveIterable<Solution_>> moveIterableList, Random workingRandom) {
+    public RandomOrderNeighborhoodIterator(List<MoveIterable<Solution_>> moveIterableList, RandomGenerator workingRandom) {
         this.unexhaustedMoveIteratorList = moveIterableList.stream()
                 .map(m -> m.iterator(workingRandom))
                 .collect(Collectors.toList());

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/BiMoveStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/BiMoveStream.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.neighborhood.stream;
 
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.neighborhood.stream.enumerating.uni.UniLeftDataset;
 import ai.timefold.solver.core.impl.neighborhood.stream.enumerating.uni.UniRightDataset;
@@ -71,7 +71,7 @@ public final class BiMoveStream<Solution_, A, B> implements InnerMoveStream<Solu
         }
 
         @Override
-        public Iterator<Move<Solution_>> iterator(Random random) {
+        public Iterator<Move<Solution_>> iterator(RandomGenerator random) {
             return new BiRandomMoveIterator<>(context, random);
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/BiRandomMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/BiRandomMoveIterator.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.bavet.common.index.UniqueRandomIterator;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
@@ -58,14 +58,14 @@ import org.jspecify.annotations.Nullable;
 final class BiRandomMoveIterator<Solution_, A, B> implements Iterator<Move<Solution_>> {
 
     private final BiMoveStreamContext<Solution_, A, B> context;
-    private final Random workingRandom;
+    private final RandomGenerator workingRandom;
 
     // Fields required for iteration.
     private final Iterator<UniTuple<A>> leftTupleIterator;
     private final int rightIteratorStoreIndex;
     private @Nullable Move<Solution_> nextMove;
 
-    public BiRandomMoveIterator(BiMoveStreamContext<Solution_, A, B> context, Random workingRandom) {
+    public BiRandomMoveIterator(BiMoveStreamContext<Solution_, A, B> context, RandomGenerator workingRandom) {
         this.context = Objects.requireNonNull(context);
         this.workingRandom = Objects.requireNonNull(workingRandom);
         var leftDatasetInstance = context.getLeftDatasetInstance();

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/MoveIterable.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/MoveIterable.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.neighborhood.stream;
 
 import java.util.Iterator;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.preview.api.move.Move;
 
@@ -10,6 +10,6 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public interface MoveIterable<Solution_> extends Iterable<Move<Solution_>> {
 
-    Iterator<Move<Solution_>> iterator(Random random);
+    Iterator<Move<Solution_>> iterator(RandomGenerator random);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/enumerating/common/AbstractLeftDatasetInstance.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/enumerating/common/AbstractLeftDatasetInstance.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.impl.neighborhood.stream.enumerating.common;
 
 import java.util.Iterator;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.bavet.common.index.UniqueRandomIterator;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
@@ -64,7 +64,7 @@ public abstract class AbstractLeftDatasetInstance<Solution_, Tuple_ extends Tupl
         return tupleList.iterator();
     }
 
-    public Iterator<Tuple_> randomIterator(Random workingRandom) {
+    public Iterator<Tuple_> randomIterator(RandomGenerator workingRandom) {
         return UniqueRandomIterator.of(tupleList, workingRandom);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/enumerating/common/AbstractRightDatasetInstance.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/enumerating/common/AbstractRightDatasetInstance.java
@@ -2,8 +2,8 @@ package ai.timefold.solver.core.impl.neighborhood.stream.enumerating.common;
 
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Predicate;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.bavet.common.index.Indexer;
 import ai.timefold.solver.core.impl.bavet.common.index.IndexerFactory;
@@ -73,11 +73,11 @@ public abstract class AbstractRightDatasetInstance<Solution_, Right_>
         return indexer.iterator(compositeKey);
     }
 
-    public Iterator<UniTuple<Right_>> randomIterator(Object compositeKey, Random workingRandom) {
+    public Iterator<UniTuple<Right_>> randomIterator(Object compositeKey, RandomGenerator workingRandom) {
         return indexer.randomIterator(compositeKey, workingRandom);
     }
 
-    public Iterator<UniTuple<Right_>> randomIterator(Object compositeKey, Random workingRandom,
+    public Iterator<UniTuple<Right_>> randomIterator(Object compositeKey, RandomGenerator workingRandom,
             Predicate<UniTuple<Right_>> predicate) {
         return indexer.randomIterator(compositeKey, workingRandom, predicate);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractMoveScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractMoveScope.java
@@ -1,6 +1,6 @@
 package ai.timefold.solver.core.impl.phase.scope;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
@@ -66,7 +66,7 @@ public abstract class AbstractMoveScope<Solution_> {
         return getStepScope().getWorkingSolution();
     }
 
-    public Random getWorkingRandom() {
+    public RandomGenerator getWorkingRandom() {
         return getStepScope().getWorkingRandom();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
@@ -1,6 +1,6 @@
 package ai.timefold.solver.core.impl.phase.scope;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
@@ -239,7 +239,7 @@ public abstract class AbstractPhaseScope<Solution_> {
         innerScoreDirector.assertShadowVariablesAreNotStale(workingScore, completedAction);
     }
 
-    public Random getWorkingRandom() {
+    public RandomGenerator getWorkingRandom() {
         return getSolverScope().getWorkingRandom();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractStepScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractStepScope.java
@@ -1,6 +1,6 @@
 package ai.timefold.solver.core.impl.phase.scope;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
@@ -66,7 +66,7 @@ public abstract class AbstractStepScope<Solution_> {
         return getPhaseScope().getWorkingSolution();
     }
 
-    public Random getWorkingRandom() {
+    public RandomGenerator getWorkingRandom() {
         return getPhaseScope().getWorkingRandom();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/random/DefaultRandomFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/random/DefaultRandomFactory.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.solver.random;
 
 import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.config.solver.random.RandomType;
 
@@ -28,7 +29,7 @@ public class DefaultRandomFactory implements RandomFactory {
     }
 
     @Override
-    public Random createRandom() {
+    public RandomGenerator createRandom() {
         switch (randomType) {
             case JDK:
                 return randomSeed == null ? new Random() : new Random(randomSeed);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/random/RandomFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/random/RandomFactory.java
@@ -1,6 +1,6 @@
 package ai.timefold.solver.core.impl.solver.random;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * @see DefaultRandomFactory
@@ -10,6 +10,6 @@ public interface RandomFactory {
     /**
      * @return never null
      */
-    Random createRandom();
+    RandomGenerator createRandom();
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/random/RandomUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/random/RandomUtils.java
@@ -1,18 +1,20 @@
 package ai.timefold.solver.core.impl.solver.random;
 
+import java.util.List;
 import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class RandomUtils {
 
     /**
-     * Mimics {@link Random#nextInt(int)} for longs.
+     * Mimics {@link java.util.Random#nextInt(int)} for longs.
      *
      * @param random never null
      * @param n {@code > 0L}
-     * @return like {@link Random#nextInt(int)} but for a long
-     * @see Random#nextInt(int)
+     * @return like {@link java.util.Random#nextInt(int)} but for a long
+     * @see java.util.Random#nextInt(int)
      */
-    public static long nextLong(Random random, long n) {
+    public static long nextLong(RandomGenerator random, long n) {
         // This code is based on java.util.Random#nextInt(int)'s javadoc.
         if (n <= 0L) {
             throw new IllegalArgumentException("n must be positive");
@@ -31,19 +33,34 @@ public class RandomUtils {
     }
 
     /**
-     * Mimics {@link Random#nextInt(int)} for doubles.
+     * Mimics {@link java.util.Random#nextInt(int)} for doubles.
      *
      * @param random never null
      * @param n {@code > 0.0}
-     * @return like {@link Random#nextInt(int)} but for a double
-     * @see Random#nextInt(int)
+     * @return like {@link java.util.Random#nextInt(int)} but for a double
+     * @see java.util.Random#nextInt(int)
      */
-    public static double nextDouble(Random random, double n) {
+    public static double nextDouble(RandomGenerator random, double n) {
         // This code is based on java.util.Random#nextInt(int)'s javadoc.
         if (n <= 0.0) {
             throw new IllegalArgumentException("n must be positive");
         }
         return random.nextDouble() * n;
+    }
+
+    /**
+     * Implements {@link java.util.Collections#shuffle(List, Random)} for {@link RandomGenerator}.
+     * There is a {@link RandomGenerator} overload for shuffle in JDK 21, but not JDK 17.
+     * TODO: Remove me when Minimum JDK 21
+     */
+    public static <Item_> void shuffle(List<Item_> shuffledList, RandomGenerator random) {
+        var listSize = shuffledList.size();
+        for (var rightIndex = listSize - 1; rightIndex > 0; rightIndex--) {
+            var leftIndex = random.nextInt(rightIndex + 1); // leftIndex <= rightIndex
+            var leftValue = shuffledList.get(leftIndex);
+            var rightValue = shuffledList.set(rightIndex, leftValue);
+            shuffledList.set(leftIndex, rightValue);
+        }
     }
 
     private RandomUtils() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
@@ -49,7 +50,7 @@ public class SolverScope<Solution_> {
     private Set<SolverMetric> solverMetricSet = Collections.emptySet();
     private Tags monitoringTags;
     private int startingSolverCount;
-    private Random workingRandom;
+    private RandomGenerator workingRandom;
     private InnerScoreDirector<Solution_, ?> scoreDirector;
     private AbstractSolver<Solution_> solver;
     private DefaultProblemChangeDirector<Solution_> problemChangeDirector;
@@ -142,11 +143,11 @@ public class SolverScope<Solution_> {
         this.startingSolverCount = startingSolverCount;
     }
 
-    public Random getWorkingRandom() {
+    public RandomGenerator getWorkingRandom() {
         return workingRandom;
     }
 
-    public void setWorkingRandom(Random workingRandom) {
+    public void setWorkingRandom(RandomGenerator workingRandom) {
         this.workingRandom = workingRandom;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/util/ElementAwareLinkedList.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/util/ElementAwareLinkedList.java
@@ -6,8 +6,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Consumer;
+import java.util.random.RandomGenerator;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -189,7 +189,7 @@ public final class ElementAwareLinkedList<T> implements Iterable<T> {
      * @param random The random instance to use for shuffling.
      * @return never null
      */
-    public Iterator<T> randomizedIterator(Random random) {
+    public Iterator<T> randomizedIterator(RandomGenerator random) {
         return switch (size) {
             case 0 -> Collections.emptyIterator();
             case 1 -> Collections.singleton(first.element()).iterator();
@@ -267,9 +267,9 @@ public final class ElementAwareLinkedList<T> implements Iterable<T> {
 
         private final List<T> elementList;
         private final List<Integer> unusedIndexList;
-        private final Random random;
+        private final RandomGenerator random;
 
-        public RandomElementAwareListIterator(List<T> copiedList, List<Integer> unusedIndexList, Random random) {
+        public RandomElementAwareListIterator(List<T> copiedList, List<Integer> unusedIndexList, RandomGenerator random) {
             this.random = random;
             this.elementList = copiedList;
             this.unusedIndexList = unusedIndexList;

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BooleanSupplier;
+import java.util.random.RandomGenerator;
 import java.util.stream.IntStream;
 
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
@@ -2393,7 +2394,7 @@ class DefaultSolverTest {
         @Override
         public Iterator<InvalidMove> createRandomMoveIterator(
                 ScoreDirector<TestdataListSolution> scoreDirector,
-                Random workingRandom) {
+                RandomGenerator workingRandom) {
             return createOriginalMoveIterator(scoreDirector);
         }
     }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/singleentity/MixedCustomMoveIteratorFactory.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/singleentity/MixedCustomMoveIteratorFactory.java
@@ -1,7 +1,7 @@
 package ai.timefold.solver.core.testdomain.mixed.singleentity;
 
 import java.util.Iterator;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.stream.Stream;
 
 import ai.timefold.solver.core.api.score.director.ScoreDirector;
@@ -23,7 +23,7 @@ public class MixedCustomMoveIteratorFactory
 
     @Override
     public Iterator<ChangeMove<TestdataMixedSolution>>
-            createRandomMoveIterator(ScoreDirector<TestdataMixedSolution> scoreDirector, Random workingRandom) {
+            createRandomMoveIterator(ScoreDirector<TestdataMixedSolution> scoreDirector, RandomGenerator workingRandom) {
         var solutionDescriptor = TestdataMixedSolution.buildSolutionDescriptor();
         var variableDescriptor =
                 solutionDescriptor.findEntityDescriptor(TestdataMixedEntity.class).getGenuineVariableDescriptor("basicValue");

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorGeneratedGizmoSupplierTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/TimefoldProcessorGeneratedGizmoSupplierTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import jakarta.inject.Inject;
 
@@ -232,7 +232,7 @@ class TimefoldProcessorGeneratedGizmoSupplierTest {
 
         @Override
         public Iterator<DummyMove> createRandomMoveIterator(ScoreDirector<TestdataSolution> scoreDirector,
-                Random workingRandom) {
+                RandomGenerator workingRandom) {
             return null;
         }
     }


### PR DESCRIPTION
Note: there is a tempoarily workaround since
Collections.shuffle(List, RandomGenerator) is not available until JDK 21.

This is a backward-incompatible change since it also affects custom move iterators.
Do not merge until Timefold Solver 2.0 is branched.