### PR TITLE
chore: add escape hatch for SolverConfig in Quarkus build time

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
@@ -37,23 +37,23 @@ import org.jspecify.annotations.Nullable;
         "moveSelectorConfigList",
         "foragerConfig"
 })
-public class ConstructionHeuristicPhaseConfig extends PhaseConfig<ConstructionHeuristicPhaseConfig> {
+public final class ConstructionHeuristicPhaseConfig extends PhaseConfig<ConstructionHeuristicPhaseConfig> {
 
     public static final String XML_ELEMENT_NAME = "constructionHeuristic";
 
     // Warning: all fields are null (and not defaulted) because they can be inherited
     // and also because the input config file should match the output config file
 
-    protected ConstructionHeuristicType constructionHeuristicType = null;
-    protected EntitySorterManner entitySorterManner = null;
-    protected ValueSorterManner valueSorterManner = null;
+    private ConstructionHeuristicType constructionHeuristicType = null;
+    private EntitySorterManner entitySorterManner = null;
+    private ValueSorterManner valueSorterManner = null;
 
     @XmlElements({
             @XmlElement(name = "queuedEntityPlacer", type = QueuedEntityPlacerConfig.class),
             @XmlElement(name = "queuedValuePlacer", type = QueuedValuePlacerConfig.class),
             @XmlElement(name = "pooledEntityPlacer", type = PooledEntityPlacerConfig.class)
     })
-    protected EntityPlacerConfig entityPlacerConfig = null;
+    private EntityPlacerConfig entityPlacerConfig = null;
 
     /** Simpler alternative for {@link #entityPlacerConfig}. */
     @XmlElements({
@@ -68,10 +68,10 @@ public class ConstructionHeuristicPhaseConfig extends PhaseConfig<ConstructionHe
             @XmlElement(name = SwapMoveSelectorConfig.XML_ELEMENT_NAME, type = SwapMoveSelectorConfig.class),
             @XmlElement(name = UnionMoveSelectorConfig.XML_ELEMENT_NAME, type = UnionMoveSelectorConfig.class)
     })
-    protected List<MoveSelectorConfig> moveSelectorConfigList = null;
+    private List<MoveSelectorConfig> moveSelectorConfigList = null;
 
     @XmlElement(name = "forager")
-    protected ConstructionHeuristicForagerConfig foragerConfig = null;
+    private ConstructionHeuristicForagerConfig foragerConfig = null;
 
     // ************************************************************************
     // Constructors and simple getters/setters

--- a/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/decider/forager/ConstructionHeuristicForagerConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/decider/forager/ConstructionHeuristicForagerConfig.java
@@ -13,7 +13,7 @@ import org.jspecify.annotations.Nullable;
 @XmlType(propOrder = {
         "pickEarlyType"
 })
-public class ConstructionHeuristicForagerConfig extends AbstractConfig<ConstructionHeuristicForagerConfig> {
+public final class ConstructionHeuristicForagerConfig extends AbstractConfig<ConstructionHeuristicForagerConfig> {
 
     private ConstructionHeuristicPickEarlyType pickEarlyType = null;
 

--- a/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
@@ -23,7 +23,7 @@ import org.jspecify.annotations.Nullable;
 @XmlType(propOrder = {
         "moveSelectorConfig"
 })
-public class PooledEntityPlacerConfig extends EntityPlacerConfig<PooledEntityPlacerConfig> {
+public final class PooledEntityPlacerConfig extends EntityPlacerConfig<PooledEntityPlacerConfig> {
 
     @XmlElements({
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
@@ -27,12 +27,12 @@ import org.jspecify.annotations.Nullable;
         "entitySelectorConfig",
         "moveSelectorConfigList"
 })
-public class QueuedEntityPlacerConfig extends EntityPlacerConfig<QueuedEntityPlacerConfig> {
+public final class QueuedEntityPlacerConfig extends EntityPlacerConfig<QueuedEntityPlacerConfig> {
 
     public static final String XML_ELEMENT_NAME = "queuedEntityPlacer";
 
     @XmlElement(name = "entitySelector")
-    protected EntitySelectorConfig entitySelectorConfig = null;
+    private EntitySelectorConfig entitySelectorConfig = null;
 
     @XmlElements({
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
@@ -46,7 +46,7 @@ public class QueuedEntityPlacerConfig extends EntityPlacerConfig<QueuedEntityPla
             @XmlElement(name = SwapMoveSelectorConfig.XML_ELEMENT_NAME, type = SwapMoveSelectorConfig.class),
             @XmlElement(name = UnionMoveSelectorConfig.XML_ELEMENT_NAME, type = UnionMoveSelectorConfig.class)
     })
-    protected List<MoveSelectorConfig> moveSelectorConfigList = null;
+    private List<MoveSelectorConfig> moveSelectorConfigList = null;
 
     public @Nullable EntitySelectorConfig getEntitySelectorConfig() {
         return entitySelectorConfig;

--- a/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
@@ -26,14 +26,14 @@ import org.jspecify.annotations.Nullable;
         "valueSelectorConfig",
         "moveSelectorConfig"
 })
-public class QueuedValuePlacerConfig extends EntityPlacerConfig<QueuedValuePlacerConfig> {
+public final class QueuedValuePlacerConfig extends EntityPlacerConfig<QueuedValuePlacerConfig> {
 
     public static final String XML_ELEMENT_NAME = "queuedValuePlacer";
 
-    protected Class<?> entityClass = null;
+    private Class<?> entityClass = null;
 
     @XmlElement(name = "valueSelector")
-    protected ValueSelectorConfig valueSelectorConfig = null;
+    private ValueSelectorConfig valueSelectorConfig = null;
 
     @XmlElements({
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/core/src/main/java/ai/timefold/solver/core/config/exhaustivesearch/ExhaustiveSearchPhaseConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/exhaustivesearch/ExhaustiveSearchPhaseConfig.java
@@ -32,20 +32,20 @@ import org.jspecify.annotations.Nullable;
         "entitySelectorConfig",
         "moveSelectorConfig"
 })
-public class ExhaustiveSearchPhaseConfig extends PhaseConfig<ExhaustiveSearchPhaseConfig> {
+public final class ExhaustiveSearchPhaseConfig extends PhaseConfig<ExhaustiveSearchPhaseConfig> {
 
     public static final String XML_ELEMENT_NAME = "exhaustiveSearch";
 
     // Warning: all fields are null (and not defaulted) because they can be inherited
     // and also because the input config file should match the output config file
 
-    protected ExhaustiveSearchType exhaustiveSearchType = null;
-    protected NodeExplorationType nodeExplorationType = null;
-    protected EntitySorterManner entitySorterManner = null;
-    protected ValueSorterManner valueSorterManner = null;
+    private ExhaustiveSearchType exhaustiveSearchType = null;
+    private NodeExplorationType nodeExplorationType = null;
+    private EntitySorterManner entitySorterManner = null;
+    private ValueSorterManner valueSorterManner = null;
 
     @XmlElement(name = "entitySelector")
-    protected EntitySelectorConfig entitySelectorConfig = null;
+    private EntitySelectorConfig entitySelectorConfig = null;
 
     @XmlElements({
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
@@ -59,7 +59,7 @@ public class ExhaustiveSearchPhaseConfig extends PhaseConfig<ExhaustiveSearchPha
             @XmlElement(name = SwapMoveSelectorConfig.XML_ELEMENT_NAME, type = SwapMoveSelectorConfig.class),
             @XmlElement(name = UnionMoveSelectorConfig.XML_ELEMENT_NAME, type = UnionMoveSelectorConfig.class)
     })
-    protected MoveSelectorConfig moveSelectorConfig = null;
+    private MoveSelectorConfig moveSelectorConfig = null;
 
     public @Nullable ExhaustiveSearchType getExhaustiveSearchType() {
         return exhaustiveSearchType;

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
@@ -36,29 +36,29 @@ import org.jspecify.annotations.Nullable;
         "betaDistributionAlpha",
         "betaDistributionBeta"
 })
-public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig> {
+public final class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig> {
 
     @XmlElement(name = "originEntitySelector")
-    protected EntitySelectorConfig originEntitySelectorConfig = null;
+    private EntitySelectorConfig originEntitySelectorConfig = null;
     @XmlElement(name = "originSubListSelector")
-    protected SubListSelectorConfig originSubListSelectorConfig = null;
+    private SubListSelectorConfig originSubListSelectorConfig = null;
     @XmlElement(name = "originValueSelector")
-    protected ValueSelectorConfig originValueSelectorConfig = null;
-    protected Class<? extends NearbyDistanceMeter> nearbyDistanceMeterClass = null;
+    private ValueSelectorConfig originValueSelectorConfig = null;
+    private Class<? extends NearbyDistanceMeter> nearbyDistanceMeterClass = null;
 
-    protected NearbySelectionDistributionType nearbySelectionDistributionType = null;
+    private NearbySelectionDistributionType nearbySelectionDistributionType = null;
 
-    protected Integer blockDistributionSizeMinimum = null;
-    protected Integer blockDistributionSizeMaximum = null;
-    protected Double blockDistributionSizeRatio = null;
-    protected Double blockDistributionUniformDistributionProbability = null;
+    private Integer blockDistributionSizeMinimum = null;
+    private Integer blockDistributionSizeMaximum = null;
+    private Double blockDistributionSizeRatio = null;
+    private Double blockDistributionUniformDistributionProbability = null;
 
-    protected Integer linearDistributionSizeMaximum = null;
+    private Integer linearDistributionSizeMaximum = null;
 
-    protected Integer parabolicDistributionSizeMaximum = null;
+    private Integer parabolicDistributionSizeMaximum = null;
 
-    protected Double betaDistributionAlpha = null;
-    protected Double betaDistributionBeta = null;
+    private Double betaDistributionAlpha = null;
+    private Double betaDistributionBeta = null;
 
     public @Nullable EntitySelectorConfig getOriginEntitySelectorConfig() {
         return originEntitySelectorConfig;

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/entity/EntitySelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/entity/EntitySelectorConfig.java
@@ -40,7 +40,7 @@ import org.jspecify.annotations.Nullable;
         "selectedCountLimit"
 })
 @NullMarked
-public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
+public final class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
 
     public static EntitySelectorConfig newMimicSelectorConfig(String mimicSelectorRef) {
         return new EntitySelectorConfig()
@@ -49,41 +49,41 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
 
     @Nullable
     @XmlAttribute
-    protected String id = null;
+    private String id = null;
     @XmlAttribute
     @Nullable
-    protected String mimicSelectorRef = null;
+    private String mimicSelectorRef = null;
 
     @Nullable
-    protected Class<?> entityClass = null;
+    private Class<?> entityClass = null;
     @Nullable
-    protected SelectionCacheType cacheType = null;
+    private SelectionCacheType cacheType = null;
     @Nullable
-    protected SelectionOrder selectionOrder = null;
+    private SelectionOrder selectionOrder = null;
 
     @Nullable
     @XmlElement(name = "nearbySelection")
-    protected NearbySelectionConfig nearbySelectionConfig = null;
+    private NearbySelectionConfig nearbySelectionConfig = null;
 
     @Nullable
-    protected Class<? extends SelectionFilter> filterClass = null;
+    private Class<? extends SelectionFilter> filterClass = null;
 
     @Nullable
-    protected EntitySorterManner sorterManner = null;
+    private EntitySorterManner sorterManner = null;
     @Nullable
-    protected Class<? extends Comparator> comparatorClass = null;
+    private Class<? extends Comparator> comparatorClass = null;
     @Nullable
-    protected Class<? extends ComparatorFactory> comparatorFactoryClass = null;
+    private Class<? extends ComparatorFactory> comparatorFactoryClass = null;
     @Nullable
-    protected SelectionSorterOrder sorterOrder = null;
+    private SelectionSorterOrder sorterOrder = null;
     @Nullable
-    protected Class<? extends SelectionSorter> sorterClass = null;
+    private Class<? extends SelectionSorter> sorterClass = null;
 
     @Nullable
-    protected Class<? extends SelectionProbabilityWeightFactory> probabilityWeightFactoryClass = null;
+    private Class<? extends SelectionProbabilityWeightFactory> probabilityWeightFactoryClass = null;
 
     @Nullable
-    protected Long selectedCountLimit = null;
+    private Long selectedCountLimit = null;
 
     public EntitySelectorConfig() {
     }

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/entity/pillar/PillarSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/entity/pillar/PillarSelectorConfig.java
@@ -17,13 +17,13 @@ import org.jspecify.annotations.Nullable;
         "minimumSubPillarSize",
         "maximumSubPillarSize"
 })
-public class PillarSelectorConfig extends SelectorConfig<PillarSelectorConfig> {
+public final class PillarSelectorConfig extends SelectorConfig<PillarSelectorConfig> {
 
     @XmlElement(name = "entitySelector")
-    protected EntitySelectorConfig entitySelectorConfig = null;
+    private EntitySelectorConfig entitySelectorConfig = null;
 
-    protected Integer minimumSubPillarSize = null;
-    protected Integer maximumSubPillarSize = null;
+    private Integer minimumSubPillarSize = null;
+    private Integer maximumSubPillarSize = null;
 
     public @Nullable EntitySelectorConfig getEntitySelectorConfig() {
         return entitySelectorConfig;

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/list/DestinationSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/list/DestinationSelectorConfig.java
@@ -19,7 +19,7 @@ import org.jspecify.annotations.Nullable;
         "valueSelectorConfig",
         "nearbySelectionConfig",
 })
-public class DestinationSelectorConfig extends SelectorConfig<DestinationSelectorConfig> {
+public final class DestinationSelectorConfig extends SelectorConfig<DestinationSelectorConfig> {
 
     @XmlElement(name = "entitySelector")
     private EntitySelectorConfig entitySelectorConfig;

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/list/SubListSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/list/SubListSelectorConfig.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.Nullable;
         "minimumSubListSize",
         "maximumSubListSize",
 })
-public class SubListSelectorConfig extends SelectorConfig<SubListSelectorConfig> {
+public final class SubListSelectorConfig extends SelectorConfig<SubListSelectorConfig> {
 
     @XmlAttribute
     private String id = null;

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
@@ -33,7 +33,7 @@ import org.jspecify.annotations.Nullable;
         "moveSelectorConfigList",
         "ignoreEmptyChildIterators"
 })
-public class CartesianProductMoveSelectorConfig extends MoveSelectorConfig<CartesianProductMoveSelectorConfig> {
+public final class CartesianProductMoveSelectorConfig extends MoveSelectorConfig<CartesianProductMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "cartesianProductMoveSelector";
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
@@ -38,7 +38,7 @@ import org.jspecify.annotations.Nullable;
         "moveSelectorConfigList",
         "selectorProbabilityWeightFactoryClass"
 })
-public class UnionMoveSelectorConfig
+public final class UnionMoveSelectorConfig
         extends MoveSelectorConfig<UnionMoveSelectorConfig>
         implements NearbyAutoConfigurationEnabled<UnionMoveSelectorConfig> {
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/factory/MoveIteratorFactoryConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/factory/MoveIteratorFactoryConfig.java
@@ -18,14 +18,15 @@ import org.jspecify.annotations.Nullable;
         "moveIteratorFactoryClass",
         "moveIteratorFactoryCustomProperties"
 })
-public class MoveIteratorFactoryConfig extends MoveSelectorConfig<MoveIteratorFactoryConfig> {
+public final class MoveIteratorFactoryConfig extends MoveSelectorConfig<MoveIteratorFactoryConfig> {
 
     public static final String XML_ELEMENT_NAME = "moveIteratorFactory";
 
-    protected Class<? extends MoveIteratorFactory> moveIteratorFactoryClass = null;
+    private Class<? extends MoveIteratorFactory> moveIteratorFactoryClass = null;
 
     @XmlJavaTypeAdapter(JaxbCustomPropertiesAdapter.class)
-    protected @Nullable Map<String, String> moveIteratorFactoryCustomProperties = null;
+    @Nullable
+    private Map<String, String> moveIteratorFactoryCustomProperties = null;
 
     public @Nullable Class<? extends MoveIteratorFactory> getMoveIteratorFactoryClass() {
         return moveIteratorFactoryClass;

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/factory/MoveListFactoryConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/factory/MoveListFactoryConfig.java
@@ -18,14 +18,14 @@ import org.jspecify.annotations.Nullable;
         "moveListFactoryClass",
         "moveListFactoryCustomProperties"
 })
-public class MoveListFactoryConfig extends MoveSelectorConfig<MoveListFactoryConfig> {
+public final class MoveListFactoryConfig extends MoveSelectorConfig<MoveListFactoryConfig> {
 
     public static final String XML_ELEMENT_NAME = "moveListFactory";
 
-    protected Class<? extends MoveListFactory> moveListFactoryClass = null;
+    private Class<? extends MoveListFactory> moveListFactoryClass = null;
 
     @XmlJavaTypeAdapter(JaxbCustomPropertiesAdapter.class)
-    protected Map<String, String> moveListFactoryCustomProperties = null;
+    private Map<String, String> moveListFactoryCustomProperties = null;
 
     public @Nullable Class<? extends MoveListFactory> getMoveListFactoryClass() {
         return moveListFactoryClass;

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.Nullable;
         "entitySelectorConfig",
         "valueSelectorConfig"
 })
-public class ChangeMoveSelectorConfig
+public final class ChangeMoveSelectorConfig
         extends MoveSelectorConfig<ChangeMoveSelectorConfig>
         implements NearbyAutoConfigurationEnabled<ChangeMoveSelectorConfig> {
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/MultistageMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/MultistageMoveSelectorConfig.java
@@ -14,13 +14,13 @@ import org.jspecify.annotations.NonNull;
         "entityClass",
         "variableName"
 })
-public class MultistageMoveSelectorConfig extends MoveSelectorConfig<MultistageMoveSelectorConfig> {
+public final class MultistageMoveSelectorConfig extends MoveSelectorConfig<MultistageMoveSelectorConfig> {
     public static final String XML_ELEMENT_NAME = "multistageMoveSelector";
 
-    protected Class<?> stageProviderClass;
+    private Class<?> stageProviderClass;
 
-    protected Class<?> entityClass = null;
-    protected String variableName = null;
+    private Class<?> entityClass = null;
+    private String variableName = null;
 
     // **************************
     // Getters/Setters

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
@@ -14,7 +14,7 @@ import org.jspecify.annotations.Nullable;
 @XmlType(propOrder = {
         "valueSelectorConfig"
 })
-public class PillarChangeMoveSelectorConfig extends AbstractPillarMoveSelectorConfig<PillarChangeMoveSelectorConfig> {
+public final class PillarChangeMoveSelectorConfig extends AbstractPillarMoveSelectorConfig<PillarChangeMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "pillarChangeMoveSelector";
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
@@ -17,7 +17,7 @@ import org.jspecify.annotations.Nullable;
         "secondaryPillarSelectorConfig",
         "variableNameIncludeList"
 })
-public class PillarSwapMoveSelectorConfig extends AbstractPillarMoveSelectorConfig<PillarSwapMoveSelectorConfig> {
+public final class PillarSwapMoveSelectorConfig extends AbstractPillarMoveSelectorConfig<PillarSwapMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "pillarSwapMoveSelector";
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/RuinRecreateMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/RuinRecreateMoveSelectorConfig.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.Nullable;
         "entitySelectorConfig",
         "variableName"
 })
-public class RuinRecreateMoveSelectorConfig extends MoveSelectorConfig<RuinRecreateMoveSelectorConfig> {
+public final class RuinRecreateMoveSelectorConfig extends MoveSelectorConfig<RuinRecreateMoveSelectorConfig> {
 
     // Determined by benchmarking on multiple datasets.
     private static final int DEFAULT_MINIMUM_RUINED_COUNT = 5;
@@ -28,15 +28,15 @@ public class RuinRecreateMoveSelectorConfig extends MoveSelectorConfig<RuinRecre
 
     public static final String XML_ELEMENT_NAME = "ruinRecreateMoveSelector";
 
-    protected Integer minimumRuinedCount = null;
-    protected Integer maximumRuinedCount = null;
+    private Integer minimumRuinedCount = null;
+    private Integer maximumRuinedCount = null;
 
-    protected Double minimumRuinedPercentage = null;
-    protected Double maximumRuinedPercentage = null;
+    private Double minimumRuinedPercentage = null;
+    private Double maximumRuinedPercentage = null;
 
     @XmlElement(name = "entitySelector")
-    protected EntitySelectorConfig entitySelectorConfig = null;
-    protected String variableName = null;
+    private EntitySelectorConfig entitySelectorConfig = null;
+    private String variableName = null;
 
     // **************************
     // Getters/Setters

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfig.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.Nullable;
         "secondaryEntitySelectorConfig",
         "variableNameIncludeList"
 })
-public class SwapMoveSelectorConfig
+public final class SwapMoveSelectorConfig
         extends MoveSelectorConfig<SwapMoveSelectorConfig>
         implements NearbyAutoConfigurationEnabled<SwapMoveSelectorConfig> {
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.Nullable;
         "valueSelectorConfig",
         "destinationSelectorConfig"
 })
-public class ListChangeMoveSelectorConfig
+public final class ListChangeMoveSelectorConfig
         extends MoveSelectorConfig<ListChangeMoveSelectorConfig>
         implements NearbyAutoConfigurationEnabled<ListChangeMoveSelectorConfig> {
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListMultistageMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListMultistageMoveSelectorConfig.java
@@ -12,10 +12,10 @@ import org.jspecify.annotations.NonNull;
 @XmlType(propOrder = {
         "stageProviderClass"
 })
-public class ListMultistageMoveSelectorConfig extends MoveSelectorConfig<ListMultistageMoveSelectorConfig> {
+public final class ListMultistageMoveSelectorConfig extends MoveSelectorConfig<ListMultistageMoveSelectorConfig> {
     public static final String XML_ELEMENT_NAME = "listMultistageMoveSelector";
 
-    protected Class<?> stageProviderClass;
+    private Class<?> stageProviderClass;
 
     // **************************
     // Getters/Setters

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorConfig.java
@@ -16,7 +16,7 @@ import org.jspecify.annotations.Nullable;
         "minimumRuinedPercentage",
         "maximumRuinedPercentage"
 })
-public class ListRuinRecreateMoveSelectorConfig extends MoveSelectorConfig<ListRuinRecreateMoveSelectorConfig> {
+public final class ListRuinRecreateMoveSelectorConfig extends MoveSelectorConfig<ListRuinRecreateMoveSelectorConfig> {
 
     // Determined by benchmarking on multiple datasets.
     private static final int DEFAULT_MINIMUM_RUINED_COUNT = 5;
@@ -24,11 +24,11 @@ public class ListRuinRecreateMoveSelectorConfig extends MoveSelectorConfig<ListR
 
     public static final String XML_ELEMENT_NAME = "listRuinRecreateMoveSelector";
 
-    protected Integer minimumRuinedCount = null;
-    protected Integer maximumRuinedCount = null;
+    private Integer minimumRuinedCount = null;
+    private Integer maximumRuinedCount = null;
 
-    protected Double minimumRuinedPercentage = null;
-    protected Double maximumRuinedPercentage = null;
+    private Double minimumRuinedPercentage = null;
+    private Double maximumRuinedPercentage = null;
 
     // **************************
     // Getters/Setters

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/ListSwapMoveSelectorConfig.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.Nullable;
         "valueSelectorConfig",
         "secondaryValueSelectorConfig"
 })
-public class ListSwapMoveSelectorConfig
+public final class ListSwapMoveSelectorConfig
         extends MoveSelectorConfig<ListSwapMoveSelectorConfig>
         implements NearbyAutoConfigurationEnabled<ListSwapMoveSelectorConfig> {
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
@@ -18,7 +18,7 @@ import org.jspecify.annotations.Nullable;
         "subListSelectorConfig",
         "destinationSelectorConfig"
 })
-public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListChangeMoveSelectorConfig> {
+public final class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListChangeMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "subListChangeMoveSelector";
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
@@ -17,7 +17,7 @@ import org.jspecify.annotations.Nullable;
         "subListSelectorConfig",
         "secondarySubListSelectorConfig"
 })
-public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwapMoveSelectorConfig> {
+public final class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwapMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "subListSwapMoveSelector";
 

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
@@ -22,14 +22,14 @@ import org.jspecify.annotations.Nullable;
         "originSelectorConfig",
         "valueSelectorConfig"
 })
-public class KOptListMoveSelectorConfig
+public final class KOptListMoveSelectorConfig
         extends MoveSelectorConfig<KOptListMoveSelectorConfig>
         implements NearbyAutoConfigurationEnabled<KOptListMoveSelectorConfig> {
 
     public static final String XML_ELEMENT_NAME = "kOptListMoveSelector";
 
-    protected Integer minimumK = null;
-    protected Integer maximumK = null;
+    private Integer minimumK = null;
+    private Integer maximumK = null;
 
     @XmlElement(name = "originSelector")
     private ValueSelectorConfig originSelectorConfig = null;

--- a/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/value/ValueSelectorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/heuristic/selector/value/ValueSelectorConfig.java
@@ -41,49 +41,49 @@ import org.jspecify.annotations.Nullable;
         "selectedCountLimit"
 })
 @NullMarked
-public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
+public final class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
 
     @XmlAttribute
     @Nullable
-    protected String id = null;
+    private String id = null;
     @XmlAttribute
     @Nullable
-    protected String mimicSelectorRef = null;
+    private String mimicSelectorRef = null;
 
     @Nullable
-    protected Class<?> downcastEntityClass = null;
+    private Class<?> downcastEntityClass = null;
     @XmlAttribute
     @Nullable
-    protected String variableName = null;
+    private String variableName = null;
 
     @Nullable
-    protected SelectionCacheType cacheType = null;
+    private SelectionCacheType cacheType = null;
     @Nullable
-    protected SelectionOrder selectionOrder = null;
+    private SelectionOrder selectionOrder = null;
 
     @XmlElement(name = "nearbySelection")
     @Nullable
-    protected NearbySelectionConfig nearbySelectionConfig = null;
+    private NearbySelectionConfig nearbySelectionConfig = null;
 
     @Nullable
-    protected Class<? extends SelectionFilter> filterClass = null;
+    private Class<? extends SelectionFilter> filterClass = null;
 
     @Nullable
-    protected ValueSorterManner sorterManner = null;
+    private ValueSorterManner sorterManner = null;
     @Nullable
-    protected Class<? extends Comparator> comparatorClass = null;
+    private Class<? extends Comparator> comparatorClass = null;
     @Nullable
-    protected Class<? extends ComparatorFactory> comparatorFactoryClass = null;
+    private Class<? extends ComparatorFactory> comparatorFactoryClass = null;
     @Nullable
-    protected SelectionSorterOrder sorterOrder = null;
+    private SelectionSorterOrder sorterOrder = null;
     @Nullable
-    protected Class<? extends SelectionSorter> sorterClass = null;
+    private Class<? extends SelectionSorter> sorterClass = null;
 
     @Nullable
-    protected Class<? extends SelectionProbabilityWeightFactory> probabilityWeightFactoryClass = null;
+    private Class<? extends SelectionProbabilityWeightFactory> probabilityWeightFactoryClass = null;
 
     @Nullable
-    protected Long selectedCountLimit = null;
+    private Long selectedCountLimit = null;
 
     public ValueSelectorConfig() {
     }

--- a/core/src/main/java/ai/timefold/solver/core/config/localsearch/LocalSearchPhaseConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/localsearch/LocalSearchPhaseConfig.java
@@ -40,14 +40,14 @@ import org.jspecify.annotations.Nullable;
         "acceptorConfig",
         "foragerConfig"
 })
-public class LocalSearchPhaseConfig extends PhaseConfig<LocalSearchPhaseConfig> {
+public final class LocalSearchPhaseConfig extends PhaseConfig<LocalSearchPhaseConfig> {
 
     public static final String XML_ELEMENT_NAME = "localSearch";
 
     // Warning: all fields are null (and not defaulted) because they can be inherited
     // and also because the input config file should match the output config file
 
-    protected LocalSearchType localSearchType = null;
+    private LocalSearchType localSearchType = null;
 
     @XmlElements({
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/core/src/main/java/ai/timefold/solver/core/config/localsearch/decider/acceptor/LocalSearchAcceptorConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/localsearch/decider/acceptor/LocalSearchAcceptorConfig.java
@@ -30,29 +30,29 @@ import org.jspecify.annotations.Nullable;
         "stepCountingHillClimbingSize",
         "stepCountingHillClimbingType"
 })
-public class LocalSearchAcceptorConfig extends AbstractConfig<LocalSearchAcceptorConfig> {
+public final class LocalSearchAcceptorConfig extends AbstractConfig<LocalSearchAcceptorConfig> {
 
     @XmlElement(name = "acceptorType")
     private List<AcceptorType> acceptorTypeList = null;
 
-    protected Integer entityTabuSize = null;
-    protected Double entityTabuRatio = null;
-    protected Integer fadingEntityTabuSize = null;
-    protected Double fadingEntityTabuRatio = null;
-    protected Integer valueTabuSize = null;
-    protected Integer fadingValueTabuSize = null;
-    protected Integer moveTabuSize = null;
-    protected Integer fadingMoveTabuSize = null;
+    private Integer entityTabuSize = null;
+    private Double entityTabuRatio = null;
+    private Integer fadingEntityTabuSize = null;
+    private Double fadingEntityTabuRatio = null;
+    private Integer valueTabuSize = null;
+    private Integer fadingValueTabuSize = null;
+    private Integer moveTabuSize = null;
+    private Integer fadingMoveTabuSize = null;
 
-    protected String simulatedAnnealingStartingTemperature = null;
+    private String simulatedAnnealingStartingTemperature = null;
 
-    protected Integer lateAcceptanceSize = null;
+    private Integer lateAcceptanceSize = null;
 
-    protected String greatDelugeWaterLevelIncrementScore = null;
-    protected Double greatDelugeWaterLevelIncrementRatio = null;
+    private String greatDelugeWaterLevelIncrementScore = null;
+    private Double greatDelugeWaterLevelIncrementRatio = null;
 
-    protected Integer stepCountingHillClimbingSize = null;
-    protected StepCountingHillClimbingType stepCountingHillClimbingType = null;
+    private Integer stepCountingHillClimbingSize = null;
+    private StepCountingHillClimbingType stepCountingHillClimbingType = null;
 
     public @Nullable List<AcceptorType> getAcceptorTypeList() {
         return acceptorTypeList;

--- a/core/src/main/java/ai/timefold/solver/core/config/localsearch/decider/forager/LocalSearchForagerConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/localsearch/decider/forager/LocalSearchForagerConfig.java
@@ -16,12 +16,12 @@ import org.jspecify.annotations.Nullable;
         "finalistPodiumType",
         "breakTieRandomly"
 })
-public class LocalSearchForagerConfig extends AbstractConfig<LocalSearchForagerConfig> {
+public final class LocalSearchForagerConfig extends AbstractConfig<LocalSearchForagerConfig> {
 
-    protected LocalSearchPickEarlyType pickEarlyType = null;
-    protected Integer acceptedCountLimit = null;
-    protected FinalistPodiumType finalistPodiumType = null;
-    protected Boolean breakTieRandomly = null;
+    private LocalSearchPickEarlyType pickEarlyType = null;
+    private Integer acceptedCountLimit = null;
+    private FinalistPodiumType finalistPodiumType = null;
+    private Boolean breakTieRandomly = null;
 
     public @Nullable LocalSearchPickEarlyType getPickEarlyType() {
         return pickEarlyType;

--- a/core/src/main/java/ai/timefold/solver/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.Nullable;
         "runnablePartThreadLimit",
         "phaseConfigList"
 })
-public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchPhaseConfig> {
+public final class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchPhaseConfig> {
 
     public static final String XML_ELEMENT_NAME = "partitionedSearch";
     public static final String ACTIVE_THREAD_COUNT_AUTO = "AUTO";
@@ -37,11 +37,11 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
     // Warning: all fields are null (and not defaulted) because they can be inherited
     // and also because the input config file should match the output config file
 
-    protected Class<? extends SolutionPartitioner<?>> solutionPartitionerClass = null;
+    private Class<? extends SolutionPartitioner<?>> solutionPartitionerClass = null;
     @XmlJavaTypeAdapter(JaxbCustomPropertiesAdapter.class)
-    protected Map<String, String> solutionPartitionerCustomProperties = null;
+    private Map<String, String> solutionPartitionerCustomProperties = null;
 
-    protected String runnablePartThreadLimit = null;
+    private String runnablePartThreadLimit = null;
 
     @XmlElements({
             @XmlElement(name = ConstructionHeuristicPhaseConfig.XML_ELEMENT_NAME,
@@ -51,7 +51,7 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
             @XmlElement(name = LocalSearchPhaseConfig.XML_ELEMENT_NAME, type = LocalSearchPhaseConfig.class),
             @XmlElement(name = PartitionedSearchPhaseConfig.XML_ELEMENT_NAME, type = PartitionedSearchPhaseConfig.class)
     })
-    protected List<PhaseConfig> phaseConfigList = null;
+    private List<PhaseConfig> phaseConfigList = null;
 
     // ************************************************************************
     // Constructors and simple getters/setters

--- a/core/src/main/java/ai/timefold/solver/core/config/phase/custom/CustomPhaseConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/phase/custom/CustomPhaseConfig.java
@@ -25,7 +25,7 @@ import org.jspecify.annotations.Nullable;
         "customProperties",
 })
 @NullMarked
-public class CustomPhaseConfig extends PhaseConfig<CustomPhaseConfig> {
+public final class CustomPhaseConfig extends PhaseConfig<CustomPhaseConfig> {
 
     public static final String XML_ELEMENT_NAME = "customPhase";
 
@@ -33,13 +33,16 @@ public class CustomPhaseConfig extends PhaseConfig<CustomPhaseConfig> {
     // and also because the input config file should match the output config file
 
     @XmlElement(name = "customPhaseCommandClass")
-    protected @Nullable List<Class<? extends PhaseCommand>> customPhaseCommandClassList = null;
+    @Nullable
+    private List<Class<? extends PhaseCommand>> customPhaseCommandClassList = null;
 
     @XmlJavaTypeAdapter(JaxbCustomPropertiesAdapter.class)
-    protected @Nullable Map<String, String> customProperties = null;
+    @Nullable
+    private Map<String, String> customProperties = null;
 
     @XmlTransient
-    protected @Nullable List<? extends PhaseCommand> customPhaseCommandList = null;
+    @Nullable
+    private List<? extends PhaseCommand> customPhaseCommandList = null;
 
     // ************************************************************************
     // Constructors and simple getters/setters

--- a/core/src/main/java/ai/timefold/solver/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -29,30 +29,30 @@ import org.jspecify.annotations.Nullable;
         "initializingScoreTrend",
         "assertionScoreDirectorFactory"
 })
-public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFactoryConfig> {
+public final class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFactoryConfig> {
 
-    protected Class<? extends EasyScoreCalculator> easyScoreCalculatorClass = null;
-
-    @XmlJavaTypeAdapter(JaxbCustomPropertiesAdapter.class)
-    protected Map<String, String> easyScoreCalculatorCustomProperties = null;
-
-    protected Class<? extends ConstraintProvider> constraintProviderClass = null;
+    private Class<? extends EasyScoreCalculator> easyScoreCalculatorClass = null;
 
     @XmlJavaTypeAdapter(JaxbCustomPropertiesAdapter.class)
-    protected Map<String, String> constraintProviderCustomProperties = null;
-    protected Boolean constraintStreamAutomaticNodeSharing;
-    protected Boolean constraintStreamProfilingEnabled;
+    private Map<String, String> easyScoreCalculatorCustomProperties = null;
 
-    protected Class<? extends IncrementalScoreCalculator> incrementalScoreCalculatorClass = null;
+    private Class<? extends ConstraintProvider> constraintProviderClass = null;
 
     @XmlJavaTypeAdapter(JaxbCustomPropertiesAdapter.class)
-    protected Map<String, String> incrementalScoreCalculatorCustomProperties = null;
+    private Map<String, String> constraintProviderCustomProperties = null;
+    private Boolean constraintStreamAutomaticNodeSharing;
+    private Boolean constraintStreamProfilingEnabled;
+
+    private Class<? extends IncrementalScoreCalculator> incrementalScoreCalculatorClass = null;
+
+    @XmlJavaTypeAdapter(JaxbCustomPropertiesAdapter.class)
+    private Map<String, String> incrementalScoreCalculatorCustomProperties = null;
 
     // TODO: this should be rather an enum?
-    protected String initializingScoreTrend = null;
+    private String initializingScoreTrend = null;
 
     @XmlElement(name = "assertionScoreDirectorFactory")
-    protected ScoreDirectorFactoryConfig assertionScoreDirectorFactory = null;
+    private ScoreDirectorFactoryConfig assertionScoreDirectorFactory = null;
 
     // ************************************************************************
     // Constructors and simple getters/setters

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
@@ -212,32 +212,32 @@ public final class SolverConfig extends AbstractConfig<SolverConfig> {
     // Warning: all fields are null (and not defaulted) because they can be inherited
     // and also because the input config file should match the output config file
     @XmlElement(name = "enablePreviewFeature")
-    protected Set<PreviewFeature> enablePreviewFeatureSet = null;
-    protected EnvironmentMode environmentMode = null;
-    protected Boolean daemon = null;
-    protected RandomType randomType = null;
-    protected Long randomSeed = null;
-    protected Class<? extends RandomFactory> randomFactoryClass = null;
-    protected String moveThreadCount = null;
-    protected Integer moveThreadBufferSize = null;
-    protected Class<? extends ThreadFactory> threadFactoryClass = null;
+    private Set<PreviewFeature> enablePreviewFeatureSet = null;
+    private EnvironmentMode environmentMode = null;
+    private Boolean daemon = null;
+    private RandomType randomType = null;
+    private Long randomSeed = null;
+    private Class<? extends RandomFactory> randomFactoryClass = null;
+    private String moveThreadCount = null;
+    private Integer moveThreadBufferSize = null;
+    private Class<? extends ThreadFactory> threadFactoryClass = null;
 
-    protected Class<?> solutionClass = null;
+    private Class<?> solutionClass = null;
 
     @XmlElement(name = "entityClass")
-    protected List<Class<?>> entityClassList = null;
+    private List<Class<?>> entityClassList = null;
     @XmlTransient
-    protected Map<String, MemberAccessor> gizmoMemberAccessorMap = null;
+    private Map<String, MemberAccessor> gizmoMemberAccessorMap = null;
     @XmlTransient
-    protected Map<String, SolutionCloner> gizmoSolutionClonerMap = null;
+    private Map<String, SolutionCloner> gizmoSolutionClonerMap = null;
 
     @XmlElement(name = "scoreDirectorFactory")
-    protected ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = null;
+    private ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = null;
 
     @XmlElement(name = "termination")
     private TerminationConfig terminationConfig;
 
-    protected Class<? extends NearbyDistanceMeter<?, ?>> nearbyDistanceMeterClass = null;
+    private Class<? extends NearbyDistanceMeter<?, ?>> nearbyDistanceMeterClass = null;
 
     @XmlElements({
             @XmlElement(name = ConstructionHeuristicPhaseConfig.XML_ELEMENT_NAME,
@@ -247,10 +247,10 @@ public final class SolverConfig extends AbstractConfig<SolverConfig> {
             @XmlElement(name = LocalSearchPhaseConfig.XML_ELEMENT_NAME, type = LocalSearchPhaseConfig.class),
             @XmlElement(name = PartitionedSearchPhaseConfig.XML_ELEMENT_NAME, type = PartitionedSearchPhaseConfig.class)
     })
-    protected List<PhaseConfig> phaseConfigList = null;
+    private List<PhaseConfig> phaseConfigList = null;
 
     @XmlElement(name = "monitoring")
-    protected MonitoringConfig monitoringConfig = null;
+    private MonitoringConfig monitoringConfig = null;
 
     // ************************************************************************
     // Constructors and simple getters/setters

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
@@ -44,6 +44,7 @@ import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.config.solver.random.RandomType;
 import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
+import ai.timefold.solver.core.impl.domain.common.DomainAccessType;
 import ai.timefold.solver.core.impl.domain.common.accessor.MemberAccessor;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 import ai.timefold.solver.core.impl.io.jaxb.SolverConfigIO;
@@ -230,6 +231,8 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
     protected Map<String, MemberAccessor> gizmoMemberAccessorMap = null;
     @XmlTransient
     protected Map<String, SolutionCloner> gizmoSolutionClonerMap = null;
+    @XmlTransient
+    protected DomainAccessType resolvedDomainAccessType = null;
 
     @XmlElement(name = "scoreDirectorFactory")
     protected ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = null;
@@ -643,9 +646,21 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
                         SolverMetric.PROBLEM_VALUE_COUNT, SolverMetric.PROBLEM_SIZE_LOG)));
     }
 
+    public DomainAccessType determineDomainAccessType() {
+        if (resolvedDomainAccessType == null) {
+            return DomainAccessType.AUTO;
+        }
+        return resolvedDomainAccessType;
+    }
+
     // ************************************************************************
     // Builder methods
     // ************************************************************************
+
+    public SolverConfig adaptForQuarkusBuildTime() {
+        resolvedDomainAccessType = DomainAccessType.FORCE_REFLECTION;
+        return this;
+    }
 
     public void offerRandomSeedFromSubSingleIndex(long subSingleIndex) {
         if ((environmentMode == null || environmentMode.isReproducible()) && randomFactoryClass == null && randomSeed == null) {
@@ -682,6 +697,8 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
                 gizmoMemberAccessorMap, inheritedConfig.getGizmoMemberAccessorMap());
         gizmoSolutionClonerMap = ConfigUtils.inheritMergeableMapProperty(
                 gizmoSolutionClonerMap, inheritedConfig.getGizmoSolutionClonerMap());
+        resolvedDomainAccessType =
+                ConfigUtils.inheritOverwritableProperty(resolvedDomainAccessType, inheritedConfig.resolvedDomainAccessType);
 
         scoreDirectorFactoryConfig = ConfigUtils.inheritConfig(scoreDirectorFactoryConfig,
                 inheritedConfig.getScoreDirectorFactoryConfig());

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
@@ -44,7 +44,6 @@ import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.config.solver.random.RandomType;
 import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
-import ai.timefold.solver.core.impl.domain.common.DomainAccessType;
 import ai.timefold.solver.core.impl.domain.common.accessor.MemberAccessor;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 import ai.timefold.solver.core.impl.io.jaxb.SolverConfigIO;
@@ -78,7 +77,7 @@ import org.jspecify.annotations.Nullable;
         "nearbyDistanceMeterClass",
         "phaseConfigList",
 })
-public class SolverConfig extends AbstractConfig<SolverConfig> {
+public final class SolverConfig extends AbstractConfig<SolverConfig> {
 
     public static final String XML_ELEMENT_NAME = "solver";
     public static final String XML_NAMESPACE = "https://timefold.ai/xsd/solver";
@@ -231,8 +230,6 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
     protected Map<String, MemberAccessor> gizmoMemberAccessorMap = null;
     @XmlTransient
     protected Map<String, SolutionCloner> gizmoSolutionClonerMap = null;
-    @XmlTransient
-    protected DomainAccessType resolvedDomainAccessType = null;
 
     @XmlElement(name = "scoreDirectorFactory")
     protected ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = null;
@@ -646,21 +643,9 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
                         SolverMetric.PROBLEM_VALUE_COUNT, SolverMetric.PROBLEM_SIZE_LOG)));
     }
 
-    public DomainAccessType determineDomainAccessType() {
-        if (resolvedDomainAccessType == null) {
-            return DomainAccessType.AUTO;
-        }
-        return resolvedDomainAccessType;
-    }
-
     // ************************************************************************
     // Builder methods
     // ************************************************************************
-
-    public SolverConfig adaptForQuarkusBuildTime() {
-        resolvedDomainAccessType = DomainAccessType.FORCE_REFLECTION;
-        return this;
-    }
 
     public void offerRandomSeedFromSubSingleIndex(long subSingleIndex) {
         if ((environmentMode == null || environmentMode.isReproducible()) && randomFactoryClass == null && randomSeed == null) {
@@ -697,8 +682,6 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
                 gizmoMemberAccessorMap, inheritedConfig.getGizmoMemberAccessorMap());
         gizmoSolutionClonerMap = ConfigUtils.inheritMergeableMapProperty(
                 gizmoSolutionClonerMap, inheritedConfig.getGizmoSolutionClonerMap());
-        resolvedDomainAccessType =
-                ConfigUtils.inheritOverwritableProperty(resolvedDomainAccessType, inheritedConfig.resolvedDomainAccessType);
 
         scoreDirectorFactoryConfig = ConfigUtils.inheritConfig(scoreDirectorFactoryConfig,
                 inheritedConfig.getScoreDirectorFactoryConfig());

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/SolverManagerConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/SolverManagerConfig.java
@@ -17,14 +17,14 @@ import org.slf4j.LoggerFactory;
         "parallelSolverCount",
         "threadFactoryClass"
 })
-public class SolverManagerConfig extends AbstractConfig<SolverManagerConfig> {
+public final class SolverManagerConfig extends AbstractConfig<SolverManagerConfig> {
 
     public static final String PARALLEL_SOLVER_COUNT_AUTO = "AUTO";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SolverManagerConfig.class);
 
-    protected String parallelSolverCount = null;
-    protected Class<? extends ThreadFactory> threadFactoryClass = null;
+    private String parallelSolverCount = null;
+    private Class<? extends ThreadFactory> threadFactoryClass = null;
 
     // Future features:
     // throttlingDelay
@@ -91,11 +91,11 @@ public class SolverManagerConfig extends AbstractConfig<SolverManagerConfig> {
         return resolvedParallelSolverCount;
     }
 
-    protected int getAvailableProcessors() {
+    private int getAvailableProcessors() {
         return Runtime.getRuntime().availableProcessors();
     }
 
-    protected int resolveParallelSolverCountAutomatically(int availableProcessorCount) {
+    private int resolveParallelSolverCountAutomatically(int availableProcessorCount) {
         // Tweaked based on experience
         if (availableProcessorCount < 2) {
             return 1;

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/SolverManagerConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/SolverManagerConfig.java
@@ -91,11 +91,11 @@ public final class SolverManagerConfig extends AbstractConfig<SolverManagerConfi
         return resolvedParallelSolverCount;
     }
 
-    private int getAvailableProcessors() {
+    private static int getAvailableProcessors() {
         return Runtime.getRuntime().availableProcessors();
     }
 
-    private int resolveParallelSolverCountAutomatically(int availableProcessorCount) {
+    private static int resolveParallelSolverCountAutomatically(int availableProcessorCount) {
         // Tweaked based on experience
         if (availableProcessorCount < 2) {
             return 1;

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/monitoring/MonitoringConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/monitoring/MonitoringConfig.java
@@ -15,9 +15,9 @@ import org.jspecify.annotations.Nullable;
 @XmlType(propOrder = {
         "solverMetricList",
 })
-public class MonitoringConfig extends AbstractConfig<MonitoringConfig> {
+public final class MonitoringConfig extends AbstractConfig<MonitoringConfig> {
     @XmlElement(name = "metric")
-    protected List<SolverMetric> solverMetricList = null;
+    private List<SolverMetric> solverMetricList = null;
 
     // ************************************************************************
     // Constructors and simple getters/setters

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/termination/DiminishedReturnsTerminationConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/termination/DiminishedReturnsTerminationConfig.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.Nullable;
         "slidingWindowDays",
         "minimumImprovementRatio"
 })
-public class DiminishedReturnsTerminationConfig extends AbstractConfig<DiminishedReturnsTerminationConfig> {
+public final class DiminishedReturnsTerminationConfig extends AbstractConfig<DiminishedReturnsTerminationConfig> {
     @XmlJavaTypeAdapter(JaxbDurationAdapter.class)
     private Duration slidingWindowDuration = null;
     private Long slidingWindowMilliseconds = null;

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/termination/TerminationConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/termination/TerminationConfig.java
@@ -40,7 +40,7 @@ import org.jspecify.annotations.Nullable;
         "moveCountLimit",
         "terminationConfigList"
 })
-public class TerminationConfig extends AbstractConfig<TerminationConfig> {
+public final class TerminationConfig extends AbstractConfig<TerminationConfig> {
 
     private TerminationCompositionStyle terminationCompositionStyle = null;
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -26,6 +26,7 @@ import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.AbstractFromConfigFactory;
 import ai.timefold.solver.core.impl.constructionheuristic.DefaultConstructionHeuristicPhaseFactory;
+import ai.timefold.solver.core.impl.domain.common.DomainAccessType;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicy;
@@ -66,8 +67,14 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
     private final SolverConfig solverConfig;
     private final SolutionDescriptor<Solution_> solutionDescriptor;
     private final ScoreDirectorFactory<Solution_, ?> scoreDirectorFactory;
+    private final DomainAccessType domainAccessType;
 
     public DefaultSolverFactory(SolverConfig solverConfig) {
+        this(solverConfig, DomainAccessType.AUTO);
+    }
+
+    public DefaultSolverFactory(SolverConfig solverConfig, DomainAccessType domainAccessType) {
+        this.domainAccessType = domainAccessType;
         this.clock = Objects.requireNonNullElse(solverConfig.getClock(), Clock.systemDefaultZone());
         this.solverConfig = Objects.requireNonNull(solverConfig, "The solverConfig (" + solverConfig + ") cannot be null.");
         this.solutionDescriptor = buildSolutionDescriptor();
@@ -190,7 +197,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
                             .formatted(solverConfig.getEntityClassList()));
         }
         return SolutionDescriptor.buildSolutionDescriptor(solverConfig.getEnablePreviewFeatureSet(),
-                solverConfig.determineDomainAccessType(),
+                domainAccessType,
                 (Class<Solution_>) solverConfig.getSolutionClass(),
                 solverConfig.getGizmoMemberAccessorMap(),
                 solverConfig.getGizmoSolutionClonerMap(),

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -26,7 +26,6 @@ import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
 import ai.timefold.solver.core.impl.AbstractFromConfigFactory;
 import ai.timefold.solver.core.impl.constructionheuristic.DefaultConstructionHeuristicPhaseFactory;
-import ai.timefold.solver.core.impl.domain.common.DomainAccessType;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicy;
@@ -191,7 +190,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
                             .formatted(solverConfig.getEntityClassList()));
         }
         return SolutionDescriptor.buildSolutionDescriptor(solverConfig.getEnablePreviewFeatureSet(),
-                DomainAccessType.AUTO,
+                solverConfig.determineDomainAccessType(),
                 (Class<Solution_>) solverConfig.getSolutionClass(),
                 solverConfig.getGizmoMemberAccessorMap(),
                 solverConfig.getGizmoSolutionClonerMap(),

--- a/core/src/main/resources/solver.xsd
+++ b/core/src/main/resources/solver.xsd
@@ -3,7 +3,7 @@
     
   <xs:element name="solver" type="tns:solverConfig"/>
     
-  <xs:complexType name="solverConfig">
+  <xs:complexType final="extension restriction" name="solverConfig">
         
     <xs:complexContent>
             
@@ -69,7 +69,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="monitoringConfig">
+  <xs:complexType final="extension restriction" name="monitoringConfig">
         
     <xs:complexContent>
             
@@ -87,7 +87,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="scoreDirectorFactoryConfig">
+  <xs:complexType final="extension restriction" name="scoreDirectorFactoryConfig">
         
     <xs:complexContent>
             
@@ -143,7 +143,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="terminationConfig">
+  <xs:complexType final="extension restriction" name="terminationConfig">
         
     <xs:complexContent>
             
@@ -203,7 +203,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="diminishedReturnsTerminationConfig">
+  <xs:complexType final="extension restriction" name="diminishedReturnsTerminationConfig">
         
     <xs:complexContent>
             
@@ -233,7 +233,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="constructionHeuristicPhaseConfig">
+  <xs:complexType final="extension restriction" name="constructionHeuristicPhaseConfig">
         
     <xs:complexContent>
             
@@ -305,7 +305,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="queuedEntityPlacerConfig">
+  <xs:complexType final="extension restriction" name="queuedEntityPlacerConfig">
         
     <xs:complexContent>
             
@@ -357,7 +357,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="entitySelectorConfig">
+  <xs:complexType final="extension restriction" name="entitySelectorConfig">
         
     <xs:complexContent>
             
@@ -415,7 +415,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="nearbySelectionConfig">
+  <xs:complexType final="extension restriction" name="nearbySelectionConfig">
         
     <xs:complexContent>
             
@@ -457,7 +457,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="subListSelectorConfig">
+  <xs:complexType final="extension restriction" name="subListSelectorConfig">
         
     <xs:complexContent>
             
@@ -485,7 +485,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="valueSelectorConfig">
+  <xs:complexType final="extension restriction" name="valueSelectorConfig">
         
     <xs:complexContent>
             
@@ -531,7 +531,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="cartesianProductMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="cartesianProductMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -623,7 +623,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="changeMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="changeMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -643,7 +643,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="kOptListMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="kOptListMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -667,7 +667,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="listChangeMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="listChangeMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -687,7 +687,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="destinationSelectorConfig">
+  <xs:complexType final="extension restriction" name="destinationSelectorConfig">
         
     <xs:complexContent>
             
@@ -709,7 +709,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="listSwapMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="listSwapMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -729,7 +729,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="moveIteratorFactoryConfig">
+  <xs:complexType final="extension restriction" name="moveIteratorFactoryConfig">
         
     <xs:complexContent>
             
@@ -749,7 +749,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="moveListFactoryConfig">
+  <xs:complexType final="extension restriction" name="moveListFactoryConfig">
         
     <xs:complexContent>
             
@@ -769,7 +769,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="pillarChangeMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="pillarChangeMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -809,7 +809,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="pillarSelectorConfig">
+  <xs:complexType final="extension restriction" name="pillarSelectorConfig">
         
     <xs:complexContent>
             
@@ -831,7 +831,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="pillarSwapMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="pillarSwapMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -863,7 +863,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="ruinRecreateMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="ruinRecreateMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -891,7 +891,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="listRuinRecreateMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="listRuinRecreateMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -915,7 +915,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="subListChangeMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="subListChangeMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -937,7 +937,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="subListSwapMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="subListSwapMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -959,7 +959,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="swapMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="swapMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -993,7 +993,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="unionMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="unionMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -1049,7 +1049,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="multistageMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="multistageMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -1071,7 +1071,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="listMultistageMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="listMultistageMoveSelectorConfig">
         
     <xs:complexContent>
             
@@ -1089,7 +1089,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="pooledEntityPlacerConfig">
+  <xs:complexType final="extension restriction" name="pooledEntityPlacerConfig">
         
     <xs:complexContent>
             
@@ -1125,7 +1125,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="queuedValuePlacerConfig">
+  <xs:complexType final="extension restriction" name="queuedValuePlacerConfig">
         
     <xs:complexContent>
             
@@ -1165,7 +1165,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="constructionHeuristicForagerConfig">
+  <xs:complexType final="extension restriction" name="constructionHeuristicForagerConfig">
         
     <xs:complexContent>
             
@@ -1183,7 +1183,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="customPhaseConfig">
+  <xs:complexType final="extension restriction" name="customPhaseConfig">
         
     <xs:complexContent>
             
@@ -1203,7 +1203,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="exhaustiveSearchPhaseConfig">
+  <xs:complexType final="extension restriction" name="exhaustiveSearchPhaseConfig">
         
     <xs:complexContent>
             
@@ -1249,7 +1249,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="localSearchPhaseConfig">
+  <xs:complexType final="extension restriction" name="localSearchPhaseConfig">
         
     <xs:complexContent>
             
@@ -1309,7 +1309,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="localSearchAcceptorConfig">
+  <xs:complexType final="extension restriction" name="localSearchAcceptorConfig">
         
     <xs:complexContent>
             
@@ -1355,7 +1355,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="localSearchForagerConfig">
+  <xs:complexType final="extension restriction" name="localSearchForagerConfig">
         
     <xs:complexContent>
             
@@ -1379,7 +1379,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="partitionedSearchPhaseConfig">
+  <xs:complexType final="extension restriction" name="partitionedSearchPhaseConfig">
         
     <xs:complexContent>
             
@@ -1415,7 +1415,7 @@
       
   </xs:complexType>
     
-  <xs:complexType name="solverManagerConfig">
+  <xs:complexType final="extension restriction" name="solverManagerConfig">
         
     <xs:complexContent>
             

--- a/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
+++ b/quarkus-integration/quarkus/deployment/src/main/java/ai/timefold/solver/quarkus/deployment/TimefoldProcessor.java
@@ -45,6 +45,7 @@ import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescripto
 import ai.timefold.solver.core.impl.domain.variable.declarative.RootVariableSource;
 import ai.timefold.solver.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 import ai.timefold.solver.core.impl.score.stream.test.DefaultConstraintVerifier;
+import ai.timefold.solver.core.impl.solver.DefaultSolverFactory;
 import ai.timefold.solver.quarkus.TimefoldRecorder;
 import ai.timefold.solver.quarkus.bean.BeanUtil;
 import ai.timefold.solver.quarkus.bean.DefaultTimefoldBeanProvider;
@@ -606,7 +607,7 @@ class TimefoldProcessor {
 
         var constraintMetaModelsBySolverNames = new HashMap<String, ConstraintMetaModel>();
         solverConfigBuildItem.getSolverConfigMap().forEach((solverName, solverConfig) -> {
-            var solverFactory = SolverFactory.create(solverConfig);
+            var solverFactory = new DefaultSolverFactory<>(solverConfig, DomainAccessType.FORCE_REFLECTION);
             var constraintMetaModel = BeanUtil.buildConstraintMetaModel(solverFactory);
             // Avoid changing the original solver config.
             constraintMetaModelsBySolverNames.put(solverName, constraintMetaModel);

--- a/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/constraints/TimefoldProcessorConstraintProviderTest.java
+++ b/quarkus-integration/quarkus/deployment/src/test/java/ai/timefold/solver/quarkus/constraints/TimefoldProcessorConstraintProviderTest.java
@@ -7,6 +7,8 @@ import jakarta.inject.Inject;
 
 import ai.timefold.solver.core.api.solver.SolverFactory;
 import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.quarkus.deployment.api.ConstraintMetaModelBuildItem;
+import ai.timefold.solver.quarkus.deployment.config.TimefoldBuildTimeConfig;
 import ai.timefold.solver.quarkus.testdomain.normal.TestdataQuarkusConstraintProvider;
 import ai.timefold.solver.quarkus.testdomain.normal.TestdataQuarkusEntity;
 import ai.timefold.solver.quarkus.testdomain.normal.TestdataQuarkusSolution;
@@ -16,6 +18,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.test.QuarkusUnitTest;
 
 class TimefoldProcessorConstraintProviderTest {
@@ -24,7 +27,20 @@ class TimefoldProcessorConstraintProviderTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestdataQuarkusEntity.class,
-                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class))
+            .addBuildChainCustomizer(customizer -> customizer.addBuildStep(context -> {
+                var constraintMetaModelsBySolverNames = context
+                        .consume(ConstraintMetaModelBuildItem.class)
+                        .constraintMetaModelsBySolverNames();
+                assertEquals(1, constraintMetaModelsBySolverNames.size());
+                var constraintMetaModel = constraintMetaModelsBySolverNames.get(
+                        TimefoldBuildTimeConfig.DEFAULT_SOLVER_NAME);
+                assertNotNull(constraintMetaModel);
+                assertEquals(1, constraintMetaModel.getConstraints().size());
+            })
+                    .consumes(ConstraintMetaModelBuildItem.class)
+                    .produces(SyntheticBeanBuildItem.class)
+                    .build());
 
     @Inject
     SolverConfig solverConfig;

--- a/tools/benchmark/src/main/resources/benchmark.xsd
+++ b/tools/benchmark/src/main/resources/benchmark.xsd
@@ -305,7 +305,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="solverConfig">
+  <xs:complexType final="extension restriction" name="solverConfig">
             
     
     <xs:complexContent>
@@ -395,7 +395,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="monitoringConfig">
+  <xs:complexType final="extension restriction" name="monitoringConfig">
             
     
     <xs:complexContent>
@@ -422,7 +422,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="scoreDirectorFactoryConfig">
+  <xs:complexType final="extension restriction" name="scoreDirectorFactoryConfig">
             
     
     <xs:complexContent>
@@ -506,7 +506,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="terminationConfig">
+  <xs:complexType final="extension restriction" name="terminationConfig">
             
     
     <xs:complexContent>
@@ -596,7 +596,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="diminishedReturnsTerminationConfig">
+  <xs:complexType final="extension restriction" name="diminishedReturnsTerminationConfig">
             
     
     <xs:complexContent>
@@ -641,7 +641,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="constructionHeuristicPhaseConfig">
+  <xs:complexType final="extension restriction" name="constructionHeuristicPhaseConfig">
             
     
     <xs:complexContent>
@@ -749,7 +749,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="queuedEntityPlacerConfig">
+  <xs:complexType final="extension restriction" name="queuedEntityPlacerConfig">
             
     
     <xs:complexContent>
@@ -827,7 +827,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="entitySelectorConfig">
+  <xs:complexType final="extension restriction" name="entitySelectorConfig">
             
     
     <xs:complexContent>
@@ -914,7 +914,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="nearbySelectionConfig">
+  <xs:complexType final="extension restriction" name="nearbySelectionConfig">
             
     
     <xs:complexContent>
@@ -977,7 +977,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="subListSelectorConfig">
+  <xs:complexType final="extension restriction" name="subListSelectorConfig">
             
     
     <xs:complexContent>
@@ -1019,7 +1019,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="valueSelectorConfig">
+  <xs:complexType final="extension restriction" name="valueSelectorConfig">
             
     
     <xs:complexContent>
@@ -1088,7 +1088,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="cartesianProductMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="cartesianProductMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1226,7 +1226,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="changeMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="changeMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1256,7 +1256,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="kOptListMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="kOptListMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1292,7 +1292,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="listChangeMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="listChangeMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1322,7 +1322,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="destinationSelectorConfig">
+  <xs:complexType final="extension restriction" name="destinationSelectorConfig">
             
     
     <xs:complexContent>
@@ -1355,7 +1355,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="listSwapMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="listSwapMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1385,7 +1385,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="moveIteratorFactoryConfig">
+  <xs:complexType final="extension restriction" name="moveIteratorFactoryConfig">
             
     
     <xs:complexContent>
@@ -1415,7 +1415,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="moveListFactoryConfig">
+  <xs:complexType final="extension restriction" name="moveListFactoryConfig">
             
     
     <xs:complexContent>
@@ -1445,7 +1445,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="pillarChangeMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="pillarChangeMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1505,7 +1505,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="pillarSelectorConfig">
+  <xs:complexType final="extension restriction" name="pillarSelectorConfig">
             
     
     <xs:complexContent>
@@ -1538,7 +1538,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="pillarSwapMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="pillarSwapMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1586,7 +1586,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="ruinRecreateMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="ruinRecreateMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1628,7 +1628,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="listRuinRecreateMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="listRuinRecreateMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1664,7 +1664,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="subListChangeMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="subListChangeMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1697,7 +1697,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="subListSwapMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="subListSwapMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1730,7 +1730,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="swapMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="swapMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1781,7 +1781,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="unionMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="unionMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1865,7 +1865,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="multistageMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="multistageMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1898,7 +1898,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="listMultistageMoveSelectorConfig">
+  <xs:complexType final="extension restriction" name="listMultistageMoveSelectorConfig">
             
     
     <xs:complexContent>
@@ -1925,7 +1925,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="pooledEntityPlacerConfig">
+  <xs:complexType final="extension restriction" name="pooledEntityPlacerConfig">
             
     
     <xs:complexContent>
@@ -1979,7 +1979,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="queuedValuePlacerConfig">
+  <xs:complexType final="extension restriction" name="queuedValuePlacerConfig">
             
     
     <xs:complexContent>
@@ -2039,7 +2039,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="constructionHeuristicForagerConfig">
+  <xs:complexType final="extension restriction" name="constructionHeuristicForagerConfig">
             
     
     <xs:complexContent>
@@ -2066,7 +2066,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="customPhaseConfig">
+  <xs:complexType final="extension restriction" name="customPhaseConfig">
             
     
     <xs:complexContent>
@@ -2096,7 +2096,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="exhaustiveSearchPhaseConfig">
+  <xs:complexType final="extension restriction" name="exhaustiveSearchPhaseConfig">
             
     
     <xs:complexContent>
@@ -2165,7 +2165,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="localSearchPhaseConfig">
+  <xs:complexType final="extension restriction" name="localSearchPhaseConfig">
             
     
     <xs:complexContent>
@@ -2255,7 +2255,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="localSearchAcceptorConfig">
+  <xs:complexType final="extension restriction" name="localSearchAcceptorConfig">
             
     
     <xs:complexContent>
@@ -2324,7 +2324,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="localSearchForagerConfig">
+  <xs:complexType final="extension restriction" name="localSearchForagerConfig">
             
     
     <xs:complexContent>
@@ -2360,7 +2360,7 @@
   </xs:complexType>
       
   
-  <xs:complexType name="partitionedSearchPhaseConfig">
+  <xs:complexType final="extension restriction" name="partitionedSearchPhaseConfig">
             
     
     <xs:complexContent>


### PR DESCRIPTION
Due to what I assume to be classloader shenanigans, the generated Gizmo classes cannot access annotations on fields/methods at Quarkus build time.

An escape hatch was added to SolverConfig for those users that need to build a Solver or related components at Quarkus build time.