### PR TITLE
fix: provide a more accurate problem scale log when entity dependent value ranges are used for list variables

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/ProblemScaleTracker.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/ProblemScaleTracker.java
@@ -4,69 +4,29 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
 
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.impl.score.director.ListValueRangeStatistics;
 import ai.timefold.solver.core.impl.util.MathUtils;
 
 public class ProblemScaleTracker {
     private final long logBase;
     private final Set<Object> visitedAnchorSet = Collections.newSetFromMap(new IdentityHashMap<>());
-
+    private final ListValueRangeStatistics listValueRangeStatistics = new ListValueRangeStatistics();
     private long basicProblemScaleLog = 0L;
-    private int listPinnedValueCount = 0;
-    private int listTotalEntityCount = 0;
-    private int listMovableEntityCount = 0;
-    private int listTotalValueCount = 0;
+    private boolean listAllowsUnassignedValues = false;
 
     public ProblemScaleTracker(long logBase) {
         this.logBase = logBase;
     }
 
     // Simple getters
-    public long getBasicProblemScaleLog() {
-        return basicProblemScaleLog;
+    public long getProblemScaleLog() {
+        return basicProblemScaleLog + listValueRangeStatistics.computeListProblemScaleLog(listAllowsUnassignedValues, logBase);
     }
 
-    public int getListPinnedValueCount() {
-        return listPinnedValueCount;
-    }
-
-    public int getListTotalEntityCount() {
-        return listTotalEntityCount;
-    }
-
-    public int getListMovableEntityCount() {
-        return listMovableEntityCount;
-    }
-
-    public int getListTotalValueCount() {
-        return listTotalValueCount;
-    }
-
-    public void setListTotalValueCount(int listTotalValueCount) {
-        this.listTotalValueCount = listTotalValueCount;
-    }
-
-    // Complex methods
-    public boolean isAnchorVisited(Object anchor) {
-        if (visitedAnchorSet.contains(anchor)) {
-            return true;
-        }
-        visitedAnchorSet.add(anchor);
-        return false;
-    }
-
-    public void addListValueCount(int count) {
-        listTotalValueCount += count;
-    }
-
-    public void addPinnedListValueCount(int count) {
-        listPinnedValueCount += count;
-    }
-
-    public void incrementListEntityCount(boolean isMovable) {
-        listTotalEntityCount++;
-        if (isMovable) {
-            listMovableEntityCount++;
-        }
+    public void processListValueRange(boolean listAllowsUnassignedValues, ValueRange<?> valueRange) {
+        this.listAllowsUnassignedValues |= listAllowsUnassignedValues;
+        listValueRangeStatistics.addValueRange(valueRange);
     }
 
     public void addBasicProblemScale(long count) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/ProblemScaleTracker.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/ProblemScaleTracker.java
@@ -9,6 +9,7 @@ public class ProblemScaleTracker<Solution_> {
     private final long logBase;
     private final ListValueRangeStatistics<Solution_> listValueRangeStatistics;
     private long basicProblemScaleLog = 0L;
+    private long cachedTotalProblemScaleLog = -1L;
 
     public ProblemScaleTracker(ListVariableDescriptor<Solution_> listVariableDescriptor,
             ValueRangeManager<Solution_> valueRangeManager,
@@ -17,9 +18,12 @@ public class ProblemScaleTracker<Solution_> {
         this.listValueRangeStatistics = new ListValueRangeStatistics<>(listVariableDescriptor, valueRangeManager);
     }
 
-    // Simple getters
     public long getProblemScaleLog() {
-        return basicProblemScaleLog + listValueRangeStatistics.computeListProblemScaleLog(logBase);
+        if (cachedTotalProblemScaleLog != -1L) {
+            return cachedTotalProblemScaleLog;
+        }
+        cachedTotalProblemScaleLog = basicProblemScaleLog + listValueRangeStatistics.computeListProblemScaleLog(logBase);
+        return cachedTotalProblemScaleLog;
     }
 
     public void addBasicProblemScale(long count) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/ProblemScaleTracker.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/ProblemScaleTracker.java
@@ -1,32 +1,25 @@
 package ai.timefold.solver.core.impl.domain.solution.descriptor;
 
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.Set;
-
-import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.score.director.ListValueRangeStatistics;
+import ai.timefold.solver.core.impl.score.director.ValueRangeManager;
 import ai.timefold.solver.core.impl.util.MathUtils;
 
-public class ProblemScaleTracker {
+public class ProblemScaleTracker<Solution_> {
     private final long logBase;
-    private final Set<Object> visitedAnchorSet = Collections.newSetFromMap(new IdentityHashMap<>());
-    private final ListValueRangeStatistics listValueRangeStatistics = new ListValueRangeStatistics();
+    private final ListValueRangeStatistics<Solution_> listValueRangeStatistics;
     private long basicProblemScaleLog = 0L;
-    private boolean listAllowsUnassignedValues = false;
 
-    public ProblemScaleTracker(long logBase) {
+    public ProblemScaleTracker(ListVariableDescriptor<Solution_> listVariableDescriptor,
+            ValueRangeManager<Solution_> valueRangeManager,
+            long logBase) {
         this.logBase = logBase;
+        this.listValueRangeStatistics = new ListValueRangeStatistics<>(listVariableDescriptor, valueRangeManager);
     }
 
     // Simple getters
     public long getProblemScaleLog() {
-        return basicProblemScaleLog + listValueRangeStatistics.computeListProblemScaleLog(listAllowsUnassignedValues, logBase);
-    }
-
-    public void processListValueRange(boolean listAllowsUnassignedValues, ValueRange<?> valueRange) {
-        this.listAllowsUnassignedValues |= listAllowsUnassignedValues;
-        listValueRangeStatistics.addValueRange(valueRange);
+        return basicProblemScaleLog + listValueRangeStatistics.computeListProblemScaleLog(logBase);
     }
 
     public void addBasicProblemScale(long count) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/ReachableValues.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/ReachableValues.java
@@ -83,6 +83,14 @@ public final class ReachableValues<Entity_, Value_> {
         return entityList;
     }
 
+    public int getReachableEntitiesSize(Object value) {
+        var itemValue = fetchItemValue(value);
+        if (itemValue == null) {
+            return 0;
+        }
+        return itemValue.getReachableEntitySize();
+    }
+
     public List<Value_> extractValuesAsList(Object value) {
         var itemValue = fetchItemValue(value);
         if (itemValue == null) {
@@ -191,6 +199,10 @@ public final class ReachableValues<Entity_, Value_> {
 
         boolean containsValue(int valueIndex) {
             return valueBitSet.get(valueIndex);
+        }
+
+        int getReachableEntitySize() {
+            return entityBitSet.cardinality();
         }
 
         List<Entity_> getRandomAccessEntityList(List<Entity_> allEntities) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/ReachableValues.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/ReachableValues.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 
 import ai.timefold.solver.core.impl.domain.valuerange.descriptor.FromEntityPropertyValueRangeDescriptor;
@@ -93,6 +94,14 @@ public final class ReachableValues<Entity_, Value_> {
             onDemandRandomAccessValue[itemValue.ordinal] = valueList;
         }
         return valueList;
+    }
+
+    public Set<Entity_> extractAllEntitiesAsSet() {
+        return entitiesIndex.indexMap().keySet();
+    }
+
+    public Set<Value_> extractAllValuesAsSet() {
+        return valuesIndex.indexMap().keySet();
     }
 
     public int getSize() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ListValueRangeStatistics.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ListValueRangeStatistics.java
@@ -1,0 +1,58 @@
+package ai.timefold.solver.core.impl.score.director;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.impl.util.MathUtils;
+import ai.timefold.solver.core.impl.util.MutableInt;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class ListValueRangeStatistics {
+    private final Map<ValueRangeState.HashedValueRange<?>, MutableInt> valueRangeToInstanceCount;
+
+    public ListValueRangeStatistics() {
+        valueRangeToInstanceCount = new HashMap<>();
+    }
+
+    public void addValueRange(ValueRange<?> valueRange) {
+        var hashedValueRange = ValueRangeState.HashedValueRange.of(valueRange);
+        valueRangeToInstanceCount
+                .computeIfAbsent(hashedValueRange, ignored -> new MutableInt(0))
+                .increment();
+    }
+
+    public long computeListProblemScaleLog(boolean allowsUnassignedValues, long logBase) {
+        var valueToRangeCount = new IdentityHashMap<Object, MutableInt>();
+        // Unassigned values are treated as if they are assigned to a virtual entity to simplify calculations
+        var entityCount = allowsUnassignedValues ? 1 : 0;
+        for (var entry : valueRangeToInstanceCount.entrySet()) {
+            var iterator = entry.getKey().item().createOriginalIterator();
+            var valueRangeInstanceCount = entry.getValue().intValue();
+            entityCount += valueRangeInstanceCount;
+            while (iterator.hasNext()) {
+                var value = iterator.next();
+                valueToRangeCount.computeIfAbsent(value, ignored -> new MutableInt(0))
+                        .add(valueRangeInstanceCount);
+
+            }
+        }
+
+        if (entityCount == 0) {
+            return 0L;
+        }
+
+        var valueCount = valueToRangeCount.size();
+        var validPercentageLog = 0L;
+        var additionalCount = allowsUnassignedValues ? 1 : 0;
+        for (var validEntityCount : valueToRangeCount.values()) {
+            validPercentageLog += MathUtils.getScaledApproximateLog(MathUtils.LOG_PRECISION, logBase,
+                    (validEntityCount.doubleValue() + additionalCount) / entityCount);
+        }
+        return MathUtils.getPossibleArrangementsScaledApproximateLog(MathUtils.LOG_PRECISION, logBase,
+                valueCount, entityCount) + validPercentageLog;
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ListValueRangeStatistics.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ListValueRangeStatistics.java
@@ -42,7 +42,7 @@ public class ListValueRangeStatistics<Solution_> {
 
         for (var value : valueSet) {
             validPercentageLog += MathUtils.getScaledApproximateLog(MathUtils.LOG_PRECISION, logBase,
-                    ((double) reachableValues.extractEntitiesAsList(value).size() + additionalCount) / entityCount);
+                    ((double) reachableValues.getReachableEntitiesSize(value) + additionalCount) / entityCount);
         }
 
         return MathUtils.getPossibleArrangementsScaledApproximateLog(MathUtils.LOG_PRECISION, logBase,

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ListValueRangeStatistics.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ListValueRangeStatistics.java
@@ -1,57 +1,50 @@
 package ai.timefold.solver.core.impl.score.director;
 
-import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.Map;
-
-import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.util.MathUtils;
-import ai.timefold.solver.core.impl.util.MutableInt;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @NullMarked
-public class ListValueRangeStatistics {
-    private final Map<ValueRangeState.HashedValueRange<?>, MutableInt> valueRangeToInstanceCount;
+public class ListValueRangeStatistics<Solution_> {
+    @Nullable
+    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
+    private final ValueRangeManager<Solution_> valueRangeManager;
 
-    public ListValueRangeStatistics() {
-        valueRangeToInstanceCount = new HashMap<>();
+    public ListValueRangeStatistics(@Nullable ListVariableDescriptor<Solution_> listVariableDescriptor,
+            ValueRangeManager<Solution_> valueRangeManager) {
+        this.listVariableDescriptor = listVariableDescriptor;
+        this.valueRangeManager = valueRangeManager;
     }
 
-    public void addValueRange(ValueRange<?> valueRange) {
-        var hashedValueRange = ValueRangeState.HashedValueRange.of(valueRange);
-        valueRangeToInstanceCount
-                .computeIfAbsent(hashedValueRange, ignored -> new MutableInt(0))
-                .increment();
-    }
-
-    public long computeListProblemScaleLog(boolean allowsUnassignedValues, long logBase) {
-        var valueToRangeCount = new IdentityHashMap<Object, MutableInt>();
-        // Unassigned values are treated as if they are assigned to a virtual entity to simplify calculations
-        var entityCount = allowsUnassignedValues ? 1 : 0;
-        for (var entry : valueRangeToInstanceCount.entrySet()) {
-            var iterator = entry.getKey().item().createOriginalIterator();
-            var valueRangeInstanceCount = entry.getValue().intValue();
-            entityCount += valueRangeInstanceCount;
-            while (iterator.hasNext()) {
-                var value = iterator.next();
-                valueToRangeCount.computeIfAbsent(value, ignored -> new MutableInt(0))
-                        .add(valueRangeInstanceCount);
-
-            }
-        }
-
-        if (entityCount == 0) {
+    public long computeListProblemScaleLog(long logBase) {
+        if (listVariableDescriptor == null) {
+            // No list variable
             return 0L;
         }
+        var allowsUnassignedValues = listVariableDescriptor.allowsUnassignedValues();
+        var reachableValues = valueRangeManager.getReachableValues(listVariableDescriptor);
+        var entityCount = reachableValues.extractAllEntitiesAsSet().size();
+        if (entityCount == 0) {
+            // No entities
+            return 0L;
+        }
+        if (allowsUnassignedValues) {
+            // Unassigned values are treated as if they are assigned to a virtual entity to simplify calculations
+            entityCount++;
+        }
 
-        var valueCount = valueToRangeCount.size();
+        var valueSet = reachableValues.extractAllValuesAsSet();
+        var valueCount = valueSet.size();
         var validPercentageLog = 0L;
         var additionalCount = allowsUnassignedValues ? 1 : 0;
-        for (var validEntityCount : valueToRangeCount.values()) {
+
+        for (var value : valueSet) {
             validPercentageLog += MathUtils.getScaledApproximateLog(MathUtils.LOG_PRECISION, logBase,
-                    (validEntityCount.doubleValue() + additionalCount) / entityCount);
+                    ((double) reachableValues.extractEntitiesAsList(value).size() + additionalCount) / entityCount);
         }
+
         return MathUtils.getPossibleArrangementsScaledApproximateLog(MathUtils.LOG_PRECISION, logBase,
                 valueCount, entityCount) + validPercentageLog;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeManager.java
@@ -180,7 +180,7 @@ public final class ValueRangeManager<Solution_> {
             AbstractValueRangeDescriptor<Solution_> abstractValueRangeDescriptor, Entity_ entity,
             @Nullable SelectionSorter<Solution_, Value_> sorter) {
         ValueRangeState<Solution_, Entity_, Value_> descriptor = fromDescriptor(abstractValueRangeDescriptor);
-        return descriptor.getFromEntity(entity, getInitializationStatistics().genuineEntityCount(), sorter);
+        return descriptor.getFromEntity(entity, sorter);
     }
 
     public long countOnSolution(AbstractValueRangeDescriptor<Solution_> abstractValueRangeDescriptor, Solution_ solution) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeState.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeState.java
@@ -370,7 +370,7 @@ final class ValueRangeState<Solution_, Entity_, Value_> {
      * The record holds a reference to {@link ValueRange},
      * a precomputed hash to avoid recalculating it every time.
      */
-    private record HashedValueRange<T>(ValueRange<T> item, int hash) {
+    record HashedValueRange<T>(ValueRange<T> item, int hash) {
 
         public static <Value_> HashedValueRange<Value_> of(ValueRange<Value_> valueRange) {
             return new HashedValueRange<>(valueRange, valueRange.hashCode());

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeState.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeState.java
@@ -139,9 +139,9 @@ final class ValueRangeState<Solution_, Entity_, Value_> {
         return sortableValueRange.sort(SelectionSorterAdapter.of(cachedWorkingSolution, sorter));
     }
 
-    public ValueRange<Value_> getFromEntity(Entity_ entity, int entityCount,
+    public ValueRange<Value_> getFromEntity(Entity_ entity,
             @Nullable SelectionSorter<Solution_, Value_> sorter) {
-        var entityMap = ensureEntityMapIsInitialized(entityCount);
+        var entityMap = ensureEntityMapIsInitialized();
         var item = entityMap.get(entity);
         // No item, we set the left side by default
         if (item == null) {
@@ -149,11 +149,11 @@ final class ValueRangeState<Solution_, Entity_, Value_> {
             entityMap.put(entity, newItem);
             if (newItem.entity() != null && newItem.leftItem() == null && newItem.rightItem() == null) {
                 // Placeholder for another entity
-                return getFromEntity(Objects.requireNonNull(newItem.entity()), entityCount, sorter);
+                return getFromEntity(Objects.requireNonNull(newItem.entity()), sorter);
             }
             return Objects.requireNonNull(newItem.leftItem());
         }
-        var valueRange = pickValueBySorter(item, sorter, (p, s) -> getFromEntity(p, entityCount, s));
+        var valueRange = pickValueBySorter(item, sorter, (p, s) -> getFromEntity(p, s));
         if (valueRange != null) {
             return valueRange;
         }
@@ -177,10 +177,10 @@ final class ValueRangeState<Solution_, Entity_, Value_> {
     }
 
     private Map<Entity_, ValueRangeItem<Solution_, Entity_, ValueRange<Value_>, Value_>>
-            ensureEntityMapIsInitialized(int entityCount) {
+            ensureEntityMapIsInitialized() {
         if (fromEntityMap == null) {
-            fromEntityMap = new IdentityHashMap<>(entityCount);
-            valueRangeDeduplicationCache = HashMap.newHashMap(entityCount);
+            fromEntityMap = new IdentityHashMap<>();
+            valueRangeDeduplicationCache = new HashMap<>();
         }
         return fromEntityMap;
     }
@@ -284,7 +284,7 @@ final class ValueRangeState<Solution_, Entity_, Value_> {
         var valueIndexItem = new ReachableValuesIndex<>(valueIndexMap, reachableValueList);
         for (var i = 0; i < entityList.size(); i++) {
             var entity = entityList.get(i);
-            var valueRange = getFromEntity(entity, entityList.size(), null);
+            var valueRange = getFromEntity(entity, null);
             loadEntityValueRange(i, valueIndexMap, valueRange, reachableValueList);
         }
         var sorterAdapter = sorter != null ? SelectionSorterAdapter.of(cachedWorkingSolution, sorter) : null;

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeStatistics.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeStatistics.java
@@ -165,21 +165,7 @@ final class ValueRangeStatistics<Solution_> {
                 processProblemScale(valueRangeManager, entityDescriptor, entity, problemScaleTracker);
             }
         });
-        var result = problemScaleTracker.getBasicProblemScaleLog();
-        if (problemScaleTracker.getListTotalEntityCount() != 0L) {
-            // List variables do not support from entity value ranges
-            var totalListValueCount = problemScaleTracker.getListTotalValueCount();
-            var totalListMovableValueCount = totalListValueCount - problemScaleTracker.getListPinnedValueCount();
-            var possibleTargetsForListValue = problemScaleTracker.getListMovableEntityCount();
-            var listVariableDescriptor = solutionDescriptor.getListVariableDescriptor();
-            if (listVariableDescriptor != null && listVariableDescriptor.allowsUnassignedValues()) {
-                // Treat unassigned values as assigned to a single virtual vehicle for the sake of this calculation
-                possibleTargetsForListValue++;
-            }
-
-            result += MathUtils.getPossibleArrangementsScaledApproximateLog(MathUtils.LOG_PRECISION, logBase,
-                    totalListMovableValueCount, possibleTargetsForListValue);
-        }
+        var result = problemScaleTracker.getProblemScaleLog();
         var scale = (result / (double) MathUtils.LOG_PRECISION) / MathUtils.getLogInBase(logBase, 10d);
         if (Double.isNaN(scale) || Double.isInfinite(scale)) {
             return 0;
@@ -237,15 +223,8 @@ final class ValueRangeStatistics<Solution_> {
                     }
                 }
                 case ListVariableDescriptor<Solution_> listVariableDescriptor -> {
-                    var size = valueRangeManager.countOnSolution(listVariableDescriptor.getValueRangeDescriptor(), solution);
-                    tracker.setListTotalValueCount((int) size);
-                    if (entityDescriptor.isMovable(solution, entity)) {
-                        tracker.incrementListEntityCount(true);
-                        tracker.addPinnedListValueCount(listVariableDescriptor.getFirstUnpinnedIndex(entity));
-                    } else {
-                        tracker.incrementListEntityCount(false);
-                        tracker.addPinnedListValueCount(listVariableDescriptor.getListSize(entity));
-                    }
+                    tracker.processListValueRange(listVariableDescriptor.allowsUnassignedValues(),
+                            valueRangeManager.getFromEntity(listVariableDescriptor.getValueRangeDescriptor(), entity));
                 }
                 default -> throw new IllegalStateException("Unhandled subclass of %s encountered (%s)."
                         .formatted(VariableDescriptor.class.getSimpleName(), variableDescriptor.getClass().getSimpleName()));

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeStatistics.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/ValueRangeStatistics.java
@@ -1,7 +1,5 @@
 package ai.timefold.solver.core.impl.score.director;
 
-import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -10,7 +8,6 @@ import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.ProblemScaleTracker;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
-import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.util.MathUtils;
@@ -28,6 +25,10 @@ final class ValueRangeStatistics<Solution_> {
     private final Solution_ solution;
     private @Nullable SolutionInitializationStatistics cachedInitializationStatistics = null;
     private @Nullable ProblemSizeStatistics cachedProblemSizeStatistics = null;
+
+    // Negative if not calculated, non-negative if cached
+    private long cachedApproximateValueCount = -1L;
+    private double cachedProblemScale = -1.0;
 
     ValueRangeStatistics(ValueRangeManager<Solution_> valueRangeManager, SolutionDescriptor<Solution_> solutionDescriptor,
             Solution_ solution) {
@@ -57,18 +58,37 @@ final class ValueRangeStatistics<Solution_> {
         var notInAnyListValueCount = new MutableInt();
         var genuineEntityCount = new MutableInt();
         var shadowEntityCount = new MutableInt();
+        var approximateValueCount = new MutableLong();
+        var maxValueRangeSize = new MutableLong(0L);
 
         var listVariableDescriptor = solutionDescriptor.getListVariableDescriptor();
         if (listVariableDescriptor != null) {
             var countOnSolution =
                     (int) valueRangeManager.countOnSolution(listVariableDescriptor.getValueRangeDescriptor(), solution);
             notInAnyListValueCount.add(countOnSolution);
+            maxValueRangeSize.setValue(countOnSolution);
+            if (listVariableDescriptor.canExtractValueRangeFromSolution()) {
+                approximateValueCount.add(countOnSolution);
+            }
             if (!listVariableDescriptor.allowsUnassignedValues()) {
                 // We count every possibly unassigned element in every list variable.
                 // And later we subtract the assigned elements.
                 unassignedValueCount.add(countOnSolution);
             }
         }
+
+        for (var basicVariable : solutionDescriptor.getBasicVariableDescriptorList()) {
+            if (basicVariable.canExtractValueRangeFromSolution()) {
+                var countOnSolution = valueRangeManager.countOnSolution(basicVariable.getValueRangeDescriptor(), solution);
+                approximateValueCount.add(countOnSolution);
+                if (maxValueRangeSize.longValue() < countOnSolution) {
+                    maxValueRangeSize.setValue(countOnSolution);
+                }
+            }
+        }
+
+        var logBase = (maxValueRangeSize.longValue() < 2) ? 10 : maxValueRangeSize.longValue();
+        var problemScaleTracker = new ProblemScaleTracker<>(listVariableDescriptor, valueRangeManager, logBase);
 
         solutionDescriptor.visitAllEntities(solution, entity -> {
             var entityDescriptor = solutionDescriptor.findEntityDescriptorOrFail(entity.getClass());
@@ -79,11 +99,20 @@ final class ValueRangeStatistics<Solution_> {
                     uninitializedEntityCount.increment();
                     uninitializedVariableCount.add(uninitializedVariableCountForEntity);
                 }
+                processProblemScale(valueRangeManager, entityDescriptor, entity, problemScaleTracker);
             } else {
                 shadowEntityCount.increment();
             }
             if (finisher != null) {
                 finisher.accept(entity);
+            }
+
+            for (var genuineVariable : entityDescriptor.getGenuineVariableDescriptorList()) {
+                if (genuineVariable instanceof BasicVariableDescriptor<Solution_> basicVariableDescriptor
+                        && !basicVariableDescriptor.canExtractValueRangeFromSolution()) {
+                    approximateValueCount
+                            .add(valueRangeManager.countOnEntity(basicVariableDescriptor.getValueRangeDescriptor(), entity));
+                }
             }
             if (!entityDescriptor.hasAnyListVariables()) {
                 return;
@@ -94,6 +123,10 @@ final class ValueRangeStatistics<Solution_> {
             if (!listVariableDescriptor.allowsUnassignedValues() && listVariableEntityDescriptor.matchesEntity(entity)) {
                 unassignedValueCount.subtract(countOnEntity);
             }
+            if (!listVariableDescriptor.canExtractValueRangeFromSolution()) {
+                approximateValueCount
+                        .add(valueRangeManager.countOnEntity(listVariableDescriptor.getValueRangeDescriptor(), entity));
+            }
             // TODO maybe detect duplicates and elements that are outside the value range
         });
         var statistics = new SolutionInitializationStatistics(genuineEntityCount.intValue(),
@@ -103,44 +136,36 @@ final class ValueRangeStatistics<Solution_> {
         if (cachedInitializationStatistics == null) {
             this.cachedInitializationStatistics = statistics;
         }
+        cachedApproximateValueCount = approximateValueCount.longValue();
+        var problemScaleLogAsLong = problemScaleTracker.getProblemScaleLog();
+        var scale = (problemScaleLogAsLong / (double) MathUtils.LOG_PRECISION) / MathUtils.getLogInBase(logBase, 10d);
+        if (Double.isNaN(scale) || Double.isInfinite(scale)) {
+            cachedProblemScale = 0.0;
+        } else {
+            cachedProblemScale = scale;
+        }
         return statistics;
     }
 
     public ProblemSizeStatistics getProblemSizeStatistics() {
+        if (cachedProblemScale < 0) {
+            computeInitializationStatistics(null, false);
+        }
         if (cachedProblemSizeStatistics == null) {
             cachedProblemSizeStatistics = new ProblemSizeStatistics(
                     solutionDescriptor.getGenuineEntityCount(solution),
                     solutionDescriptor.getGenuineVariableCount(solution),
-                    getApproximateValueCount(),
-                    getProblemScale());
+                    cachedApproximateValueCount,
+                    cachedProblemScale);
         }
         return cachedProblemSizeStatistics;
     }
 
     long getApproximateValueCount() {
-        var genuineVariableDescriptorSet =
-                Collections.newSetFromMap(new IdentityHashMap<GenuineVariableDescriptor<Solution_>, Boolean>());
-        solutionDescriptor.visitAllEntities(solution, entity -> {
-            var entityDescriptor = solutionDescriptor.findEntityDescriptorOrFail(entity.getClass());
-            if (entityDescriptor.isGenuine()) {
-                genuineVariableDescriptorSet.addAll(entityDescriptor.getGenuineVariableDescriptorList());
-            }
-        });
-        var out = new MutableLong();
-        for (var variableDescriptor : genuineVariableDescriptorSet) {
-            var valueRangeDescriptor = variableDescriptor.getValueRangeDescriptor();
-            if (valueRangeDescriptor.canExtractValueRangeFromSolution()) {
-                out.add(valueRangeManager.countOnSolution(valueRangeDescriptor, solution));
-            } else {
-                solutionDescriptor.visitEntitiesByEntityClass(solution,
-                        variableDescriptor.getEntityDescriptor().getEntityClass(),
-                        entity -> {
-                            out.add(valueRangeManager.countOnEntity(valueRangeDescriptor, entity));
-                            return false;
-                        });
-            }
+        if (cachedApproximateValueCount == -1) {
+            computeInitializationStatistics(null, false);
         }
-        return out.longValue();
+        return cachedApproximateValueCount;
     }
 
     /**
@@ -157,61 +182,14 @@ final class ValueRangeStatistics<Solution_> {
      *         Returns {@code 0} if the calculation results in NaN or infinity.
      */
     double getProblemScale() {
-        var logBase = Math.max(2, getMaximumValueRangeSize());
-        var problemScaleTracker = new ProblemScaleTracker(logBase);
-        solutionDescriptor.visitAllEntities(solution, entity -> {
-            var entityDescriptor = solutionDescriptor.findEntityDescriptorOrFail(entity.getClass());
-            if (entityDescriptor.isGenuine()) {
-                processProblemScale(valueRangeManager, entityDescriptor, entity, problemScaleTracker);
-            }
-        });
-        var result = problemScaleTracker.getProblemScaleLog();
-        var scale = (result / (double) MathUtils.LOG_PRECISION) / MathUtils.getLogInBase(logBase, 10d);
-        if (Double.isNaN(scale) || Double.isInfinite(scale)) {
-            return 0;
+        if (cachedProblemScale < 0) {
+            computeInitializationStatistics(null, false);
         }
-        return scale;
-    }
-
-    /**
-     * Calculates the maximum value range size across all entities in the working solution.
-     * <p>
-     * The "maximum value range size" is defined as the largest number of possible values
-     * for any genuine variable across all entities.
-     * This is determined by inspecting the value range descriptors of each variable in each entity.
-     *
-     * @return The maximum value range size, or 0 if no genuine variables are found.
-     */
-    long getMaximumValueRangeSize() {
-        return solutionDescriptor.extractAllEntitiesStream(solution)
-                .mapToLong(entity -> {
-                    var entityDescriptor = solutionDescriptor.findEntityDescriptorOrFail(entity.getClass());
-                    return entityDescriptor.isGenuine()
-                            ? getMaximumValueCount(entityDescriptor, entity)
-                            : 0L;
-                })
-                .max()
-                .orElse(0L);
-    }
-
-    private long getMaximumValueCount(EntityDescriptor<Solution_> entityDescriptor, Object entity) {
-        var maximumValueCount = 0L;
-        for (var variableDescriptor : entityDescriptor.getGenuineVariableDescriptorList()) {
-            if (variableDescriptor.canExtractValueRangeFromSolution()) {
-                maximumValueCount = Math.max(maximumValueCount,
-                        valueRangeManager.countOnSolution(variableDescriptor.getValueRangeDescriptor(), solution));
-            } else {
-                maximumValueCount =
-                        Math.max(maximumValueCount,
-                                valueRangeManager.countOnEntity(variableDescriptor.getValueRangeDescriptor(), entity));
-            }
-        }
-        return maximumValueCount;
-
+        return cachedProblemScale;
     }
 
     private void processProblemScale(ValueRangeManager<Solution_> valueRangeManager,
-            EntityDescriptor<Solution_> entityDescriptor, Object entity, ProblemScaleTracker tracker) {
+            EntityDescriptor<Solution_> entityDescriptor, Object entity, ProblemScaleTracker<Solution_> tracker) {
         for (var variableDescriptor : entityDescriptor.getGenuineVariableDescriptorList()) {
             var valueCount = variableDescriptor.canExtractValueRangeFromSolution()
                     ? valueRangeManager.countOnSolution(variableDescriptor.getValueRangeDescriptor(), solution)
@@ -223,8 +201,7 @@ final class ValueRangeStatistics<Solution_> {
                     }
                 }
                 case ListVariableDescriptor<Solution_> listVariableDescriptor -> {
-                    tracker.processListValueRange(listVariableDescriptor.allowsUnassignedValues(),
-                            valueRangeManager.getFromEntity(listVariableDescriptor.getValueRangeDescriptor(), entity));
+                    // Intentionally empty, we don't need to process it here
                 }
                 default -> throw new IllegalStateException("Unhandled subclass of %s encountered (%s)."
                         .formatted(VariableDescriptor.class.getSimpleName(), variableDescriptor.getClass().getSimpleName()));

--- a/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
@@ -45,6 +45,18 @@ public class MathUtils {
         return Math.round(scale * getLogInBase(base, value));
     }
 
+    /**
+     * Returns a scaled approximation of a log.
+     *
+     * @param scale What to scale the result by. Typically, a power of 10.
+     * @param base The base of the log
+     * @param value The parameter to the log function
+     * @return A value approximately equal to {@code scale * log_base(value)}, rounded to the nearest integer.
+     */
+    public static long getScaledApproximateLog(long scale, long base, double value) {
+        return Math.round(scale * getLogInBase(base, value));
+    }
+
     public static double getLogInBase(double base, double value) {
         return Math.log(value) / Math.log(base);
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorTest.java
@@ -523,6 +523,7 @@ class SwapMoveSelectorTest {
         var e2 = new TestdataAllowsUnassignedMultiVarEntityProvidingEntity("B", List.of(v2, v3), List.of(v2, v3));
         var e3 = new TestdataAllowsUnassignedMultiVarEntityProvidingEntity("C", List.of(v1, v4), List.of(v1, v3, v4));
         solution.setEntityList(List.of(e1, e2, e3));
+        solution.setSolutionValueRange(List.of(v1));
 
         var scoreDirector =
                 mockScoreDirector(TestdataAllowsUnassignedMultiVarEntityProvidingSolution.buildSolutionDescriptor());

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/ValueRangeManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/ValueRangeManagerTest.java
@@ -843,6 +843,16 @@ class ValueRangeManagerTest {
 
             softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(3L);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(2L + 3L);
+            // 100% of the possible positions for v1 are valid,
+            // 100% of the possible positions for v2 are valid,
+            // 50% of the possible positions for v3 are valid,
+            // So the actual problem scale would be half the total permutation count.
+            softly.assertThat(
+                            // Use pow to get the approximate number of combinations
+                            Math.pow(10, (valueRangeManager.getStatistics().getProblemScale())))
+                    // There should be 12 possible combinations
+                    // (total ways to split 3 values across 2 lists = 24, half of that is 12)
+                    .isCloseTo(12.0, Percentage.withPercentage(1.0));
         });
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/ValueRangeManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/ValueRangeManagerTest.java
@@ -848,8 +848,8 @@ class ValueRangeManagerTest {
             // 50% of the possible positions for v3 are valid,
             // So the actual problem scale would be half the total permutation count.
             softly.assertThat(
-                            // Use pow to get the approximate number of combinations
-                            Math.pow(10, (valueRangeManager.getStatistics().getProblemScale())))
+                    // Use pow to get the approximate number of combinations
+                    Math.pow(10, (valueRangeManager.getStatistics().getProblemScale())))
                     // There should be 12 possible combinations
                     // (total ways to split 3 values across 2 lists = 24, half of that is 12)
                     .isCloseTo(12.0, Percentage.withPercentage(1.0));

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/director/ValueRangeManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/director/ValueRangeManagerTest.java
@@ -735,7 +735,6 @@ class ValueRangeManagerTest {
         assertSoftly(softly -> {
             softly.assertThat(solutionDescriptor.getGenuineEntityCount(solution)).isEqualTo(entityCount);
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(entityCount);
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(valueCount);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(valueCount);
             softly.assertThat(valueRangeManager.getStatistics().getProblemScale())
                     .isEqualTo(20.0);
@@ -754,7 +753,6 @@ class ValueRangeManagerTest {
         assertSoftly(softly -> {
             softly.assertThat(solutionDescriptor.getGenuineEntityCount(solution)).isEqualTo(entityCount);
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(entityCount);
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(0);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(0);
             softly.assertThat(valueRangeManager.getStatistics().getProblemScale())
                     .isEqualTo(0);
@@ -773,7 +771,6 @@ class ValueRangeManagerTest {
         assertSoftly(softly -> {
             softly.assertThat(solutionDescriptor.getGenuineEntityCount(solution)).isEqualTo(entityCount);
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(entityCount);
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(1);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(1);
             softly.assertThat(valueRangeManager.getStatistics().getProblemScale())
                     .isEqualTo(0);
@@ -793,7 +790,6 @@ class ValueRangeManagerTest {
         assertSoftly(softly -> {
             softly.assertThat(solutionDescriptor.getGenuineEntityCount(solution)).isEqualTo(entityCount);
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(entityCount * variableCount);
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(3L);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount())
                     .isEqualTo(variableCount * valueCount);
             softly.assertThat(valueRangeManager.getStatistics().getProblemScale())
@@ -819,7 +815,6 @@ class ValueRangeManagerTest {
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(2L);
 
             // Add 1 to the value range sizes, since the value range allows unassigned
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(4L);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(3L + 4L);
             softly.assertThat(valueRangeManager.getStatistics().getProblemScale())
                     .isCloseTo(Math.log10(3 * 4), Percentage.withPercentage(1.0));
@@ -841,7 +836,6 @@ class ValueRangeManagerTest {
             softly.assertThat(solutionDescriptor.getGenuineEntityCount(solution)).isEqualTo(2L);
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(2L);
 
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(3L);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(2L + 3L);
             // 100% of the possible positions for v1 are valid,
             // 100% of the possible positions for v2 are valid,
@@ -872,7 +866,6 @@ class ValueRangeManagerTest {
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(1L);
 
             // Add 1 to the value range sizes, since the value range allows unassigned
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(2L);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(2L);
             softly.assertThat(valueRangeManager.getStatistics().getProblemScale())
                     .isCloseTo(Math.log10(2), Percentage.withPercentage(1.0));
@@ -890,7 +883,6 @@ class ValueRangeManagerTest {
         assertSoftly(softly -> {
             softly.assertThat(solutionDescriptor.getGenuineEntityCount(solution)).isEqualTo(entityCount);
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(entityCount);
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(valueCount);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(valueCount);
             softly.assertThat(valueRangeManager.getStatistics().getProblemScale())
                     .isCloseTo(MathUtils.getPossibleArrangementsScaledApproximateLog(MathUtils.LOG_PRECISION, 10, 500, 20)
@@ -909,7 +901,6 @@ class ValueRangeManagerTest {
         assertSoftly(softly -> {
             softly.assertThat(solutionDescriptor.getGenuineEntityCount(solution)).isEqualTo(entityCount);
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(entityCount);
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(valueCount);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(valueCount);
             softly.assertThat(valueRangeManager.getStatistics().getProblemScale()).isEqualTo(0.0);
         });
@@ -926,7 +917,6 @@ class ValueRangeManagerTest {
         assertSoftly(softly -> {
             softly.assertThat(solutionDescriptor.getGenuineEntityCount(solution)).isEqualTo(entityCount);
             softly.assertThat(solutionDescriptor.getGenuineVariableCount(solution)).isEqualTo(entityCount);
-            softly.assertThat(valueRangeManager.getStatistics().getMaximumValueRangeSize()).isEqualTo(valueCount);
             softly.assertThat(valueRangeManager.getStatistics().getApproximateValueCount()).isEqualTo(valueCount);
             softly.assertThat(valueRangeManager.getStatistics().getProblemScale())
                     .isCloseTo(Math.log10(2), Percentage.withPercentage(1.0));

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -1903,6 +1903,8 @@ class DefaultSolverTest {
         var v1 = new TestdataValue("1");
         var v2 = new TestdataValue("2");
         var v3 = new TestdataValue("3");
+
+        problem.setSolutionValueRange(List.of(v1));
         // The entity has been assigned a value v3 for the second value range,
         // which is not included in the entity's value ranges
         var e1 = new TestdataAllowsUnassignedMultiVarEntityProvidingEntity("e1", List.of(v1, v2, v3), v3, List.of(v1, v2), v3,


### PR DESCRIPTION
Previously, the logic just assumed the values from entity dependent value ranges are unique, which massively inflated the problem scale log for list variables.

Now, we track the number of entities a value is allowed to be in, and use that to scale the problem scale. For instance, if a value is only allowed to be in 25% of entities, it should reduce the problem scale by 25%.