### PR TITLE
feat(spring): improve type conversion in DiminishedReturnsProperty

### DIFF
--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/DiminishedReturnsProperty.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/DiminishedReturnsProperty.java
@@ -7,6 +7,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.time.Duration;
+
 
 import org.springframework.boot.convert.DurationStyle;
 
@@ -15,19 +17,19 @@ public enum DiminishedReturnsProperty {
         value -> {
             if (value instanceof Boolean b) return b;
             if (value instanceof String s) return Boolean.parseBoolean(s);
-            throw new IllegalArgumentException("Cannot convert " + value + " to Boolean");
+            throw new IllegalArgumentException("Cannot convert (%s) to Boolean".formatted(value));
         }),
     SLIDING_WINDOW_DURATION("sliding-window-duration", DiminishedReturnsProperties::setSlidingWindowDuration,
         value -> {
-            if (value instanceof java.time.Duration d) return d;
+            if (value instanceof Duration d) return d;
             if (value instanceof String s) return DurationStyle.detectAndParse(s);
-            throw new IllegalArgumentException("Cannot convert " + value + " to Duration");
+            throw new IllegalArgumentException("Cannot convert (%s) to Duration".formatted(value));
         }),
     MINIMUM_IMPROVEMENT_RATIO("minimum-improvement-ratio", DiminishedReturnsProperties::setMinimumImprovementRatio,
         value -> {
             if (value instanceof Number n) return n.doubleValue();
             if (value instanceof String s) return Double.valueOf(s);
-            throw new IllegalArgumentException("Cannot convert " + value + " to Double");
+            throw new IllegalArgumentException("Cannot convert (%s) to Double".formatted(value));
         }),;
 
     private final String propertyName;

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/DiminishedReturnsProperty.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/DiminishedReturnsProperty.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.spring.boot.autoconfigure.config;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
@@ -7,30 +8,34 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.time.Duration;
-
 
 import org.springframework.boot.convert.DurationStyle;
 
 public enum DiminishedReturnsProperty {
     ENABLED("enabled", DiminishedReturnsProperties::setEnabled,
-        value -> {
-            if (value instanceof Boolean b) return b;
-            if (value instanceof String s) return Boolean.parseBoolean(s);
-            throw new IllegalArgumentException("Cannot convert (%s) to Boolean".formatted(value));
-        }),
+            value -> {
+                if (value instanceof Boolean b)
+                    return b;
+                if (value instanceof String s)
+                    return Boolean.parseBoolean(s);
+                throw new IllegalArgumentException("Cannot convert (%s) to Boolean".formatted(value));
+            }),
     SLIDING_WINDOW_DURATION("sliding-window-duration", DiminishedReturnsProperties::setSlidingWindowDuration,
-        value -> {
-            if (value instanceof Duration d) return d;
-            if (value instanceof String s) return DurationStyle.detectAndParse(s);
-            throw new IllegalArgumentException("Cannot convert (%s) to Duration".formatted(value));
-        }),
+            value -> {
+                if (value instanceof Duration d)
+                    return d;
+                if (value instanceof String s)
+                    return DurationStyle.detectAndParse(s);
+                throw new IllegalArgumentException("Cannot convert (%s) to Duration".formatted(value));
+            }),
     MINIMUM_IMPROVEMENT_RATIO("minimum-improvement-ratio", DiminishedReturnsProperties::setMinimumImprovementRatio,
-        value -> {
-            if (value instanceof Number n) return n.doubleValue();
-            if (value instanceof String s) return Double.valueOf(s);
-            throw new IllegalArgumentException("Cannot convert (%s) to Double".formatted(value));
-        }),;
+            value -> {
+                if (value instanceof Number n)
+                    return n.doubleValue();
+                if (value instanceof String s)
+                    return Double.valueOf(s);
+                throw new IllegalArgumentException("Cannot convert (%s) to Double".formatted(value));
+            }),;
 
     private final String propertyName;
     private final BiConsumer<DiminishedReturnsProperties, Object> propertyUpdater;

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/DiminishedReturnsProperty.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/DiminishedReturnsProperty.java
@@ -12,11 +12,23 @@ import org.springframework.boot.convert.DurationStyle;
 
 public enum DiminishedReturnsProperty {
     ENABLED("enabled", DiminishedReturnsProperties::setEnabled,
-            value -> Boolean.parseBoolean((String) value)),
+        value -> {
+            if (value instanceof Boolean b) return b;
+            if (value instanceof String s) return Boolean.parseBoolean(s);
+            throw new IllegalArgumentException("Cannot convert " + value + " to Boolean");
+        }),
     SLIDING_WINDOW_DURATION("sliding-window-duration", DiminishedReturnsProperties::setSlidingWindowDuration,
-            value -> DurationStyle.detectAndParse((String) value)),
+        value -> {
+            if (value instanceof java.time.Duration d) return d;
+            if (value instanceof String s) return DurationStyle.detectAndParse(s);
+            throw new IllegalArgumentException("Cannot convert " + value + " to Duration");
+        }),
     MINIMUM_IMPROVEMENT_RATIO("minimum-improvement-ratio", DiminishedReturnsProperties::setMinimumImprovementRatio,
-            value -> Double.valueOf((String) value)),;
+        value -> {
+            if (value instanceof Number n) return n.doubleValue();
+            if (value instanceof String s) return Double.valueOf(s);
+            throw new IllegalArgumentException("Cannot convert " + value + " to Double");
+        }),;
 
     private final String propertyName;
     private final BiConsumer<DiminishedReturnsProperties, Object> propertyUpdater;


### PR DESCRIPTION
Previously, DiminishedReturnsProperty only supported String inputs for Boolean, Double, and Duration properties. Passing Boolean, Number, or Duration objects directly would cause a ClassCastException.

This commit updates the property converters to handle:
- Boolean: accepts Boolean or String
- Double: accepts Number or String
- Duration: accepts Duration or String

This ensures compatibility when Spring Boot binds YAML or Properties directly to DiminishedReturnsProperties, improving type safety and preventing runtime errors.