### PR TITLE
chore: gitignore every Eclipse JDT produced file and folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,12 @@ target
 local
 
 # Eclipse, Netbeans and IntelliJ files
-/.*
+.*
 !/.github
-!/.specify
 !/.ci
+!/.mvn
 !.gitignore
 !.gitattributes
-!/.mvn
 /nbproject
 *.ipr
 *.iws


### PR DESCRIPTION
.settings and others show up when using the Claude Code with Java LSP provided by the JDT-LS project in