### PR TITLE
deps: remove commons-math3 from solver-core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,6 +40,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelector.java
@@ -6,9 +6,8 @@ import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDe
 import ai.timefold.solver.core.impl.heuristic.selector.entity.EntitySelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.impl.util.MathUtils;
 import ai.timefold.solver.core.preview.api.move.Move;
-
-import org.apache.commons.math3.util.CombinatoricsUtils;
 
 final class RuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<Solution_> {
 
@@ -42,7 +41,7 @@ final class RuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<Solu
         var maximumSelectedCount = maximumSelectedCountSupplier.applyAsInt(entityCount);
         for (int selectedCount = minimumSelectedCount; selectedCount <= maximumSelectedCount; selectedCount++) {
             // Order is significant, and each entity can only be picked once
-            totalSize += CombinatoricsUtils.factorial((int) entityCount) / CombinatoricsUtils.factorial(selectedCount);
+            totalSize += MathUtils.factorial((int) entityCount) / MathUtils.factorial(selectedCount);
         }
         return totalSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveSelector.java
@@ -12,9 +12,8 @@ import ai.timefold.solver.core.impl.heuristic.selector.move.generic.GenericMoveS
 import ai.timefold.solver.core.impl.heuristic.selector.value.IterableValueSelector;
 import ai.timefold.solver.core.impl.heuristic.selector.value.decorator.FilteringValueSelector;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.impl.util.MathUtils;
 import ai.timefold.solver.core.preview.api.move.Move;
-
-import org.apache.commons.math3.util.CombinatoricsUtils;
 
 final class KOptListMoveSelector<Solution_> extends GenericMoveSelector<Solution_> {
 
@@ -81,7 +80,7 @@ final class KOptListMoveSelector<Solution_> extends GenericMoveSelector<Solution
                 // And we chose k of them to remove in a k-opt
                 final long edgeChoices;
                 if (valueSelectorSize <= Integer.MAX_VALUE) {
-                    edgeChoices = CombinatoricsUtils.binomialCoefficient((int) (valueSelectorSize - 1), i);
+                    edgeChoices = MathUtils.binomialCoefficient((int) (valueSelectorSize - 1), i);
                 } else {
                     edgeChoices = Long.MAX_VALUE;
                 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptUtils.java
@@ -10,8 +10,6 @@ import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
 import ai.timefold.solver.core.impl.util.MathUtils;
 import ai.timefold.solver.core.impl.util.Pair;
 
-import org.apache.commons.math3.util.CombinatoricsUtils;
-
 final class KOptUtils {
 
     private KOptUtils() {
@@ -188,7 +186,7 @@ final class KOptUtils {
         for (var i = 1; i < k; i++) {
             for (var j = 0; j <= i; j++) {
                 var sign = ((k + j - 1) % 2 == 0) ? 1 : -1;
-                totalTypes += sign * CombinatoricsUtils.binomialCoefficient(i, j) * MathUtils.factorial(j) * (1L << j);
+                totalTypes += sign * MathUtils.binomialCoefficient(i, j) * MathUtils.factorial(j) * (1L << j);
             }
         }
         return totalTypes;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/kopt/KOptUtils.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 
 import ai.timefold.solver.core.api.function.TriPredicate;
 import ai.timefold.solver.core.impl.domain.variable.ListVariableStateSupply;
+import ai.timefold.solver.core.impl.util.MathUtils;
 import ai.timefold.solver.core.impl.util.Pair;
 
 import org.apache.commons.math3.util.CombinatoricsUtils;
@@ -187,7 +188,7 @@ final class KOptUtils {
         for (var i = 1; i < k; i++) {
             for (var j = 0; j <= i; j++) {
                 var sign = ((k + j - 1) % 2 == 0) ? 1 : -1;
-                totalTypes += sign * CombinatoricsUtils.binomialCoefficient(i, j) * CombinatoricsUtils.factorial(j) * (1L << j);
+                totalTypes += sign * CombinatoricsUtils.binomialCoefficient(i, j) * MathUtils.factorial(j) * (1L << j);
             }
         }
         return totalTypes;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveSelector.java
@@ -12,9 +12,8 @@ import ai.timefold.solver.core.impl.heuristic.selector.value.IterableValueSelect
 import ai.timefold.solver.core.impl.heuristic.selector.value.decorator.FilteringValueSelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.impl.util.MathUtils;
 import ai.timefold.solver.core.preview.api.move.Move;
-
-import org.apache.commons.math3.util.CombinatoricsUtils;
 
 final class ListRuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<Solution_> {
 
@@ -54,7 +53,7 @@ final class ListRuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<
         var maximumSelectedCount = maximumSelectedCountSupplier.applyAsInt(valueCount);
         for (var selectedCount = minimumSelectedCount; selectedCount <= maximumSelectedCount; selectedCount++) {
             // Order is significant, and each entity can only be picked once
-            totalSize += CombinatoricsUtils.factorial((int) valueCount) / CombinatoricsUtils.factorial(selectedCount);
+            totalSize += MathUtils.factorial((int) valueCount) / MathUtils.factorial(selectedCount);
         }
         return totalSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
@@ -1,7 +1,8 @@
+/**
+ * Includes code takes from Apache's commons-math library, v3.6.1 (Apache 2.0-licensed)
+ * These methods are clearly marked in comments, their modifications listed.
+ */
 package ai.timefold.solver.core.impl.util;
-
-import org.apache.commons.math3.util.CombinatoricsUtils;
-import org.apache.commons.math3.util.FastMath;
 
 public class MathUtils {
 
@@ -96,6 +97,255 @@ public class MathUtils {
             logSum += Math.log(i);
         }
         return logSum;
+    }
+
+    /**
+     * Returns an exact representation of the <a
+     * href="http://mathworld.wolfram.com/BinomialCoefficient.html"> Binomial
+     * Coefficient</a>, "{@code n choose k}", the number of
+     * {@code k}-element subsets that can be selected from an
+     * {@code n}-element set.
+     * <p>
+     * <Strong>Preconditions</strong>:
+     * <ul>
+     * <li>{@code 0 <= k <= n } (otherwise
+     * {@code MathIllegalArgumentException} is thrown)</li>
+     * <li>The result is small enough to fit into a {@code long}. The
+     * largest value of {@code n} for which all coefficients are
+     * {@code  < Long.MAX_VALUE} is 66. If the computed value exceeds
+     * {@code Long.MAX_VALUE} a {@code MathArithMeticException} is
+     * thrown.</li>
+     * </ul>
+     * </p>
+     * Taken from `commons-math` 3.6.1 (Apache 2.0 licensed.)
+     * Refactored to not depend on any other `commons-math` methods or types.
+     *
+     * @param n the size of the set
+     * @param k the size of the subsets to be counted
+     * @return {@code n choose k} represented by a long integer.
+     */
+    public static long binomialCoefficient(final int n, final int k) {
+        if (n < k) {
+            throw new IllegalArgumentException("must have n >= k for binomial coefficient (n, k), got k = %d, n = %d"
+                    .formatted(k, n));
+        }
+        if (n < 0) {
+            throw new IllegalArgumentException("must have n >= 0 for binomial coefficient (n, k), got n = %d".formatted(n));
+        }
+        if ((n == k) || (k == 0)) {
+            return 1;
+        }
+        if ((k == 1) || (k == n - 1)) {
+            return n;
+        }
+        // Use symmetry for large k
+        if (k > n / 2) {
+            return binomialCoefficient(n, n - k);
+        }
+
+        // We use the formula
+        // (n choose k) = n! / (n-k)! / k!
+        // (n choose k) == ((n-k+1)*...*n) / (1*...*k)
+        // which could be written
+        // (n choose k) == (n-1 choose k-1) * n / k
+        long result = 1;
+        if (n <= 61) {
+            // For n <= 61, the naive implementation cannot overflow.
+            var i = n - k + 1;
+            for (var j = 1; j <= k; j++) {
+                result = result * i / j;
+                i++;
+            }
+        } else if (n <= 66) {
+            // For n > 61 but n <= 66, the result cannot overflow,
+            // but we must take care not to overflow intermediate values.
+            var i = n - k + 1;
+            for (var j = 1; j <= k; j++) {
+                // We know that (result * i) is divisible by j,
+                // but (result * i) may overflow, so we split j:
+                // Filter out the gcd, d, so j/d and i/d are integer.
+                // result is divisible by (j/d) because (j/d)
+                // is relative prime to (i/d) and is a divisor of
+                // result * (i/d).
+                final long d = gcd(i, j);
+                result = (result / (j / d)) * (i / d);
+                i++;
+            }
+        } else {
+            // For n > 66, a result overflow might occur, so we check
+            // the multiplication, taking care to not overflow
+            // unnecessary.
+            var i = n - k + 1;
+            for (var j = 1; j <= k; j++) {
+                final long d = gcd(i, j);
+                result = mulAndCheck(result / (j / d), i / d);
+                i++;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Taken from `commons-math` 3.6.1 (Apache 2.0 licensed.)
+     * Refactored to not depend on any other `commons-math` methods or types,
+     * replaced local variable types with inference.
+     */
+    private static int gcd(int p, int q) {
+        var a = p;
+        var b = q;
+        if (a == 0 || b == 0) {
+            if (a == Integer.MIN_VALUE || b == Integer.MIN_VALUE) {
+                throw new ArithmeticException("overflow: gcd(%d, %d) is 2^31"
+                        .formatted(p, q));
+            }
+            return Math.abs(a + b);
+        }
+
+        long al = a;
+        long bl = b;
+        var useLong = false;
+        if (a < 0) {
+            if (Integer.MIN_VALUE == a) {
+                useLong = true;
+            } else {
+                a = -a;
+            }
+            al = -al;
+        }
+        if (b < 0) {
+            if (Integer.MIN_VALUE == b) {
+                useLong = true;
+            } else {
+                b = -b;
+            }
+            bl = -bl;
+        }
+        if (useLong) {
+            if (al == bl) {
+                throw new ArithmeticException("overflow: gcd(%d, %d) is 2^31"
+                        .formatted(p, q));
+            }
+            var blbu = bl;
+            bl = al;
+            al = blbu % al;
+            if (al == 0) {
+                if (bl > Integer.MAX_VALUE) {
+                    throw new ArithmeticException("overflow: gcd(%d, %d) is 2^31"
+                            .formatted(p, q));
+                }
+                return (int) bl;
+            }
+            blbu = bl;
+
+            // Now "al" and "bl" fit in an "int".
+            b = (int) al;
+            a = (int) (blbu % al);
+        }
+
+        return gcdPositive(a, b);
+    }
+
+    /**
+     * Computes the greatest common divisor of two <em>positive</em> numbers
+     * (this precondition is <em>not</em> checked and the result is undefined
+     * if not fulfilled) using the "binary gcd" method which avoids division
+     * and modulo operations.
+     * See Knuth 4.5.2 algorithm B.
+     * The algorithm is due to Josef Stein (1961).
+     * <br/>
+     * Special cases:
+     * <ul>
+     * <li>The result of {@code gcd(x, x)}, {@code gcd(0, x)} and
+     * {@code gcd(x, 0)} is the value of {@code x}.</li>
+     * <li>The invocation {@code gcd(0, 0)} is the only one which returns
+     * {@code 0}.</li>
+     * </ul>
+     * <p>
+     * Taken from `commons-math` 3.6.1 (Apache 2.0 licensed.)
+     * Refactored to not depend on any other `commons-math` methods or types,
+     * replaced local variable types with inference.
+     *
+     * @param a Positive number.
+     * @param b Positive number.
+     * @return the greatest common divisor.
+     */
+    private static int gcdPositive(int a, int b) {
+        if (a == 0) {
+            return b;
+        } else if (b == 0) {
+            return a;
+        }
+
+        // Make "a" and "b" odd, keeping track of common power of 2.
+        var aTwos = Integer.numberOfTrailingZeros(a);
+        a >>= aTwos;
+        var bTwos = Integer.numberOfTrailingZeros(b);
+        b >>= bTwos;
+        var shift = Math.min(aTwos, bTwos);
+
+        // "a" and "b" are positive.
+        // If a > b then "gdc(a, b)" is equal to "gcd(a - b, b)".
+        // If a < b then "gcd(a, b)" is equal to "gcd(b - a, a)".
+        // Hence, in the successive iterations:
+        //  "a" becomes the absolute difference of the current values,
+        //  "b" becomes the minimum of the current values.
+        while (a != b) {
+            var delta = a - b;
+            b = Math.min(a, b);
+            a = Math.abs(delta);
+
+            // Remove any power of 2 in "a" ("b" is guaranteed to be odd).
+            a >>= Integer.numberOfTrailingZeros(a);
+        }
+
+        // Recover the common power of 2.
+        return a << shift;
+    }
+
+    /**
+     * Taken from `commons-math` 3.6.1 (Apache 2.0 licensed.)
+     * Refactored to not depend on any other `commons-math` methods or types,
+     * replaced local variable types with inference and introduced multiple return.
+     */
+    private static long mulAndCheck(long a, long b) {
+        if (a > b) {
+            // use symmetry to reduce boundary cases
+            return mulAndCheck(b, a);
+        } else {
+            if (a < 0) {
+                if (b < 0) {
+                    // check for positive overflow with negative a, negative b
+                    if (a >= Long.MAX_VALUE / b) {
+                        return a * b;
+                    } else {
+                        throw new ArithmeticException();
+                    }
+                } else if (b > 0) {
+                    // check for negative overflow with negative a, positive b
+                    if (Long.MIN_VALUE / b <= a) {
+                        return a * b;
+                    } else {
+                        throw new ArithmeticException();
+                    }
+                } else {
+                    // assert b == 0
+                    return 0;
+                }
+            } else if (a > 0) {
+                // assert a > 0
+                // assert b > 0
+
+                // check for positive overflow with positive a, positive b
+                if (a <= Long.MAX_VALUE / b) {
+                    return a * b;
+                } else {
+                    throw new ArithmeticException();
+                }
+            } else {
+                // assert a == 0
+                return 0;
+            }
+        }
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
@@ -80,10 +80,12 @@ public class MathUtils {
         return switch (n) {
             case 0, 1 -> 1;
             default -> {
-                if (FACTORIAL_CACHE[n - 2] == 0L) {
-                    FACTORIAL_CACHE[n - 2] = n * factorial(n - 1);
+                var factorialCacheIndex = n - 2; // n={0,1} are already handled above.
+                var factorial = FACTORIAL_CACHE[factorialCacheIndex];
+                if (factorial != 0L) {
+                    yield factorial;
                 }
-                yield FACTORIAL_CACHE[n - 2];
+                yield FACTORIAL_CACHE[factorialCacheIndex] = n * factorial(n - 1);
             }
         };
     }
@@ -106,17 +108,13 @@ public class MathUtils {
      * {@code k}-element subsets that can be selected from an
      * {@code n}-element set.
      * <p>
-     * <Strong>Preconditions</strong>:
+     * <strong>Preconditions</strong>:
      * <ul>
-     * <li>{@code 0 <= k <= n } (otherwise
-     * {@link IllegalArgumentException} is thrown)</li>
-     * <li>The result is small enough to fit into a {@code long}. The
-     * largest value of {@code n} for which all coefficients are
-     * {@code  < Long.MAX_VALUE} is 66. If the computed value exceeds
-     * {@code Long.MAX_VALUE} a {@link ArithmeticException} is
-     * thrown.</li>
+     * <li>{@code 0 <= k <= n } (otherwise {@link IllegalArgumentException} is thrown)</li>
+     * <li>The result is small enough to fit into a {@code long}.
+     * The largest value of {@code n} for which all coefficients are less than {@code Long.MAX_VALUE} is 66.
+     * If the computed value exceeds {@code Long.MAX_VALUE} a {@link ArithmeticException} is thrown.</li>
      * </ul>
-     * </p>
      * Taken from `commons-math` 3.6.1 (Apache 2.0 licensed.)
      * Refactored to not depend on any other `commons-math` methods or types.
      *

--- a/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
@@ -1,15 +1,18 @@
 package ai.timefold.solver.core.impl.util;
 
 import org.apache.commons.math3.util.CombinatoricsUtils;
+import org.apache.commons.math3.util.FastMath;
 
 public class MathUtils {
+
     public static final long LOG_PRECISION = 1_000_000L;
+    private static final int FACTORIAL_MAX_N = 20;
+    private static final long[] FACTORIAL_CACHE = new long[FACTORIAL_MAX_N - 1]; // 0 and 1 are hard-coded.
 
     private MathUtils() {
     }
 
-    public static long getPossibleArrangementsScaledApproximateLog(long scale, long base,
-            int listSize, int partitions) {
+    public static long getPossibleArrangementsScaledApproximateLog(long scale, long base, int listSize, int partitions) {
         double result;
         if (listSize == 0 || partitions == 0) {
             // Only one way to divide an empty list, and the log of 1 is 0
@@ -20,12 +23,11 @@ public class MathUtils {
             // If it a single partition, it the same as the number of permutations.
             // If it two partitions, it the same as the number of permutations of a list of size
             // n + 1 (where we add an element to seperate the two partitions)
-            result = CombinatoricsUtils.factorialLog(listSize + partitions - 1);
+            result = factorialLog(listSize + partitions - 1);
         } else {
             // If it n > 2 partitions, (listSize + partitions - 1)! will overcount by
             // a multiple of (partitions - 1)!
-            result = CombinatoricsUtils.factorialLog(listSize + partitions - 1)
-                    - CombinatoricsUtils.factorialLog(partitions - 1);
+            result = factorialLog(listSize + partitions - 1) - factorialLog(partitions - 1);
         }
 
         // Need to change base to use the given base
@@ -34,7 +36,7 @@ public class MathUtils {
 
     /**
      * Returns a scaled approximation of a log
-     * 
+     *
      * @param scale What to scale the result by. Typically, a power of 10.
      * @param base The base of the log
      * @param value The parameter to the log function
@@ -65,4 +67,35 @@ public class MathUtils {
         // Avoid divide by zero exception on a fast CPU
         return count * 1000L / (timeMillisSpent == 0L ? 1L : timeMillisSpent);
     }
+
+    public static long factorial(int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("Factorial of %d is undefined."
+                    .formatted(n));
+        } else if (n > FACTORIAL_MAX_N) {
+            throw new IllegalArgumentException("Factorial of %d is too large to fit in a long."
+                    .formatted(n));
+        }
+        return switch (n) {
+            case 0, 1 -> 1;
+            default -> {
+                if (FACTORIAL_CACHE[n - 2] == 0L) {
+                    FACTORIAL_CACHE[n - 2] = n * factorial(n - 1);
+                }
+                yield FACTORIAL_CACHE[n - 2];
+            }
+        };
+    }
+
+    private static double factorialLog(int n) {
+        if (n <= FACTORIAL_MAX_N) {
+            return Math.log(factorial(n));
+        }
+        var logSum = 0.0d;
+        for (var i = 2; i <= n; i++) {
+            logSum += Math.log(i);
+        }
+        return logSum;
+    }
+
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
@@ -1,9 +1,9 @@
-/**
- * Includes code takes from Apache's commons-math library, v3.6.1 (Apache 2.0-licensed)
- * These methods are clearly marked in comments, their modifications listed.
- */
 package ai.timefold.solver.core.impl.util;
 
+/**
+ * Includes code taken from Apache's commons-math library, v3.6.1 (Apache 2.0-licensed)
+ * These methods are clearly marked in comments, their modifications listed.
+ */
 public class MathUtils {
 
     public static final long LOG_PRECISION = 1_000_000L;

--- a/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/util/MathUtils.java
@@ -109,11 +109,11 @@ public class MathUtils {
      * <Strong>Preconditions</strong>:
      * <ul>
      * <li>{@code 0 <= k <= n } (otherwise
-     * {@code MathIllegalArgumentException} is thrown)</li>
+     * {@link IllegalArgumentException} is thrown)</li>
      * <li>The result is small enough to fit into a {@code long}. The
      * largest value of {@code n} for which all coefficients are
      * {@code  < Long.MAX_VALUE} is 66. If the computed value exceeds
-     * {@code Long.MAX_VALUE} a {@code MathArithMeticException} is
+     * {@code Long.MAX_VALUE} a {@link ArithmeticException} is
      * thrown.</li>
      * </ul>
      * </p>

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -253,6 +253,5 @@ module ai.timefold.solver.core {
     requires org.jspecify;
     requires org.slf4j;
     requires io.quarkus.gizmo2;
-    requires java.desktop;
 
 }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -254,5 +254,6 @@ module ai.timefold.solver.core {
     requires org.jspecify;
     requires org.slf4j;
     requires io.quarkus.gizmo2;
+    requires java.desktop;
 
 }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -247,7 +247,6 @@ module ai.timefold.solver.core {
     opens ai.timefold.solver.core.config.solver.termination to jakarta.xml.bind, org.glassfish.jaxb.runtime;
     opens ai.timefold.solver.core.config.util to jakarta.xml.bind, org.glassfish.jaxb.runtime;
 
-    requires commons.math3;
     requires jakarta.xml.bind;
     requires java.xml;
     requires micrometer.core;

--- a/core/src/test/java/ai/timefold/solver/core/impl/util/MathUtilsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/util/MathUtilsTest.java
@@ -212,28 +212,29 @@ class MathUtilsTest {
         assertThat(MathUtils.getLogInBase(9, 3)).isEqualTo(0.5, tolerance);
     }
 
-    @CsvSource({
-            "1, 1",
-            "2, 2",
-            "3, 6",
-            "4, 24",
-            "5, 120",
-            "6, 720",
-            "7, 5040",
-            "8, 40320",
-            "9, 362880",
-            "10, 3628800",
-            "11, 39916800",
-            "12, 479001600",
-            "13, 6227020800",
-            "14, 87178291200",
-            "15, 1307674368000",
-            "16, 20922789888000",
-            "17, 355687428096000",
-            "18, 6402373705728000",
-            "19, 121645100408832000",
-            "20, 2432902008176640000"
-    })
+    @CsvSource("""
+             0, 1
+             1, 1
+             2, 2
+             3, 6
+             4, 24
+             5, 120
+             6, 720
+             7, 5040
+             8, 40320
+             9, 362880
+            10, 3628800
+            11, 39916800
+            12, 479001600
+            13, 6227020800
+            14, 87178291200
+            15, 1307674368000
+            16, 20922789888000
+            17, 355687428096000
+            18, 6402373705728000
+            19, 121645100408832000
+            20, 2432902008176640000
+            """)
     @ParameterizedTest
     void factorial(int n, long factorial) {
         assertThat(MathUtils.factorial(n)).isEqualTo(factorial);
@@ -245,5 +246,32 @@ class MathUtilsTest {
                 .hasMessage("Factorial of -1 is undefined.");
         assertThatThrownBy(() -> MathUtils.factorial(21))
                 .hasMessage("Factorial of 21 is too large to fit in a long.");
+    }
+
+    @CsvSource("""
+             0,  0,   1
+             1,  0,   1
+             1,  1,   1
+             5,  0,   1
+             5,  1,   5
+             5,  2,  10
+             5,  3,  10
+             5,  4,   5
+             5,  5,   1
+            10,  0,   1
+            10,  1,  10
+            10,  2,  45
+            10,  3, 120
+            10,  4, 210
+            10,  5, 252
+            10,  6, 210
+            10,  7, 120
+            10,  8,  45
+            10,  9,  10
+            10, 10,   1
+            """)
+    @ParameterizedTest
+    void binomialCoefficient(int n, int k, long coefficient) {
+        assertThat(MathUtils.binomialCoefficient(n, k)).isEqualTo(coefficient);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/util/MathUtilsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/util/MathUtilsTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -10,6 +11,8 @@ import java.util.Set;
 
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class MathUtilsTest {
     // https://stackoverflow.com/a/11916946
@@ -207,5 +210,40 @@ class MathUtilsTest {
         assertThat(MathUtils.getLogInBase(3, 9)).isEqualTo(2.0, tolerance);
         assertThat(MathUtils.getLogInBase(3, 27)).isEqualTo(3.0, tolerance);
         assertThat(MathUtils.getLogInBase(9, 3)).isEqualTo(0.5, tolerance);
+    }
+
+    @CsvSource({
+            "1, 1",
+            "2, 2",
+            "3, 6",
+            "4, 24",
+            "5, 120",
+            "6, 720",
+            "7, 5040",
+            "8, 40320",
+            "9, 362880",
+            "10, 3628800",
+            "11, 39916800",
+            "12, 479001600",
+            "13, 6227020800",
+            "14, 87178291200",
+            "15, 1307674368000",
+            "16, 20922789888000",
+            "17, 355687428096000",
+            "18, 6402373705728000",
+            "19, 121645100408832000",
+            "20, 2432902008176640000"
+    })
+    @ParameterizedTest
+    void factorial(int n, long factorial) {
+        assertThat(MathUtils.factorial(n)).isEqualTo(factorial);
+    }
+
+    @Test
+    void factorialBounds() {
+        assertThatThrownBy(() -> MathUtils.factorial(-1))
+                .hasMessage("Factorial of -1 is undefined.");
+        assertThatThrownBy(() -> MathUtils.factorial(21))
+                .hasMessage("Factorial of 21 is too large to fit in a long.");
     }
 }


### PR DESCRIPTION
commons-math3 hasn't seen a release in a long time, and gives JPMS-related warnings; removing it from where we can.
It still remains in benchmark, in enterprise-core and in some tests.