### PR TITLE
docs: link to plus enterprise pages

### DIFF
--- a/docs/src/modules/ROOT/pages/commercial-editions/_only-enterprise.adoc
+++ b/docs/src/modules/ROOT/pages/commercial-editions/_only-enterprise.adoc
@@ -1,1 +1,1 @@
-NOTE: This feature is exclusive to Timefold Solver Enterprise Edition.
+NOTE: This feature is exclusive to xref:commercial-editions/commercial-editions.adoc[Timefold Solver Enterprise Edition].

--- a/docs/src/modules/ROOT/pages/commercial-editions/_only-plus-and-enterprise.adoc
+++ b/docs/src/modules/ROOT/pages/commercial-editions/_only-plus-and-enterprise.adoc
@@ -1,1 +1,1 @@
-NOTE: This feature is exclusive to Timefold Solver Plus and Enterprise Editions.
+NOTE: This feature is exclusive to xref:commercial-editions/commercial-editions.adoc[Timefold Solver Plus and Enterprise Editions.]

--- a/docs/src/modules/ROOT/pages/commercial-editions/commercial-editions.adoc
+++ b/docs/src/modules/ROOT/pages/commercial-editions/commercial-editions.adoc
@@ -14,8 +14,10 @@ TIP: Looking for quicker time-to-value?
 Timefold offers https://docs.timefold.ai/[pre-built, fully tuned optimization models], no constraint building required.
 Just plug into our API and start optimizing immediately.
 
-We offer free trials to everyone as well as free licenses to non-profit organizations, start-ups and for academic research.
-xref:commercial-editions/installation.adoc#solverObtainLicenseKey[See: How to obtain a license key?]
+== Free trials and licenses
+
+We offer free trials to everyone as well as free licenses to non-profit organizations and for academic research.
+See our https://licenses.timefold.ai/[license portal] to get your license, then follow the xref:commercial-editions/installation.adoc[installation guide] to get started.
 
 == Feature Comparison
 


### PR DESCRIPTION
The current mentions of Plus/Enterprise are text only. This changes that to also link to the correct page to get more information on those editions. Made it more explicit that you can get your license key from our license tool.