### PR TITLE
feat: improve unassign move generation

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
@@ -22,6 +22,7 @@ public abstract class UpcomingSelectionIterator<S> extends SelectionIterator<S> 
 
     protected boolean upcomingCreated = false;
     protected boolean hasUpcomingSelection = true;
+    private boolean recheckUpcomingSelection = false;
     protected S upcomingSelection;
 
     @Override
@@ -29,6 +30,11 @@ public abstract class UpcomingSelectionIterator<S> extends SelectionIterator<S> 
         if (!upcomingCreated) {
             upcomingSelection = createUpcomingSelection();
             upcomingCreated = true;
+            if (recheckUpcomingSelection) {
+                // We ensure that the variable remains consistent if "discardUpcomingSelection" was called previously.
+                hasUpcomingSelection = upcomingSelection != null;
+                recheckUpcomingSelection = false;
+            }
         }
         return hasUpcomingSelection;
     }
@@ -54,8 +60,7 @@ public abstract class UpcomingSelectionIterator<S> extends SelectionIterator<S> 
 
     public void discardUpcomingSelection() {
         upcomingCreated = false;
-        upcomingSelection = null;
-        hasUpcomingSelection = true;
+        recheckUpcomingSelection = true;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
@@ -54,6 +54,8 @@ public abstract class UpcomingSelectionIterator<S> extends SelectionIterator<S> 
 
     public void discardUpcomingSelection() {
         upcomingCreated = false;
+        upcomingSelection = null;
+        hasUpcomingSelection = true;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
@@ -41,6 +41,12 @@ public abstract class UpcomingSelectionIterator<S> extends SelectionIterator<S> 
 
     @Override
     public S next() {
+        if (recheckUpcomingSelection) {
+            upcomingSelection = createUpcomingSelection();
+            // We ensure that the variable remains consistent if "discardUpcomingSelection" was called previously.
+            hasUpcomingSelection = upcomingSelection != null;
+            recheckUpcomingSelection = false;
+        }
         if (!hasUpcomingSelection) {
             throw new NoSuchElementException();
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
@@ -25,8 +25,7 @@ public abstract class UpcomingSelectionIterator<S> extends SelectionIterator<S> 
     private boolean recheckUpcomingSelection = false;
     protected S upcomingSelection;
 
-    @Override
-    public boolean hasNext() {
+    private void readAndRecheckUpcomingValue() {
         if (!upcomingCreated) {
             upcomingSelection = createUpcomingSelection();
             upcomingCreated = true;
@@ -36,14 +35,20 @@ public abstract class UpcomingSelectionIterator<S> extends SelectionIterator<S> 
                 recheckUpcomingSelection = false;
             }
         }
+    }
+
+    @Override
+    public boolean hasNext() {
+        readAndRecheckUpcomingValue();
         return hasUpcomingSelection;
     }
 
     @Override
     public S next() {
-        if (!hasNext()) {
+        if (!hasUpcomingSelection) {
             throw new NoSuchElementException();
         }
+        readAndRecheckUpcomingValue();
         upcomingCreated = false;
         return upcomingSelection;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java
@@ -41,17 +41,8 @@ public abstract class UpcomingSelectionIterator<S> extends SelectionIterator<S> 
 
     @Override
     public S next() {
-        if (recheckUpcomingSelection) {
-            upcomingSelection = createUpcomingSelection();
-            // We ensure that the variable remains consistent if "discardUpcomingSelection" was called previously.
-            hasUpcomingSelection = upcomingSelection != null;
-            recheckUpcomingSelection = false;
-        }
-        if (!hasUpcomingSelection) {
+        if (!hasNext()) {
             throw new NoSuchElementException();
-        }
-        if (!upcomingCreated) {
-            upcomingSelection = createUpcomingSelection();
         }
         upcomingCreated = false;
         return upcomingSelection;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelector.java
@@ -127,7 +127,7 @@ public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solu
                     - (allowsUnassignedValues ? listVariableStateSupply.getUnassignedCount() : 0);
             var totalSize = Math.addExact(entitySelector.getSize(), totalValueSize);
             var maybeAssignedMovableValues =
-                    allowsUnassignedValues && (totalValueSize - listVariableStateSupply.getUnassignedCount()) > 0;
+                    allowsUnassignedValues && totalValueSize > 0;
             return new ElementPositionRandomIterator<>(listVariableStateSupply, entitySelector,
                     replayingValueSelector != null ? replayingValueSelector.iterator() : null, valueSelector, workingRandom,
                     totalSize, allowsUnassignedValues, maybeAssignedMovableValues);

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelector.java
@@ -126,11 +126,9 @@ public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solu
             var totalValueSize = valueSelector.getSize()
                     - (allowsUnassignedValues ? listVariableStateSupply.getUnassignedCount() : 0);
             var totalSize = Math.addExact(entitySelector.getSize(), totalValueSize);
-            var maybeMovableValues =
-                    allowsUnassignedValues && totalValueSize > 0;
             return new ElementPositionRandomIterator<>(listVariableStateSupply, entitySelector,
                     replayingValueSelector != null ? replayingValueSelector.iterator() : null, valueSelector, workingRandom,
-                    totalSize, allowsUnassignedValues, maybeMovableValues);
+                    totalSize, allowsUnassignedValues, allowsUnassignedValues && totalValueSize > 0);
         } else {
             if (entitySelector.getSize() == 0) {
                 return Collections.emptyIterator();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelector.java
@@ -126,9 +126,11 @@ public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solu
             var totalValueSize = valueSelector.getSize()
                     - (allowsUnassignedValues ? listVariableStateSupply.getUnassignedCount() : 0);
             var totalSize = Math.addExact(entitySelector.getSize(), totalValueSize);
+            var maybeAssignedMovableValues =
+                    allowsUnassignedValues && (totalValueSize - listVariableStateSupply.getUnassignedCount()) > 0;
             return new ElementPositionRandomIterator<>(listVariableStateSupply, entitySelector,
                     replayingValueSelector != null ? replayingValueSelector.iterator() : null, valueSelector, workingRandom,
-                    totalSize, allowsUnassignedValues);
+                    totalSize, allowsUnassignedValues, maybeAssignedMovableValues);
         } else {
             if (entitySelector.getSize() == 0) {
                 return Collections.emptyIterator();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelector.java
@@ -126,11 +126,11 @@ public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solu
             var totalValueSize = valueSelector.getSize()
                     - (allowsUnassignedValues ? listVariableStateSupply.getUnassignedCount() : 0);
             var totalSize = Math.addExact(entitySelector.getSize(), totalValueSize);
-            var maybeAssignedMovableValues =
+            var maybeMovableValues =
                     allowsUnassignedValues && totalValueSize > 0;
             return new ElementPositionRandomIterator<>(listVariableStateSupply, entitySelector,
                     replayingValueSelector != null ? replayingValueSelector.iterator() : null, valueSelector, workingRandom,
-                    totalSize, allowsUnassignedValues, maybeAssignedMovableValues);
+                    totalSize, allowsUnassignedValues, maybeMovableValues);
         } else {
             if (entitySelector.getSize() == 0) {
                 return Collections.emptyIterator();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
@@ -32,7 +32,7 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
     public ElementPositionRandomIterator(ListVariableStateSupply<Solution_, Object, Object> listVariableStateSupply,
             EntitySelector<Solution_> entitySelector, Iterator<Object> replayingValueIterator,
             IterableValueSelector<Solution_> valueSelector, RandomGenerator workingRandom, long totalSize,
-            boolean allowsUnassignedValues) {
+            boolean allowsUnassignedValues, boolean maybeAssignedMovableValues) {
         this.listVariableStateSupply = listVariableStateSupply;
         this.listVariableDescriptor = listVariableStateSupply.getSourceVariableDescriptor();
         this.entitySelector = entitySelector;
@@ -46,8 +46,7 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
                     .formatted(totalSize));
         }
         this.allowsUnassignedValues = allowsUnassignedValues;
-        this.maybeAssignedMovableValues =
-                allowsUnassignedValues && (valueSelector.getSize() - listVariableStateSupply.getUnassignedCount()) > 0;
+        this.maybeAssignedMovableValues = maybeAssignedMovableValues;
         this.valueIterator = null;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
@@ -76,11 +76,13 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
                 tryUpdateEntityIterator();
             }
             // There will be a valid destination if the entity iterator has a next element 
-            // or if there is at least one assigned value, which would result in an unassigning move.
+            // or if there is at least one non-pinned assigned value,
+            // which would result in an unassigning move.
             return entityIterator.hasNext() || maybeAssignedMovableValues;
         }
         // There will be a valid destination if the entity iterator has a next element
-        // or if there is at least one assigned value, which would result in an unassigning move.
+        // or if there is at least one non-pinned assigned value,
+        // which would result in an unassigning move.
         return selectedValue != null
                 && (entityIterator.hasNext() || maybeAssignedMovableValues);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
@@ -23,6 +23,7 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
     private final RandomGenerator workingRandom;
     private final long totalSize;
     private final boolean allowsUnassignedValues;
+    private final boolean maybeAssignedMovableValues;
     private Iterator<Object> valueIterator;
     private Object selectedValue;
     private boolean hasNextValue = false;
@@ -44,6 +45,8 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
                     .formatted(totalSize));
         }
         this.allowsUnassignedValues = allowsUnassignedValues;
+        this.maybeAssignedMovableValues =
+                allowsUnassignedValues && (valueSelector.getSize() - listVariableStateSupply.getUnassignedCount()) > 0;
         this.valueIterator = null;
     }
 
@@ -74,14 +77,12 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
             }
             // There will be a valid destination if the entity iterator has a next element 
             // or if there is at least one assigned value, which would result in an unassigning move.
-            return entityIterator.hasNext()
-                    || (allowsUnassignedValues && (valueSelector.getSize() - listVariableStateSupply.getUnassignedCount()) > 0);
+            return entityIterator.hasNext() || maybeAssignedMovableValues;
         }
         // There will be a valid destination if the entity iterator has a next element
         // or if there is at least one assigned value, which would result in an unassigning move.
         return selectedValue != null
-                && (entityIterator.hasNext() || (allowsUnassignedValues
-                        && (valueSelector.getSize() - listVariableStateSupply.getUnassignedCount()) > 0));
+                && (entityIterator.hasNext() || maybeAssignedMovableValues);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
@@ -72,9 +72,16 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
                 // and the entity iterator must discard the previous entity
                 tryUpdateEntityIterator();
             }
-            return entityIterator.hasNext();
+            // There will be a valid destination if the entity iterator has a next element 
+            // or if there is at least one assigned value, which would result in an unassigning move.
+            return entityIterator.hasNext()
+                    || (allowsUnassignedValues && (valueSelector.getSize() - listVariableStateSupply.getUnassignedCount()) > 0);
         }
-        return selectedValue != null && entityIterator.hasNext();
+        // There will be a valid destination if the entity iterator has a next element
+        // or if there is at least one assigned value, which would result in an unassigning move.
+        return selectedValue != null
+                && (entityIterator.hasNext() || (allowsUnassignedValues
+                        && (valueSelector.getSize() - listVariableStateSupply.getUnassignedCount()) > 0));
     }
 
     @Override
@@ -96,7 +103,7 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
         // to account for the unassigned destination, which is an extra element.
         var entityBoundary = allowsUnassignedValues ? entitySize + 1 : entitySize;
         var random = RandomUtils.nextLong(workingRandom, allowsUnassignedValues ? totalSize + 1 : totalSize);
-        if (allowsUnassignedValues && random == 0) {
+        if (allowsUnassignedValues && (random == 0 || !entityIterator.hasNext())) {
             // We have already excluded all unassigned elements,
             // the only way to get an unassigned destination is to explicitly add it.
             return ElementPosition.unassigned();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
@@ -24,7 +24,7 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
     private final RandomGenerator workingRandom;
     private final long totalSize;
     private final boolean allowsUnassignedValues;
-    private final boolean maybeAssignedMovableValues;
+    private final boolean maybeMovableValues;
     private Iterator<Object> valueIterator;
     private Object selectedValue;
     private boolean hasNextValue = false;
@@ -32,7 +32,7 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
     public ElementPositionRandomIterator(ListVariableStateSupply<Solution_, Object, Object> listVariableStateSupply,
             EntitySelector<Solution_> entitySelector, Iterator<Object> replayingValueIterator,
             IterableValueSelector<Solution_> valueSelector, RandomGenerator workingRandom, long totalSize,
-            boolean allowsUnassignedValues, boolean maybeAssignedMovableValues) {
+            boolean allowsUnassignedValues, boolean maybeMovableValues) {
         this.listVariableStateSupply = listVariableStateSupply;
         this.listVariableDescriptor = listVariableStateSupply.getSourceVariableDescriptor();
         this.entitySelector = entitySelector;
@@ -46,7 +46,7 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
                     .formatted(totalSize));
         }
         this.allowsUnassignedValues = allowsUnassignedValues;
-        this.maybeAssignedMovableValues = maybeAssignedMovableValues;
+        this.maybeMovableValues = maybeMovableValues;
         this.valueIterator = null;
     }
 
@@ -78,13 +78,13 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
             // There will be a valid destination if the entity iterator has a next element 
             // or if there is at least one non-pinned assigned value,
             // which would result in an unassigning move.
-            return entityIterator.hasNext() || maybeAssignedMovableValues;
+            return entityIterator.hasNext() || maybeMovableValues;
         }
         // There will be a valid destination if the entity iterator has a next element
         // or if there is at least one non-pinned assigned value,
         // which would result in an unassigning move.
         return selectedValue != null
-                && (entityIterator.hasNext() || maybeAssignedMovableValues);
+                && (entityIterator.hasNext() || maybeMovableValues);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementPositionRandomIterator.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.list;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
@@ -96,6 +97,9 @@ final class ElementPositionRandomIterator<Solution_> implements Iterator<Element
 
     @Override
     public ElementPosition next() {
+        if (!hasNextValue) {
+            throw new NoSuchElementException();
+        }
         this.hasNextValue = false;
         // This code operates under the assumption that the entity selector already filtered out all immovable entities.
         // At this point, entities are only partially pinned, or not pinned at all.

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
@@ -519,7 +519,7 @@ class ElementDestinationSelectorTest {
 
         // First, we select v1, which is pinned, and the entity iterator does not return a feasible destination.
         // However, the value selector has another assigned value,
-        // which makes maybeAssignedNonPinnedMovableValues in ElementDestinationSelector to be set to true
+        // which makes maybeMovableValues in ElementDestinationSelector to be set to true
         // We always return 0 to meet the bailout size,
         // and then return 1 to ensure the entity is selected by destination iterator
         var random = new TestRandom(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
@@ -22,6 +22,7 @@ import static ai.timefold.solver.core.testutil.PlannerAssert.assertEmptyNeverEnd
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
 import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockScoreDirector;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Random;
 
 import ai.timefold.solver.core.api.solver.SolutionManager;
@@ -664,6 +666,7 @@ class ElementDestinationSelectorTest {
     @Test
     void discardOldValuesAndResetState() {
         var v1 = new TestdataListEntityProvidingValue("V1");
+        var v2 = new TestdataListEntityProvidingValue("V2");
         var a = new TestdataListEntityProvidingEntity("A", List.of(), List.of());
         var solution = new TestdataListEntityProvidingSolution();
         solution.setEntityList(List.of(a));
@@ -672,26 +675,28 @@ class ElementDestinationSelectorTest {
         scoreDirector.setWorkingSolution(solution);
 
         var entitySelector = mockEntitySelector(a);
-        var entityIterator = mockUpcomingSelectionIterator(a);
+        var entityIterator = mockUpcomingSelectionIterator(a, null, a);
         doReturn(entityIterator).when(entitySelector).iterator();
         var valueSelector = mockIterableValueSelector(getEntityRangeListVariableDescriptor(scoreDirector), v1);
         IterableValueSelector<TestdataListEntityProvidingSolution> replayingValueSelector =
-                mockReplayingValueSelector(getEntityRangeListVariableDescriptor(scoreDirector), v1);
+                mockReplayingValueSelector(getEntityRangeListVariableDescriptor(scoreDirector), v1, v1, v2);
 
         var selector = new ElementDestinationSelector<>(entitySelector, replayingValueSelector, valueSelector, true, false);
         // Value 0 makes the iterator to always request an entity from the related iterator
-        var random = new TestRandom(0);
+        var random = new TestRandom(0, 0);
         solvingStarted(selector, scoreDirector, random);
         var iterator = selector.iterator();
-        assertThat(entityIterator.hasNext()).isTrue();
+        // entityIterator returns a
         assertThat(iterator.hasNext()).isTrue();
-        iterator.next();
-        // No more values and the iterator is exhausted
+        assertThat(iterator.next()).isNotNull();
+        // entityIterator gets null and call noUpcomingSelection
         assertThat(iterator.hasNext()).isFalse();
-        assertThat(entityIterator.hasNext()).isFalse();
-        assertThat(entityIterator.hasUpcomingSelection()).isFalse();
-        // Reset
-        entityIterator.discardUpcomingSelection();
-        assertThat(entityIterator.hasUpcomingSelection()).isTrue();
+        assertThatCode(iterator::next).isInstanceOf(NoSuchElementException.class);
+        // replayingValueSelector returns v2, discardUpcomingSelection is called, and entityIterator returns a again
+        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator.next()).isNotNull();
+        // iterator exhausted again
+        assertThat(iterator.hasNext()).isFalse();
+        assertThatCode(iterator::next).isInstanceOf(NoSuchElementException.class);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
@@ -12,6 +12,7 @@ import static ai.timefold.solver.core.testdomain.list.TestdataListUtils.getPinne
 import static ai.timefold.solver.core.testdomain.list.TestdataListUtils.mockEntitySelector;
 import static ai.timefold.solver.core.testdomain.list.TestdataListUtils.mockIterableFromEntityPropertyValueSelector;
 import static ai.timefold.solver.core.testdomain.list.TestdataListUtils.mockIterableValueSelector;
+import static ai.timefold.solver.core.testdomain.list.TestdataListUtils.mockUpcomingSelectionIterator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfIterableSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfIterator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCodesOfNeverEndingIterableSelector;
@@ -658,5 +659,39 @@ class ElementDestinationSelectorTest {
         // Even using only the value selector,
         // the entity iterator must discard the previous entity during the hasNext() calls
         verify(entityIterator, times(1)).discardUpcomingSelection();
+    }
+
+    @Test
+    void discardOldValuesAndResetState() {
+        var v1 = new TestdataListEntityProvidingValue("V1");
+        var a = new TestdataListEntityProvidingEntity("A", List.of(), List.of());
+        var solution = new TestdataListEntityProvidingSolution();
+        solution.setEntityList(List.of(a));
+
+        var scoreDirector = mockScoreDirector(TestdataListEntityProvidingSolution.buildSolutionDescriptor());
+        scoreDirector.setWorkingSolution(solution);
+
+        var entitySelector = mockEntitySelector(a);
+        var entityIterator = mockUpcomingSelectionIterator(a);
+        doReturn(entityIterator).when(entitySelector).iterator();
+        var valueSelector = mockIterableValueSelector(getEntityRangeListVariableDescriptor(scoreDirector), v1);
+        IterableValueSelector<TestdataListEntityProvidingSolution> replayingValueSelector =
+                mockReplayingValueSelector(getEntityRangeListVariableDescriptor(scoreDirector), v1);
+
+        var selector = new ElementDestinationSelector<>(entitySelector, replayingValueSelector, valueSelector, true, false);
+        // Value 0 makes the iterator to always request an entity from the related iterator
+        var random = new TestRandom(0);
+        solvingStarted(selector, scoreDirector, random);
+        var iterator = selector.iterator();
+        assertThat(entityIterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isTrue();
+        iterator.next();
+        // No more values and the iterator is exhausted
+        assertThat(iterator.hasNext()).isFalse();
+        assertThat(entityIterator.hasNext()).isFalse();
+        assertThat(entityIterator.hasUpcomingSelection()).isFalse();
+        // Reset
+        entityIterator.discardUpcomingSelection();
+        assertThat(entityIterator.hasUpcomingSelection()).isTrue();
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
@@ -473,6 +473,51 @@ class ElementDestinationSelectorTest {
     }
 
     @Test
+    void randomAllEntitiesPinned() {
+        var v1 = new TestdataPinnedUnassignedValuesListValue("1"); // assigned to a (pinned entity)
+        var v2 = new TestdataPinnedUnassignedValuesListValue("2"); // unassigned
+        var v3 = new TestdataPinnedUnassignedValuesListValue("3"); // unassigned
+        var a = new TestdataPinnedUnassignedValuesListEntity("A", v1);
+        var b = new TestdataPinnedUnassignedValuesListEntity("B");
+        a.setPlanningPinToIndex(1);
+        b.setPlanningPinToIndex(1);
+
+        var solution = new TestdataPinnedUnassignedValuesListSolution();
+        solution.setEntityList(List.of(a, b));
+        solution.setValueList(List.of(v1, v2, v3));
+        SolutionManager.updateShadowVariables(solution);
+
+        var scoreDirector = mockScoreDirector(TestdataPinnedUnassignedValuesListSolution.buildSolutionDescriptor());
+        scoreDirector.setWorkingSolution(solution);
+
+        // No available entities because all of them are pinned
+        var entitySelector = mockEntitySelector(TestdataPinnedUnassignedValuesListEntity.buildEntityDescriptor());
+        // v2 and v3 are unassigned → unassigned destination is generated, leading to no-change move
+        // v1 is assigned to a pinned entity → unassigned destination is generated
+        var valueSelector = TestdataListUtils.mockNeverEndingIterableValueSelector(
+                TestdataPinnedUnassignedValuesListEntity.buildVariableDescriptorForValueList(), v3, v2, v1);
+        var replayingValueSelector = TestdataListUtils.mockNeverEndingIterableValueSelector(
+                TestdataPinnedUnassignedValuesListEntity.buildVariableDescriptorForValueList(), v3, v2, v1);
+
+        var selector = new ElementDestinationSelector<>(entitySelector, replayingValueSelector, valueSelector, true, false);
+
+        var solverScope = new SolverScope<TestdataPinnedUnassignedValuesListSolution>();
+        solverScope.setScoreDirector(scoreDirector);
+        solverScope.setWorkingRandom(new Random(0));
+        selector.solvingStarted(solverScope);
+        selector.phaseStarted(new LocalSearchPhaseScope<>(solverScope, 0));
+
+        // Initial state:
+        // - A [1] (fully pinned)
+        // - B []   (fully pinned)
+        assertCodesOfNeverEndingIterableSelector(selector, entitySelector.getSize(),
+                "UnassignedLocation",
+                "UnassignedLocation",
+                "UnassignedLocation",
+                "UnassignedLocation");
+    }
+
+    @Test
     void emptyIfThereAreNoEntities() {
         var v1 = new TestdataListValue("1");
         var v2 = new TestdataListValue("2");

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
@@ -35,14 +35,20 @@ import java.util.Random;
 
 import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
+import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.UpcomingSelectionIterator;
 import ai.timefold.solver.core.impl.heuristic.selector.entity.FromSolutionEntitySelector;
 import ai.timefold.solver.core.impl.heuristic.selector.entity.decorator.FilteringEntityByValueSelector;
+import ai.timefold.solver.core.impl.heuristic.selector.entity.decorator.FilteringEntitySelector;
 import ai.timefold.solver.core.impl.heuristic.selector.value.IterableValueSelector;
 import ai.timefold.solver.core.impl.heuristic.selector.value.decorator.FilteringValueRangeSelector;
+import ai.timefold.solver.core.impl.heuristic.selector.value.mimic.ManualValueMimicRecorder;
+import ai.timefold.solver.core.impl.heuristic.selector.value.mimic.MimicReplayingValueSelector;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.preview.api.domain.metamodel.ElementPosition;
+import ai.timefold.solver.core.testdomain.TestdataValue;
 import ai.timefold.solver.core.testdomain.list.TestdataListEntity;
 import ai.timefold.solver.core.testdomain.list.TestdataListSolution;
 import ai.timefold.solver.core.testdomain.list.TestdataListUtils;
@@ -59,6 +65,8 @@ import ai.timefold.solver.core.testdomain.list.unassignedvar.pinned.TestdataPinn
 import ai.timefold.solver.core.testdomain.list.valuerange.TestdataListEntityProvidingEntity;
 import ai.timefold.solver.core.testdomain.list.valuerange.TestdataListEntityProvidingSolution;
 import ai.timefold.solver.core.testdomain.list.valuerange.TestdataListEntityProvidingValue;
+import ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.pinned.TestdataListUnassignedPinnedEntityProvidingEntity;
+import ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.pinned.TestdataListUnassignedPinnedEntityProvidingSolution;
 import ai.timefold.solver.core.testutil.TestRandom;
 
 import org.junit.jupiter.api.Test;
@@ -476,48 +484,62 @@ class ElementDestinationSelectorTest {
     }
 
     @Test
-    void randomAllEntitiesPinned() {
-        var v1 = new TestdataPinnedUnassignedValuesListValue("1"); // assigned to a (pinned entity)
-        var v2 = new TestdataPinnedUnassignedValuesListValue("2"); // unassigned
-        var v3 = new TestdataPinnedUnassignedValuesListValue("3"); // unassigned
-        var a = new TestdataPinnedUnassignedValuesListEntity("A", v1);
-        var b = new TestdataPinnedUnassignedValuesListEntity("B");
-        a.setPlanningPinToIndex(1);
-        b.setPlanningPinToIndex(1);
-
-        var solution = new TestdataPinnedUnassignedValuesListSolution();
+    void refreshReachableEntities() {
+        var v1 = new TestdataValue("1");
+        var v2 = new TestdataValue("2");
+        var a = new TestdataListUnassignedPinnedEntityProvidingEntity("A", List.of(v1)); // Pinned
+        var b = new TestdataListUnassignedPinnedEntityProvidingEntity("B", List.of(v2)); // Not pinned
+        // a is pinned
+        a.setPinned(true);
+        a.setValueList(List.of(v1));
+        b.setValueList(List.of(v2));
+        var solution = new TestdataListUnassignedPinnedEntityProvidingSolution();
         solution.setEntityList(List.of(a, b));
-        solution.setValueList(List.of(v1, v2, v3));
         SolutionManager.updateShadowVariables(solution);
 
-        var scoreDirector = mockScoreDirector(TestdataPinnedUnassignedValuesListSolution.buildSolutionDescriptor());
+        var scoreDirector = mockScoreDirector(TestdataListUnassignedPinnedEntityProvidingSolution.buildSolutionDescriptor());
         scoreDirector.setWorkingSolution(solution);
 
-        // No available entities because all of them are pinned
-        var entitySelector = mockEntitySelector(TestdataPinnedUnassignedValuesListEntity.buildEntityDescriptor());
-        // v2 and v3 are unassigned → unassigned destination is generated, leading to no-change move
-        // v1 is assigned to a pinned entity → unassigned destination is generated
-        var valueSelector = TestdataListUtils.mockNeverEndingIterableValueSelector(
-                TestdataPinnedUnassignedValuesListEntity.buildVariableDescriptorForValueList(), v3, v2, v1);
-        var replayingValueSelector = TestdataListUtils.mockNeverEndingIterableValueSelector(
-                TestdataPinnedUnassignedValuesListEntity.buildVariableDescriptorForValueList(), v3, v2, v1);
+        // Value selector
+        var listVariableDescriptor = TestdataListUnassignedPinnedEntityProvidingEntity.buildVariableDescriptorForValueList();
+        var iterableValueSelector = mockIterableValueSelector(listVariableDescriptor, v1, v2);
+        var mimicRecorder = new ManualValueMimicRecorder<>(iterableValueSelector);
+        var replayingValueSelector = new MimicReplayingValueSelector<>(mimicRecorder);
+        // Entity selector with non-pinned entity filtered by value
+        var entityDescriptor = TestdataListUnassignedPinnedEntityProvidingEntity.buildEntityDescriptor();
+        var entitySelector = new FromSolutionEntitySelector<>(entityDescriptor, SelectionCacheType.PHASE, true);
+        var filteringEntity = new FilteringEntityByValueSelector<>(entitySelector, replayingValueSelector, true, false);
+        var pinningFilterFunction = entityDescriptor.getEffectiveMovableEntityFilter();
+        var nonPinnedEntitySelector = FilteringEntitySelector.of(filteringEntity, SelectionFilter
+                .compose((director, selection) -> pinningFilterFunction.test(director.getWorkingSolution(), selection)));
+        // Destination selector with non-pinned entity selector filtered by value
+        var selector =
+                new ElementDestinationSelector<>(nonPinnedEntitySelector, replayingValueSelector, iterableValueSelector, true,
+                        false);
 
-        var selector = new ElementDestinationSelector<>(entitySelector, replayingValueSelector, valueSelector, true, false);
-
-        var solverScope = new SolverScope<TestdataPinnedUnassignedValuesListSolution>();
-        solverScope.setScoreDirector(scoreDirector);
-        solverScope.setWorkingRandom(new Random(0));
-        selector.solvingStarted(solverScope);
-        selector.phaseStarted(new LocalSearchPhaseScope<>(solverScope, 0));
-
-        // Initial state:
-        // - A [1] (fully pinned)
-        // - B []   (fully pinned)
-        assertCodesOfNeverEndingIterableSelector(selector, entitySelector.getSize(),
-                "UnassignedLocation",
-                "UnassignedLocation",
-                "UnassignedLocation",
-                "UnassignedLocation");
+        // First, we select v1, which is pinned, and the entity iterator does not return a feasible destination.
+        // However, the value selector has another assigned value,
+        // which makes maybeAssignedNonPinnedMovableValues in ElementDestinationSelector to be set to true
+        // We always return 0 to meet the bailout size,
+        // and then return 1 to ensure the entity is selected by destination iterator
+        var random = new TestRandom(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+        var solverScope = solvingStarted(selector, scoreDirector, random);
+        phaseStarted(selector, solverScope);
+        var iterator = selector.iterator();
+        mimicRecorder.setRecordedValue(v1);
+        assertThat(iterator.hasNext()).isTrue();
+        // The expected position is unassigned as v1 has no feasible destination
+        assertThat(iterator.next()).isSameAs(ElementPosition.unassigned());
+        // Next, we select v2, which is not pinned, and the entity iterator returns a feasible destination.
+        // This will cause the iterator to call tryUpdateEntityIterator, and reload the entity list
+        // b is the only reachable non-pinned entity for v2
+        mimicRecorder.setRecordedValue(v2);
+        assertThat(iterator.hasNext()).isTrue();
+        var position = iterator.next().ensureAssigned();
+        var entity = position.entity();
+        var index = position.index();
+        assertThat(entity).isSameAs(b);
+        assertThat(index).isSameAs(0);
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListUtils.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListUtils.java
@@ -387,13 +387,10 @@ public final class TestdataListUtils {
             this.values = Objects.requireNonNull(values);
         }
 
-        public boolean hasUpcomingSelection() {
-            return hasUpcomingSelection;
-        }
-
         @Override
         protected Selection_ createUpcomingSelection() {
-            if (index >= values.length) {
+            if (index >= values.length || values[index] == null) {
+                index++;
                 return noUpcomingSelection();
             }
             return values[index++];

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListUtils.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/TestdataListUtils.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySelectorConfig;
@@ -21,6 +22,7 @@ import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescr
 import ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicy;
 import ai.timefold.solver.core.impl.heuristic.selector.SelectorTestUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter;
+import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.UpcomingSelectionIterator;
 import ai.timefold.solver.core.impl.heuristic.selector.entity.EntitySelector;
 import ai.timefold.solver.core.impl.heuristic.selector.list.DestinationSelector;
 import ai.timefold.solver.core.impl.heuristic.selector.list.DestinationSelectorFactory;
@@ -215,6 +217,10 @@ public final class TestdataListUtils {
         return mockNeverEndingDestinationSelector(locationsInList.length, locationsInList);
     }
 
+    public static <Selection_> MockedUpcomingSelectionIterator<Selection_> mockUpcomingSelectionIterator(Selection_... values) {
+        return new MockedUpcomingSelectionIterator<>(values);
+    }
+
     public static <Solution_> DestinationSelector<Solution_> mockNeverEndingDestinationSelector(long size,
             ElementPosition... locationsInList) {
         var destinationSelector = mock(DestinationSelector.class);
@@ -370,6 +376,28 @@ public final class TestdataListUtils {
         doReturn(ClassInstanceCache.create()).when(configPolicy).getClassInstanceCache();
         return DestinationSelectorFactory.<S> create(destinationSelectorConfig)
                 .buildDestinationSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, randomSelection, "any", false);
+    }
+
+    public static class MockedUpcomingSelectionIterator<Selection_> extends UpcomingSelectionIterator<Selection_> {
+
+        private final Selection_[] values;
+        private int index = 0;
+
+        public MockedUpcomingSelectionIterator(Selection_[] values) {
+            this.values = Objects.requireNonNull(values);
+        }
+
+        public boolean hasUpcomingSelection() {
+            return hasUpcomingSelection;
+        }
+
+        @Override
+        protected Selection_ createUpcomingSelection() {
+            if (index >= values.length) {
+                return noUpcomingSelection();
+            }
+            return values[index++];
+        }
     }
 
     private static <T> Iterator<T> cyclicIterator(List<T> elements) {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/unassignedvar/pinned/TestdataListUnassignedPinnedEntityProvidingEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/unassignedvar/pinned/TestdataListUnassignedPinnedEntityProvidingEntity.java
@@ -1,0 +1,78 @@
+package ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.pinned;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.entity.PlanningPinToIndex;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+import ai.timefold.solver.core.testdomain.TestdataValue;
+
+@PlanningEntity
+public class TestdataListUnassignedPinnedEntityProvidingEntity extends TestdataObject {
+
+    public static EntityDescriptor<TestdataListUnassignedPinnedEntityProvidingSolution> buildEntityDescriptor() {
+        return TestdataListUnassignedPinnedEntityProvidingSolution.buildSolutionDescriptor()
+                .findEntityDescriptorOrFail(TestdataListUnassignedPinnedEntityProvidingEntity.class);
+    }
+
+    public static ListVariableDescriptor<TestdataListUnassignedPinnedEntityProvidingSolution>
+            buildVariableDescriptorForValueList() {
+        return (ListVariableDescriptor<TestdataListUnassignedPinnedEntityProvidingSolution>) buildEntityDescriptor()
+                .getGenuineVariableDescriptor("valueList");
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    private final List<TestdataValue> valueRange;
+    @PlanningListVariable(valueRangeProviderRefs = "valueRange", allowsUnassignedValues = true)
+    private List<TestdataValue> valueList;
+    @PlanningPin
+    private boolean pinned;
+    @PlanningPinToIndex
+    private int pinIndex;
+
+    public TestdataListUnassignedPinnedEntityProvidingEntity() {
+        // Required for cloning
+        valueRange = new ArrayList<>();
+        valueList = new ArrayList<>();
+    }
+
+    public TestdataListUnassignedPinnedEntityProvidingEntity(String code, List<TestdataValue> valueRange) {
+        super(code);
+        this.valueRange = valueRange;
+        valueList = new ArrayList<>();
+    }
+
+    public List<TestdataValue> getValueRange() {
+        return valueRange;
+    }
+
+    public List<TestdataValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    public boolean isPinned() {
+        return pinned;
+    }
+
+    public void setPinned(boolean pinned) {
+        this.pinned = pinned;
+    }
+
+    public int getPinIndex() {
+        return pinIndex;
+    }
+
+    public void setPinIndex(int pinIndex) {
+        this.pinIndex = pinIndex;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/unassignedvar/pinned/TestdataListUnassignedPinnedEntityProvidingSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/unassignedvar/pinned/TestdataListUnassignedPinnedEntityProvidingSolution.java
@@ -1,0 +1,41 @@
+package ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.pinned;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.score.SimpleScore;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+@PlanningSolution
+public class TestdataListUnassignedPinnedEntityProvidingSolution {
+
+    public static SolutionDescriptor<TestdataListUnassignedPinnedEntityProvidingSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataListUnassignedPinnedEntityProvidingSolution.class,
+                TestdataListUnassignedPinnedEntityProvidingEntity.class);
+    }
+
+    private List<TestdataListUnassignedPinnedEntityProvidingEntity> entityList;
+
+    private SimpleScore score;
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataListUnassignedPinnedEntityProvidingEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataListUnassignedPinnedEntityProvidingEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}


### PR DESCRIPTION
The list change move selector may be prematurely removed from the union move selector iterator during a given step when it picks a random value and all reachable entities from that value are pinned, leaving no valid entities available.

We are not verifying whether any values are assigned, so at least one valid destination could be generated. This PR updates the `hasNext` logic of the iterator to address that. One downside of configuring the list change selector to return true whenever there are any assigned values is that it can generate no-change moves, which waste CPU cycles. This situation can occur if the planning value is unassigned and all of its reachable entities are pinned.

Some experiments found no regressions from this change in the FSR.