### PR TITLE
fix: fix rewardsWith and penalizesBy handling of mixed constraints

### DIFF
--- a/tools/test/src/main/java/ai/timefold/solver/test/impl/score/stream/AbstractSingleConstraintAssertion.java
+++ b/tools/test/src/main/java/ai/timefold/solver/test/impl/score/stream/AbstractSingleConstraintAssertion.java
@@ -303,12 +303,12 @@ public abstract sealed class AbstractSingleConstraintAssertion<Solution_, Score_
         var actualScoreImpactType = constraint.getScoreImpactType();
         if (actualScoreImpactType == ScoreImpactType.MIXED) {
             // Impact means we need to check for expected impact type and actual impact match.
-            if (requireNonNull(scoreImpactType) == ScoreImpactType.REWARD) {
+            if (requireNonNull(scoreImpactType) == ScoreImpactType.PENALTY) {
                 var negatedImpact = deducedImpacts.value();
                 if (equalityPredicate.test(matchWeightTotal, negatedImpact)) {
                     return;
                 }
-            } else if (scoreImpactType == ScoreImpactType.PENALTY && equalityPredicate.test(matchWeightTotal, impact)) {
+            } else if (scoreImpactType == ScoreImpactType.REWARD && equalityPredicate.test(matchWeightTotal, impact)) {
                 return;
             }
         } else if (actualScoreImpactType == scoreImpactType && equalityPredicate.test(matchWeightTotal, impact)) {
@@ -327,12 +327,12 @@ public abstract sealed class AbstractSingleConstraintAssertion<Solution_, Score_
         var actualScoreImpactType = constraint.getScoreImpactType();
         if (actualScoreImpactType == ScoreImpactType.MIXED) {
             // Impact means we need to check for expected impact type and actual impact match.
-            if (requireNonNull(scoreImpactType) == ScoreImpactType.REWARD) {
+            if (requireNonNull(scoreImpactType) == ScoreImpactType.PENALTY) {
                 var negatedImpact = deducedImpacts.value();
                 if (comparator.compare(matchWeightTotal, negatedImpact) < 0) {
                     return;
                 }
-            } else if (scoreImpactType == ScoreImpactType.PENALTY && comparator.compare(matchWeightTotal, impact) < 0) {
+            } else if (scoreImpactType == ScoreImpactType.REWARD && comparator.compare(matchWeightTotal, impact) < 0) {
                 return;
             }
         } else if (actualScoreImpactType == scoreImpactType && comparator.compare(matchWeightTotal, impact) < 0) {
@@ -351,12 +351,12 @@ public abstract sealed class AbstractSingleConstraintAssertion<Solution_, Score_
         var actualScoreImpactType = constraint.getScoreImpactType();
         if (actualScoreImpactType == ScoreImpactType.MIXED) {
             // Impact means we need to check for expected impact type and actual impact match.
-            if (requireNonNull(scoreImpactType) == ScoreImpactType.REWARD) {
+            if (requireNonNull(scoreImpactType) == ScoreImpactType.PENALTY) {
                 var negatedImpact = deducedImpacts.value();
                 if (comparator.compare(matchWeightTotal, negatedImpact) > 0) {
                     return;
                 }
-            } else if (scoreImpactType == ScoreImpactType.PENALTY && comparator.compare(matchWeightTotal, impact) > 0) {
+            } else if (scoreImpactType == ScoreImpactType.REWARD && comparator.compare(matchWeightTotal, impact) > 0) {
                 return;
             }
         } else if (actualScoreImpactType == scoreImpactType && comparator.compare(matchWeightTotal, impact) > 0) {
@@ -570,9 +570,9 @@ public abstract sealed class AbstractSingleConstraintAssertion<Solution_, Score_
                     if (actualImpactType == ScoreImpactType.MIXED) {
                         var isImpactPositive = constraintMatchTotal.getScore().compareTo(zeroScore) > 0;
                         var isImpactNegative = constraintMatchTotal.getScore().compareTo(zeroScore) < 0;
-                        if (isImpactPositive && scoreImpactType == ScoreImpactType.PENALTY) {
+                        if (isImpactPositive && scoreImpactType == ScoreImpactType.REWARD) {
                             return constraintMatchTotal.getConstraintMatchSet().size();
-                        } else if (isImpactNegative && scoreImpactType == ScoreImpactType.REWARD) {
+                        } else if (isImpactNegative && scoreImpactType == ScoreImpactType.PENALTY) {
                             return constraintMatchTotal.getConstraintMatchSet().size();
                         } else {
                             return 0;

--- a/tools/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
+++ b/tools/test/src/test/java/ai/timefold/solver/test/api/score/stream/SingleConstraintAssertionTest.java
@@ -71,6 +71,25 @@ class SingleConstraintAssertionTest {
                     TestdataDependencyEntity.class,
                     TestdataDependencyValue.class);
 
+    private static final String REWARD_CODE = "A";
+    private static final String PENALIZE_CODE = "B";
+
+    private static final String THERE_SHOULD_BE_PENALTIES = "There should be penalties";
+    private static final String THERE_SHOULD_BE_NO_PENALTIES = "There should be no penalties";
+    private static final String EXPECTED_PENALTY_MORE_THAN = "Expected penalty more than";
+    private static final String EXPECTED_PENALTY_LESS_THAN = "Expected penalty less than";
+    private static final String EXPECTED_EXACTLY_ONE_PENALTY = "There should only be one penalty";
+    private static final String EXPECTED_PENALTY = "Expected penalty";
+
+    private static final String THERE_SHOULD_BE_REWARDS = "There should be rewards";
+    private static final String THERE_SHOULD_BE_NO_REWARDS = "There should be no rewards";
+    private static final String EXPECTED_REWARD_MORE_THAN = "Expected reward more than";
+    private static final String EXPECTED_REWARD_LESS_THAN = "Expected reward less than";
+    private static final String EXPECTED_EXACTLY_ONE_REWARD = "There should only be one reward";
+    private static final String EXPECTED_REWARD = "Expected reward";
+
+    private static final String THERE_SHOULD_BE_NO_IMPACT = "There should be no impact";
+
     @Test
     void triggerVariableListenersListSingleSolution() {
         var solution = TestdataListMultipleShadowVariableSolution.generateSolution(2, 1);
@@ -95,7 +114,7 @@ class SingleConstraintAssertionTest {
                 .verifyThat(TestdataListMultipleShadowVariableConstraintProvider::penalizeCascadingUpdate)
                 .givenSolution(solution)
                 .settingAllShadowVariables()
-                .justifiesWith(DefaultConstraintJustification.of(SimpleScore.of(-10), solution.getValueList().get(0))))
+                .justifiesWith(DefaultConstraintJustification.of(SimpleScore.of(-10), solution.getValueList().getFirst())))
                 .doesNotThrowAnyException();
 
         // Test cascade indictment
@@ -103,7 +122,7 @@ class SingleConstraintAssertionTest {
                 .verifyThat(TestdataListMultipleShadowVariableConstraintProvider::penalizeCascadingUpdate)
                 .givenSolution(solution)
                 .settingAllShadowVariables()
-                .indictsWith(solution.getValueList().get(0)))
+                .indictsWith(solution.getValueList().getFirst()))
                 .doesNotThrowAnyException();
     }
 
@@ -140,11 +159,11 @@ class SingleConstraintAssertionTest {
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::penalizeEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .penalizes("There should be penalties.")).doesNotThrowAnyException();
+                .penalizes(THERE_SHOULD_BE_PENALTIES)).doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::penalizeEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .rewards("There should be rewards")).hasMessageContaining("There should be rewards")
-                .hasMessageContaining("Expected reward");
+                .rewards(THERE_SHOULD_BE_REWARDS)).hasMessageContaining(THERE_SHOULD_BE_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
     }
 
     @Test
@@ -153,11 +172,11 @@ class SingleConstraintAssertionTest {
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::rewardEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .rewards("There should be rewards")).doesNotThrowAnyException();
+                .rewards(THERE_SHOULD_BE_REWARDS)).doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::rewardEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .penalizes("There should be penalties.")).hasMessageContaining("There should be penalties")
-                .hasMessageContaining("Expected penalty");
+                .penalizes(THERE_SHOULD_BE_PENALTIES)).hasMessageContaining(THERE_SHOULD_BE_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY);
     }
 
     @Test
@@ -167,7 +186,7 @@ class SingleConstraintAssertionTest {
         // Test with no entities - should have no impact
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::penalizeEveryEntity)
                 .given()
-                .hasNoImpact("There should be no impact")).doesNotThrowAnyException();
+                .hasNoImpact(THERE_SHOULD_BE_NO_IMPACT)).doesNotThrowAnyException();
 
         // Test without custom message - no entities
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::penalizeEveryEntity)
@@ -177,9 +196,9 @@ class SingleConstraintAssertionTest {
         // Test with entities that trigger penalties - should fail
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::penalizeEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .hasNoImpact("There should be no impact"))
+                .hasNoImpact(THERE_SHOULD_BE_NO_IMPACT))
                 .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("There should be no impact")
+                .hasMessageContaining(THERE_SHOULD_BE_NO_IMPACT)
                 .hasMessageContaining("Constraint")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("no impact")
@@ -198,9 +217,9 @@ class SingleConstraintAssertionTest {
         // Test with entities that trigger rewards - should fail
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::rewardEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .hasNoImpact("There should be no impact"))
+                .hasNoImpact(THERE_SHOULD_BE_NO_IMPACT))
                 .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("There should be no impact")
+                .hasMessageContaining(THERE_SHOULD_BE_NO_IMPACT)
                 .hasMessageContaining("Constraint")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("no impact")
@@ -226,14 +245,14 @@ class SingleConstraintAssertionTest {
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .hasNoImpact("There should be no impact")).doesNotThrowAnyException();
+                .hasNoImpact(THERE_SHOULD_BE_NO_IMPACT)).doesNotThrowAnyException();
 
         // Test mixed constraint with entities that cause penalties - should fail
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .hasNoImpact("There should be no impact"))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .hasNoImpact(THERE_SHOULD_BE_NO_IMPACT))
                 .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("There should be no impact")
+                .hasMessageContaining(THERE_SHOULD_BE_NO_IMPACT)
                 .hasMessageContaining("Constraint")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("no impact")
@@ -241,7 +260,7 @@ class SingleConstraintAssertionTest {
 
         // Test mixed constraint with entities that cause penalties - without custom message
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
                 .hasNoImpact())
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining("Constraint")
@@ -251,10 +270,10 @@ class SingleConstraintAssertionTest {
 
         // Test mixed constraint with entities that cause rewards - should fail
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .hasNoImpact("There should be no impact"))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .hasNoImpact(THERE_SHOULD_BE_NO_IMPACT))
                 .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("There should be no impact")
+                .hasMessageContaining(THERE_SHOULD_BE_NO_IMPACT)
                 .hasMessageContaining("Constraint")
                 .hasMessageContaining("Expected")
                 .hasMessageContaining("no impact")
@@ -262,7 +281,7 @@ class SingleConstraintAssertionTest {
 
         // Test mixed constraint with entities that cause rewards - without custom message
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
                 .hasNoImpact())
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining("Constraint")
@@ -275,150 +294,150 @@ class SingleConstraintAssertionTest {
     void impacts() {
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .penalizes("There should be no penalties", 0))
+                .rewards(THERE_SHOULD_BE_NO_REWARDS, 0))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizes("There should be no penalties", 0))
-                .hasMessageContaining("There should be no penalties")
-                .hasMessageContaining("Expected penalty");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewards(THERE_SHOULD_BE_NO_REWARDS, 0))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizes("There should be penalties", 1))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewards(THERE_SHOULD_BE_REWARDS, 1))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizes("There should only be one penalty", 2))
-                .hasMessageContaining("There should only be one penalty")
-                .hasMessageContaining("Expected penalty");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewards(EXPECTED_EXACTLY_ONE_REWARD, 2))
+                .hasMessageContaining(EXPECTED_EXACTLY_ONE_REWARD)
+                .hasMessageContaining(EXPECTED_REWARD);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .rewards("There should not be rewards", 1))
-                .hasMessageContaining("There should not be rewards")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .penalizes(THERE_SHOULD_BE_NO_PENALTIES, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY);
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .rewards("There should be no rewards", 0))
+                .penalizes(THERE_SHOULD_BE_NO_PENALTIES, 0))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewards("There should be no rewards", 0))
-                .hasMessageContaining("There should be no rewards")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizes(THERE_SHOULD_BE_NO_PENALTIES, 0))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewards("There should be rewards", 1))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizes(THERE_SHOULD_BE_NO_PENALTIES, 1))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewards("There should only be one reward", 2))
-                .hasMessageContaining("There should only be one reward")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizes(EXPECTED_EXACTLY_ONE_PENALTY, 2))
+                .hasMessageContaining(EXPECTED_EXACTLY_ONE_PENALTY)
+                .hasMessageContaining(EXPECTED_PENALTY);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .penalizes("There should not be penalties", 1))
-                .hasMessageContaining("There should not be penalties")
-                .hasMessageContaining("Expected penalty");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .rewards(THERE_SHOULD_BE_NO_REWARDS, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
     }
 
     @Test
     void impactsMoreThan() {
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .penalizesMoreThan("There should be penalties", 0))
-                .hasMessageContaining("There should be penalties")
-                .hasMessageContaining("Expected penalty more than");
+                .rewardsMoreThan(THERE_SHOULD_BE_REWARDS, 0))
+                .hasMessageContaining(THERE_SHOULD_BE_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD_MORE_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesMoreThan("There should be no penalties", 0))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsMoreThan(THERE_SHOULD_BE_NO_REWARDS, 0))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesMoreThan("There should be penalties", 1))
-                .hasMessageContaining("There should be penalties")
-                .hasMessageContaining("Expected penalty more than");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsMoreThan(THERE_SHOULD_BE_REWARDS, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD_MORE_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesMoreThan("There should only be one penalty", 2))
-                .hasMessageContaining("There should only be one penalty")
-                .hasMessageContaining("Expected penalty");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsMoreThan(EXPECTED_EXACTLY_ONE_REWARD, 2))
+                .hasMessageContaining(EXPECTED_EXACTLY_ONE_REWARD)
+                .hasMessageContaining(EXPECTED_REWARD);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .rewardsMoreThan("There should not be rewards", 1))
-                .hasMessageContaining("There should not be rewards")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .penalizesMoreThan(THERE_SHOULD_BE_NO_PENALTIES, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY);
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .rewardsMoreThan("There should be no rewards", 0))
-                .hasMessageContaining("There should be no rewards")
-                .hasMessageContaining("Expected reward more than");
+                .penalizesMoreThan(THERE_SHOULD_BE_NO_PENALTIES, 0))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY_MORE_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsMoreThan("There should be no rewards", 0))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesMoreThan(THERE_SHOULD_BE_NO_PENALTIES, 0))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsMoreThan("There should be rewards", 1))
-                .hasMessageContaining("There should be rewards")
-                .hasMessageContaining("Expected reward more than");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesMoreThan(THERE_SHOULD_BE_PENALTIES, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY_MORE_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsMoreThan("There should only be one reward", 2))
-                .hasMessageContaining("There should only be one reward")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesMoreThan(EXPECTED_EXACTLY_ONE_PENALTY, 2))
+                .hasMessageContaining(EXPECTED_EXACTLY_ONE_PENALTY)
+                .hasMessageContaining(EXPECTED_PENALTY);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .penalizesMoreThan("There should not be penalties", 1))
-                .hasMessageContaining("There should not be penalties")
-                .hasMessageContaining("Expected penalty");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .rewardsMoreThan(THERE_SHOULD_BE_NO_REWARDS, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
     }
 
     @Test
     void impactsLessThan() {
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .penalizesLessThan("There should be penalties", 1))
+                .rewardsLessThan(THERE_SHOULD_BE_REWARDS, 1))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesLessThan("There should be no penalties", 1))
-                .hasMessageContaining("There should be no penalties")
-                .hasMessageContaining("Expected penalty less than");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsLessThan(THERE_SHOULD_BE_NO_REWARDS, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD_LESS_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesLessThan("There should be less than 2 rewards", 2))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsLessThan("There should be less than 2 rewards", 2))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesLessThan("There be less than 3 rewards", 3))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsLessThan("There be less than 3 rewards", 3))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .rewardsLessThan("There should be 1 reward", 2))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .penalizesLessThan("There should be 1 reward", 2))
                 .doesNotThrowAnyException();
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .rewardsLessThan("There should be no rewards", 1))
+                .penalizesLessThan(THERE_SHOULD_BE_NO_PENALTIES, 1))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsLessThan("There should be no rewards", 1))
-                .hasMessageContaining("There should be no rewards")
-                .hasMessageContaining("Expected reward less than");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesLessThan(THERE_SHOULD_BE_NO_PENALTIES, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY_LESS_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsLessThan("There should be less than 2 rewards", 2))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesLessThan("There should be less than 2 penalities", 2))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsLessThan("There should be less than 2 rewards", 3))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesLessThan("There should be less than 2 penalities", 3))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .penalizesLessThan("There should not be penalties", 2))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .rewardsLessThan(THERE_SHOULD_BE_NO_REWARDS, 2))
                 .doesNotThrowAnyException();
     }
 
@@ -426,150 +445,150 @@ class SingleConstraintAssertionTest {
     void impactsBy() {
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .penalizesBy("There should be no penalties", 0))
+                .rewardsWith(THERE_SHOULD_BE_NO_REWARDS, 0))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesBy("There should be no penalties", 0))
-                .hasMessageContaining("There should be no penalties")
-                .hasMessageContaining("Expected penalty");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsWith(THERE_SHOULD_BE_NO_REWARDS, 0))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesBy("There should be penalties", 1))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsWith(THERE_SHOULD_BE_REWARDS, 1))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesBy("There should only be one penalty", 2))
-                .hasMessageContaining("There should only be one penalty")
-                .hasMessageContaining("Expected penalty");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsWith(EXPECTED_EXACTLY_ONE_REWARD, 2))
+                .hasMessageContaining(EXPECTED_EXACTLY_ONE_REWARD)
+                .hasMessageContaining(EXPECTED_REWARD);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .rewardsWith("There should not be rewards", 1))
-                .hasMessageContaining("There should not be rewards")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .penalizesBy(THERE_SHOULD_BE_NO_PENALTIES, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY);
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .rewardsWith("There should be no rewards", 0))
+                .penalizesBy(THERE_SHOULD_BE_NO_PENALTIES, 0))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsWith("There should be no rewards", 0))
-                .hasMessageContaining("There should be no rewards")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesBy(THERE_SHOULD_BE_NO_PENALTIES, 0))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsWith("There should be rewards", 1))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesBy(THERE_SHOULD_BE_PENALTIES, 1))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsWith("There should only be one reward", 2))
-                .hasMessageContaining("There should only be one reward")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesBy(EXPECTED_EXACTLY_ONE_PENALTY, 2))
+                .hasMessageContaining(EXPECTED_EXACTLY_ONE_PENALTY)
+                .hasMessageContaining(EXPECTED_PENALTY);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .penalizesBy("There should not be penalties", 1))
-                .hasMessageContaining("There should not be penalties")
-                .hasMessageContaining("Expected penalty");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .rewardsWith(THERE_SHOULD_BE_NO_REWARDS, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
     }
 
     @Test
     void impactsByMoreThan() {
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .penalizesByMoreThan("There should be no penalties", 0))
-                .hasMessageContaining("There should be no penalties")
-                .hasMessageContaining("Expected penalty more than");
+                .rewardsWithMoreThan(THERE_SHOULD_BE_NO_REWARDS, 0))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD_MORE_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesByMoreThan("There should be no penalties", 0))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsWithMoreThan(THERE_SHOULD_BE_NO_REWARDS, 0))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesByMoreThan("There should be penalties", 1))
-                .hasMessageContaining("There should be penalties")
-                .hasMessageContaining("Expected penalty more than");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsWithMoreThan(THERE_SHOULD_BE_REWARDS, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD_MORE_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesByMoreThan("There should only be one penalty", 2))
-                .hasMessageContaining("There should only be one penalty")
-                .hasMessageContaining("Expected penalty more than");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsWithMoreThan(EXPECTED_EXACTLY_ONE_REWARD, 2))
+                .hasMessageContaining(EXPECTED_EXACTLY_ONE_REWARD)
+                .hasMessageContaining(EXPECTED_REWARD_MORE_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .rewardsWithMoreThan("There should not be rewards", 1))
-                .hasMessageContaining("There should not be rewards")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .penalizesByMoreThan(THERE_SHOULD_BE_NO_PENALTIES, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY);
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .rewardsWithMoreThan("There should be no rewards", 0))
-                .hasMessageContaining("There should be no rewards")
-                .hasMessageContaining("Expected reward more than");
+                .penalizesByMoreThan(THERE_SHOULD_BE_NO_PENALTIES, 0))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY_MORE_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsWithMoreThan("There should be no rewards", 0))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesByMoreThan(THERE_SHOULD_BE_NO_PENALTIES, 0))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsWithMoreThan("There should be rewards", 1))
-                .hasMessageContaining("There should be rewards")
-                .hasMessageContaining("Expected reward more than");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesByMoreThan(THERE_SHOULD_BE_PENALTIES, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY_MORE_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsWithMoreThan("There should only be one reward", 2))
-                .hasMessageContaining("There should only be one reward")
-                .hasMessageContaining("Expected reward");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesByMoreThan(EXPECTED_EXACTLY_ONE_PENALTY, 2))
+                .hasMessageContaining(EXPECTED_EXACTLY_ONE_PENALTY)
+                .hasMessageContaining(EXPECTED_PENALTY);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .penalizesByMoreThan("There should not be penalties", 1))
-                .hasMessageContaining("There should not be penalties")
-                .hasMessageContaining("Expected penalty");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .rewardsWithMoreThan(THERE_SHOULD_BE_NO_REWARDS, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
     }
 
     @Test
     void impactsByLessThan() {
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .penalizesByLessThan("There should be no penalties", 1))
+                .rewardsWithLessThan(THERE_SHOULD_BE_NO_PENALTIES, 1))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesByLessThan("There should be penalties", 1))
-                .hasMessageContaining("There should be penalties")
-                .hasMessageContaining("Expected penalty less than");
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsWithLessThan(THERE_SHOULD_BE_REWARDS, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD_LESS_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesByLessThan("There should be penalties", 2))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsWithLessThan(THERE_SHOULD_BE_REWARDS, 2))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .penalizesByLessThan("There should only be one penalty", 3))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .rewardsWithLessThan(EXPECTED_EXACTLY_ONE_REWARD, 3))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("A", new TestdataValue()))
-                .rewardsWithLessThan("There should not be rewards", 2))
+                .given(new TestdataConstraintVerifierFirstEntity(REWARD_CODE, new TestdataValue()))
+                .penalizesByLessThan(THERE_SHOULD_BE_NO_PENALTIES, 2))
                 .doesNotThrowAnyException();
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
                 .given()
-                .rewardsWithLessThan("There should be no rewards", 1))
+                .penalizesByLessThan(THERE_SHOULD_BE_NO_PENALTIES, 1))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsWithLessThan("There should be no rewards", 1))
-                .hasMessageContaining("There should be no rewards")
-                .hasMessageContaining("Expected reward less than");
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesByLessThan(THERE_SHOULD_BE_NO_PENALTIES, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY_LESS_THAN);
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsWithLessThan("There should be rewards", 2))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesByLessThan(THERE_SHOULD_BE_PENALTIES, 2))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .rewardsWithLessThan("There should only be one reward", 3))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .penalizesByLessThan(EXPECTED_EXACTLY_ONE_PENALTY, 3))
                 .doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::impactEveryEntity)
-                .given(new TestdataConstraintVerifierFirstEntity("B", new TestdataValue()))
-                .penalizesByLessThan("There should not be penalties", 2))
+                .given(new TestdataConstraintVerifierFirstEntity(PENALIZE_CODE, new TestdataValue()))
+                .rewardsWithLessThan(THERE_SHOULD_BE_NO_REWARDS, 2))
                 .doesNotThrowAnyException();
     }
 
@@ -579,11 +598,11 @@ class SingleConstraintAssertionTest {
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::penalizeEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .penalizes("There should be penalties.", 3)).doesNotThrowAnyException();
+                .penalizes(THERE_SHOULD_BE_PENALTIES, 3)).doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::penalizeEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .rewards("There should be rewards", 1)).hasMessageContaining("There should be rewards")
-                .hasMessageContaining("Expected reward");
+                .rewards(THERE_SHOULD_BE_REWARDS, 1)).hasMessageContaining(THERE_SHOULD_BE_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
     }
 
     @Test
@@ -592,12 +611,12 @@ class SingleConstraintAssertionTest {
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::penalizeEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .penalizesBy("There should be penalties.", BigDecimal.valueOf(3))).doesNotThrowAnyException();
+                .penalizesBy(THERE_SHOULD_BE_PENALTIES, BigDecimal.valueOf(3))).doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::penalizeEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .penalizesBy("There should be penalties.", new BigDecimal("3.01")))
-                .hasMessageContaining("There should be penalties")
-                .hasMessageContaining("Expected penalty");
+                .penalizesBy(THERE_SHOULD_BE_PENALTIES, new BigDecimal("3.01")))
+                .hasMessageContaining(THERE_SHOULD_BE_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY);
     }
 
     @Test
@@ -606,11 +625,11 @@ class SingleConstraintAssertionTest {
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::rewardEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .rewards("There should be rewards", 3)).doesNotThrowAnyException();
+                .rewards(THERE_SHOULD_BE_REWARDS, 3)).doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::rewardEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .penalizes("There should be penalties.", 1)).hasMessageContaining("There should be penalties")
-                .hasMessageContaining("Expected penalty");
+                .penalizes(THERE_SHOULD_BE_PENALTIES, 1)).hasMessageContaining(THERE_SHOULD_BE_PENALTIES)
+                .hasMessageContaining(EXPECTED_PENALTY);
     }
 
     @Test
@@ -619,12 +638,12 @@ class SingleConstraintAssertionTest {
 
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::rewardEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .rewardsWith("There should be rewards", BigDecimal.valueOf(3))).doesNotThrowAnyException();
+                .rewardsWith(THERE_SHOULD_BE_REWARDS, BigDecimal.valueOf(3))).doesNotThrowAnyException();
         assertThatCode(() -> constraintVerifier.verifyThat(TestdataConstraintVerifierConstraintProvider::rewardEveryEntity)
                 .given(solution.getEntityList().toArray())
-                .rewardsWith("There should be rewards.", new BigDecimal("3.01")))
-                .hasMessageContaining("There should be rewards")
-                .hasMessageContaining("Expected reward");
+                .rewardsWith(THERE_SHOULD_BE_REWARDS, new BigDecimal("3.01")))
+                .hasMessageContaining(THERE_SHOULD_BE_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
     }
 
     @Test
@@ -633,14 +652,14 @@ class SingleConstraintAssertionTest {
                 .verifyThat(TestdataConstraintVerifierConstraintProvider::differentStringEntityHaveDifferentValues)
                 .given(new TestdataConstraintVerifierSecondEntity("A", "1"),
                         new TestdataConstraintVerifierSecondEntity("B", "1"))
-                .penalizes("There should be penalties", 1)).doesNotThrowAnyException();
+                .penalizes(THERE_SHOULD_BE_PENALTIES, 1)).doesNotThrowAnyException();
 
         assertThatCode(() -> constraintVerifier
                 .verifyThat(TestdataConstraintVerifierConstraintProvider::differentStringEntityHaveDifferentValues)
                 .given(new TestdataConstraintVerifierSecondEntity("A", "1"),
                         new TestdataConstraintVerifierSecondEntity("B", "1"))
-                .rewards("There should be rewards", 1)).hasMessageContaining("There should be rewards")
-                .hasMessageContaining("Expected reward");
+                .rewards(THERE_SHOULD_BE_REWARDS, 1)).hasMessageContaining(THERE_SHOULD_BE_REWARDS)
+                .hasMessageContaining(EXPECTED_REWARD);
     }
 
     @Test
@@ -661,22 +680,22 @@ class SingleConstraintAssertionTest {
         assertThatCode(() -> verifier
                 .verifyThat(TestdataAllowsUnassignedListConstraintProvider::penalizeEveryAssignedValue)
                 .given(entity, value1, value2)
-                .penalizes("There should be no penalties", 0))
-                .hasMessageContaining("There should be no penalties");
+                .penalizes(THERE_SHOULD_BE_NO_PENALTIES, 0))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES);
         assertThatCode(() -> verifier
                 .verifyThat(TestdataAllowsUnassignedListConstraintProvider::penalizeEveryValue)
                 .given(entity, value1, value2)
-                .penalizes("There should be no penalties", 1))
-                .hasMessageContaining("There should be no penalties");
+                .penalizes(THERE_SHOULD_BE_NO_PENALTIES, 1))
+                .hasMessageContaining(THERE_SHOULD_BE_NO_PENALTIES);
 
         assertThatCode(() -> verifier
                 .verifyThat(TestdataAllowsUnassignedListConstraintProvider::penalizeEveryAssignedValue)
                 .given(entity, value1, value2)
-                .penalizes("There should be penalties", 1)).doesNotThrowAnyException();
+                .penalizes(THERE_SHOULD_BE_PENALTIES, 1)).doesNotThrowAnyException();
         assertThatCode(() -> verifier
                 .verifyThat(TestdataAllowsUnassignedListConstraintProvider::penalizeEveryValue)
                 .given(entity, value1, value2)
-                .penalizes("There should be penalties", 2)).doesNotThrowAnyException();
+                .penalizes(THERE_SHOULD_BE_PENALTIES, 2)).doesNotThrowAnyException();
     }
 
     private static final class TestdataAllowsUnassignedListConstraintProvider implements ConstraintProvider {
@@ -720,11 +739,11 @@ class SingleConstraintAssertionTest {
         assertThatCode(() -> verifier
                 .verifyThat(TestdataDisallowsUnassignedListConstraintProvider::penalizeEveryAssignedValue)
                 .given(entity, value1, value2)
-                .penalizes("There should be penalties", 1)).doesNotThrowAnyException();
+                .penalizes(THERE_SHOULD_BE_PENALTIES, 1)).doesNotThrowAnyException();
         assertThatCode(() -> verifier
                 .verifyThat(TestdataDisallowsUnassignedListConstraintProvider::penalizeEveryValue)
                 .given(entity, value1, value2)
-                .penalizes("There should be penalties", 2)).doesNotThrowAnyException();
+                .penalizes(THERE_SHOULD_BE_PENALTIES, 2)).doesNotThrowAnyException();
     }
 
     private static final class TestdataDisallowsUnassignedListConstraintProvider implements ConstraintProvider {
@@ -768,11 +787,11 @@ class SingleConstraintAssertionTest {
                 .verifyThat(
                         TestdataDisallowsUnassignedListWithoutInverseShadowVarConstraintProvider::penalizeEveryAssignedValue)
                 .given(entity, value1, value2)
-                .penalizes("There should be penalties", 1)).doesNotThrowAnyException();
+                .penalizes(THERE_SHOULD_BE_PENALTIES, 1)).doesNotThrowAnyException();
         assertThatCode(() -> verifier
                 .verifyThat(TestdataDisallowsUnassignedListWithoutInverseShadowVarConstraintProvider::penalizeEveryValue)
                 .given(entity, value1, value2)
-                .penalizes("There should be penalties", 2)).doesNotThrowAnyException();
+                .penalizes(THERE_SHOULD_BE_PENALTIES, 2)).doesNotThrowAnyException();
     }
 
     private static final class TestdataDisallowsUnassignedListWithoutInverseShadowVarConstraintProvider
@@ -1149,7 +1168,7 @@ class SingleConstraintAssertionTest {
                 () -> constraintVerifierForJustification
                         .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
                         .givenSolution(solution)
-                        .indictsWith(solution.getEntityList().get(0), badEntity))
+                        .indictsWith(solution.getEntityList().getFirst(), badEntity))
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining(
                         "Indictment: Justify with first justification")
@@ -1167,7 +1186,7 @@ class SingleConstraintAssertionTest {
                 () -> constraintVerifierForJustification
                         .verifyThat(TestdataConstraintVerifierJustificationProvider::justifyWithFirstJustification)
                         .given(solution.getEntityList().toArray())
-                        .indictsWith(solution.getEntityList().get(0), badEntity, "bad indictment"))
+                        .indictsWith(solution.getEntityList().getFirst(), badEntity, "bad indictment"))
                 .hasMessageContaining("Broken expectation")
                 .hasMessageContaining(
                         "Indictment: Justify with first justification")


### PR DESCRIPTION
Before, rewardsWith expects negative impact values and penalizesBy expects positive impact values.

Now, rewardsWith expects positive impact value and penalizesBy expect negative impact values.