### PR TITLE
fix(migration): add missing rewrite scripts

### DIFF
--- a/tools/migration/src/main/java/ai/timefold/solver/migration/v2/GeneralMethodDeleteInvocationMigrationRecipe.java
+++ b/tools/migration/src/main/java/ai/timefold/solver/migration/v2/GeneralMethodDeleteInvocationMigrationRecipe.java
@@ -110,6 +110,11 @@ public class GeneralMethodDeleteInvocationMigrationRecipe extends AbstractRecipe
                 new RemoveMethodInvocations(
                         "ai.timefold.solver.core.api.score.stream.tri.TriConstraintBuilder indictWith(..)"),
                 new RemoveMethodInvocations(
-                        "ai.timefold.solver.core.api.score.stream.quad.QuadConstraintBuilder indictWith(..)"));
+                        "ai.timefold.solver.core.api.score.stream.quad.QuadConstraintBuilder indictWith(..)"),
+                // indictWith in tests
+                new RemoveMethodInvocations(
+                        "ai.timefold.solver.test.api.score.stream.SingleConstraintAssertion indictsWith(..)"),
+                new RemoveMethodInvocations(
+                        "ai.timefold.solver.test.api.score.stream.SingleConstraintAssertion indictsWithExactly(..)"));
     }
 }

--- a/tools/migration/src/main/java/ai/timefold/solver/migration/v2/GeneralTypeChangeMigrationRecipe.java
+++ b/tools/migration/src/main/java/ai/timefold/solver/migration/v2/GeneralTypeChangeMigrationRecipe.java
@@ -55,6 +55,9 @@ public class GeneralTypeChangeMigrationRecipe extends AbstractRecipe {
                         "ai.timefold.solver.core.api.score.BendableScore", true),
                 new ChangeType("ai.timefold.solver.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore",
                         "ai.timefold.solver.core.api.score.BendableBigDecimalScore", true),
+                // ConstraintRef
+                new ChangeType("ai.timefold.solver.core.api.score.constraint.ConstraintRef",
+                        "ai.timefold.solver.core.api.score.stream.ConstraintRef", true),
                 // Problem fact
                 new ChangeType("ai.timefold.solver.core.api.solver.ProblemFactChange",
                         "ai.timefold.solver.core.api.solver.change.ProblemChange", true),

--- a/tools/migration/src/test/java/ai/timefold/solver/migration/v2/GeneralMethodDeleteInvocationMigrationRecipeTest.java
+++ b/tools/migration/src/test/java/ai/timefold/solver/migration/v2/GeneralMethodDeleteInvocationMigrationRecipeTest.java
@@ -112,6 +112,12 @@ class GeneralMethodDeleteInvocationMigrationRecipeTest implements RewriteTest {
                                         package ai.timefold.solver.core.api.score.stream.quad;
                                         public interface QuadConstraintBuilder<A, B, C, D, Score_> {
                                             QuadConstraintBuilder<A, B, C, D, Score_> indictWith(Object indictment);
+                                        }""",
+                                """
+                                        package ai.timefold.solver.test.api.score.stream;
+                                        public interface SingleConstraintAssertion {
+                                            SingleConstraintAssertion indictsWith(Object matcher);
+                                            SingleConstraintAssertion indictsWithExactly(Object... matchers);
                                         }"""));
     }
 
@@ -304,6 +310,8 @@ class GeneralMethodDeleteInvocationMigrationRecipeTest implements RewriteTest {
                         import ai.timefold.solver.core.api.score.stream.bi.BiConstraintBuilder;
                         import ai.timefold.solver.core.api.score.stream.tri.TriConstraintBuilder;
                         import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintBuilder;
+                        import ai.timefold.solver.test.api.score.stream.SingleConstraintAssertion;
+
                         import java.util.function.Function;
 
                         public class Test {
@@ -311,11 +319,14 @@ class GeneralMethodDeleteInvocationMigrationRecipeTest implements RewriteTest {
                                 BiConstraintBuilder<Object, Object, ?> bi;
                                 TriConstraintBuilder<Object, Object, Object, ?> tri;
                                 QuadConstraintBuilder<Object, Object, Object, Object, ?> quad;
+                                SingleConstraintAssertion assertion;
                                 public void test() {
                                     uni.indictWith(Function.identity());
                                     bi.indictWith((a, b) -> a);
                                     tri.indictWith(null);
                                     quad.indictWith(null);
+                                    assertion.indictsWith(null);
+                                    assertion.indictsWithExactly(null);
                                 }
                         }""",
                 """
@@ -325,6 +336,8 @@ class GeneralMethodDeleteInvocationMigrationRecipeTest implements RewriteTest {
                         import ai.timefold.solver.core.api.score.stream.bi.BiConstraintBuilder;
                         import ai.timefold.solver.core.api.score.stream.tri.TriConstraintBuilder;
                         import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintBuilder;
+                        import ai.timefold.solver.test.api.score.stream.SingleConstraintAssertion;
+
                         import java.util.function.Function;
 
                         public class Test {
@@ -332,6 +345,7 @@ class GeneralMethodDeleteInvocationMigrationRecipeTest implements RewriteTest {
                                 BiConstraintBuilder<Object, Object, ?> bi;
                                 TriConstraintBuilder<Object, Object, Object, ?> tri;
                                 QuadConstraintBuilder<Object, Object, Object, Object, ?> quad;
+                                SingleConstraintAssertion assertion;
                                 public void test() {
                                 }
                         }"""));

--- a/tools/migration/src/test/java/ai/timefold/solver/migration/v2/GeneralTypeChangeMigrationRecipeTest.java
+++ b/tools/migration/src/test/java/ai/timefold/solver/migration/v2/GeneralTypeChangeMigrationRecipeTest.java
@@ -61,7 +61,29 @@ class GeneralTypeChangeMigrationRecipeTest implements RewriteTest {
                                 "package ai.timefold.solver.core.impl.heuristic.selector.move.generic; public interface PillarChangeMove {}",
                                 "package ai.timefold.solver.core.impl.heuristic.selector.move.generic; public interface PillarSwapMove {}",
                                 "package ai.timefold.solver.core.impl.heuristic.selector.move.generic; public interface RuinRecreateMove {}",
-                                "package ai.timefold.solver.core.impl.heuristic.selector.move.generic; public interface SwapMove {}"));
+                                "package ai.timefold.solver.core.impl.heuristic.selector.move.generic; public interface SwapMove {}",
+                                "package ai.timefold.solver.core.api.score.constraint; public class ConstraintRef {}"));
+    }
+
+    @Test
+    void migrateConstraintRef() {
+        rewriteRun(java(
+                """
+                        package timefold;
+
+                        import ai.timefold.solver.core.api.score.constraint.ConstraintRef;
+
+                        public class Test {
+                                ConstraintRef constraintRef;
+                        }""",
+                """
+                        package timefold;
+
+                        import ai.timefold.solver.core.api.score.stream.ConstraintRef;
+
+                        public class Test {
+                                ConstraintRef constraintRef;
+                        }"""));
     }
 
     @Test


### PR DESCRIPTION
Found 2 missing migrations while upgrading the quickstarts again from 1.x to 2.0

- Indictments calls on the constraintstream was removed, but if you had a test for this, the indictment calls were still there after migration. 
- ConstraintRef didn't have a package migration for some reason? 