### PR TITLE
perf: significantly improve assertion speed

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/AbstractFromConfigFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/AbstractFromConfigFactory.java
@@ -10,6 +10,7 @@ import ai.timefold.solver.core.config.heuristic.selector.common.SelectionOrder;
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicy;
 
@@ -77,7 +78,7 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
             getTheOnlyEntityDescriptorWithBasicVariables(SolutionDescriptor<Solution_> solutionDescriptor) {
         var entityDescriptors = solutionDescriptor.getGenuineEntityDescriptors()
                 .stream()
-                .filter(EntityDescriptor::hasAnyGenuineBasicVariables)
+                .filter(EntityDescriptor::hasAnyBasicVariables)
                 .toList();
         if (entityDescriptors.size() != 1) {
             throw new IllegalArgumentException(
@@ -91,7 +92,7 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
             getTheOnlyEntityDescriptorWithListVariable(SolutionDescriptor<Solution_> solutionDescriptor) {
         var entityDescriptors = solutionDescriptor.getGenuineEntityDescriptors()
                 .stream()
-                .filter(EntityDescriptor::hasAnyGenuineListVariables)
+                .filter(EntityDescriptor::hasAnyListVariables)
                 .toList();
         if (entityDescriptors.size() != 1) {
             throw new IllegalArgumentException(
@@ -151,22 +152,22 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
                 .toList();
     }
 
-    protected List<GenuineVariableDescriptor<Solution_>> deduceBasicVariableDescriptorList(
+    protected List<BasicVariableDescriptor<Solution_>> deduceBasicVariableDescriptorList(
             EntityDescriptor<Solution_> entityDescriptor, List<String> variableNameIncludeList) {
         Objects.requireNonNull(entityDescriptor);
-        var variableDescriptorList = entityDescriptor.getGenuineBasicVariableDescriptorList();
+        var basicVariableDescriptorList = entityDescriptor.getBasicVariableDescriptorList();
         if (variableNameIncludeList == null) {
-            return variableDescriptorList;
+            return basicVariableDescriptorList;
         }
 
         return variableNameIncludeList.stream()
-                .map(variableNameInclude -> variableDescriptorList.stream()
+                .map(variableNameInclude -> basicVariableDescriptorList.stream()
                         .filter(variableDescriptor -> variableDescriptor.getVariableName().equals(variableNameInclude))
                         .findFirst()
                         .orElseThrow(() -> new IllegalArgumentException(
                                 "The config (%s) has a variableNameInclude (%s) which does not exist in the entity (%s)'s variableDescriptorList (%s)."
                                         .formatted(config, variableNameInclude, entityDescriptor.getEntityClass(),
-                                                variableDescriptorList))))
+                                                basicVariableDescriptorList))))
                 .toList();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
@@ -118,7 +118,7 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
         // When an entity has both list and basic variables,
         // the CH configuration will require two separate placers to initialize each variable,
         // which cannot be deduced automatically by default, since a single placer would be returned
-        if (listVariableDescriptor.getEntityDescriptor().hasAnyGenuineBasicVariables()) {
+        if (listVariableDescriptor.getEntityDescriptor().hasAnyBasicVariables()) {
             throw new IllegalArgumentException("""
                     The entity (%s) has both basic and list variables and cannot be deduced automatically.
                     Maybe customize the phase configuration and add separate construction heuristic phases for each variable."""

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/entity/descriptor/EntityDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/entity/descriptor/EntityDescriptor.java
@@ -14,13 +14,13 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.SequencedCollection;
+import java.util.SequencedMap;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.entity.PlanningPin;
@@ -70,17 +70,10 @@ import org.jspecify.annotations.Nullable;
  */
 public class EntityDescriptor<Solution_> {
 
-    protected static final Class[] VARIABLE_ANNOTATION_CLASSES = {
-            PlanningVariable.class,
-            PlanningListVariable.class,
-            InverseRelationShadowVariable.class,
-            IndexShadowVariable.class,
-            PreviousElementShadowVariable.class,
-            NextElementShadowVariable.class,
-            ShadowVariable.class,
-            CascadingUpdateShadowVariable.class,
-            ShadowVariablesInconsistent.class
-    };
+    protected static final Class[] VARIABLE_ANNOTATION_CLASSES =
+            { PlanningVariable.class, PlanningListVariable.class, InverseRelationShadowVariable.class,
+                    IndexShadowVariable.class, PreviousElementShadowVariable.class, NextElementShadowVariable.class,
+                    ShadowVariable.class, CascadingUpdateShadowVariable.class, ShadowVariablesInconsistent.class };
 
     private final int ordinal;
     private final SolutionDescriptor<Solution_> solutionDescriptor;
@@ -94,9 +87,9 @@ public class EntityDescriptor<Solution_> {
     private SelectionSorter<Solution_, Object> descendingSorter;
 
     // Only declared variable descriptors, excludes inherited variable descriptors
-    private Map<String, GenuineVariableDescriptor<Solution_>> declaredGenuineVariableDescriptorMap;
-    private Map<String, ShadowVariableDescriptor<Solution_>> declaredShadowVariableDescriptorMap;
-    private Map<String, CascadingUpdateShadowVariableDescriptor<Solution_>> declaredCascadingUpdateShadowVariableDecriptorMap;
+    private SequencedMap<String, GenuineVariableDescriptor<Solution_>> declaredGenuineVariableDescriptorMap;
+    private SequencedMap<String, ShadowVariableDescriptor<Solution_>> declaredShadowVariableDescriptorMap;
+    private SequencedMap<String, CascadingUpdateShadowVariableDescriptor<Solution_>> declaredCascadingUpdateShadowVariableDecriptorMap;
 
     private List<MovableFilter<Solution_>> declaredPinEntityFilterList;
     private List<EntityDescriptor<Solution_>> effectiveInheritedEntityDescriptorList;
@@ -105,19 +98,19 @@ public class EntityDescriptor<Solution_> {
     private MovableFilter<Solution_> effectiveMovableEntityFilter;
     private PlanningPinToIndexReader effectivePlanningPinToIndexReader;
 
-    // Caches the inherited and declared variable descriptors
-    private Map<String, GenuineVariableDescriptor<Solution_>> effectiveGenuineVariableDescriptorMap;
-    private Map<String, ShadowVariableDescriptor<Solution_>> effectiveShadowVariableDescriptorMap;
-    private Map<String, VariableDescriptor<Solution_>> effectiveVariableDescriptorMap;
-    // Duplicate of effectiveGenuineVariableDescriptorMap.values() for faster iteration on the hot path.
+    // Caches the inherited and declared variable descriptors; provides views for fast iteration.
+    private SequencedMap<String, GenuineVariableDescriptor<Solution_>> effectiveGenuineVariableDescriptorMap;
+    private SequencedMap<String, ShadowVariableDescriptor<Solution_>> effectiveShadowVariableDescriptorMap;
+    private SequencedMap<String, VariableDescriptor<Solution_>> effectiveVariableDescriptorMap;
+    private List<VariableDescriptor<Solution_>> declaredVariableDescriptorList;
     private List<GenuineVariableDescriptor<Solution_>> effectiveGenuineVariableDescriptorList;
-    private List<ListVariableDescriptor<Solution_>> effectiveGenuineListVariableDescriptorList;
+    private List<BasicVariableDescriptor<Solution_>> effectiveBasicVariableDescriptorList;
+    private List<ListVariableDescriptor<Solution_>> effectiveListVariableDescriptorList;
 
-    private final UniNeighborhoodsPredicate<Solution_, Object> entityMovablePredicate =
-            (solutionView, entity) -> {
-                var moveDirector = (MoveDirector<Solution_, ?>) solutionView;
-                return !moveDirector.isPinned(this, entity);
-            };
+    private final UniNeighborhoodsPredicate<Solution_, Object> entityMovablePredicate = (solutionView, entity) -> {
+        var moveDirector = (MoveDirector<Solution_, ?>) solutionView;
+        return !moveDirector.isPinned(this, entity);
+    };
 
     // Caches the metamodel
     private PlanningEntityMetaModel<Solution_, ?> entityMetaModel = null;
@@ -162,7 +155,7 @@ public class EntityDescriptor<Solution_> {
         processEntityAnnotations();
         declaredGenuineVariableDescriptorMap = new LinkedHashMap<>();
         declaredShadowVariableDescriptorMap = new LinkedHashMap<>();
-        declaredCascadingUpdateShadowVariableDecriptorMap = new HashMap<>();
+        declaredCascadingUpdateShadowVariableDecriptorMap = new LinkedHashMap<>();
         declaredPinEntityFilterList = new ArrayList<>(2);
         // Only iterate declared fields and methods, not inherited members, to avoid registering the same one twice
         // The inherited classes will be analyzed in a later step
@@ -195,7 +188,8 @@ public class EntityDescriptor<Solution_> {
         }
         // We use the parent class of the entity as the base annotation
         if (entityAnnotation == null) {
-            entityAnnotation = declaredInheritedEntityClassList.stream().filter(c -> !c.equals(entityClass))
+            entityAnnotation = declaredInheritedEntityClassList.stream()
+                    .filter(c -> !c.equals(entityClass))
                     .findFirst()
                     .map(c -> c.getAnnotation(PlanningEntity.class))
                     .orElseThrow(
@@ -209,8 +203,7 @@ public class EntityDescriptor<Solution_> {
             return;
         }
         var comparatorClass = entityAnnotation.comparatorClass();
-        if (comparatorClass != null
-                && PlanningEntity.NullComparator.class.isAssignableFrom(comparatorClass)) {
+        if (comparatorClass != null && PlanningEntity.NullComparator.class.isAssignableFrom(comparatorClass)) {
             comparatorClass = null;
         }
         var comparatorFactoryClass = entityAnnotation.comparatorFactoryClass();
@@ -229,8 +222,7 @@ public class EntityDescriptor<Solution_> {
             var comparator = ConfigUtils.newInstance(this::toString, "comparatorClass", comparatorClass);
             descendingSorter = new ComparatorSelectionSorter<>(comparator, SelectionSorterOrder.DESCENDING);
         } else if (comparatorFactoryClass != null) {
-            var comparator = ConfigUtils.newInstance(this::toString, "comparatorFactoryClass",
-                    comparatorFactoryClass);
+            var comparator = ConfigUtils.newInstance(this::toString, "comparatorFactoryClass", comparatorFactoryClass);
             descendingSorter = new ComparatorFactorySelectionSorter<>(comparator, SelectionSorterOrder.DESCENDING);
         }
     }
@@ -265,16 +257,15 @@ public class EntityDescriptor<Solution_> {
             } else if (member instanceof Method method) {
                 annotation = method.getAnnotation(variableAnnotationClass);
             } else {
-                throw new IllegalStateException("Member must be a field or a method, but was (%s)."
-                        .formatted(member.getClass().getSimpleName()));
+                throw new IllegalStateException(
+                        "Member must be a field or a method, but was (%s).".formatted(member.getClass().getSimpleName()));
             }
             if (annotation == null) {
                 throw new IllegalStateException("Impossible state: cannot get annotation on a %s-annotated member (%s)."
                         .formatted(variableAnnotationClass, member));
             }
-            var memberAccessor = descriptorPolicy.getMemberAccessorFactory()
-                    .buildAndCacheMemberAccessor(member, FIELD_OR_GETTER_METHOD_WITH_SETTER, variableAnnotationClass,
-                            descriptorPolicy.getDomainAccessType());
+            var memberAccessor = descriptorPolicy.getMemberAccessorFactory().buildAndCacheMemberAccessor(member,
+                    FIELD_OR_GETTER_METHOD_WITH_SETTER, variableAnnotationClass, descriptorPolicy.getDomainAccessType());
             registerVariableAccessor(variableDescriptorCounter.intValue(), variableAnnotationClass, memberAccessor);
             variableDescriptorCounter.increment();
         }
@@ -291,9 +282,8 @@ public class EntityDescriptor<Solution_> {
             }
             throw new IllegalStateException("""
                     The entityClass (%s) has a @%s annotated member (%s), duplicated by member for variableDescriptor (%s).
-                    Maybe the annotation is defined on both the field and its getter."""
-                    .formatted(entityClass.getCanonicalName(), variableAnnotationClass.getSimpleName(), memberAccessor,
-                            duplicate));
+                    Maybe the annotation is defined on both the field and its getter.""".formatted(
+                    entityClass.getCanonicalName(), variableAnnotationClass.getSimpleName(), memberAccessor, duplicate));
         } else if (variableAnnotationClass.equals(PlanningVariable.class)) {
             var type = memberAccessor.getType();
             if (type.isArray()) {
@@ -309,9 +299,8 @@ public class EntityDescriptor<Solution_> {
             } else {
                 throw new IllegalStateException("""
                         The entityClass (%s) has a @%s annotated member (%s) that has an unsupported type (%s).
-                        Maybe use %s."""
-                        .formatted(entityClass.getCanonicalName(), PlanningListVariable.class.getSimpleName(), memberAccessor,
-                                memberAccessor.getType(), List.class.getCanonicalName()));
+                        Maybe use %s.""".formatted(entityClass.getCanonicalName(), PlanningListVariable.class.getSimpleName(),
+                        memberAccessor, memberAccessor.getType(), List.class.getCanonicalName()));
             }
         } else if (variableAnnotationClass.equals(InverseRelationShadowVariable.class)) {
             var variableDescriptor =
@@ -347,13 +336,13 @@ public class EntityDescriptor<Solution_> {
                         variableDescriptor);
             }
         } else if (variableAnnotationClass.equals(ShadowVariablesInconsistent.class)) {
-            var variableDescriptor = new ShadowVariablesInconsistentVariableDescriptor<>(nextVariableDescriptorOrdinal, this,
-                    memberAccessor);
+            var variableDescriptor =
+                    new ShadowVariablesInconsistentVariableDescriptor<>(nextVariableDescriptorOrdinal, this, memberAccessor);
             shadowVariablesInconsistentDescriptor = variableDescriptor;
             declaredShadowVariableDescriptorMap.put(memberName, variableDescriptor);
         } else {
-            throw new IllegalStateException("The variableAnnotationClass (%s) is not implemented."
-                    .formatted(variableAnnotationClass));
+            throw new IllegalStateException(
+                    "The variableAnnotationClass (%s) is not implemented.".formatted(variableAnnotationClass));
         }
     }
 
@@ -375,11 +364,11 @@ public class EntityDescriptor<Solution_> {
     private void processPlanningPinIndexAnnotation(DescriptorPolicy descriptorPolicy, Member member) {
         var annotatedMember = ((AnnotatedElement) member);
         if (annotatedMember.isAnnotationPresent(PlanningPinToIndex.class)) {
-            if (!hasAnyGenuineListVariables()) {
+            if (!hasAnyListVariables()) {
                 throw new IllegalStateException(
-                        "The entityClass (%s) has a %s annotated member (%s) but no %s annotated member."
-                                .formatted(entityClass.getCanonicalName(), PlanningPinToIndex.class.getSimpleName(), member,
-                                        PlanningListVariable.class.getSimpleName()));
+                        "The entityClass (%s) has a %s annotated member (%s) but no %s annotated member.".formatted(
+                                entityClass.getCanonicalName(), PlanningPinToIndex.class.getSimpleName(), member,
+                                PlanningListVariable.class.getSimpleName()));
             }
             var memberAccessor = descriptorPolicy.getMemberAccessorFactory().buildAndCacheMemberAccessor(member,
                     FIELD_OR_READ_METHOD, PlanningPinToIndex.class, descriptorPolicy.getDomainAccessType());
@@ -439,8 +428,7 @@ public class EntityDescriptor<Solution_> {
         }
         // It is not allowed to redefine genuine or shadow variables
         var redefinedGenuineVariables = declaredGenuineVariableDescriptorMap.keySet().stream()
-                .filter(key -> effectiveGenuineVariableDescriptorMap.containsKey(key))
-                .toList();
+                .filter(key -> effectiveGenuineVariableDescriptorMap.containsKey(key)).toList();
         if (!redefinedGenuineVariables.isEmpty()) {
             throw new IllegalStateException("""
                     The entityClass (%s) redefines the genuine variables (%s), which is not permitted.
@@ -449,8 +437,7 @@ public class EntityDescriptor<Solution_> {
         }
         effectiveGenuineVariableDescriptorMap.putAll(declaredGenuineVariableDescriptorMap);
         var redefinedShadowVariables = declaredShadowVariableDescriptorMap.keySet().stream()
-                .filter(key -> effectiveShadowVariableDescriptorMap.containsKey(key))
-                .toList();
+                .filter(key -> effectiveShadowVariableDescriptorMap.containsKey(key)).toList();
         if (!redefinedShadowVariables.isEmpty()) {
             throw new IllegalStateException("""
                     The entityClass (%s) redefines the shadow variables (%s), which is not permitted.
@@ -463,11 +450,23 @@ public class EntityDescriptor<Solution_> {
                 .newLinkedHashMap(effectiveGenuineVariableDescriptorMap.size() + effectiveShadowVariableDescriptorMap.size());
         effectiveVariableDescriptorMap.putAll(effectiveGenuineVariableDescriptorMap);
         effectiveVariableDescriptorMap.putAll(effectiveShadowVariableDescriptorMap);
-        effectiveGenuineVariableDescriptorList = new ArrayList<>(effectiveGenuineVariableDescriptorMap.values());
-        effectiveGenuineListVariableDescriptorList = effectiveGenuineVariableDescriptorList.stream()
-                .filter(VariableDescriptor::isListVariable)
-                .map(l -> (ListVariableDescriptor<Solution_>) l)
-                .toList();
+        effectiveGenuineVariableDescriptorList = List.copyOf(effectiveGenuineVariableDescriptorMap.values());
+        effectiveBasicVariableDescriptorList = effectiveGenuineVariableDescriptorList.stream()
+                .flatMap(descriptor -> {
+                    if (descriptor instanceof BasicVariableDescriptor<Solution_> basicVariableDescriptor) {
+                        return Stream.of(basicVariableDescriptor);
+                    } else {
+                        return Stream.empty();
+                    }
+                }).toList();
+        effectiveListVariableDescriptorList = effectiveGenuineVariableDescriptorList.stream()
+                .flatMap(descriptor -> {
+                    if (descriptor instanceof ListVariableDescriptor<Solution_> listVariableDescriptor) {
+                        return Stream.of(listVariableDescriptor);
+                    } else {
+                        return Stream.empty();
+                    }
+                }).toList();
     }
 
     private void createEffectiveMovableEntitySelectionFilter() {
@@ -490,7 +489,7 @@ public class EntityDescriptor<Solution_> {
     }
 
     private void createEffectivePlanningPinIndexReader() {
-        if (!hasAnyGenuineListVariables()) {
+        if (!hasAnyListVariables()) {
             effectivePlanningPinToIndexReader = null;
             return;
         }
@@ -508,9 +507,9 @@ public class EntityDescriptor<Solution_> {
                 effectivePlanningPinToIndexReader = entity -> (int) memberAccessor.executeGetter(entity);
             }
             default -> throw new IllegalStateException(
-                    "The entityClass (%s) has (%d) @%s-annotated members (%s), where it should only have one."
-                            .formatted(entityClass.getCanonicalName(), planningPinIndexMemberAccessorList.size(),
-                                    PlanningPinToIndex.class.getSimpleName(), planningPinIndexMemberAccessorList));
+                    "The entityClass (%s) has (%d) @%s-annotated members (%s), where it should only have one.".formatted(
+                            entityClass.getCanonicalName(), planningPinIndexMemberAccessorList.size(),
+                            PlanningPinToIndex.class.getSimpleName(), planningPinIndexMemberAccessorList));
         }
     }
 
@@ -569,8 +568,8 @@ public class EntityDescriptor<Solution_> {
         return descendingSorter;
     }
 
-    public Collection<String> getGenuineVariableNameSet() {
-        return effectiveGenuineVariableDescriptorMap.keySet();
+    public SequencedCollection<String> getGenuineVariableNameSet() {
+        return effectiveGenuineVariableDescriptorMap.sequencedKeySet();
     }
 
     public GenuineVariableDescriptor<Solution_> getGenuineVariableDescriptor(String variableName) {
@@ -581,48 +580,45 @@ public class EntityDescriptor<Solution_> {
         return shadowVariablesInconsistentDescriptor;
     }
 
-    public boolean hasBothGenuineListAndBasicVariables() {
+    public boolean hasBothListAndBasicVariables() {
         if (!isGenuine()) {
             return false;
         }
-        return hasAnyGenuineListVariables() && hasAnyGenuineBasicVariables();
+        return hasAnyListVariables() && hasAnyBasicVariables();
     }
 
-    public boolean hasAnyGenuineBasicVariables() {
+    public boolean hasAnyBasicVariables() {
         if (!isGenuine()) {
             return false;
         }
-        return getDeclaredGenuineVariableDescriptors().stream()
-                .anyMatch(descriptor -> !descriptor.isListVariable());
+        return !getBasicVariableDescriptorList().isEmpty();
     }
 
-    public boolean hasAnyGenuineListVariables() {
+    public boolean hasAnyListVariables() {
         if (!isGenuine()) {
             return false;
         }
-        return getGenuineListVariableDescriptor() != null;
+        return getListVariableDescriptor() != null;
     }
 
     public boolean isGenuine() {
         return !effectiveGenuineVariableDescriptorMap.isEmpty();
     }
 
-    public ListVariableDescriptor<Solution_> getGenuineListVariableDescriptor() {
-        if (effectiveGenuineListVariableDescriptorList.isEmpty()) {
-            return null;
-        }
-        // Earlier validation guarantees there will only ever be one.
-        return effectiveGenuineListVariableDescriptorList.getFirst();
-    }
-
     public List<GenuineVariableDescriptor<Solution_>> getGenuineVariableDescriptorList() {
         return effectiveGenuineVariableDescriptorList;
     }
 
-    public List<GenuineVariableDescriptor<Solution_>> getGenuineBasicVariableDescriptorList() {
-        return effectiveGenuineVariableDescriptorList.stream()
-                .filter(descriptor -> !descriptor.isListVariable())
-                .toList();
+    public List<BasicVariableDescriptor<Solution_>> getBasicVariableDescriptorList() {
+        return effectiveBasicVariableDescriptorList;
+    }
+
+    public ListVariableDescriptor<Solution_> getListVariableDescriptor() {
+        if (effectiveListVariableDescriptorList.isEmpty()) {
+            return null;
+        }
+        // Earlier validation guarantees there will only ever be one.
+        return effectiveListVariableDescriptorList.getFirst();
     }
 
     public long getGenuineVariableCount() {
@@ -643,15 +639,15 @@ public class EntityDescriptor<Solution_> {
         return count;
     }
 
-    public Collection<ShadowVariableDescriptor<Solution_>> getShadowVariableDescriptors() {
-        return effectiveShadowVariableDescriptorMap.values();
+    public SequencedCollection<ShadowVariableDescriptor<Solution_>> getShadowVariableDescriptors() {
+        return effectiveShadowVariableDescriptorMap.sequencedValues();
     }
 
     public ShadowVariableDescriptor<Solution_> getShadowVariableDescriptor(String variableName) {
         return effectiveShadowVariableDescriptorMap.get(variableName);
     }
 
-    public Map<String, VariableDescriptor<Solution_>> getVariableDescriptorMap() {
+    public SequencedMap<String, VariableDescriptor<Solution_>> getVariableDescriptorMap() {
         return effectiveVariableDescriptorMap;
     }
 
@@ -667,37 +663,37 @@ public class EntityDescriptor<Solution_> {
         return !declaredGenuineVariableDescriptorMap.isEmpty();
     }
 
-    public Collection<GenuineVariableDescriptor<Solution_>> getDeclaredGenuineVariableDescriptors() {
-        return declaredGenuineVariableDescriptorMap.values();
+    public SequencedCollection<GenuineVariableDescriptor<Solution_>> getDeclaredGenuineVariableDescriptors() {
+        return declaredGenuineVariableDescriptorMap.sequencedValues();
     }
 
-    public Collection<ShadowVariableDescriptor<Solution_>> getDeclaredShadowVariableDescriptors() {
-        return declaredShadowVariableDescriptorMap.values();
+    public SequencedCollection<ShadowVariableDescriptor<Solution_>> getDeclaredShadowVariableDescriptors() {
+        return declaredShadowVariableDescriptorMap.sequencedValues();
     }
 
-    public Collection<CascadingUpdateShadowVariableDescriptor<Solution_>>
+    public SequencedCollection<CascadingUpdateShadowVariableDescriptor<Solution_>>
             getDeclaredCascadingUpdateShadowVariableDescriptors() {
-        return declaredCascadingUpdateShadowVariableDecriptorMap.values();
+        return declaredCascadingUpdateShadowVariableDecriptorMap.sequencedValues();
     }
 
-    public Collection<VariableDescriptor<Solution_>> getDeclaredVariableDescriptors() {
-        Collection<VariableDescriptor<Solution_>> variableDescriptors = new ArrayList<>(
-                declaredGenuineVariableDescriptorMap.size() + declaredShadowVariableDescriptorMap.size());
-        variableDescriptors.addAll(declaredGenuineVariableDescriptorMap.values());
-        variableDescriptors.addAll(declaredShadowVariableDescriptorMap.values());
-        return variableDescriptors;
+    public SequencedCollection<VariableDescriptor<Solution_>> getDeclaredVariableDescriptors() {
+        if (declaredVariableDescriptorList != null) {
+            return declaredVariableDescriptorList;
+        }
+        declaredVariableDescriptorList = Stream.concat(declaredGenuineVariableDescriptorMap.values().stream(),
+                declaredShadowVariableDescriptorMap.values().stream())
+                .toList();
+        return declaredVariableDescriptorList;
     }
 
     public String buildInvalidVariableNameExceptionMessage(String variableName) {
         if (!ReflectionHelper.hasGetterMethod(entityClass, variableName)
                 && !ReflectionHelper.hasField(entityClass, variableName)) {
-            String exceptionMessage =
-                    """
-                            The variableName (%s) for entityClass (%s) does not exist as a getter or field on that class.
-                            Check the spelling of the variableName (%s)."""
-                            .formatted(variableName, entityClass.getCanonicalName(), variableName);
-            if (variableName.length() >= 2
-                    && !Character.isUpperCase(variableName.charAt(0))
+            String exceptionMessage = """
+                    The variableName (%s) for entityClass (%s) does not exist as a getter or field on that class.
+                    Check the spelling of the variableName (%s).""".formatted(variableName, entityClass.getCanonicalName(),
+                    variableName);
+            if (variableName.length() >= 2 && !Character.isUpperCase(variableName.charAt(0))
                     && Character.isUpperCase(variableName.charAt(1))) {
                 String correctedVariableName = variableName.substring(0, 1).toUpperCase() + variableName.substring(1);
                 exceptionMessage +=
@@ -801,17 +797,15 @@ public class EntityDescriptor<Solution_> {
     }
 
     public boolean isMovable(Solution_ workingSolution, Object entity) {
-        return isGenuine() &&
-                (effectiveMovableEntityFilter == null
-                        || effectiveMovableEntityFilter.test(workingSolution, entity));
+        return isGenuine()
+                && (effectiveMovableEntityFilter == null || effectiveMovableEntityFilter.test(workingSolution, entity));
     }
 
     public PlanningEntityMetaModel<Solution_, ?> getEntityMetaModel() {
         if (entityMetaModel != null) {
             return entityMetaModel;
         }
-        entityMetaModel = solutionDescriptor.getMetaModel()
-                .entity(entityClass);
+        entityMetaModel = solutionDescriptor.getMetaModel().entity(entityClass);
         return entityMetaModel;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -17,12 +17,14 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.SequencedCollection;
+import java.util.SequencedMap;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -86,43 +88,34 @@ public final class SolutionDescriptor<Solution_> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SolutionDescriptor.class);
     private static final EntityDescriptor<?> NULL_ENTITY_DESCRIPTOR = new EntityDescriptor<>(-1, null, PlanningEntity.class);
-    private static final Class[] ANNOTATED_MEMBERS_CLASSES = {
-            ProblemFactCollectionProperty.class,
-            ValueRangeProvider.class,
-            PlanningEntityCollectionProperty.class,
-            PlanningScore.class };
+    private static final Class[] ANNOTATED_MEMBERS_CLASSES = { ProblemFactCollectionProperty.class, ValueRangeProvider.class,
+            PlanningEntityCollectionProperty.class, PlanningScore.class };
 
     public static <Solution_> SolutionDescriptor<Solution_> buildSolutionDescriptor(Class<Solution_> solutionClass,
             Class<?>... entityClasses) {
         return buildSolutionDescriptor(solutionClass, Arrays.asList(entityClasses));
     }
 
-    public static <Solution_> SolutionDescriptor<Solution_> buildSolutionDescriptor(
-            Class<Solution_> solutionClass,
+    public static <Solution_> SolutionDescriptor<Solution_> buildSolutionDescriptor(Class<Solution_> solutionClass,
             List<Class<?>> entityClassList) {
         return buildSolutionDescriptor(EnumSet.noneOf(PreviewFeature.class), solutionClass, entityClassList);
     }
 
     public static <Solution_> SolutionDescriptor<Solution_> buildSolutionDescriptor(
-            Set<PreviewFeature> enabledPreviewFeaturesSet,
-            Class<Solution_> solutionClass,
-            Class<?>... entityClasses) {
+            Set<PreviewFeature> enabledPreviewFeaturesSet, Class<Solution_> solutionClass, Class<?>... entityClasses) {
         return buildSolutionDescriptor(enabledPreviewFeaturesSet, solutionClass, List.of(entityClasses));
     }
 
     public static <Solution_> SolutionDescriptor<Solution_> buildSolutionDescriptor(
-            Set<PreviewFeature> enabledPreviewFeaturesSet,
-            Class<Solution_> solutionClass,
-            List<Class<?>> entityClassList) {
-        return buildSolutionDescriptor(enabledPreviewFeaturesSet, DomainAccessType.FORCE_REFLECTION, solutionClass, null,
-                null, entityClassList);
+            Set<PreviewFeature> enabledPreviewFeaturesSet, Class<Solution_> solutionClass, List<Class<?>> entityClassList) {
+        return buildSolutionDescriptor(enabledPreviewFeaturesSet, DomainAccessType.FORCE_REFLECTION, solutionClass, null, null,
+                entityClassList);
     }
 
     public static <Solution_> SolutionDescriptor<Solution_> buildSolutionDescriptor(
-            Set<PreviewFeature> enabledPreviewFeatureSet,
-            DomainAccessType domainAccessType,
-            Class<Solution_> solutionClass, Map<String, MemberAccessor> memberAccessorMap,
-            Map<String, SolutionCloner> solutionClonerMap, List<Class<?>> entityClassList) {
+            Set<PreviewFeature> enabledPreviewFeatureSet, DomainAccessType domainAccessType, Class<Solution_> solutionClass,
+            Map<String, MemberAccessor> memberAccessorMap, Map<String, SolutionCloner> solutionClonerMap,
+            List<Class<?>> entityClassList) {
         assertMutable(solutionClass, "solutionClass");
         assertSingleInheritance(solutionClass);
         assertValidAnnotatedMembers(solutionClass);
@@ -144,7 +137,8 @@ public final class SolutionDescriptor<Solution_> {
         for (var entityClass : entityClassList) {
             var inheritedEntityClasses = extractInheritedClasses(entityClass);
             var filteredInheritedEntityClasses = inheritedEntityClasses.stream()
-                    .filter(c -> !updatedEntityClassList.contains(c)).toList();
+                    .filter(c -> !updatedEntityClassList.contains(c))
+                    .toList();
             updatedEntityClassList.addAll(filteredInheritedEntityClasses);
         }
         for (var entityClass : sortEntityClassList(updatedEntityClassList)) {
@@ -164,13 +158,11 @@ public final class SolutionDescriptor<Solution_> {
         if (clz.isRecord()) {
             throw new IllegalArgumentException("""
                     The %s (%s) cannot be a record as it needs to be mutable.
-                    Use a regular class instead."""
-                    .formatted(classType, clz.getCanonicalName()));
+                    Use a regular class instead.""".formatted(classType, clz.getCanonicalName()));
         } else if (clz.isEnum()) {
             throw new IllegalArgumentException("""
                     The %s (%s) cannot be an enum as it needs to be mutable.
-                    Use a regular class instead."""
-                    .formatted(classType, clz.getCanonicalName()));
+                    Use a regular class instead.""".formatted(classType, clz.getCanonicalName()));
         }
     }
 
@@ -184,12 +176,10 @@ public final class SolutionDescriptor<Solution_> {
             var annotatedMembers = extractAnnotatedMembers(clazz).stream()
                     .map(Member::getName)
                     .toList();
-            throw new IllegalStateException(
-                    """
-                            The class %s is not annotated with @PlanningSolution but defines annotated members.
-                            Maybe annotate %s with @PlanningSolution.
-                            Maybe remove the annotated members (%s)."""
-                            .formatted(clazz.getName(), clazz.getName(), annotatedMembers));
+            throw new IllegalStateException("""
+                    The class %s is not annotated with @PlanningSolution but defines annotated members.
+                    Maybe annotate %s with @PlanningSolution.
+                    Maybe remove the annotated members (%s).""".formatted(clazz.getName(), clazz.getName(), annotatedMembers));
         }
         // We check the first level of the inheritance chain
         var otherClazz = clazz.getSuperclass();
@@ -198,12 +188,11 @@ public final class SolutionDescriptor<Solution_> {
             var annotatedMembers = extractAnnotatedMembers(otherClazz).stream()
                     .map(Member::getName)
                     .toList();
-            throw new IllegalStateException(
-                    """
-                            The class %s is not annotated with @PlanningSolution but defines annotated members.
-                            Maybe annotate %s with @PlanningSolution.
-                            Maybe remove the annotated members (%s)."""
-                            .formatted(otherClazz.getName(), otherClazz.getName(), annotatedMembers));
+            throw new IllegalStateException("""
+                    The class %s is not annotated with @PlanningSolution but defines annotated members.
+                    Maybe annotate %s with @PlanningSolution.
+                    Maybe remove the annotated members (%s).""".formatted(otherClazz.getName(), otherClazz.getName(),
+                    annotatedMembers));
         }
     }
 
@@ -211,11 +200,10 @@ public final class SolutionDescriptor<Solution_> {
         var inheritedClassList =
                 ConfigUtils.getAllAnnotatedLineageClasses(solutionClass.getSuperclass(), PlanningSolution.class);
         if (inheritedClassList.size() > 1) {
-            throw new IllegalStateException(
-                    """
-                            The class %s inherits its @%s annotation from multiple classes (%s).
-                            Remove solution class(es) from the inheritance chain to create a single-level inheritance structure."""
-                            .formatted(solutionClass.getName(), PlanningSolution.class.getSimpleName(), inheritedClassList));
+            throw new IllegalStateException("""
+                    The class %s inherits its @%s annotation from multiple classes (%s).
+                    Remove solution class(es) from the inheritance chain to create a single-level inheritance structure."""
+                    .formatted(solutionClass.getName(), PlanningSolution.class.getSimpleName(), inheritedClassList));
         }
     }
 
@@ -256,25 +244,28 @@ public final class SolutionDescriptor<Solution_> {
     private final Class<Solution_> solutionClass;
     private final MemberAccessorFactory memberAccessorFactory;
 
-    private DomainAccessType domainAccessType;
-    private LookupStrategyResolver lookUpStrategyResolver;
-
-    private final Map<String, MemberAccessor> problemFactMemberAccessorMap = new LinkedHashMap<>();
-    private final Map<String, MemberAccessor> problemFactCollectionMemberAccessorMap = new LinkedHashMap<>();
-    private final Map<String, MemberAccessor> entityMemberAccessorMap = new LinkedHashMap<>();
-    private final Map<String, MemberAccessor> entityCollectionMemberAccessorMap = new LinkedHashMap<>();
-    private Set<Class<?>> problemFactOrEntityClassSet;
-    private List<ListVariableDescriptor<Solution_>> listVariableDescriptorList;
-    private ScoreDescriptor<?> scoreDescriptor;
+    private final SequencedMap<String, MemberAccessor> problemFactMemberAccessorMap = new LinkedHashMap<>();
+    private final SequencedMap<String, MemberAccessor> problemFactCollectionMemberAccessorMap = new LinkedHashMap<>();
+    private final SequencedMap<String, MemberAccessor> entityMemberAccessorMap = new LinkedHashMap<>();
+    private final SequencedMap<String, MemberAccessor> entityCollectionMemberAccessorMap = new LinkedHashMap<>();
 
     private ConstraintWeightSupplier<Solution_, ?> constraintWeightSupplier;
-    private final Map<Class<?>, EntityDescriptor<Solution_>> entityDescriptorMap = new LinkedHashMap<>();
+    private final SequencedMap<Class<?>, EntityDescriptor<Solution_>> entityDescriptorMap = new LinkedHashMap<>();
     private final List<Class<?>> reversedEntityClassList = new ArrayList<>();
     private final ConcurrentMap<Class<?>, EntityDescriptor<Solution_>> lowestEntityDescriptorMap = new ConcurrentHashMap<>();
     private final ConcurrentMap<Class<?>, MemberAccessor> planningIdMemberAccessorMap = new ConcurrentHashMap<>();
 
+    // Lazily initialized fields
+    private SequencedSet<Class<?>> problemFactOrEntityClassSet;
+    private ScoreDescriptor<?> scoreDescriptor;
+    private DomainAccessType domainAccessType;
+    private LookupStrategyResolver lookUpStrategyResolver;
     private PlanningSolutionMetaModel<Solution_> planningSolutionMetaModel;
     private SolutionCloner<Solution_> solutionCloner;
+    private List<EntityDescriptor<Solution_>> genuineEntityDescriptorList;
+    private List<BasicVariableDescriptor<Solution_>> basicVariableDescriptorList;
+    private List<ListVariableDescriptor<Solution_>> listVariableDescriptorList;
+    private List<DeclarativeShadowVariableDescriptor<Solution_>> declarativeShadowVariableDescriptorList;
 
     // ************************************************************************
     // Constructors and simple getters/setters
@@ -292,13 +283,14 @@ public final class SolutionDescriptor<Solution_> {
         var entityClass = entityDescriptor.getEntityClass();
         for (var otherEntityClass : entityDescriptorMap.keySet()) {
             if (entityClass.isAssignableFrom(otherEntityClass)) {
-                throw new IllegalArgumentException(
-                        "An earlier entityClass (%s) should not be a subclass of a later entityClass (%s). Switch their declaration so superclasses are defined earlier."
-                                .formatted(otherEntityClass, entityClass));
+                throw new IllegalArgumentException("""
+                        An earlier entityClass (%s) should not be a subclass of a later entityClass (%s).
+                        Switch their declaration so superclasses are defined earlier."""
+                        .formatted(otherEntityClass, entityClass));
             }
         }
         entityDescriptorMap.put(entityClass, entityDescriptor);
-        reversedEntityClassList.add(0, entityClass);
+        reversedEntityClassList.addFirst(entityClass);
         lowestEntityDescriptorMap.put(entityClass, entityDescriptor);
     }
 
@@ -310,14 +302,19 @@ public final class SolutionDescriptor<Solution_> {
         for (var lineageClass : ConfigUtils.getAllParents(solutionClass)) {
             var memberList = ConfigUtils.getDeclaredMembers(lineageClass);
             var constraintWeightFieldList = memberList.stream()
-                    .filter(member -> member instanceof Field field
-                            && ConstraintWeightOverrides.class.isAssignableFrom(field.getType()))
-                    .map(f -> ((Field) f))
-                    .toList();
+                    .flatMap(member -> {
+                        if (member instanceof Field field
+                                && ConstraintWeightOverrides.class.isAssignableFrom(field.getType())) {
+                            return Stream.of(field);
+                        } else {
+                            return Stream.empty();
+                        }
+                    }).toList();
             switch (constraintWeightFieldList.size()) {
-                case 0:
-                    break;
-                case 1:
+                case 0 -> {
+                    // Do nothing.
+                }
+                case 1 -> {
                     if (constraintWeightSupplier != null) {
                         // The bottom-most class wins, they are parsed first due to ConfigUtil.getAllParents().
                         throw new IllegalStateException(
@@ -325,9 +322,9 @@ public final class SolutionDescriptor<Solution_> {
                                         .formatted(lineageClass, ConstraintWeightOverrides.class));
                     }
                     constraintWeightSupplier = OverridesBasedConstraintWeightSupplier.create(this, descriptorPolicy,
-                            constraintWeightFieldList.get(0));
-                    break;
-                default:
+                            constraintWeightFieldList.getFirst());
+                }
+                default ->
                     throw new IllegalStateException("The solutionClass (%s) has more than one field (%s) of type %s."
                             .formatted(solutionClass, constraintWeightFieldList, ConstraintWeightOverrides.class));
             }
@@ -346,8 +343,8 @@ public final class SolutionDescriptor<Solution_> {
         for (var lineageClass : lineageClassList) {
             var memberList = ConfigUtils.getDeclaredMembers(lineageClass);
             for (var member : memberList) {
-                if (member instanceof Method method && potentiallyOverwritingMethodList.stream().anyMatch(
-                        m -> member.getName().equals(m.getName()) // Shortcut to discard negatives faster
+                if (member instanceof Method method
+                        && potentiallyOverwritingMethodList.stream().anyMatch(m -> member.getName().equals(m.getName()) // Shortcut to discard negatives faster
                                 && ReflectionHelper.isMethodOverwritten(method, m.getDeclaringClass()))) {
                     // Ignore member because it is an overwritten method
                     continue;
@@ -368,12 +365,10 @@ public final class SolutionDescriptor<Solution_> {
         // Do not check if problemFactCollectionMemberAccessorMap and problemFactMemberAccessorMap are empty
         // because they are only required for ConstraintStreams.
         if (scoreDescriptor == null) {
-            throw new IllegalStateException(
-                    """
-                            The solutionClass (%s) must have 1 member with a @%s annotation.
-                            Maybe add a getScore() method with a @%s annotation."""
-                            .formatted(solutionClass, PlanningScore.class.getSimpleName(),
-                                    PlanningScore.class.getSimpleName()));
+            throw new IllegalStateException("""
+                    The solutionClass (%s) must have 1 member with a @%s annotation.
+                    Maybe add a getScore() method with a @%s annotation.""".formatted(solutionClass,
+                    PlanningScore.class.getSimpleName(), PlanningScore.class.getSimpleName()));
         }
     }
 
@@ -395,16 +390,15 @@ public final class SolutionDescriptor<Solution_> {
         if (solutionSuperclass == null) {
             throw new IllegalStateException("""
                     The solutionClass (%s) has been specified as a solution in the configuration, \
-                    but does not have a @%s annotation."""
-                    .formatted(solutionClass.getCanonicalName(), PlanningSolution.class.getSimpleName()));
+                    but does not have a @%s annotation.""".formatted(solutionClass.getCanonicalName(),
+                    PlanningSolution.class.getSimpleName()));
         }
         var parentSolutionAnnotation = solutionSuperclass.getAnnotation(PlanningSolution.class);
         if (parentSolutionAnnotation == null) {
             throw new IllegalStateException("""
                     The solutionClass (%s) has been specified as a solution in the configuration, \
-                    but neither it nor its superclass (%s) have a @%s annotation."""
-                    .formatted(solutionClass.getCanonicalName(), solutionSuperclass.getCanonicalName(),
-                            PlanningSolution.class.getSimpleName()));
+                    but neither it nor its superclass (%s) have a @%s annotation.""".formatted(solutionClass.getCanonicalName(),
+                    solutionSuperclass.getCanonicalName(), PlanningSolution.class.getSimpleName()));
         }
         return parentSolutionAnnotation;
     }
@@ -417,15 +411,12 @@ public final class SolutionDescriptor<Solution_> {
         }
     }
 
-    private void processFactEntityOrScoreAnnotation(DescriptorPolicy descriptorPolicy,
-            Member member) {
-        var annotationClass = extractFactEntityOrScoreAnnotationClass(
-                member);
+    private void processFactEntityOrScoreAnnotation(DescriptorPolicy descriptorPolicy, Member member) {
+        var annotationClass = extractFactEntityOrScoreAnnotationClass(member);
         if (annotationClass == null) {
             return;
         }
-        if (annotationClass.equals(ProblemFactProperty.class)
-                || annotationClass.equals(ProblemFactCollectionProperty.class)) {
+        if (annotationClass.equals(ProblemFactProperty.class) || annotationClass.equals(ProblemFactCollectionProperty.class)) {
             processProblemFactPropertyAnnotation(descriptorPolicy, member, annotationClass);
         } else if (annotationClass.equals(PlanningEntityProperty.class)
                 || annotationClass.equals(PlanningEntityCollectionProperty.class)) {
@@ -441,11 +432,8 @@ public final class SolutionDescriptor<Solution_> {
     }
 
     private static Class<? extends Annotation> extractFactEntityOrScoreAnnotationClass(Member member) {
-        return ConfigUtils.extractAnnotationClass(member,
-                ProblemFactProperty.class,
-                ProblemFactCollectionProperty.class,
-                PlanningEntityProperty.class, PlanningEntityCollectionProperty.class,
-                PlanningScore.class);
+        return ConfigUtils.extractAnnotationClass(member, ProblemFactProperty.class, ProblemFactCollectionProperty.class,
+                PlanningEntityProperty.class, PlanningEntityCollectionProperty.class, PlanningScore.class);
     }
 
     private void processProblemFactPropertyAnnotation(DescriptorPolicy descriptorPolicy, Member member,
@@ -471,8 +459,8 @@ public final class SolutionDescriptor<Solution_> {
                 problemFactType = type.getComponentType();
             } else {
                 problemFactType = ConfigUtils.extractGenericTypeParameterOrFail(PlanningSolution.class.getSimpleName(),
-                        memberAccessor.getDeclaringClass(),
-                        type, memberAccessor.getGenericType(), annotationClass, memberAccessor.getName());
+                        memberAccessor.getDeclaringClass(), type, memberAccessor.getGenericType(), annotationClass,
+                        memberAccessor.getName());
             }
         } else {
             throw new IllegalStateException("Impossible situation with annotationClass (" + annotationClass + ").");
@@ -480,12 +468,10 @@ public final class SolutionDescriptor<Solution_> {
         if (problemFactType.isAnnotationPresent(PlanningEntity.class)) {
             throw new IllegalStateException("""
                     The solutionClass (%s) has a @%s-annotated member (%s) that returns a @%s.
-                    Maybe use @%s instead?"""
-                    .formatted(solutionClass, annotationClass.getSimpleName(), memberAccessor.getName(),
-                            PlanningEntity.class.getSimpleName(),
-                            ((annotationClass == ProblemFactProperty.class)
-                                    ? PlanningEntityProperty.class.getSimpleName()
-                                    : PlanningEntityCollectionProperty.class.getSimpleName())));
+                    Maybe use @%s instead?""".formatted(solutionClass, annotationClass.getSimpleName(),
+                    memberAccessor.getName(), PlanningEntity.class.getSimpleName(),
+                    ((annotationClass == ProblemFactProperty.class) ? PlanningEntityProperty.class.getSimpleName()
+                            : PlanningEntityCollectionProperty.class.getSimpleName())));
         }
     }
 
@@ -510,8 +496,8 @@ public final class SolutionDescriptor<Solution_> {
         }
     }
 
-    private void assertNoFieldAndGetterDuplicationOrConflict(
-            MemberAccessor memberAccessor, Class<? extends Annotation> annotationClass) {
+    private void assertNoFieldAndGetterDuplicationOrConflict(MemberAccessor memberAccessor,
+            Class<? extends Annotation> annotationClass) {
         MemberAccessor duplicate;
         Class<? extends Annotation> otherAnnotationClass;
         var memberName = memberAccessor.getName();
@@ -533,8 +519,8 @@ public final class SolutionDescriptor<Solution_> {
         throw new IllegalStateException("""
                 The solutionClass (%s) has a @%s annotated member (%s) that is duplicated by a @%s annotated member (%s).
                 %s""".formatted(solutionClass, annotationClass.getSimpleName(), memberAccessor,
-                otherAnnotationClass.getSimpleName(),
-                duplicate, annotationClass.equals(otherAnnotationClass)
+                otherAnnotationClass.getSimpleName(), duplicate,
+                annotationClass.equals(otherAnnotationClass)
                         ? "Maybe the annotation is defined on both the field and its getter."
                         : "Maybe 2 mutually exclusive annotations are configured."));
     }
@@ -560,8 +546,7 @@ public final class SolutionDescriptor<Solution_> {
                 for (var variableDescriptor : entityDescriptor.getDeclaredVariableDescriptors()) {
                     LOGGER.trace("            {} variable {} ({})",
                             variableDescriptor instanceof GenuineVariableDescriptor ? "Genuine" : "Shadow",
-                            variableDescriptor.getVariableName(),
-                            variableDescriptor.getMemberAccessorSpeedNote());
+                            variableDescriptor.getVariableName(), variableDescriptor.getMemberAccessorSpeedNote());
                 }
             }
         }
@@ -592,7 +577,7 @@ public final class SolutionDescriptor<Solution_> {
         var globalShadowOrder = 0;
         while (!pairList.isEmpty()) {
             pairList.sort(Comparator.comparingInt(MutablePair::getValue));
-            var pair = pairList.remove(0);
+            var pair = pairList.removeFirst();
             var shadow = pair.getKey();
             if (pair.getValue() != 0) {
                 if (pair.getValue() < 0) {
@@ -625,18 +610,13 @@ public final class SolutionDescriptor<Solution_> {
         }
     }
 
-    private Set<Class<?>> collectEntityAndProblemFactClasses() {
+    private SequencedSet<Class<?>> collectEntityAndProblemFactClasses() {
         // Figure out all problem fact or entity types that are used within this solution,
         // using the knowledge we've already gained by processing all the annotations.
-        var entityClassStream = entityDescriptorMap.keySet()
-                .stream();
-        var factClassStream = problemFactMemberAccessorMap
-                .values()
-                .stream()
-                .map(MemberAccessor::getType);
+        var entityClassStream = entityDescriptorMap.keySet().stream();
+        var factClassStream = problemFactMemberAccessorMap.values().stream().map(MemberAccessor::getType);
         var problemFactOrEntityClassStream = concat(entityClassStream, factClassStream);
-        var factCollectionClassStream = problemFactCollectionMemberAccessorMap.values()
-                .stream()
+        var factCollectionClassStream = problemFactCollectionMemberAccessorMap.values().stream()
                 .map(accessor -> ConfigUtils
                         .extractGenericTypeParameter("solutionClass", getSolutionClass(), accessor.getType(),
                                 accessor.getGenericType(), ProblemFactCollectionProperty.class, accessor.getName())
@@ -644,24 +624,25 @@ public final class SolutionDescriptor<Solution_> {
         problemFactOrEntityClassStream = concat(problemFactOrEntityClassStream, factCollectionClassStream);
         // Add constraint configuration, if configured.
         if (constraintWeightSupplier != null) {
-            problemFactOrEntityClassStream = concat(problemFactOrEntityClassStream,
-                    Stream.of(constraintWeightSupplier.getProblemFactClass()));
+            problemFactOrEntityClassStream =
+                    concat(problemFactOrEntityClassStream, Stream.of(constraintWeightSupplier.getProblemFactClass()));
         }
-        return problemFactOrEntityClassStream.collect(Collectors.toSet());
+        return problemFactOrEntityClassStream.collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private List<ListVariableDescriptor<Solution_>> findListVariableDescriptors() {
         return getGenuineEntityDescriptors().stream()
                 .map(EntityDescriptor::getGenuineVariableDescriptorList)
                 .flatMap(Collection::stream)
-                .filter(VariableDescriptor::isListVariable)
-                .map(variableDescriptor -> ((ListVariableDescriptor<Solution_>) variableDescriptor))
+                .flatMap(e -> e instanceof ListVariableDescriptor<Solution_> listVariableDescriptor
+                        ? Stream.of(listVariableDescriptor)
+                        : Stream.empty())
                 .toList();
     }
 
     private void initSolutionCloner(DescriptorPolicy descriptorPolicy) {
-        solutionCloner = solutionCloner == null ? descriptorPolicy.getGeneratedSolutionClonerMap()
-                .get(GizmoSolutionClonerFactory.getGeneratedClassName(this))
+        solutionCloner = solutionCloner == null
+                ? descriptorPolicy.getGeneratedSolutionClonerMap().get(GizmoSolutionClonerFactory.getGeneratedClassName(this))
                 : solutionCloner;
 
         if (solutionCloner instanceof GizmoSolutionCloner<Solution_> gizmoSolutionCloner) {
@@ -697,28 +678,28 @@ public final class SolutionDescriptor<Solution_> {
         return (ScoreDescriptor<Score_>) scoreDescriptor;
     }
 
-    public Map<String, MemberAccessor> getProblemFactMemberAccessorMap() {
+    public SequencedMap<String, MemberAccessor> getProblemFactMemberAccessorMap() {
         return problemFactMemberAccessorMap;
     }
 
-    public Map<String, MemberAccessor> getProblemFactCollectionMemberAccessorMap() {
+    public SequencedMap<String, MemberAccessor> getProblemFactCollectionMemberAccessorMap() {
         return problemFactCollectionMemberAccessorMap;
     }
 
-    public Map<String, MemberAccessor> getEntityMemberAccessorMap() {
+    public SequencedMap<String, MemberAccessor> getEntityMemberAccessorMap() {
         return entityMemberAccessorMap;
     }
 
-    public Map<String, MemberAccessor> getEntityCollectionMemberAccessorMap() {
+    public SequencedMap<String, MemberAccessor> getEntityCollectionMemberAccessorMap() {
         return entityCollectionMemberAccessorMap;
     }
 
-    public Set<Class<?>> getProblemFactOrEntityClassSet() {
+    public SequencedSet<Class<?>> getProblemFactOrEntityClassSet() {
         return problemFactOrEntityClassSet;
     }
 
     public ListVariableDescriptor<Solution_> getListVariableDescriptor() {
-        return listVariableDescriptorList.isEmpty() ? null : listVariableDescriptorList.get(0);
+        return listVariableDescriptorList.isEmpty() ? null : listVariableDescriptorList.getFirst();
     }
 
     public SolutionCloner<Solution_> getSolutionCloner() {
@@ -739,8 +720,8 @@ public final class SolutionDescriptor<Solution_> {
                 for (var variableDescriptor : entityDescriptor.getGenuineVariableDescriptorList()) {
                     if (variableDescriptor.isListVariable()) {
                         var listVariableDescriptor = (ListVariableDescriptor<Solution_>) variableDescriptor;
-                        var listVariableMetaModel = new DefaultPlanningListVariableMetaModel<>(entityMetaModel,
-                                listVariableDescriptor);
+                        var listVariableMetaModel =
+                                new DefaultPlanningListVariableMetaModel<>(entityMetaModel, listVariableDescriptor);
                         entityMetaModel.addVariable(listVariableMetaModel);
                     } else {
                         var basicVariableDescriptor = (BasicVariableDescriptor<Solution_>) variableDescriptor;
@@ -762,10 +743,13 @@ public final class SolutionDescriptor<Solution_> {
     }
 
     public List<BasicVariableDescriptor<Solution_>> getBasicVariableDescriptorList() {
-        return getGenuineEntityDescriptors().stream()
-                .flatMap(entityDescriptor -> entityDescriptor.getGenuineBasicVariableDescriptorList().stream())
-                .map(descriptor -> (BasicVariableDescriptor<Solution_>) descriptor)
+        if (basicVariableDescriptorList != null) {
+            return basicVariableDescriptorList;
+        }
+        basicVariableDescriptorList = getGenuineEntityDescriptors().stream()
+                .flatMap(entityDescriptor -> entityDescriptor.getBasicVariableDescriptorList().stream())
                 .toList();
+        return basicVariableDescriptorList;
     }
 
     public boolean hasBasicVariable() {
@@ -785,21 +769,21 @@ public final class SolutionDescriptor<Solution_> {
         return (ConstraintWeightSupplier<Solution_, Score_>) constraintWeightSupplier;
     }
 
-    public Set<Class<?>> getEntityClassSet() {
-        return entityDescriptorMap.keySet();
+    public SequencedSet<Class<?>> getEntityClassSet() {
+        return entityDescriptorMap.sequencedKeySet();
     }
 
-    public Collection<EntityDescriptor<Solution_>> getEntityDescriptors() {
-        return entityDescriptorMap.values();
+    public SequencedCollection<EntityDescriptor<Solution_>> getEntityDescriptors() {
+        return entityDescriptorMap.sequencedValues();
     }
 
-    public Collection<EntityDescriptor<Solution_>> getGenuineEntityDescriptors() {
-        var genuineEntityDescriptorList = new ArrayList<EntityDescriptor<Solution_>>(entityDescriptorMap.size());
-        for (var entityDescriptor : entityDescriptorMap.values()) {
-            if (entityDescriptor.hasAnyDeclaredGenuineVariableDescriptor()) {
-                genuineEntityDescriptorList.add(entityDescriptor);
-            }
+    public SequencedCollection<EntityDescriptor<Solution_>> getGenuineEntityDescriptors() {
+        if (genuineEntityDescriptorList != null) {
+            return genuineEntityDescriptorList;
         }
+        genuineEntityDescriptorList = entityDescriptorMap.values().stream()
+                .filter(EntityDescriptor::hasAnyDeclaredGenuineVariableDescriptor)
+                .toList();
         return genuineEntityDescriptorList;
     }
 
@@ -884,12 +868,6 @@ public final class SolutionDescriptor<Solution_> {
     // Extraction methods
     // ************************************************************************
 
-    public Collection<Object> getAllEntitiesAndProblemFacts(Solution_ solution) {
-        var facts = new ArrayList<>();
-        visitAll(solution, facts::add);
-        return facts;
-    }
-
     /**
      * @param solution never null
      * @return {@code >= 0}
@@ -964,9 +942,8 @@ public final class SolutionDescriptor<Solution_> {
             var optionalTypeParameter = ConfigUtils.extractGenericTypeParameter("solutionClass",
                     entityCollectionMemberAccessor.getDeclaringClass(), entityCollectionMemberAccessor.getType(),
                     entityCollectionMemberAccessor.getGenericType(), null, entityCollectionMemberAccessor.getName());
-            boolean collectionGuaranteedToContainOnlyGivenEntityType = optionalTypeParameter
-                    .map(entityClass::isAssignableFrom)
-                    .orElse(false);
+            boolean collectionGuaranteedToContainOnlyGivenEntityType =
+                    optionalTypeParameter.map(entityClass::isAssignableFrom).orElse(false);
             if (collectionGuaranteedToContainOnlyGivenEntityType) {
                 /*
                  * In a typical case typeParameter is specified and it is the expected entity or its superclass.
@@ -981,9 +958,8 @@ public final class SolutionDescriptor<Solution_> {
                 continue;
             }
             // The collection now is either raw, or it is not of an entity type, such as perhaps a parent interface.
-            boolean collectionCouldPossiblyContainGivenEntityType = optionalTypeParameter
-                    .map(e -> e.isAssignableFrom(entityClass))
-                    .orElse(true);
+            boolean collectionCouldPossiblyContainGivenEntityType =
+                    optionalTypeParameter.map(e -> e.isAssignableFrom(entityClass)).orElse(true);
             if (!collectionCouldPossiblyContainGivenEntityType) {
                 // There is no way how this collection could possibly contain entities of the given type.
                 continue;
@@ -1046,14 +1022,6 @@ public final class SolutionDescriptor<Solution_> {
         return result.longValue();
     }
 
-    public List<ShadowVariableDescriptor<Solution_>> getAllShadowVariableDescriptors() {
-        var out = new ArrayList<ShadowVariableDescriptor<Solution_>>();
-        for (var entityDescriptor : entityDescriptorMap.values()) {
-            out.addAll(entityDescriptor.getShadowVariableDescriptors());
-        }
-        return out;
-    }
-
     public int getValueRangeDescriptorCount() {
         var count = 0;
         for (var entityDescriptor : entityDescriptorMap.values()) {
@@ -1063,16 +1031,20 @@ public final class SolutionDescriptor<Solution_> {
     }
 
     public List<DeclarativeShadowVariableDescriptor<Solution_>> getDeclarativeShadowVariableDescriptors() {
-        var out = new HashSet<DeclarativeShadowVariableDescriptor<Solution_>>();
-        for (var entityDescriptor : entityDescriptorMap.values()) {
-            entityDescriptor.getShadowVariableDescriptors();
-            for (var shadowVariableDescriptor : entityDescriptor.getShadowVariableDescriptors()) {
-                if (shadowVariableDescriptor instanceof DeclarativeShadowVariableDescriptor<Solution_> declarativeShadowVariableDescriptor) {
-                    out.add(declarativeShadowVariableDescriptor);
-                }
-            }
+        if (declarativeShadowVariableDescriptorList != null) {
+            return declarativeShadowVariableDescriptorList;
         }
-        return new ArrayList<>(out);
+        declarativeShadowVariableDescriptorList = entityDescriptorMap.values().stream()
+                .flatMap(entityDescriptor -> entityDescriptor.getShadowVariableDescriptors().stream())
+                .flatMap(shadowVariableDescriptor -> {
+                    if (shadowVariableDescriptor instanceof DeclarativeShadowVariableDescriptor<Solution_> declarativeShadowVariableDescriptor) {
+                        return Stream.of(declarativeShadowVariableDescriptor);
+                    }
+                    return Stream.empty();
+                })
+                .distinct()
+                .toList();
+        return declarativeShadowVariableDescriptorList;
     }
 
     public Stream<Object> extractAllEntitiesStream(Solution_ solution) {
@@ -1109,7 +1081,8 @@ public final class SolutionDescriptor<Solution_> {
                             The solutionClass (%s)'s %s (%s) should never return null.
                             %sMaybe that property (%s) was set with null instead of an empty collection/array when the class (%s) instance was created."""
                             .formatted(solutionClass, isFact ? "factCollectionProperty" : "entityCollectionProperty",
-                                    memberAccessor, memberAccessor instanceof ReflectionFieldMemberAccessor ? ""
+                                    memberAccessor,
+                                    memberAccessor instanceof ReflectionFieldMemberAccessor ? ""
                                             : "Maybe the getter/method always returns null instead of the actual data.\n",
                                     memberAccessor.getName(), solutionClass.getSimpleName()));
         }
@@ -1145,8 +1118,7 @@ public final class SolutionDescriptor<Solution_> {
         for (var entry : oldEntities.entrySet()) {
             var entityClassName = entry.getKey();
             for (var oldEntity : entry.getValue()) {
-                var newEntity = newEntities.getOrDefault(entityClassName, Collections.emptySet())
-                        .stream()
+                var newEntity = newEntities.getOrDefault(entityClassName, Collections.emptySet()).stream()
                         .filter(e -> Objects.equals(e, oldEntity))
                         .findFirst()
                         .orElse(null);
@@ -1158,14 +1130,14 @@ public final class SolutionDescriptor<Solution_> {
             }
         }
 
-        var addedNewEntities = newEntities.values().stream()
-                .flatMap(Collection::stream)
+        var addedNewEntities = newEntities.values().stream().flatMap(Collection::stream)
                 .filter(newEntity -> !oldToNewEntities.containsValue(newEntity))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         // Genuine variables first, then sort by ordinal.
-        var variableDescriptorComparator = Comparator.<VariableDescriptor<Solution_>, String> comparing(
-                variableDescriptor -> variableDescriptor instanceof GenuineVariableDescriptor<Solution_> ? "0" : "1")
+        var variableDescriptorComparator = Comparator
+                .<VariableDescriptor<Solution_>, String> comparing(
+                        variableDescriptor -> variableDescriptor instanceof GenuineVariableDescriptor<Solution_> ? "0" : "1")
                 .thenComparingInt(VariableDescriptor::getOrdinal);
         var solutionDiff = new DefaultPlanningSolutionDiff<>(getMetaModel(), oldSolution, newSolution, removedOldEntities,
                 addedNewEntities);
@@ -1174,8 +1146,7 @@ public final class SolutionDescriptor<Solution_> {
             var newEntity = entry.getValue();
             var entityDescriptor = findEntityDescriptorOrFail(oldEntity.getClass());
             var entityDiff = new DefaultPlanningEntityDiff<>(solutionDiff, entry.getKey());
-            entityDescriptor.getVariableDescriptorMap().values().stream()
-                    .sorted(variableDescriptorComparator)
+            entityDescriptor.getVariableDescriptorMap().values().stream().sorted(variableDescriptorComparator)
                     .flatMap(variableDescriptor -> {
                         var oldValue = variableDescriptor.getValue(oldEntity);
                         var newValue = variableDescriptor.getValue(newEntity);
@@ -1194,8 +1165,7 @@ public final class SolutionDescriptor<Solution_> {
     }
 
     private SortedMap<String, Set<Object>> sortEntitiesForDiff(Solution_ solution) {
-        return getEntityDescriptors().stream()
-                .map(descriptor -> descriptor.extractEntities(solution))
+        return getEntityDescriptors().stream().map(descriptor -> descriptor.extractEntities(solution))
                 .flatMap(Collection::stream)
                 // TreeMap and LinkedHashSet for fully reproducible ordering of entities and variables.
                 .collect(Collectors.groupingBy(s -> s.getClass().getCanonicalName(), TreeMap::new,

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/IndexShadowVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/IndexShadowVariableDescriptor.java
@@ -67,7 +67,7 @@ public final class IndexShadowVariableDescriptor<Solution_> extends ShadowVariab
                             variableMemberAccessor, sourceVariableName, sourceVariableName, entitiesWithSourceVariable));
         }
         VariableDescriptor<Solution_> variableDescriptor =
-                entitiesWithSourceVariable.get(0).getVariableDescriptor(sourceVariableName);
+                entitiesWithSourceVariable.getFirst().getVariableDescriptor(sourceVariableName);
         if (variableDescriptor == null) {
             throw new IllegalStateException("""
                     Impossible state: variableDescriptor (%s) is null but previous checks indicate that \

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/cascade/CascadingUpdateShadowVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/cascade/CascadingUpdateShadowVariableDescriptor.java
@@ -43,7 +43,7 @@ public final class CascadingUpdateShadowVariableDescriptor<Solution_> extends Sh
     }
 
     public String getTargetMethodName() {
-        var variableMemberAccessor = shadowVariableTargetList.get(0).variableMemberAccessor();
+        var variableMemberAccessor = shadowVariableTargetList.getFirst().variableMemberAccessor();
         return Arrays
                 .stream(variableMemberAccessor.getDeclaredAnnotationsByType(CascadingUpdateShadowVariable.class))
                 .findFirst().map(CascadingUpdateShadowVariable::targetMethodName)
@@ -129,9 +129,10 @@ public final class CascadingUpdateShadowVariableDescriptor<Solution_> extends Sh
                                     variableMemberAccessor.getName(),
                                     targetMethodName));
         }
-        targetMethod = descriptorPolicy.getMemberAccessorFactory().buildAndCacheMemberAccessor(allSourceMethodMembers.get(0),
-                MemberAccessorType.VOID_METHOD, null, descriptorPolicy.getDomainAccessType());
-        firstTargetVariableDescriptor = targetVariableDescriptorList.get(0);
+        targetMethod =
+                descriptorPolicy.getMemberAccessorFactory().buildAndCacheMemberAccessor(allSourceMethodMembers.getFirst(),
+                        MemberAccessorType.VOID_METHOD, null, descriptorPolicy.getDomainAccessType());
+        firstTargetVariableDescriptor = targetVariableDescriptorList.getFirst();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
@@ -76,7 +76,7 @@ public abstract class GenuineVariableDescriptor<Solution_> extends VariableDescr
             valueRangeDescriptorList.add(buildValueRangeDescriptor(descriptorPolicy, valueRangeProviderMemberAccessor));
         }
         if (valueRangeDescriptorList.size() == 1) {
-            valueRangeDescriptor = valueRangeDescriptorList.get(0);
+            valueRangeDescriptor = valueRangeDescriptorList.getFirst();
         } else {
             valueRangeDescriptor = descriptorPolicy.buildCompositeValueRangeDescriptor(this, valueRangeDescriptorList);
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
@@ -90,7 +90,7 @@ public final class ListVariableDescriptor<Solution_> extends GenuineVariableDesc
         var applicableShadowDescriptors = inverseRelationEntityDescriptor.getShadowVariableDescriptors()
                 .stream()
                 .filter(f -> f instanceof InverseRelationShadowVariableDescriptor<Solution_> inverseRelationShadowVariableDescriptor
-                        && Objects.equals(inverseRelationShadowVariableDescriptor.getSourceVariableDescriptorList().get(0),
+                        && Objects.equals(inverseRelationShadowVariableDescriptor.getSourceVariableDescriptorList().getFirst(),
                                 this))
                 .toList();
         if (applicableShadowDescriptors.isEmpty()) {
@@ -108,7 +108,7 @@ public final class ListVariableDescriptor<Solution_> extends GenuineVariableDesc
                                             .map(ShadowVariableDescriptor::getSimpleEntityAndVariableName)
                                             .collect(Collectors.joining(", ", "[", "]"))));
         } else {
-            return (InverseRelationShadowVariableDescriptor<Solution_>) applicableShadowDescriptors.get(0);
+            return (InverseRelationShadowVariableDescriptor<Solution_>) applicableShadowDescriptors.getFirst();
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/nextprev/AbstractNextPrevElementShadowVariableDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/nextprev/AbstractNextPrevElementShadowVariableDescriptor.java
@@ -2,7 +2,6 @@ package ai.timefold.solver.core.impl.domain.variable.nextprev;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
 import ai.timefold.solver.core.impl.domain.common.accessor.MemberAccessor;
@@ -41,48 +40,46 @@ abstract class AbstractNextPrevElementShadowVariableDescriptor<Solution_> extend
         String sourceVariableName = getSourceVariableName();
         List<EntityDescriptor<Solution_>> entitiesWithSourceVariable =
                 entityDescriptor.getSolutionDescriptor().getEntityDescriptors().stream()
-                        .filter(entityDescriptor -> entityDescriptor.hasVariableDescriptor(sourceVariableName))
-                        .collect(Collectors.toList());
+                        .filter(entityDescriptor -> entityDescriptor.hasVariableDescriptor(sourceVariableName)).toList();
         if (entitiesWithSourceVariable.isEmpty()) {
-            throw new IllegalArgumentException("The entityClass (" + entityDescriptor.getEntityClass()
-                    + ") has a @" + getAnnotationName()
-                    + " annotated property (" + variableMemberAccessor.getName()
-                    + ") with sourceVariableName (" + sourceVariableName
-                    + ") which is not a valid planning variable on any of the entity classes ("
-                    + entityDescriptor.getSolutionDescriptor().getEntityDescriptors() + ").");
+            throw new IllegalArgumentException("""
+                    The entityClass (%s) has a @%s-annotated property (%s) with sourceVariableName (%s) \
+                    which is not a valid planning variable on any of the entity classes (%s)."""
+                    .formatted(entityDescriptor.getEntityClass().getCanonicalName(), getAnnotationName(),
+                            variableMemberAccessor.getName(), sourceVariableName,
+                            entityDescriptor.getSolutionDescriptor().getEntityDescriptors()));
         }
         if (entitiesWithSourceVariable.size() > 1) {
-            throw new IllegalArgumentException("The entityClass (" + entityDescriptor.getEntityClass()
-                    + ") has a @" + getAnnotationName()
-                    + " annotated property (" + variableMemberAccessor.getName()
-                    + ") with sourceVariableName (" + sourceVariableName
-                    + ") which is not a unique planning variable."
-                    + " A planning variable with the name (" + sourceVariableName + ") exists on multiple entity classes ("
-                    + entitiesWithSourceVariable + ").");
+            throw new IllegalArgumentException(
+                    """
+                            The entityClass (%s) has a @%s-annotated property (%s) with sourceVariableName (%s) which is not a unique planning variable.
+                            A planning variable with the name (%s) exists on multiple entity classes (%s)."""
+                            .formatted(entityDescriptor.getEntityClass().getCanonicalName(), getAnnotationName(),
+                                    variableMemberAccessor.getName(), sourceVariableName, sourceVariableName,
+                                    entitiesWithSourceVariable));
         }
         VariableDescriptor<Solution_> variableDescriptor =
-                entitiesWithSourceVariable.get(0).getVariableDescriptor(sourceVariableName);
+                entitiesWithSourceVariable.getFirst().getVariableDescriptor(sourceVariableName);
         if (variableDescriptor == null) {
-            throw new IllegalStateException(
-                    "Impossible state: variableDescriptor (" + variableDescriptor + ") is null"
-                            + " but previous checks indicate that the entityClass (" + entitiesWithSourceVariable.get(0)
-                            + ") has a planning variable with sourceVariableName (" + sourceVariableName + ").");
+            throw new IllegalStateException("""
+                    Impossible state: variableDescriptor for sourceVariable is null but previous checks indicate that \
+                    the entityClass (%s) has a planning variable with sourceVariableName (%s)."""
+                    .formatted(entitiesWithSourceVariable.getFirst().getEntityClass().getCanonicalName(), sourceVariableName));
         }
         if (!(variableDescriptor instanceof ListVariableDescriptor)) {
-            throw new IllegalArgumentException("The entityClass (" + entityDescriptor.getEntityClass()
-                    + ") has a @" + getAnnotationName()
-                    + " annotated property (" + variableMemberAccessor.getName()
-                    + ") with sourceVariableName (" + sourceVariableName
-                    + ") which is not a @" + PlanningListVariable.class.getSimpleName() + ".");
+            throw new IllegalArgumentException("""
+                    The entityClass (%s) has a @%s-annotated property (%s) with sourceVariableName (%s) which is not a %s."""
+                    .formatted(entityDescriptor.getEntityClass().getCanonicalName(), getAnnotationName(),
+                            variableMemberAccessor.getName(), sourceVariableName, PlanningListVariable.class.getSimpleName()));
         }
         sourceVariableDescriptor = (ListVariableDescriptor<Solution_>) variableDescriptor;
         if (!variableMemberAccessor.getType().equals(sourceVariableDescriptor.getElementType())) {
-            throw new IllegalStateException("The entityClass (" + entityDescriptor.getEntityClass()
-                    + ") has a @" + getAnnotationName()
-                    + " annotated property (" + variableMemberAccessor.getName()
-                    + ") of type (" + variableMemberAccessor.getType()
-                    + ") which is not the type of elements (" + sourceVariableDescriptor.getElementType()
-                    + ") of the source list variable (" + sourceVariableDescriptor + ").");
+            throw new IllegalArgumentException("""
+                    The entityClass (%s) has a @%s-annotated property (%s) with sourceVariableName (%s) of type (%s) \
+                    which is not the type of elements (%s) of the source list variable (%s)."""
+                    .formatted(entityDescriptor.getEntityClass().getCanonicalName(), getAnnotationName(),
+                            variableMemberAccessor.getName(), sourceVariableName, variableMemberAccessor.getType(),
+                            sourceVariableDescriptor.getElementType(), sourceVariableDescriptor));
         }
         sourceVariableDescriptor.registerSinkVariableDescriptor(this);
     }
@@ -94,8 +91,8 @@ abstract class AbstractNextPrevElementShadowVariableDescriptor<Solution_> extend
 
     @Override
     public Demand<?> getProvidedDemand() {
-        throw new UnsupportedOperationException("Impossible state: Handled by %s."
-                .formatted(ListVariableStateSupply.class.getSimpleName()));
+        throw new UnsupportedOperationException(
+                "Impossible state: Handled by %s.".formatted(ListVariableStateSupply.class.getSimpleName()));
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
@@ -147,7 +147,7 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
             return solutionDescriptor.getListVariableDescriptor().getEntityDescriptor();
         }
         var entityDescriptors = solutionDescriptor.getGenuineEntityDescriptors().stream()
-                .filter(EntityDescriptor::hasAnyGenuineBasicVariables).toList();
+                .filter(EntityDescriptor::hasAnyBasicVariables).toList();
         if (entityDescriptors.size() != 1) {
             throw new IllegalArgumentException(
                     "The phaseConfig (%s) has no entitySelector configured and because there are multiple in the entityClassSet (%s), it cannot be deduced automatically."

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/EntitySelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/EntitySelectorFactory.java
@@ -210,9 +210,9 @@ public class EntitySelectorFactory<Solution_> extends AbstractSelectorFactory<So
             var valueSelectorConfig = new ValueSelectorConfig()
                     .withMimicSelectorRef(valueRangeRecorderId.recorderId());
             // We set the name for the list variable in case there are multiple variables present
-            if (entitySelector.getEntityDescriptor().hasBothGenuineListAndBasicVariables()) {
+            if (entitySelector.getEntityDescriptor().hasBothListAndBasicVariables()) {
                 valueSelectorConfig.setVariableName(
-                        entitySelector.getEntityDescriptor().getGenuineListVariableDescriptor().getVariableName());
+                        entitySelector.getEntityDescriptor().getListVariableDescriptor().getVariableName());
             }
             var replayingValueSelector = (IterableValueSelector<Solution_>) ValueSelectorFactory
                     .<Solution_> create(valueSelectorConfig)

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntityByEntitySelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntityByEntitySelector.java
@@ -95,16 +95,16 @@ public final class FilteringEntityByEntitySelector<Solution_> extends AbstractDe
     @Override
     public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
         super.phaseStarted(phaseScope);
-        var basicVariableList = childEntitySelector.getEntityDescriptor().getGenuineBasicVariableDescriptorList().stream()
-                .filter(v -> !v.isListVariable() && !v.canExtractValueRangeFromSolution())
-                .map(v -> (BasicVariableDescriptor<Solution_>) v)
+        var basicVariableDescriptorList = childEntitySelector.getEntityDescriptor()
+                .getBasicVariableDescriptorList().stream()
+                .filter(v -> !v.canExtractValueRangeFromSolution())
                 .toList();
-        if (basicVariableList.isEmpty()) {
+        if (basicVariableDescriptorList.isEmpty()) {
             throw new IllegalStateException("Impossible state: no basic variable found for the entity %s."
                     .formatted(childEntitySelector.getEntityDescriptor().getEntityClass()));
         }
         this.allEntities = childEntitySelector.getEntityDescriptor().extractEntities(phaseScope.getWorkingSolution());
-        this.basicVariableDescriptors = basicVariableList.toArray(new BasicVariableDescriptor[0]);
+        this.basicVariableDescriptors = basicVariableDescriptorList.toArray(new BasicVariableDescriptor[0]);
         this.valueRangeManager = phaseScope.getScoreDirector().getValueRangeManager();
         if (basicVariableDescriptors.length == 1) {
             this.reachableValues = valueRangeManager.getReachableValues(basicVariableDescriptors[0]);

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/DestinationSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/DestinationSelectorFactory.java
@@ -118,8 +118,8 @@ public final class DestinationSelectorFactory<Solution_> extends AbstractSelecto
         var mimicValueSelectorConfig = new ValueSelectorConfig()
                 .withMimicSelectorRef(entityValueRangeRecorderId);
         // We set the name for the list variable in case there are multiple variables present
-        if (entityDescriptor.hasBothGenuineListAndBasicVariables()) {
-            mimicValueSelectorConfig.setVariableName(entityDescriptor.getGenuineListVariableDescriptor().getVariableName());
+        if (entityDescriptor.hasBothListAndBasicVariables()) {
+            mimicValueSelectorConfig.setVariableName(entityDescriptor.getListVariableDescriptor().getVariableName());
         }
         return (IterableValueSelector<Solution_>) ValueSelectorFactory
                 .<Solution_> create(mimicValueSelectorConfig)

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/SubListSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/SubListSelectorFactory.java
@@ -116,7 +116,7 @@ public final class SubListSelectorFactory<Solution_> extends AbstractFromConfigF
         // Mixed models require that the variable name be set
         if (configPolicy.getSolutionDescriptor().hasBothBasicAndListVariables()
                 && valueSelectorConfig.getVariableName() == null) {
-            var variableName = entityDescriptor.getGenuineListVariableDescriptor().getVariableName();
+            var variableName = entityDescriptor.getListVariableDescriptor().getVariableName();
             valueSelectorConfig.setVariableName(variableName);
         }
         ValueSelector<Solution_> valueSelector = ValueSelectorFactory

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/PillarSwapMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/PillarSwapMoveSelectorFactory.java
@@ -36,9 +36,9 @@ public class PillarSwapMoveSelectorFactory<Solution_>
         }
         var leftVariableNameIncludeList = config.getVariableNameIncludeList();
         if (leftVariableNameIncludeList == null && leftEntityDescriptor != null
-                && leftEntityDescriptor.hasAnyGenuineBasicVariables() && leftEntityDescriptor.hasAnyGenuineListVariables()) {
+                && leftEntityDescriptor.hasAnyBasicVariables() && leftEntityDescriptor.hasAnyListVariables()) {
             // Mixed models filter out the list variable
-            leftVariableNameIncludeList = leftEntityDescriptor.getGenuineBasicVariableDescriptorList().stream()
+            leftVariableNameIncludeList = leftEntityDescriptor.getBasicVariableDescriptorList().stream()
                     .map(GenuineVariableDescriptor::getVariableName)
                     .toList();
         }
@@ -54,9 +54,9 @@ public class PillarSwapMoveSelectorFactory<Solution_>
         }
         var rightVariableNameIncludeList = config.getVariableNameIncludeList();
         if (rightVariableNameIncludeList == null && rightEntityDescriptor != null
-                && rightEntityDescriptor.hasAnyGenuineBasicVariables() && rightEntityDescriptor.hasAnyGenuineListVariables()) {
+                && rightEntityDescriptor.hasAnyBasicVariables() && rightEntityDescriptor.hasAnyListVariables()) {
             // Mixed models filter out the list variable
-            rightVariableNameIncludeList = rightEntityDescriptor.getGenuineBasicVariableDescriptorList().stream()
+            rightVariableNameIncludeList = rightEntityDescriptor.getBasicVariableDescriptorList().stream()
                     .map(GenuineVariableDescriptor::getVariableName)
                     .toList();
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelectorFactory.java
@@ -33,26 +33,34 @@ public final class RuinRecreateMoveSelectorFactory<Solution_>
         var ruinRecreateEntitySelector = EntitySelectorFactory.<Solution_> create(entitySelectorConfig)
                 .buildEntitySelector(configPolicy, minimumCacheType,
                         SelectionOrder.fromRandomSelectionBoolean(true));
-        var genuineVariableDescriptorList =
-                ruinRecreateEntitySelector.getEntityDescriptor().getGenuineBasicVariableDescriptorList();
-        if (genuineVariableDescriptorList.size() != 1 && config.getVariableName() == null) {
-            throw new UnsupportedOperationException(
-                    """
-                            The entity class %s contains several variables (%s), and it cannot be deduced automatically.
-                            Maybe set the property variableName."""
-                            .formatted(
-                                    ruinRecreateEntitySelector.getEntityDescriptor().getEntityClass().getName(),
-                                    genuineVariableDescriptorList.stream().map(GenuineVariableDescriptor::getVariableName)
-                                            .toList()));
+        var entityClassName = ruinRecreateEntitySelector.getEntityDescriptor().getEntityClass().getCanonicalName();
+        var variableName = config.getVariableName();
+
+        var basicVariableDescriptorList = ruinRecreateEntitySelector.getEntityDescriptor()
+                .getBasicVariableDescriptorList();
+        if (basicVariableDescriptorList.isEmpty()) {
+            throw new UnsupportedOperationException("The entity class %s has no basic planning variable."
+                    .formatted(entityClassName));
         }
-        var variableDescriptor = genuineVariableDescriptorList.get(0);
-        if (genuineVariableDescriptorList.size() > 1) {
-            variableDescriptor = genuineVariableDescriptorList.stream()
-                    .filter(v -> v.getVariableName().equals(config.getVariableName())).findFirst().orElse(null);
+        if (basicVariableDescriptorList.size() != 1 && variableName == null) {
+            throw new UnsupportedOperationException("""
+                    The entity class %s contains several variables (%s), and it cannot be deduced automatically.
+                    Maybe set the property variableName."""
+                    .formatted(entityClassName,
+                            basicVariableDescriptorList.stream()
+                                    .map(GenuineVariableDescriptor::getVariableName)
+                                    .toList()));
+        }
+        var variableDescriptor = basicVariableDescriptorList.getFirst();
+        if (basicVariableDescriptorList.size() > 1) {
+            variableDescriptor = basicVariableDescriptorList.stream()
+                    .filter(v -> v.getVariableName().equals(variableName))
+                    .findFirst()
+                    .orElse(null);
         }
         if (variableDescriptor == null) {
             throw new UnsupportedOperationException("The entity class %s has no variable named %s."
-                    .formatted(ruinRecreateEntitySelector.getEntityDescriptor().getEntityClass(), config.getVariableName()));
+                    .formatted(entityClassName, variableName));
         }
         var nestedEntitySelectorConfig =
                 getDefaultEntitySelectorConfigForEntity(configPolicy, ruinRecreateEntitySelector.getEntityDescriptor());

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedSwapMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedSwapMove.java
@@ -7,7 +7,7 @@ import java.util.SequencedCollection;
 
 import ai.timefold.solver.core.api.domain.common.Lookup;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
-import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.move.AbstractSelectorBasedMove;
 import ai.timefold.solver.core.impl.score.director.ScoreDirector;
 import ai.timefold.solver.core.impl.score.director.VariableDescriptorAwareScoreDirector;
@@ -20,12 +20,12 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class SelectorBasedSwapMove<Solution_> extends AbstractSelectorBasedMove<Solution_> {
 
-    protected final List<GenuineVariableDescriptor<Solution_>> variableDescriptorList;
+    protected final List<BasicVariableDescriptor<Solution_>> variableDescriptorList;
 
     protected final Object leftEntity;
     protected final Object rightEntity;
 
-    public SelectorBasedSwapMove(List<GenuineVariableDescriptor<Solution_>> variableDescriptorList, Object leftEntity,
+    public SelectorBasedSwapMove(List<BasicVariableDescriptor<Solution_>> variableDescriptorList, Object leftEntity,
             Object rightEntity) {
         this.variableDescriptorList = variableDescriptorList;
         this.leftEntity = leftEntity;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelector.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.AbstractOriginalSwapIterator;
 import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.AbstractRandomSwapIterator;
@@ -14,11 +15,11 @@ public class SwapMoveSelector<Solution_> extends GenericMoveSelector<Solution_> 
 
     protected final EntitySelector<Solution_> leftEntitySelector;
     protected final EntitySelector<Solution_> rightEntitySelector;
-    protected final List<GenuineVariableDescriptor<Solution_>> variableDescriptorList;
+    protected final List<BasicVariableDescriptor<Solution_>> variableDescriptorList;
     protected final boolean randomSelection;
 
     public SwapMoveSelector(EntitySelector<Solution_> leftEntitySelector, EntitySelector<Solution_> rightEntitySelector,
-            List<GenuineVariableDescriptor<Solution_>> variableDescriptorList, boolean randomSelection) {
+            List<BasicVariableDescriptor<Solution_>> variableDescriptorList, boolean randomSelection) {
         this.leftEntitySelector = leftEntitySelector;
         this.rightEntitySelector = rightEntitySelector;
         this.variableDescriptorList = variableDescriptorList;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
@@ -1,8 +1,8 @@
 package ai.timefold.solver.core.impl.heuristic.selector.move.generic;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Objects;
+import java.util.SequencedCollection;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionOrder;
@@ -93,20 +93,19 @@ public class SwapMoveSelectorFactory<Solution_>
         if (onlyEntityDescriptor != null) {
             var variableDescriptorList = onlyEntityDescriptor.getGenuineVariableDescriptorList();
             // If there is a single list variable, unfold to list swap move selector config.
-            if (variableDescriptorList.size() == 1 && variableDescriptorList.get(0).isListVariable()) {
-                return buildListSwapMoveSelectorConfig(variableDescriptorList.get(0), true);
+            if (variableDescriptorList.size() == 1 && variableDescriptorList.getFirst().isListVariable()) {
+                return buildListSwapMoveSelectorConfig(variableDescriptorList.getFirst(), true);
             }
             // No need for unfolding or deducing
             return null;
         }
-        Collection<EntityDescriptor<Solution_>> entityDescriptors =
-                configPolicy.getSolutionDescriptor().getGenuineEntityDescriptors();
+        var entityDescriptors = configPolicy.getSolutionDescriptor().getGenuineEntityDescriptors();
         return buildUnfoldedMoveSelectorConfig(configPolicy, entityDescriptors);
     }
 
     protected MoveSelectorConfig<?>
             buildUnfoldedMoveSelectorConfig(HeuristicConfigPolicy<Solution_> configPolicy,
-                    Collection<EntityDescriptor<Solution_>> entityDescriptors) {
+                    SequencedCollection<EntityDescriptor<Solution_>> entityDescriptors) {
         var moveSelectorConfigList = new ArrayList<MoveSelectorConfig>(entityDescriptors.size());
 
         // When using a mixed model,
@@ -114,19 +113,19 @@ public class SwapMoveSelectorFactory<Solution_>
         // and delegate it to the ListSwapMoveSelectorFactory.
         // The strategy aims to provide a more normalized move selector collection for mixed models.
         var variableDescriptorList = configPolicy.getSolutionDescriptor().hasBothBasicAndListVariables()
-                ? entityDescriptors.iterator().next().getGenuineBasicVariableDescriptorList()
-                : entityDescriptors.iterator().next().getGenuineVariableDescriptorList();
+                ? entityDescriptors.getFirst().getBasicVariableDescriptorList()
+                : entityDescriptors.getFirst().getGenuineVariableDescriptorList();
 
         // Only unfold into list swap move selector for the basic scenario with 1 entity and 1 list variable.
         if (entityDescriptors.size() == 1 && variableDescriptorList.size() == 1
-                && variableDescriptorList.get(0).isListVariable()) {
+                && variableDescriptorList.getFirst().isListVariable()) {
             // No childMoveSelectorConfig.inherit() because of unfoldedMoveSelectorConfig.inheritFolded()
-            var childMoveSelectorConfig = buildListSwapMoveSelectorConfig(variableDescriptorList.get(0), false);
+            var childMoveSelectorConfig = buildListSwapMoveSelectorConfig(variableDescriptorList.getFirst(), false);
             moveSelectorConfigList.add(childMoveSelectorConfig);
         } else {
             // More complex scenarios do not support unfolding into list swap => fail fast if there is any list variable.
             for (var entityDescriptor : entityDescriptors) {
-                if (!entityDescriptor.hasAnyGenuineBasicVariables()) {
+                if (!entityDescriptor.hasAnyBasicVariables()) {
                     // We filter out entities that do not have basic variables (e.g., mixed models)
                     continue;
                 }
@@ -138,7 +137,7 @@ public class SwapMoveSelectorFactory<Solution_>
                 }
                 childMoveSelectorConfig.setEntitySelectorConfig(childEntitySelectorConfig);
                 if (config.getSecondaryEntitySelectorConfig() != null) {
-                    EntitySelectorConfig childSecondaryEntitySelectorConfig =
+                    var childSecondaryEntitySelectorConfig =
                             new EntitySelectorConfig(config.getSecondaryEntitySelectorConfig());
                     if (childSecondaryEntitySelectorConfig.getMimicSelectorRef() == null) {
                         childSecondaryEntitySelectorConfig.setEntityClass(entityDescriptor.getEntityClass());
@@ -150,12 +149,12 @@ public class SwapMoveSelectorFactory<Solution_>
             }
         }
         if (moveSelectorConfigList.isEmpty()) {
-            throw new IllegalStateException("The swap move selector cannot be created when there is no basic variables.");
+            throw new IllegalStateException("The swap move selector cannot be created when there are no basic variables.");
         }
 
         MoveSelectorConfig<?> unfoldedMoveSelectorConfig;
         if (moveSelectorConfigList.size() == 1) {
-            unfoldedMoveSelectorConfig = moveSelectorConfigList.get(0);
+            unfoldedMoveSelectorConfig = moveSelectorConfigList.getFirst();
         } else {
             unfoldedMoveSelectorConfig = new UnionMoveSelectorConfig(moveSelectorConfigList);
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
@@ -75,7 +75,7 @@ public class ListChangeMoveSelectorFactory<Solution_>
         // the recorder ID from the origin selector is required for FilteringEntityValueRangeSelector and FilteringValueRangeSelector
         // to replay the selected value and return only reachable values.
         var enableEntityValueRangeFilter =
-                !entityDescriptor.getGenuineListVariableDescriptor().canExtractValueRangeFromSolution();
+                !entityDescriptor.getListVariableDescriptor().canExtractValueRangeFromSolution();
         // A null ID means to turn off the entity value range filtering
         String entityValueRangeRecorderId = null;
         if (enableEntityValueRangeFilter) {
@@ -124,7 +124,7 @@ public class ListChangeMoveSelectorFactory<Solution_>
         var entityDescriptors =
                 onlyEntityDescriptor == null ? configPolicy.getSolutionDescriptor().getGenuineEntityDescriptors().stream()
                         // We need to filter the entity that defines the list variable
-                        .filter(EntityDescriptor::hasAnyGenuineListVariables)
+                        .filter(EntityDescriptor::hasAnyListVariables)
                         .toList()
                         : Collections.singletonList(onlyEntityDescriptor);
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
@@ -43,7 +43,7 @@ public class ListSwapMoveSelectorFactory<Solution_>
         // the recorder ID from the origin selector is required for FilteringEntityValueRangeSelector and FilteringValueRangeSelector
         // to replay the selected value and return only reachable values.
         var enableEntityValueRangeFilter =
-                !entityDescriptor.getGenuineListVariableDescriptor().canExtractValueRangeFromSolution();
+                !entityDescriptor.getListVariableDescriptor().canExtractValueRangeFromSolution();
         // A null ID means to turn off the entity value range filtering
         String entityValueRangeRecorderId = null;
         if (enableEntityValueRangeFilter) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/ValueSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/value/ValueSelectorFactory.java
@@ -495,7 +495,7 @@ public class ValueSelectorFactory<Solution_>
         var valueSelectorConfig = new ValueSelectorConfig()
                 .withMimicSelectorRef(entityValueRangeRecorderId);
         // We set the name for the list variable in case there are multiple variables present
-        if (entityDescriptor.hasBothGenuineListAndBasicVariables()) {
+        if (entityDescriptor.hasBothListAndBasicVariables()) {
             valueSelectorConfig.setVariableName(valueSelector.getVariableDescriptor().getVariableName());
         }
         var replayingValueSelector =

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -846,8 +846,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             // It may be called for a shadow entity
             return;
         }
-        var basicVariableDescriptorList = entityDescriptor.getGenuineBasicVariableDescriptorList().stream()
-                .map(v -> (BasicVariableDescriptor<Solution_>) v).toList();
+        var basicVariableDescriptorList = entityDescriptor.getBasicVariableDescriptorList();
         assertValueRangeForBasicVariables(this, basicVariableDescriptorList, entity);
     }
 
@@ -857,7 +856,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             // It may be called for a shadow entity
             return;
         }
-        var listVariableDescriptor = entityDescriptor.getGenuineListVariableDescriptor();
+        var listVariableDescriptor = entityDescriptor.getListVariableDescriptor();
         if (listVariableDescriptor == null) {
             // The entity has no genuine list variable
             return;

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeStatistics.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeStatistics.java
@@ -85,7 +85,7 @@ final class ValueRangeStatistics<Solution_> {
             if (finisher != null) {
                 finisher.accept(entity);
             }
-            if (!entityDescriptor.hasAnyGenuineListVariables()) {
+            if (!entityDescriptor.hasAnyListVariables()) {
                 return;
             }
             var listVariableEntityDescriptor = listVariableDescriptor.getEntityDescriptor();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetPrecomputeBiConstraintStream.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/bavet/bi/BavetPrecomputeBiConstraintStream.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.bavet.bi;
 
 import java.util.Objects;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -18,7 +19,7 @@ import ai.timefold.solver.core.impl.score.stream.common.RetrievalSemantics;
 public class BavetPrecomputeBiConstraintStream<Solution_, A, B> extends BavetAbstractBiConstraintStream<Solution_, A, B>
         implements TupleSource {
     private final BavetAbstractConstraintStream<Solution_> recordingPrecomputedConstraintStream;
-    private final Set<Class<?>> entityClassSet;
+    private final SequencedSet<Class<?>> entityClassSet;
     private BavetAftBridgeBiConstraintStream<Solution_, A, B> aftStream;
 
     public BavetPrecomputeBiConstraintStream(

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolver.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolver.java
@@ -237,10 +237,10 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
             assertNonNullPlanningId(entity);
             // Ensure correct state of pinning properties.
             var entityDescriptor = solverScope.getSolutionDescriptor().findEntityDescriptorOrFail(entity.getClass());
-            if (!entityDescriptor.supportsPinning() || !entityDescriptor.hasAnyGenuineListVariables()) {
+            if (!entityDescriptor.supportsPinning() || !entityDescriptor.hasAnyListVariables()) {
                 return;
             }
-            var listVariableDescriptor = entityDescriptor.getGenuineListVariableDescriptor();
+            var listVariableDescriptor = entityDescriptor.getListVariableDescriptor();
             var pinIndex = listVariableDescriptor.getFirstUnpinnedIndex(entity);
             if (entityDescriptor.isMovable(solverScope.getScoreDirector().getWorkingSolution(), entity)) {
                 if (pinIndex < 0) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -234,11 +234,11 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
             var genuineEntityDescriptorCollection = configPolicy.getSolutionDescriptor().getGenuineEntityDescriptors();
             phaseConfigList = new ArrayList<>(genuineEntityDescriptorCollection.size() + 2);
             for (var entityDescriptor : genuineEntityDescriptorCollection) {
-                if (entityDescriptor.hasBothGenuineListAndBasicVariables()) {
+                if (entityDescriptor.hasBothListAndBasicVariables()) {
                     // We add a separate step for each variable type
                     phaseConfigList.add(buildConstructionHeuristicPhaseConfigForBasicVariable(configPolicy, entityDescriptor));
                     phaseConfigList.add(buildConstructionHeuristicPhaseConfigForListVariable(configPolicy, entityDescriptor));
-                } else if (entityDescriptor.hasAnyGenuineListVariables()) {
+                } else if (entityDescriptor.hasAnyListVariables()) {
                     // There is no need to revalidate the number of list variables,
                     // as it has already been validated in SolutionDescriptor
                     phaseConfigList.add(buildConstructionHeuristicPhaseConfigForListVariable(configPolicy, entityDescriptor));
@@ -265,7 +265,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
             buildConstructionHeuristicPhaseConfigForListVariable(HeuristicConfigPolicy<Solution_> configPolicy,
                     EntityDescriptor<Solution_> entityDescriptor) {
         var constructionHeuristicPhaseConfig = new ConstructionHeuristicPhaseConfig();
-        var listVariableDescriptor = entityDescriptor.getGenuineListVariableDescriptor();
+        var listVariableDescriptor = entityDescriptor.getListVariableDescriptor();
         constructionHeuristicPhaseConfig
                 .setEntityPlacerConfig(DefaultConstructionHeuristicPhaseFactory
                         .buildListVariableQueuedValuePlacerConfig(configPolicy, listVariableDescriptor));

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/common/ReachableValuesTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/common/ReachableValuesTest.java
@@ -35,7 +35,7 @@ class ReachableValuesTest {
         var solutionDescriptor = scoreDirector.getSolutionDescriptor();
         var entityDescriptor = solutionDescriptor.findEntityDescriptor(TestdataListEntityProvidingEntity.class);
         var reachableValues = scoreDirector.getValueRangeManager()
-                .getReachableValues(entityDescriptor.getGenuineListVariableDescriptor());
+                .getReachableValues(entityDescriptor.getListVariableDescriptor());
 
         assertThat(reachableValues.extractEntitiesAsList(v1)).containsExactlyInAnyOrder(a);
         assertThat(reachableValues.extractEntitiesAsList(v2)).containsExactlyInAnyOrder(a, b);
@@ -70,7 +70,7 @@ class ReachableValuesTest {
         var solutionDescriptor = scoreDirector.getSolutionDescriptor();
         var entityDescriptor = solutionDescriptor.findEntityDescriptor(TestdataListEntityProvidingEntity.class);
         var reachableValues = scoreDirector.getValueRangeManager()
-                .getReachableValues(entityDescriptor.getGenuineListVariableDescriptor());
+                .getReachableValues(entityDescriptor.getListVariableDescriptor());
 
         assertThat(reachableValues.extractValuesAsList(v1)).containsExactlyInAnyOrder(v2, v3);
         assertThat(reachableValues.extractValuesAsList(v2)).containsExactlyInAnyOrder(v1, v3);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedSwapMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedSwapMoveTest.java
@@ -50,7 +50,7 @@ class SelectorBasedSwapMoveTest {
 
         var entityDescriptor = TestdataAllowsUnassignedEntityProvidingEntity.buildEntityDescriptor();
 
-        var abMove = new SelectorBasedSwapMove<>(entityDescriptor.getGenuineVariableDescriptorList(), a, b);
+        var abMove = new SelectorBasedSwapMove<>(entityDescriptor.getBasicVariableDescriptorList(), a, b);
         a.setValue(v2);
         b.setValue(v3);
         assertThat(abMove.isMoveDoable(scoreDirector)).isTrue();
@@ -61,7 +61,7 @@ class SelectorBasedSwapMoveTest {
         b.setValue(v3);
         assertThat(abMove.isMoveDoable(scoreDirector)).isFalse();
 
-        var bcMove = new SelectorBasedSwapMove<>(entityDescriptor.getGenuineVariableDescriptorList(), b, c);
+        var bcMove = new SelectorBasedSwapMove<>(entityDescriptor.getBasicVariableDescriptorList(), b, c);
         b.setValue(v4);
         c.setValue(v5);
         assertThat(bcMove.isMoveDoable(scoreDirector)).isTrue();
@@ -72,7 +72,7 @@ class SelectorBasedSwapMoveTest {
         c.setValue(v5);
         assertThat(bcMove.isMoveDoable(scoreDirector)).isFalse();
 
-        var aaMove = new SelectorBasedSwapMove<>(entityDescriptor.getGenuineVariableDescriptorList(), a, a);
+        var aaMove = new SelectorBasedSwapMove<>(entityDescriptor.getBasicVariableDescriptorList(), a, a);
         assertThat(aaMove.isMoveDoable(scoreDirector)).isFalse();
     }
 
@@ -93,7 +93,7 @@ class SelectorBasedSwapMoveTest {
         var scoreDirector = scoreDirectorFactory.buildScoreDirector();
         var entityDescriptor = TestdataAllowsUnassignedEntityProvidingEntity.buildEntityDescriptor();
 
-        var abMove = new SelectorBasedSwapMove<>(entityDescriptor.getGenuineVariableDescriptorList(), a, b);
+        var abMove = new SelectorBasedSwapMove<>(entityDescriptor.getBasicVariableDescriptorList(), a, b);
 
         a.setValue(v1);
         b.setValue(v1);
@@ -116,7 +116,7 @@ class SelectorBasedSwapMoveTest {
         assertThat(a.getValue()).isEqualTo(v2);
         assertThat(b.getValue()).isEqualTo(v3);
 
-        var acMove = new SelectorBasedSwapMove<>(entityDescriptor.getGenuineVariableDescriptorList(), a, c);
+        var acMove = new SelectorBasedSwapMove<>(entityDescriptor.getBasicVariableDescriptorList(), a, c);
 
         a.setValue(v2);
         c.setValue(v2);
@@ -139,7 +139,7 @@ class SelectorBasedSwapMoveTest {
         assertThat(a.getValue()).isEqualTo(v3);
         assertThat(c.getValue()).isEqualTo(v4);
 
-        var bcMove = new SelectorBasedSwapMove<>(entityDescriptor.getGenuineVariableDescriptorList(), b, c);
+        var bcMove = new SelectorBasedSwapMove<>(entityDescriptor.getBasicVariableDescriptorList(), b, c);
 
         b.setValue(v2);
         c.setValue(v2);
@@ -166,7 +166,7 @@ class SelectorBasedSwapMoveTest {
     @Test
     void rebase() {
         var entityDescriptor = TestdataEntity.buildEntityDescriptor();
-        var variableDescriptorList = entityDescriptor.getGenuineVariableDescriptorList();
+        var variableDescriptorList = entityDescriptor.getBasicVariableDescriptorList();
 
         var v1 = new TestdataValue("v1");
         var v2 = new TestdataValue("v2");
@@ -225,7 +225,7 @@ class SelectorBasedSwapMoveTest {
         var b = new TestdataEntity("b", v1);
         var c = new TestdataEntity("c", v2);
         var entityDescriptor = TestdataEntity.buildEntityDescriptor();
-        var variableDescriptorList = entityDescriptor.getGenuineVariableDescriptorList();
+        var variableDescriptorList = entityDescriptor.getBasicVariableDescriptorList();
 
         assertThat(new SelectorBasedSwapMove<>(variableDescriptorList, a, a)).hasToString("a {null} <-> a {null}");
         assertThat(new SelectorBasedSwapMove<>(variableDescriptorList, a, b)).hasToString("a {null} <-> b {v1}");
@@ -246,7 +246,7 @@ class SelectorBasedSwapMoveTest {
         var b = new TestdataMultiVarEntity("b", v1, v3, w1);
         var c = new TestdataMultiVarEntity("c", v2, v4, w2);
         var entityDescriptor = TestdataMultiVarEntity.buildEntityDescriptor();
-        var variableDescriptorList = entityDescriptor.getGenuineVariableDescriptorList();
+        var variableDescriptorList = entityDescriptor.getBasicVariableDescriptorList();
 
         assertThat(new SelectorBasedSwapMove<>(variableDescriptorList, a, a))
                 .hasToString("a {null, null, null} <-> a {null, null, null}");

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorTest.java
@@ -261,7 +261,7 @@ class SwapMoveSelectorTest {
         // It is impossible for the left and right selectors to be equal
         // when using the entity-range filtering node FilteringEntityByEntitySelector
         var moveSelector = new SwapMoveSelector<>(entityMimicRecorder, rightEntitySelector,
-                leftEntitySelector.getEntityDescriptor().getGenuineVariableDescriptorList(), false);
+                leftEntitySelector.getEntityDescriptor().getBasicVariableDescriptorList(), false);
 
         var solverScope = solvingStarted(moveSelector, scoreDirector);
         phaseStarted(moveSelector, solverScope);
@@ -485,7 +485,7 @@ class SwapMoveSelectorTest {
                 new FilteringEntityByEntitySelector<>(leftEntitySelector, replayingEntitySelector, true);
 
         var moveSelector = new SwapMoveSelector<>(entityMimicRecorder, rightEntitySelector,
-                leftEntitySelector.getEntityDescriptor().getGenuineVariableDescriptorList(), true);
+                leftEntitySelector.getEntityDescriptor().getBasicVariableDescriptorList(), true);
 
         var random = new TestRandom(0);
         var solverScope = solvingStarted(moveSelector, scoreDirector, random);
@@ -537,7 +537,7 @@ class SwapMoveSelectorTest {
                 new FilteringEntityByEntitySelector<>(leftEntitySelector, replayingEntitySelector, true);
 
         var moveSelector = new SwapMoveSelector<>(entityMimicRecorder, rightEntitySelector,
-                leftEntitySelector.getEntityDescriptor().getGenuineVariableDescriptorList(), true);
+                leftEntitySelector.getEntityDescriptor().getBasicVariableDescriptorList(), true);
 
         var random = new TestRandom(0);
         var solverScope = solvingStarted(moveSelector, scoreDirector, random);
@@ -605,7 +605,7 @@ class SwapMoveSelectorTest {
                 new FilteringEntityByEntitySelector<>(leftEntitySelector, replayingEntitySelector, true);
 
         var moveSelector = new SwapMoveSelector<>(entityMimicRecorder, rightEntitySelector,
-                leftEntitySelector.getEntityDescriptor().getGenuineVariableDescriptorList(), true);
+                leftEntitySelector.getEntityDescriptor().getBasicVariableDescriptorList(), true);
 
         var solverScope = solvingStarted(moveSelector, scoreDirector, new Random(0));
         phaseStarted(moveSelector, solverScope);

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/TestdataEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/TestdataEntity.java
@@ -3,7 +3,7 @@ package ai.timefold.solver.core.testdomain;
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
-import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
 
 @PlanningEntity
 public class TestdataEntity extends TestdataObject {
@@ -14,8 +14,8 @@ public class TestdataEntity extends TestdataObject {
         return TestdataSolution.buildSolutionDescriptor().findEntityDescriptorOrFail(TestdataEntity.class);
     }
 
-    public static GenuineVariableDescriptor<TestdataSolution> buildVariableDescriptorForValue() {
-        return buildEntityDescriptor().getGenuineVariableDescriptor("value");
+    public static BasicVariableDescriptor<TestdataSolution> buildVariableDescriptorForValue() {
+        return (BasicVariableDescriptor<TestdataSolution>) buildEntityDescriptor().getGenuineVariableDescriptor("value");
     }
 
     private TestdataValue value;

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListUtils.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListUtils.java
@@ -346,7 +346,7 @@ public final class TestdataListUtils {
         destinationSelectorConfig.setEntitySelectorConfig(new EntitySelectorConfig()
                 .withEntityClass(entityDescriptor.getEntityClass()));
         destinationSelectorConfig.setValueSelectorConfig(new ValueSelectorConfig()
-                .withVariableName(entityDescriptor.getGenuineListVariableDescriptor().getVariableName()));
+                .withVariableName(entityDescriptor.getListVariableDescriptor().getVariableName()));
         var configPolicy = mock(HeuristicConfigPolicy.class);
         doReturn(solutionDescriptor).when(configPolicy).getSolutionDescriptor();
         doReturn(mimicRecordingValueSelector).when(configPolicy).getValueMimicRecorder(any());
@@ -363,7 +363,7 @@ public final class TestdataListUtils {
                 .withEntityClass(entityDescriptor.getEntityClass()));
         destinationSelectorConfig.setValueSelectorConfig(new ValueSelectorConfig()
                 .withFilterClass(selectionFilterClass)
-                .withVariableName(entityDescriptor.getGenuineListVariableDescriptor().getVariableName()));
+                .withVariableName(entityDescriptor.getListVariableDescriptor().getVariableName()));
         var configPolicy = mock(HeuristicConfigPolicy.class);
         doReturn(solutionDescriptor).when(configPolicy).getSolutionDescriptor();
         doReturn(innerMimicRecordingValueSelector).when(configPolicy).getValueMimicRecorder(any());

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/multivar/TestdataMultiVarEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/multivar/TestdataMultiVarEntity.java
@@ -3,7 +3,7 @@ package ai.timefold.solver.core.testdomain.multivar;
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
-import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
 import ai.timefold.solver.core.testdomain.TestdataObject;
 import ai.timefold.solver.core.testdomain.TestdataValue;
 
@@ -15,12 +15,14 @@ public class TestdataMultiVarEntity extends TestdataObject {
                 .findEntityDescriptorOrFail(TestdataMultiVarEntity.class);
     }
 
-    public static GenuineVariableDescriptor<TestdataMultiVarSolution> buildVariableDescriptorForPrimaryValue() {
-        return buildEntityDescriptor().getGenuineVariableDescriptor("primaryValue");
+    public static BasicVariableDescriptor<TestdataMultiVarSolution> buildVariableDescriptorForPrimaryValue() {
+        return (BasicVariableDescriptor<TestdataMultiVarSolution>) buildEntityDescriptor()
+                .getGenuineVariableDescriptor("primaryValue");
     }
 
-    public static GenuineVariableDescriptor<TestdataMultiVarSolution> buildVariableDescriptorForSecondaryValue() {
-        return buildEntityDescriptor().getGenuineVariableDescriptor("secondaryValue");
+    public static BasicVariableDescriptor<TestdataMultiVarSolution> buildVariableDescriptorForSecondaryValue() {
+        return (BasicVariableDescriptor<TestdataMultiVarSolution>) buildEntityDescriptor()
+                .getGenuineVariableDescriptor("secondaryValue");
     }
 
     private TestdataValue primaryValue;


### PR DESCRIPTION
The basic variable descriptor list was computed every time the assertion was called. Which was on every basic variable change. 

As a result of this change, a test which used to take 2 minutes now takes under 30 seconds. It also allocates less than 10 % of the memory it originally did.