### PR TITLE
fix: handle null planning values in ValueTabuAcceptor

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
@@ -1,9 +1,7 @@
 package ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu;
 
-import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Deque;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.AbstractAcceptor;
@@ -12,29 +10,35 @@ import ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu.size.TabuS
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
+import ai.timefold.solver.core.impl.util.CollectionUtils;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Abstract superclass for all Tabu Acceptors.
  *
  * @see Acceptor
  */
-public abstract class AbstractTabuAcceptor<Solution_> extends AbstractAcceptor<Solution_> {
+@NullMarked
+public abstract sealed class AbstractTabuAcceptor<Solution_>
+        extends AbstractAcceptor<Solution_>
+        permits EntityTabuAcceptor, MoveTabuAcceptor, ValueTabuAcceptor {
 
-    protected final String logIndentation;
+    private final String logIndentation;
 
-    protected TabuSizeStrategy<Solution_> tabuSizeStrategy = null;
-    protected TabuSizeStrategy<Solution_> fadingTabuSizeStrategy = null;
-    protected boolean aspirationEnabled = true;
+    private @Nullable TabuSizeStrategy<Solution_> tabuSizeStrategy = null;
+    private @Nullable TabuSizeStrategy<Solution_> fadingTabuSizeStrategy = null;
+    private boolean aspirationEnabled = true;
 
-    protected boolean assertTabuHashCodeCorrectness = false;
+    private boolean assertTabuHashCodeCorrectness = false;
 
-    protected Map<Object, Integer> tabuToStepIndexMap;
-    protected Deque<Object> tabuSequenceDeque;
+    private Map<@Nullable Object, Integer> tabuToStepIndexMap = Collections.emptyMap(); // Avoid @Nullable.
 
-    protected int workingTabuSize = -1;
-    protected int workingFadingTabuSize = -1;
+    private int workingTabuSize = -1;
+    private int workingFadingTabuSize = -1;
 
-    public AbstractTabuAcceptor(String logIndentation) {
+    protected AbstractTabuAcceptor(String logIndentation) {
         this.logIndentation = logIndentation;
     }
 
@@ -67,15 +71,13 @@ public abstract class AbstractTabuAcceptor<Solution_> extends AbstractAcceptor<S
         workingFadingTabuSize = fadingTabuSizeStrategy == null ? 0
                 : fadingTabuSizeStrategy.determineTabuSize(lastCompletedStepScope);
         var totalTabuListSize = workingTabuSize + workingFadingTabuSize; // is at least 1
-        tabuToStepIndexMap = new HashMap<>(totalTabuListSize);
-        tabuSequenceDeque = new ArrayDeque<>();
+        tabuToStepIndexMap = CollectionUtils.newLinkedHashMap(totalTabuListSize);
     }
 
     @Override
     public void phaseEnded(LocalSearchPhaseScope<Solution_> phaseScope) {
         super.phaseEnded(phaseScope);
-        tabuToStepIndexMap = null;
-        tabuSequenceDeque = null;
+        tabuToStepIndexMap = Collections.emptyMap();
         workingTabuSize = -1;
         workingFadingTabuSize = -1;
     }
@@ -91,32 +93,33 @@ public abstract class AbstractTabuAcceptor<Solution_> extends AbstractAcceptor<S
 
     protected void adjustTabuList(int tabuStepIndex, Collection<? extends Object> tabus) {
         var totalTabuListSize = workingTabuSize + workingFadingTabuSize; // is at least 1
-        // Remove the oldest tabu(s)
-        for (var it = tabuSequenceDeque.iterator(); it.hasNext();) {
+        // Remove the oldest tabu(s).
+        var it = tabuToStepIndexMap.keySet().iterator();
+        while (it.hasNext()) {
             var oldTabu = it.next();
             var oldTabuStepIndexInteger = tabuToStepIndexMap.get(oldTabu);
             if (oldTabuStepIndexInteger == null) {
-                throw new IllegalStateException("HashCode stability violation: the hashCode() of tabu ("
-                        + oldTabu + ") of class (" + oldTabu.getClass()
-                        + ") changed during planning, since it was inserted in the tabu Map or Set.");
+                // oldTabu not null here, as null is a valid key and therefore has a valid corresponding value.
+                throw createHashcodeStabilityViolationException(oldTabu);
             }
             var oldTabuStepCount = tabuStepIndex - oldTabuStepIndexInteger; // at least 1
             if (oldTabuStepCount < totalTabuListSize) {
                 break;
             }
             it.remove();
-            tabuToStepIndexMap.remove(oldTabu);
         }
         // Add the new tabu(s)
         for (var tabu : tabus) {
-            // Push tabu to the end of the line
-            if (tabuToStepIndexMap.containsKey(tabu)) {
-                tabuToStepIndexMap.remove(tabu);
-                tabuSequenceDeque.remove(tabu);
-            }
+            // Push tabu to the end of the line; remove+put has that effect in LinkedHashMap.
+            tabuToStepIndexMap.remove(tabu);
             tabuToStepIndexMap.put(tabu, tabuStepIndex);
-            tabuSequenceDeque.add(tabu);
         }
+    }
+
+    private static IllegalStateException createHashcodeStabilityViolationException(Object tabu) {
+        return new IllegalStateException(
+                "HashCode stability violation: the hashCode() of tabu (%s) of class (%s) changed during planning, since it was inserted in the tabu Map."
+                        .formatted(tabu, tabu.getClass()));
     }
 
     @Override
@@ -162,19 +165,16 @@ public abstract class AbstractTabuAcceptor<Solution_> extends AbstractAcceptor<S
                 maximumTabuStepIndex = Math.max(tabuStepIndexInteger, maximumTabuStepIndex);
             }
             if (assertTabuHashCodeCorrectness) {
-                for (var tabu : tabuSequenceDeque) {
+                for (var tabu : tabuToStepIndexMap.keySet()) {
                     // tabu and checkingTabu can be null with a planning variable which allows unassigned values
                     if (tabu != null && tabu.equals(checkingTabu)) {
                         if (tabu.hashCode() != checkingTabu.hashCode()) {
-                            throw new IllegalStateException("HashCode/equals contract violation: tabu (" + tabu
-                                    + ") of class (" + tabu.getClass()
-                                    + ") and checkingTabu (" + checkingTabu
-                                    + ") are equals() but have a different hashCode().");
+                            throw new IllegalStateException(
+                                    "HashCode/equals contract violation: tabu (%s) of class (%s) and checkingTabu (%s) are equals() but have a different hashCode()."
+                                            .formatted(tabu, tabu.getClass(), checkingTabu));
                         }
                         if (tabuStepIndexInteger == null) {
-                            throw new IllegalStateException("HashCode stability violation: the hashCode() of tabu ("
-                                    + tabu + ") of class (" + tabu.getClass()
-                                    + ") changed during planning, since it was inserted in the tabu Map or Set.");
+                            throw createHashcodeStabilityViolationException(tabu);
                         }
                     }
                 }
@@ -193,8 +193,16 @@ public abstract class AbstractTabuAcceptor<Solution_> extends AbstractAcceptor<S
         return (workingFadingTabuSize - fadingTabuStepCount) / ((double) (workingFadingTabuSize + 1));
     }
 
+    /**
+     * @param moveScope
+     * @return some tabu lists allow null, some don't; children will override
+     */
     protected abstract Collection<? extends Object> findTabu(LocalSearchMoveScope<Solution_> moveScope);
 
+    /**
+     * @param stepScope
+     * @return some tabu lists allow null, some don't; children will override
+     */
     protected abstract Collection<? extends Object> findNewTabu(LocalSearchStepScope<Solution_> stepScope);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptor.java
@@ -5,7 +5,10 @@ import java.util.Collection;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 
-public class EntityTabuAcceptor<Solution_> extends AbstractTabuAcceptor<Solution_> {
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class EntityTabuAcceptor<Solution_> extends AbstractTabuAcceptor<Solution_> {
 
     public EntityTabuAcceptor(String logIndentation) {
         super(logIndentation);

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/MoveTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/MoveTabuAcceptor.java
@@ -6,7 +6,10 @@ import java.util.Collections;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 
-public class MoveTabuAcceptor<Solution_> extends AbstractTabuAcceptor<Solution_> {
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class MoveTabuAcceptor<Solution_> extends AbstractTabuAcceptor<Solution_> {
 
     public MoveTabuAcceptor(String logIndentation) {
         super(logIndentation);
@@ -17,12 +20,12 @@ public class MoveTabuAcceptor<Solution_> extends AbstractTabuAcceptor<Solution_>
     // ************************************************************************
 
     @Override
-    protected Collection<Object> findTabu(LocalSearchMoveScope<Solution_> moveScope) {
+    protected Collection<? extends Object> findTabu(LocalSearchMoveScope<Solution_> moveScope) {
         return Collections.singletonList(moveScope.getMove());
     }
 
     @Override
-    protected Collection<Object> findNewTabu(LocalSearchStepScope<Solution_> stepScope) {
+    protected Collection<? extends Object> findNewTabu(LocalSearchStepScope<Solution_> stepScope) {
         return Collections.singletonList(stepScope.getStep());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptor.java
@@ -5,7 +5,10 @@ import java.util.Collection;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 
-public class ValueTabuAcceptor<Solution_> extends AbstractTabuAcceptor<Solution_> {
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class ValueTabuAcceptor<Solution_> extends AbstractTabuAcceptor<Solution_> {
 
     public ValueTabuAcceptor(String logIndentation) {
         super(logIndentation);

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
@@ -251,4 +251,56 @@ class ValueTabuAcceptorTest {
         return moveScope;
     }
 
+    @Test
+    void unassignedPlanningValue() {
+        var acceptor = new ValueTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
+        acceptor.setAspirationEnabled(true);
+
+        var v0 = new TestdataValue("v0");
+        var v1 = new TestdataValue("v1");
+
+        var solverScope = new SolverScope<>();
+        solverScope.setInitializedBestScore(SimpleScore.ZERO);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        acceptor.phaseStarted(phaseScope);
+
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+
+        // Build a move scope with a null planning value
+        var moveScopeWithNull = buildMoveScope(stepScope0, 0, v0, null, v1);
+
+        // Should accept the move (no tabu yet)
+        assertThat(acceptor.isAccepted(moveScopeWithNull)).isTrue();
+
+        // stepEnded() calls adjustTabuList() which fills the tabu list
+        stepScope0.setStep(moveScopeWithNull.getMove());
+        acceptor.stepEnded(stepScope0);
+        phaseScope.setLastCompletedStepScope(stepScope0);
+
+        // Null value should not be accepted (they are still tracked as tabu)
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, 0, v0))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, 0, v1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, 0, new TestdataValue[] { null }))).isFalse();
+
+        // push the null out of the tabu list
+        stepScope1.setStep(buildMoveScope(stepScope1, v0).getMove());
+        acceptor.stepEnded(stepScope1);
+        phaseScope.setLastCompletedStepScope(stepScope1);
+
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        stepScope2.setStep(buildMoveScope(stepScope2, v1).getMove());
+        acceptor.stepEnded(stepScope2);
+        phaseScope.setLastCompletedStepScope(stepScope2);
+
+        // Null value should be accepted, as the moves pushed it out of the tabu list.
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, 0, v0))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, 0, v1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, 0, new TestdataValue[] { null }))).isTrue();
+
+        acceptor.phaseEnded(phaseScope);
+    }
+
 }


### PR DESCRIPTION
Unassigned planning values would cause an NPE. We avoid the NPE while still making unassigned values work as tabu.