### PR TITLE
perf: improve ConstraintCollectors.toList()

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/stream/ConstraintCollectors.java
@@ -767,6 +767,7 @@ public final class ConstraintCollectors {
      * For stable iteration order, use {@link #toSortedSet()}.
      * <p>
      * The default result of the collector (e.g. when never called) is an empty {@link Set}.
+     * The user must not modify this set.
      *
      * @param <A> type of the matched fact
      */
@@ -779,6 +780,7 @@ public final class ConstraintCollectors {
      * {@link ConstraintStream}.
      * <p>
      * The default result of the collector (e.g. when never called) is an empty {@link SortedSet}.
+     * The user must not modify this set.
      *
      * @param <A> type of the matched fact
      */
@@ -800,6 +802,7 @@ public final class ConstraintCollectors {
      * For stable iteration order, use {@link #toSortedSet()}.
      * <p>
      * The default result of the collector (e.g. when never called) is an empty {@link List}.
+     * The user must not modify this list.
      *
      * @param <A> type of the matched fact
      */
@@ -976,6 +979,7 @@ public final class ConstraintCollectors {
      * For stable iteration order, use {@link #toSortedMap(Function, Function, IntFunction)}.
      * <p>
      * The default result of the collector (e.g. when never called) is an empty {@link Map}.
+     * The user must not modify this map.
      *
      * @param keyMapper map matched fact to a map key
      * @param valueMapper map matched fact to a value
@@ -1103,6 +1107,7 @@ public final class ConstraintCollectors {
      * {@code {20: "Ann and Eric", 25: "Beth", 30: "Cathy and David"}}.
      * <p>
      * The default result of the collector (e.g. when never called) is an empty {@link SortedMap}.
+     * The user must not modify this map.
      *
      * @param keyMapper map matched fact to a map key
      * @param valueMapper map matched fact to a value

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIndexedIfExistsNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIndexedIfExistsNode.java
@@ -119,8 +119,9 @@ public abstract class AbstractIndexedIfExistsNode<LeftTuple_ extends Tuple, Righ
             return;
         }
         ListEntry<ExistsCounter<LeftTuple_>> counterEntry = leftTuple.getStore(inputStoreIndexLeftCounterEntry);
+        var element = counterEntry.element(); // Store so that the reference survives removal.
         updateIndexerLeft(compositeKey, counterEntry, leftTuple);
-        killCounterLeft(counterEntry.element());
+        killCounterLeft(element);
     }
 
     private void updateIndexerLeft(Object compositeKey, ListEntry<ExistsCounter<LeftTuple_>> counterEntry,

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/DefaultUniqueRandomIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/DefaultUniqueRandomIterator.java
@@ -59,7 +59,7 @@ final class DefaultUniqueRandomIterator<T> implements UniqueRandomIterator<T> {
         if (nextIndex == -1) {
             return false;
         }
-        next = source.get(nextIndex).element();
+        next = source.get(nextIndex);
         indexToOptionallyRemove = -1;
         return true;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/RandomAccessIndexerBackend.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/RandomAccessIndexerBackend.java
@@ -24,12 +24,12 @@ public final class RandomAccessIndexerBackend<T> implements IndexerBackend<T> {
 
     @Override
     public ListEntry<T> put(Object compositeKey, T tuple) {
-        return tupleList.add(tuple);
+        return tupleList.addEntry(tuple);
     }
 
     @Override
     public void remove(Object compositeKey, ListEntry<T> entry) {
-        tupleList.remove((ElementAwareArrayList.Entry<T>) entry);
+        ((ElementAwareArrayList<T>.Entry) entry).remove();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/enumerating/common/AbstractLeftDatasetInstance.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/stream/enumerating/common/AbstractLeftDatasetInstance.java
@@ -6,7 +6,6 @@ import java.util.random.RandomGenerator;
 import ai.timefold.solver.core.impl.bavet.common.index.UniqueRandomIterator;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
 import ai.timefold.solver.core.impl.util.ElementAwareArrayList;
-import ai.timefold.solver.core.impl.util.ElementAwareArrayList.Entry;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -35,7 +34,7 @@ public abstract class AbstractLeftDatasetInstance<Solution_, Tuple_ extends Tupl
                             .formatted(tuple));
         }
 
-        tuple.setStore(entryStoreIndex, tupleList.add(tuple));
+        tuple.setStore(entryStoreIndex, tupleList.addEntry(tuple));
     }
 
     @Override
@@ -50,13 +49,12 @@ public abstract class AbstractLeftDatasetInstance<Solution_, Tuple_ extends Tupl
 
     @Override
     public void retract(Tuple_ tuple) {
-        Entry<Tuple_> entry = tuple.removeStore(entryStoreIndex);
+        ElementAwareArrayList<Tuple_>.Entry entry = tuple.removeStore(entryStoreIndex);
         if (entry == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-
-        tupleList.remove(entry);
+        entry.remove();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/ListUndoableActionable.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/collector/ListUndoableActionable.java
@@ -1,15 +1,21 @@
 package ai.timefold.solver.core.impl.score.stream.collector;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import ai.timefold.solver.core.impl.util.ElementAwareArrayList;
+
 public final class ListUndoableActionable<Mapped_> implements UndoableActionable<Mapped_, List<Mapped_>> {
-    private final List<Mapped_> resultList = new ArrayList<>();
+
+    /**
+     * As long as additions and removals are performed using entry-based methods,
+     * removals have O(1) performance.
+     */
+    private final ElementAwareArrayList<Mapped_> resultList = new ElementAwareArrayList<>();
 
     @Override
     public Runnable insert(Mapped_ result) {
-        resultList.add(result);
-        return () -> resultList.remove(result);
+        var entry = resultList.addEntry(result);
+        return entry::remove;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/util/ElementAwareArrayList.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/util/ElementAwareArrayList.java
@@ -1,272 +1,465 @@
 package ai.timefold.solver.core.impl.util;
 
+import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
- * {@link ArrayList}-backed list which allows for a cheap {@link #remove(Entry) removal of an element},
+ * {@link AbstractList} implementation which allows for a cheap {@link Entry#remove() removal of an element},
  * while still providing fast iteration and random access.
  * The order of iteration is guaranteed to be the insertion order.
+ * {@code null} is a valid value.
  * <p>
  * It uses internal state of the entry to track insertion position of the element.
- * When an element is removed, the underlying collection isn't actually touched;
+ * When an entry is removed, its slot in the underlying collection is replaced with {@code null} (a gap);
  * therefore, the insertion position of later elements isn't changed.
- * This position is called a gap.
- * Gaps are removed (the list is compacted) when {@link #forEach(Consumer)} or {@link #asList()} is called.
- * This keeps the overhead low while giving us all benefits of {@link ArrayList},
- * such as memory efficiency, random access, and fast iteration.
+ * Gaps are removed (the list is fully compacted) when {@link #forEach(Consumer)} or {@link #add(int, Object)} is called.
+ * {@link #get(int)} and related index-based operations compact only the prefix up to the requested index.
+ * This keeps the overhead low while giving us most benefits of {@link ArrayList}.
  * <p>
- * This class is very thread-unsafe.
+ * Primary fast-path methods are {@link #addEntry(Object)} and {@link Entry#remove()}, both run in O(1).
+ * All standard {@link List} methods are also available and may run in O(n) or worse.
+ * <p>
+ * This class is so very not thread safe.
  *
  * @param <T>
  */
 @NullMarked
-public final class ElementAwareArrayList<T> {
+public final class ElementAwareArrayList<T extends @Nullable Object> extends AbstractList<T> {
 
-    private final List<Entry<T>> elementList = new ArrayList<>();
+    private static final int REMOVED_POSITION = -1;
+
+    private final List<@Nullable Entry> entryList = new ArrayList<>();
     private int lastElementPosition = -1;
-    private int gapCount = 0;
+    private int gapCount = 0; // Always equals the total number of null slots in entryList.
 
     /**
-     * Appends the specified element to the end of this collection.
+     * Appends the specified element to the end of this list.
      *
-     * @param element element to be appended to this collection
+     * @return the entry for later O(1) removal via {@link Entry#remove()}
      */
-    public Entry<T> add(T element) {
-        var newEntry = new Entry<>(element, ++lastElementPosition);
-        elementList.add(newEntry);
+    public Entry addEntry(T element) {
+        modCount++;
+        if (gapCount > 0 && entryList.get(lastElementPosition) == null) { // Reuse a gap if it exists.
+            var newEntry = new Entry(element, lastElementPosition);
+            entryList.set(lastElementPosition, newEntry);
+            gapCount--;
+            return newEntry;
+        }
+        var newEntry = new Entry(element, ++lastElementPosition);
+        entryList.add(newEntry);
         return newEntry;
     }
 
-    public Entry<T> get(int index) {
-        compact();
-        return elementList.get(index);
+    private Entry getEntry(int index) {
+        if (index < 0 || index >= size()) {
+            throw new IndexOutOfBoundsException(
+                    "The index (%d) must be >= 0 and < size (%d).".formatted(index, size()));
+        } else if (gapCount == 0) {
+            return Objects.requireNonNull(entryList.get(index));
+        }
+        return partialCompact(index);
     }
 
     /**
-     * Removes the first occurrence of the specified element from this collection, if present.
-     *
-     * @param entry entry to be removed from this collection
-     * @throws IllegalStateException if the element wasn't found in this collection
+     * Avoid calling this when {@code gapCount == 0}.
      */
-    public void remove(Entry<T> entry) {
+    private Entry partialCompact(int rightBoundaryPosition) {
+        var encounteredGaps = 0;
+        var lastNonNullPosition = -1;
+        for (var currentPosition = 0; currentPosition <= lastElementPosition; currentPosition++) {
+            var entry = entryList.get(currentPosition);
+            if (entry == null) {
+                encounteredGaps++;
+            } else {
+                lastNonNullPosition++;
+                if (encounteredGaps > 0) {
+                    var targetPosition = currentPosition - encounteredGaps;
+                    entry.moveTo(targetPosition);
+                    entryList.set(targetPosition, entry);
+                    entryList.set(currentPosition, null); // For consistency; the list is never in an invalid state.
+                    modCount++;
+                }
+                if (lastNonNullPosition == rightBoundaryPosition) {
+                    // Invariant: positions [0, index] are all non-null,
+                    // so all gapCount nulls lie in [index+1, lastElementPosition].
+                    // If that suffix is entirely nulls (equivalent to index == size()-1), trim it now.
+                    if (gapCount == lastElementPosition - rightBoundaryPosition) {
+                        entryList.subList(rightBoundaryPosition + 1, lastElementPosition + 1).clear();
+                        lastElementPosition = rightBoundaryPosition;
+                        gapCount = 0;
+                        modCount++;
+                    }
+                    return entry;
+                }
+            }
+        }
+        throw new IndexOutOfBoundsException(
+                "The index (%d) must be >= 0 and < size (%d).".formatted(rightBoundaryPosition, size()));
+    }
+
+    @Override
+    public T get(int index) {
+        return getEntry(index).element();
+    }
+
+    @Override
+    public boolean add(T element) {
+        addEntry(element);
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("DataFlowIssue")
+    public void add(int index, T element) {
+        var size = size();
+        if (index < 0 || index > size) {
+            throw new IndexOutOfBoundsException(
+                    "The index (%d) must be >= 0 and <= size (%d).".formatted(index, size));
+        }
+        if (index == size) {
+            addEntry(element);
+            return;
+        }
+        if (gapCount == 0) {
+            modCount++;
+            var newEntry = new Entry(element, index);
+            entryList.add(index, newEntry);
+            lastElementPosition++;
+            for (var i = index + 1; i <= lastElementPosition; i++) {
+                entryList.get(i).moveTo(i);
+            }
+            return;
+        }
+        // Compact prefix [0, index-1] so physical position k == logical position k for all k < index.
+        if (index > 0) {
+            partialCompact(index - 1); // Increases modCount.
+        }
+        var newEntry = new Entry(element, index);
+        if (entryList.get(index) == null) {
+            // Gap at the target position: fill it directly without shifting the array.
+            entryList.set(index, newEntry);
+            gapCount--;
+        } else {
+            // No gap at the target position: rotate entries rightward into the nearest gap in the suffix,
+            // consuming that gap rather than growing the backing list.
+            var displaced = newEntry;
+            for (var i = index; i <= lastElementPosition; i++) {
+                var current = entryList.get(i);
+                displaced.moveTo(i);
+                entryList.set(i, displaced);
+                if (current == null) {
+                    gapCount--;
+                    break;
+                }
+                displaced = current;
+            }
+        }
+    }
+
+    @Override
+    public T set(int index, T element) {
+        return getEntry(index).replaceElement(element);
+    }
+
+    @Override
+    public T remove(int index) {
+        var entry = getEntry(index);
+        var element = entry.element();
+        remove(entry);
+        return element;
+    }
+
+    /**
+     * Removes the element referenced by the entry in O(1).
+     *
+     * @throws IllegalStateException if the entry was already removed
+     */
+    private void remove(Entry entry) {
         if (entry.isRemoved()) {
             throw new IllegalStateException("The entry (%s) was already removed."
                     .formatted(entry));
         }
-        // For performance, we do not touch the list.
-        // Instead, we mark it as a gap by setting its position to -1.
-        // Technically, this is a memory leak of the value;
-        // in practice, compaction will clean it up relatively quickly.
-        entry.position = -1;
-        gapCount++;
+        var positionPreRemoval = entry.position;
+        if (positionPreRemoval == lastElementPosition) { // Removing the last element; just trim the list.
+            entryList.remove(lastElementPosition--);
+        } else {
+            entryList.set(positionPreRemoval, null);
+            gapCount++;
+        }
+        entry.moveTo(REMOVED_POSITION); // Mark the entry as removed.
+        modCount++;
         clearIfPossible();
     }
 
-    private boolean clearIfPossible() {
-        if (gapCount > 0 && lastElementPosition + 1 == gapCount) { // All positions are gaps. Clear the list entirely.
-            forceClear();
-            return true;
+    private void clearIfPossible() {
+        if (gapCount == 0 || lastElementPosition + 1 != gapCount) {
+            return;
         }
-        return false;
-    }
-
-    private void forceClear() {
-        elementList.clear();
+        // All positions are gaps. Clear the list entirely.
+        entryList.clear();
         gapCount = 0;
         lastElementPosition = -1;
     }
 
-    public boolean isEmpty() {
-        return size() == 0;
-    }
-
+    @Override
     public int size() {
         return lastElementPosition - gapCount + 1;
     }
 
     /**
-     * Performs the given action for each element of the collection
+     * Performs the given action for each element of the list
      * until all elements have been processed.
      *
-     * @param elementConsumer the action to be performed for each element;
-     *        mustn't modify the collection and mustn't throw exceptions,
-     *        as that'd leave the collection in an inconsistent state
+     * @param action the action to be performed for each element;
+     *        mustn't modify the list and mustn't throw exceptions,
+     *        as that'd leave the list in an inconsistent state
      */
-    public void forEach(Consumer<T> elementConsumer) {
+    @Override
+    public void forEach(Consumer<? super T> action) {
         if (gapCount == 0) {
-            forEachWithoutGaps(elementConsumer);
+            forEachWithoutGaps(action);
         } else {
             // Compact the collection as we iterate.
-            forEachCompacting(elementConsumer);
+            forEachCompacting(action);
         }
     }
 
-    private void forEachWithoutGaps(Consumer<T> elementConsumer) {
-        for (var i = 0; i <= lastElementPosition; i++) {
-            elementConsumer.accept(elementList.get(i).element());
+    @SuppressWarnings("DataFlowIssue")
+    private void forEachWithoutGaps(Consumer<? super T> elementConsumer) {
+        for (var currentPosition = 0; currentPosition <= lastElementPosition; currentPosition++) {
+            elementConsumer.accept(entryList.get(currentPosition).element());
         }
     }
 
-    private void forEachCompacting(Consumer<T> elementConsumer) {
-        if (clearIfPossible()) {
+    /**
+     * Compacts during iteration.
+     * Elements are moved to their new position (if needed) after the consumer is called on them,
+     * so that the consumer sees the original insertion order.
+     * Gaps end up at the end of the list, which is cleared in one go.
+     *
+     * @param elementConsumer to be executed over every element
+     */
+    private void forEachCompacting(Consumer<? super T> elementConsumer) {
+        var liveCount = size();
+        if (liveCount == 0) {
+            clearIfPossible(); // The list may still contain gaps, so try to clear it entirely.
             return;
         }
-        var indexesToRemove = new int[gapCount]; // Prevents iterating the entire list multiple times.
-        var encounteredGaps = 0;
-        for (var i = 0; i <= lastElementPosition; i++) {
-            var element = elementList.get(i);
-            if (element.isRemoved()) {
-                if (clearTailGapsIfPossible(i, encounteredGaps + 1, indexesToRemove)) {
-                    return;
-                } else {
-                    indexesToRemove[encounteredGaps++] = i;
-                }
-            } else {
-                elementConsumer.accept(element.element());
-                if (encounteredGaps > 0) {
-                    element.position = i - encounteredGaps;
-                }
+        var compactPosition = 0;
+        for (var currentPosition = 0; currentPosition <= lastElementPosition; currentPosition++) {
+            var entry = entryList.get(currentPosition);
+            if (entry == null) {
+                continue;
+            }
+            elementConsumer.accept(entry.element());
+            if (currentPosition != compactPosition) {
+                entry.moveTo(compactPosition);
+                entryList.set(compactPosition, entry);
+                entryList.set(currentPosition, null); // Prevent stale data.
+                modCount++;
+            }
+            if (++compactPosition == liveCount) {
+                break;
             }
         }
-        clearGaps(indexesToRemove);
-    }
-
-    /**
-     * Clears all remaining gaps if all remaining elements are gaps.
-     *
-     * @param currentGapPosition the current position in the iteration
-     * @param encounteredGaps the number of gaps encountered so far in the iteration, including the current one
-     * @param indexesToRemove the array of indexes where gaps were previously found; won't be modified
-     * @return true if all remaining elements were gaps and have been cleared
-     */
-    private boolean clearTailGapsIfPossible(int currentGapPosition, int encounteredGaps, int... indexesToRemove) {
-        var remainingGaps = gapCount - encounteredGaps;
-        if (remainingGaps == 0) {
-            return false;
-        }
-        var remainingElements = lastElementPosition - currentGapPosition;
-        if (remainingElements == remainingGaps) { // All remaining elements are gaps; we can stop here.
-            elementList.subList(currentGapPosition, lastElementPosition + 1).clear();
-            clearGaps(indexesToRemove, encounteredGaps - 2); // -2 because current gap is not yet in the array.
-            return true;
-        } else if (remainingElements > remainingGaps) { // There are still non-gap elements remaining.
-            return false;
-        } else {
-            throw new IllegalStateException(
-                    "Impossible state: the number of remaining elements (%d) is less than the number of remaining gaps (%d)."
-                            .formatted(remainingElements, remainingGaps));
-        }
-    }
-
-    private void clearGaps(int[] gaps, int topMostIndexToInclude) {
-        // Remove gaps from the back to shift only as little as we need.
-        for (var index = topMostIndexToInclude; index >= 0; index--) {
-            elementList.remove(gaps[index]);
-        }
-        lastElementPosition = elementList.size() - 1;
+        entryList.subList(compactPosition, lastElementPosition + 1).clear();
+        lastElementPosition = compactPosition - 1;
         gapCount = 0;
+        modCount++;
     }
 
-    private void clearGaps(int[] indexesToRemove) {
-        clearGaps(indexesToRemove, indexesToRemove.length - 1);
-    }
-
+    @Override
     public Iterator<T> iterator() {
-        compact();
-        return new DefaultIterator<>(elementList);
+        return listIterator(0);
     }
 
-    /**
-     * Returns a standard {@link List} view of this collection.
-     * Users mustn't modify the returned list, as that'd also change the underlying data structure.
-     *
-     * @return a standard list view of this element-aware list
-     */
-    public List<Entry<T>> asList() {
-        if (isEmpty() || compact()) {
-            return Collections.emptyList();
-        }
-        return elementList;
+    @Override
+    public ListIterator<T> listIterator(int index) {
+        return new ElementAwareListIterator(index);
     }
 
-    private boolean compact() {
-        if (gapCount == 0) {
-            return isEmpty();
-        }
-        if (clearIfPossible()) {
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
             return true;
         }
-        var indexesToRemove = new int[gapCount]; // Prevents iterating the entire list multiple times.
-        var encounteredGaps = 0;
-        for (var i = 0; i <= lastElementPosition; i++) {
-            var element = elementList.get(i);
-            if (element.isRemoved()) {
-                if (clearTailGapsIfPossible(i, encounteredGaps + 1, indexesToRemove)) {
-                    return false;
-                } else {
-                    indexesToRemove[encounteredGaps++] = i;
-                }
-            } else if (encounteredGaps > 0) {
-                element.position = i - encounteredGaps;
-            }
-        }
-        clearGaps(indexesToRemove);
-        return false;
+        return o instanceof List<?> other
+                && this.size() == other.size()
+                && super.equals(other);
     }
 
-    public static final class Entry<T> implements ListEntry<T> {
+    @Override
+    public int hashCode() {
+        return super.hashCode(); // Size not relevant; if sizes differ => lists do not equal => same hashCode is fine.
+    }
 
-        private final T element;
-        private int position;
+    private final class ElementAwareListIterator implements ListIterator<T> {
+
+        private int currentPosition;
+        private int logicalPosition;
+        private @Nullable Entry lastEntry;
+        private boolean lastWasFwd;
+        private int expectedModCount;
+
+        private ElementAwareListIterator(int startingPosition) {
+            var currentSize = size();
+            if (startingPosition < 0 || startingPosition > currentSize) {
+                throw new IndexOutOfBoundsException(
+                        "The index (%d) must be >= 0 and <= size (%d).".formatted(startingPosition, currentSize));
+            }
+            if (startingPosition > 0 && gapCount > 0) {
+                currentPosition = partialCompact(startingPosition - 1).position + 1;
+            } else {
+                currentPosition = startingPosition;
+            }
+            logicalPosition = startingPosition;
+            expectedModCount = modCount;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return logicalPosition < size();
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return logicalPosition > 0;
+        }
+
+        @Override
+        public int nextIndex() {
+            return logicalPosition;
+        }
+
+        @Override
+        public int previousIndex() {
+            return logicalPosition - 1;
+        }
+
+        @Override
+        public T next() {
+            checkModCount();
+            if (logicalPosition >= size()) {
+                throw new NoSuchElementException();
+            }
+            var entry = entryList.get(currentPosition);
+            while (entry == null) {
+                entry = entryList.get(++currentPosition);
+            }
+            currentPosition++;
+            logicalPosition++;
+            lastEntry = entry;
+            lastWasFwd = true;
+            return entry.element();
+        }
+
+        @Override
+        public T previous() {
+            checkModCount();
+            if (logicalPosition <= 0) {
+                throw new NoSuchElementException();
+            }
+            var entry = entryList.get(--currentPosition);
+            while (entry == null) {
+                entry = entryList.get(--currentPosition);
+            }
+            logicalPosition--;
+            lastEntry = entry;
+            lastWasFwd = false;
+            return entry.element();
+        }
+
+        @Override
+        public void remove() {
+            if (lastEntry == null) {
+                throw new IllegalStateException(
+                        "remove() called without a preceding next() or previous().");
+            }
+            checkModCount();
+            lastEntry.remove(); // Adjusts lastElementPosition.
+            if (lastWasFwd) {
+                logicalPosition--;
+            }
+            expectedModCount = modCount;
+            lastEntry = null;
+        }
+
+        @Override
+        public void set(T element) {
+            if (lastEntry == null) {
+                throw new IllegalStateException("set() called without a preceding next() or previous().");
+            }
+            checkModCount();
+            lastEntry.replaceElement(element);
+        }
+
+        @Override
+        public void add(T element) {
+            checkModCount();
+            ElementAwareArrayList.this.add(logicalPosition, element);
+            logicalPosition++;
+            currentPosition = logicalPosition;
+            expectedModCount = modCount;
+            lastEntry = null;
+        }
+
+        private void checkModCount() {
+            if (modCount != expectedModCount) {
+                throw new ConcurrentModificationException();
+            }
+        }
+
+    }
+
+    public final class Entry implements ListEntry<T> {
+
+        private T element; // Mutable so that ElementAwareArrayList.set(int, T) can be O(1).
+        private int position; // Keeps the element's position in the list; must be kept in sync with its actual position.
 
         private Entry(T element, int position) {
             this.element = element;
             this.position = position;
         }
 
-        public boolean isRemoved() {
-            return position < 0;
+        public void remove() {
+            ElementAwareArrayList.this.remove(this);
+        }
+
+        boolean isRemoved() {
+            return position == REMOVED_POSITION;
+        }
+
+        void moveTo(int newPosition) {
+            position = newPosition;
         }
 
         @Override
         public T element() {
+            if (isRemoved()) {
+                throw new IllegalStateException("The entry (%s) was already removed.".formatted(this));
+            }
             return element;
+        }
+
+        public T replaceElement(T newElement) {
+            var old = element();
+            element = newElement;
+            return old;
         }
 
         @Override
         public String toString() {
             return isRemoved() ? "null" : element + "@" + position;
-        }
-
-    }
-
-    public static final class DefaultIterator<T> implements Iterator<T> {
-
-        private final List<Entry<T>> list;
-        private int index = 0;
-
-        private DefaultIterator(List<Entry<T>> list) {
-            this.list = list;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return index < list.size();
-        }
-
-        @Override
-        public T next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            return list.get(index++).element();
         }
 
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/util/ListEntry.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/util/ListEntry.java
@@ -1,9 +1,10 @@
 package ai.timefold.solver.core.impl.util;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @NullMarked
-public sealed interface ListEntry<T>
+public sealed interface ListEntry<T extends @Nullable Object>
         permits ElementAwareLinkedList.Entry, ElementAwareArrayList.Entry, CompositeListEntry {
 
     T element();

--- a/core/src/test/java/ai/timefold/solver/core/impl/util/ElementAwareArrayListTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/util/ElementAwareArrayListTest.java
@@ -1,12 +1,17 @@
 package ai.timefold.solver.core.impl.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,9 +28,7 @@ class ElementAwareArrayListTest {
         void emptyList() {
             var list = new ElementAwareArrayList<String>();
 
-            assertThat(list.isEmpty()).isTrue();
-            assertThat(list.size()).isZero();
-            assertThat(list.asList()).isEmpty();
+            assertThat(list).isEmpty();
         }
 
         @Test
@@ -33,10 +36,11 @@ class ElementAwareArrayListTest {
         void addSingleElement() {
             var list = new ElementAwareArrayList<String>();
 
-            var entry = list.add("first");
+            var entry = list.addEntry("first");
 
-            assertThat(list.isEmpty()).isFalse();
-            assertThat(list.size()).isEqualTo(1);
+            assertThat(list)
+                    .isNotEmpty()
+                    .hasSize(1);
             assertThat(entry.element()).isEqualTo("first");
             assertThat(entry.isRemoved()).isFalse();
         }
@@ -46,13 +50,11 @@ class ElementAwareArrayListTest {
         void addMultipleElements() {
             var list = new ElementAwareArrayList<String>();
 
-            var entry1 = list.add("first");
-            var entry2 = list.add("second");
-            var entry3 = list.add("third");
+            list.addEntry("first");
+            list.addEntry("second");
+            list.addEntry("third");
 
-            assertThat(list.size()).isEqualTo(3);
-            assertThat(list.asList())
-                    .containsExactly(entry1, entry2, entry3);
+            assertThat(list).containsExactly("first", "second", "third");
         }
 
         @Test
@@ -60,13 +62,13 @@ class ElementAwareArrayListTest {
         void removeSingleElement() {
             var list = new ElementAwareArrayList<String>();
 
-            var entry1 = list.add("first");
-            var entry2 = list.add("second");
-            var entry3 = list.add("third");
+            var entry1 = list.addEntry("first");
+            var entry2 = list.addEntry("second");
+            var entry3 = list.addEntry("third");
 
-            list.remove(entry2);
+            entry2.remove();
 
-            assertThat(list.size()).isEqualTo(2);
+            assertThat(list).hasSize(2);
             assertThat(entry2.isRemoved()).isTrue();
             assertThat(entry1.isRemoved()).isFalse();
             assertThat(entry3.isRemoved()).isFalse();
@@ -76,12 +78,12 @@ class ElementAwareArrayListTest {
         @DisplayName("Remove already removed element throws exception")
         void removeAlreadyRemovedElement() {
             var list = new ElementAwareArrayList<String>();
-            var entry = list.add("first");
+            var entry = list.addEntry("first");
 
-            list.remove(entry);
+            entry.remove();
 
             assertThatExceptionOfType(IllegalStateException.class)
-                    .isThrownBy(() -> list.remove(entry))
+                    .isThrownBy(entry::remove)
                     .withMessageContaining("was already removed");
         }
 
@@ -90,15 +92,32 @@ class ElementAwareArrayListTest {
         void removeAllElements() {
             var list = new ElementAwareArrayList<String>();
 
-            var entry1 = list.add("first");
-            var entry2 = list.add("second");
+            var entry1 = list.addEntry("first");
+            var entry2 = list.addEntry("second");
 
-            list.remove(entry1);
-            list.remove(entry2);
+            entry1.remove();
+            entry2.remove();
 
-            assertThat(list.isEmpty()).isTrue();
-            assertThat(list.size()).isZero();
+            assertThat(list).isEmpty();
         }
+
+        @Test
+        @DisplayName("addEntry reuses the null slot at lastElementPosition when it is a gap")
+        void addEntryReusesGapAtTail() {
+            var list = new ElementAwareArrayList<String>();
+            list.addEntry("a");
+            var entryB = list.addEntry("b");
+            var entryC = list.addEntry("c");
+
+            entryB.remove(); // gap at slot 1; physical [a@0, null, c@2]
+            entryC.remove(); // c is last element → trim; physical [a@0, null], gapCount=1, lastElementPosition=1
+
+            var entryX = list.addEntry("x"); // reuses slot 1 (null at lastElementPosition)
+
+            assertThat(list).containsExactly("a", "x");
+            assertThat(entryX.toString()).contains("@1");
+        }
+
     }
 
     @Nested
@@ -124,10 +143,7 @@ class ElementAwareArrayListTest {
             list.add("second");
             list.add("third");
 
-            var result = new ArrayList<String>();
-            list.forEach(result::add);
-
-            assertThat(result).containsExactly("first", "second", "third");
+            assertThat(copyUsingForEach(list)).containsExactly("first", "second", "third");
         }
 
         @Test
@@ -135,140 +151,401 @@ class ElementAwareArrayListTest {
         void forEachWithGaps() {
             var list = new ElementAwareArrayList<String>();
             list.add("first");
-            var entry2 = list.add("second");
+            var entry2 = list.addEntry("second");
             list.add("third");
 
-            list.remove(entry2);
+            entry2.remove();
 
-            var result = new ArrayList<String>();
-            list.forEach(result::add);
-
-            assertThat(result).containsExactly("first", "third");
+            assertThat(copyUsingForEach(list)).containsExactly("first", "third");
         }
 
         @Test
         @DisplayName("forEach compacts the list when gaps exist")
         void forEachCompactsWithGaps() {
             var list = new ElementAwareArrayList<String>();
-            var entry1 = list.add("first");
-            var entry2 = list.add("second");
-            var entry3 = list.add("third");
-            var entry4 = list.add("fourth");
+            var entry1 = list.addEntry("first");
+            var entry2 = list.addEntry("second");
+            var entry3 = list.addEntry("third");
+            var entry4 = list.addEntry("fourth");
 
-            list.remove(entry2);
-            list.remove(entry3);
+            entry2.remove();
+            entry3.remove();
 
             list.forEach(s -> {
             });
 
-            // After compaction, only non-removed elements remain
-            assertThat(list.asList()).containsExactly(entry1, entry4);
-            assertThat(list.size()).isEqualTo(2);
+            assertThat(list).hasSize(2);
+            assertThat(entry1.toString()).contains("@0");
+            assertThat(entry4.toString()).contains("@1");
         }
 
         @Test
         @DisplayName("forEach clears list when all elements are removed")
         void forEachClearsWhenAllRemoved() {
             var list = new ElementAwareArrayList<String>();
-            var entry1 = list.add("first");
-            var entry2 = list.add("second");
+            var entry1 = list.addEntry("first");
+            var entry2 = list.addEntry("second");
 
-            list.remove(entry1);
-            list.remove(entry2);
+            entry1.remove();
+            entry2.remove();
 
             list.forEach(s -> {
             });
 
-            assertThat(list.isEmpty()).isTrue();
-            assertThat(list.asList()).isEmpty();
+            assertThat(list).isEmpty();
         }
 
         @Test
         @DisplayName("forEach compacts when tail gaps are encountered")
         void forEachCompactsWithTailGaps() {
             var list = new ElementAwareArrayList<String>();
-            var entry1 = list.add("first");
-            var entry2 = list.add("second");
-            var entry3 = list.add("third");
-            var entry4 = list.add("fourth");
+            var entry1 = list.addEntry("first");
+            var entry2 = list.addEntry("second");
+            var entry3 = list.addEntry("third");
+            var entry4 = list.addEntry("fourth");
 
-            list.remove(entry3);
-            list.remove(entry4);
+            entry3.remove();
+            entry4.remove();
 
-            var result = new ArrayList<String>();
-            list.forEach(result::add);
-
-            assertThat(result).containsExactly("first", "second");
-            assertThat(list.asList()).containsExactly(entry1, entry2);
+            assertThat(copyUsingForEach(list)).containsExactly("first", "second");
+            assertThat(list).hasSize(2);
+            assertThat(entry1.toString()).contains("@0");
+            assertThat(entry2.toString()).contains("@1");
         }
     }
 
     @Nested
-    @DisplayName("asList tests")
-    class AsListTests {
+    @DisplayName("Compaction tests")
+    class CompactionTests {
 
         @Test
-        @DisplayName("asList returns empty list when list is empty")
-        void asListWhenEmpty() {
+        @DisplayName("Access compacts the list when gaps exist")
+        void accessCompactsWithGaps() {
             var list = new ElementAwareArrayList<String>();
+            list.addEntry("first");
+            var entry2 = list.addEntry("second");
+            list.addEntry("third");
 
-            assertThat(list.asList()).isEmpty();
+            entry2.remove();
+
+            assertThat(list).hasSize(2);
+            assertThat(list.get(0)).isEqualTo("first");
+            assertThat(list.get(1)).isEqualTo("third");
         }
 
         @Test
-        @DisplayName("asList returns all entries when no gaps")
-        void asListWithoutGaps() {
+        @DisplayName("Access returns empty when all elements removed")
+        void accessWhenAllRemoved() {
             var list = new ElementAwareArrayList<String>();
-            var entry1 = list.add("first");
-            var entry2 = list.add("second");
+            var entry1 = list.addEntry("first");
 
-            assertThat(list.asList()).containsExactly(entry1, entry2);
+            entry1.remove();
+
+            assertThat(list).isEmpty();
         }
 
         @Test
-        @DisplayName("asList compacts the list when gaps exist")
-        void asListCompactsWithGaps() {
-            var list = new ElementAwareArrayList<String>();
-            var entry1 = list.add("first");
-            var entry2 = list.add("second");
-            var entry3 = list.add("third");
-
-            list.remove(entry2);
-
-            var result = list.asList();
-
-            assertThat(result).containsExactly(entry1, entry3);
-            assertThat(list.size()).isEqualTo(2);
-        }
-
-        @Test
-        @DisplayName("asList returns empty when all elements removed")
-        void asListWhenAllRemoved() {
-            var list = new ElementAwareArrayList<String>();
-            var entry1 = list.add("first");
-
-            list.remove(entry1);
-
-            assertThat(list.asList()).isEmpty();
-        }
-
-        @Test
-        @DisplayName("asList compacts with tail gaps")
-        void asListCompactsWithTailGaps() {
+        @DisplayName("Access compacts with tail gaps")
+        void accessCompactsWithTailGaps() {
             var list = new ElementAwareArrayList<String>();
             list.add("first");
             list.add("second");
-            var entry3 = list.add("third");
-            var entry4 = list.add("fourth");
-            var entry5 = list.add("fifth");
+            var entry3 = list.addEntry("third");
+            var entry4 = list.addEntry("fourth");
+            var entry5 = list.addEntry("fifth");
 
-            list.remove(entry3);
-            list.remove(entry4);
-            list.remove(entry5);
+            entry3.remove();
+            entry4.remove();
+            entry5.remove();
 
-            assertThat(list.asList())
-                    .hasSize(2)
-                    .doesNotContain(entry3, entry4, entry5);
+            assertThat(list).hasSize(2);
+            assertThat(entry3.isRemoved()).isTrue();
+            assertThat(entry4.isRemoved()).isTrue();
+            assertThat(entry5.isRemoved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("addAt with trailing gaps only rotates entry into first suffix gap")
+        void addAtAfterTrailingGapOnly() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+
+            e3.remove();
+            e4.remove();
+            // Physical: [a, b, null], gapCount=1, size=2 (d trim reduced lastElementPosition)
+
+            list.add(1, "x"); // partialCompact(0): no prefix gap; slot 1 non-null → rotate b into gap at slot 2
+            assertThat(list).hasSize(3);
+            assertThat(copyUsingForEach(list)).containsExactly("a", "x", "b");
+            assertThat(e1.toString()).contains("@0");
+            assertThat(e2.toString()).contains("@2");
+        }
+    }
+
+    @Nested
+    @DisplayName("Partial compaction tests")
+    class PartialCompactionTests {
+
+        @Test
+        @DisplayName("Gaps before target (not at last slot): positions updated, gapCount unchanged")
+        void getGapsBeforeTarget_noTrailingCleanup() {
+            var list = new ElementAwareArrayList<String>();
+            list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+
+            e2.remove();
+            // Physical: [a, null, c, d], gapCount=1, lastElementPosition=3, size=3
+
+            list.get(1); // c swaps to slot 1; d non-null at slot 3: gapCount(1) < suffix width(2) → no trailing cleanup
+            assertThat(e3.toString()).contains("@1"); // position updated
+            assertThat(e4.toString()).contains("@3"); // suffix position unchanged
+            assertThat(list).hasSize(3);
+
+            // Suffix entry removal still works via its unchanged raw position
+            e4.remove();
+            assertThat(copyUsingForEach(list)).containsExactly("a", "c");
+        }
+
+        @Test
+        @DisplayName("Gaps before target (at last slot): trailing cleanup triggered, gapCount=0")
+        void getGapsBeforeTarget_trailingCleanup() {
+            var list = new ElementAwareArrayList<String>();
+            list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+
+            e2.remove();
+            // Physical: [a, null, c], gapCount=1, lastElementPosition=2, size=2
+
+            list.get(1); // trailing cleanup: gapCount(1) == lastElementPosition(2) - index(1); [a, c]
+            assertThat(e3.toString()).contains("@1");
+            assertThat(list).hasSize(2);
+            // gapCount=0 now; subsequent access is direct
+            assertThat(list.get(0)).isEqualTo("a");
+            assertThat(list.get(1)).isEqualTo("c");
+        }
+
+        @Test
+        @DisplayName("Gaps only after target: target found immediately without any swaps")
+        void getGapsOnlyAfterTarget() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+
+            e3.remove();
+            // Physical: [a, b, null], gapCount=1, size=2
+
+            list.getFirst(); // a found at i=0 immediately; no gaps before → no swaps
+            assertThat(e1.toString()).contains("@0");
+            assertThat(e2.toString()).contains("@1"); // unchanged
+            assertThat(list).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("Target is last logical element, trailing gaps only (no prefix gaps): trailing cleanup triggered")
+        void getLastElement_trailingGapsWithNoPrefix() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+
+            e3.remove();
+            e4.remove();
+            // Physical: [a, b, null, null], gapCount=2, lastElementPosition=3, size=2
+
+            list.get(1); // trailing cleanup: gapCount(2) == lastElementPosition(3) - index(1); trim trailing nulls
+            assertThat(e1.toString()).contains("@0");
+            assertThat(e2.toString()).contains("@1");
+            assertThat(list).hasSize(2);
+            // Trailing cleanup set gapCount=0: subsequent access is direct.
+            assertThat(list.get(0)).isEqualTo("a");
+            assertThat(list.get(1)).isEqualTo("b");
+        }
+
+        @Test
+        @DisplayName("Target is last logical element, gaps before and after: trailing cleanup triggered")
+        void getLastElement_trailingGapsWithPrefix() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+
+            e1.remove();
+            e3.remove();
+            e4.remove();
+            // Physical: [null, b, null, null], gapCount=3, lastElementPosition=3, size=1
+
+            list.getFirst(); // b moves to slot 0; trailing cleanup: gapCount(3) == lastElementPosition(3) - index(0); [b]
+            assertThat(e2.toString()).contains("@0");
+            assertThat(list).hasSize(1);
+            // Trailing cleanup set gapCount=0: subsequent access is direct.
+            assertThat(list.getFirst()).isEqualTo("b");
+        }
+
+        @Test
+        @DisplayName("Gaps before and after target: only the prefix up to target is compacted")
+        void getGapsMixedAroundTarget() {
+            var list = new ElementAwareArrayList<String>();
+            list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+            var e5 = list.addEntry("e");
+
+            e2.remove();
+            e4.remove();
+            // Physical: [a, null, c, null, e], gapCount=2, lastElementPosition=4, size=3
+            // Negative guard: e is non-null in the suffix, so gapCount(2) < suffix width(3) → condition must NOT fire.
+
+            list.get(1); // c at i=2, gaps=1; swap to slot 1; gapCount(2) != lastElementPosition(4) - index(1) → no cleanup
+            assertThat(e3.toString()).contains("@1"); // updated
+            assertThat(e5.toString()).contains("@4"); // suffix unchanged
+            assertThat(list).hasSize(3);
+            assertThat(copyUsingForEach(list)).containsExactly("a", "c", "e");
+        }
+
+        @Test
+        @DisplayName("Entry returned by partial compaction has correct position for O(1) removal")
+        void removeEntryReturnedByPartialCompact() {
+            var list = new ElementAwareArrayList<String>();
+            list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            list.addEntry("d");
+
+            e2.remove();
+            // Physical: [a, null, c, d], gapCount=1, size=3
+
+            list.get(1); // trigger partial compact: c moves to position 1
+            assertThat(e3.toString()).contains("@1");
+
+            e3.remove(); // uses updated position
+            assertThat(e3.isRemoved()).isTrue();
+            assertThat(list).hasSize(2);
+            assertThat(copyUsingForEach(list)).containsExactly("a", "d");
+        }
+
+        @Test
+        @DisplayName("Suffix entry (position not yet updated) retains valid raw position for removal")
+        void removeSuffixEntry_positionUnchanged() {
+            var list = new ElementAwareArrayList<String>();
+            list.addEntry("a");
+            var e2 = list.addEntry("b");
+            list.addEntry("c");
+            var e4 = list.addEntry("d");
+            var e5 = list.addEntry("e");
+
+            e2.remove();
+            e4.remove();
+            // Physical: [a, null, c, null, e], gapCount=2, size=3
+
+            list.get(1); // c moves to slot 1; e5.position=4 unchanged
+
+            e5.remove(); // uses raw position 4, still valid (backing list not shrunk)
+            assertThat(e5.isRemoved()).isTrue();
+            assertThat(list).hasSize(2);
+            assertThat(copyUsingForEach(list)).containsExactly("a", "c");
+        }
+
+        @Test
+        @DisplayName("Sequential get calls migrate gaps rightward progressively")
+        void sequentialGet_gapsProgressMigrate() {
+            var list = new ElementAwareArrayList<String>();
+            list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+            var e5 = list.addEntry("e");
+
+            e2.remove();
+            e4.remove();
+            // Physical: [a, null, c, null, e], gapCount=2, size=3
+
+            list.get(1);
+            assertThat(e3.toString()).contains("@1");
+
+            // Second call: c already at slot 1, no swap needed
+            assertThat(list.get(1)).isEqualTo("c");
+
+            // Third call: e migrates to slot 2; trailing cleanup fires
+            assertThat(list.get(2)).isEqualTo("e");
+            assertThat(e5.toString()).contains("@2");
+            assertThat(list).hasSize(3);
+            assertThat(copyUsingForEach(list)).containsExactly("a", "c", "e");
+        }
+
+        @Test
+        @DisplayName("forEach fully compacts list that was previously partially compacted")
+        void getThenForEach_fullCompactCorrect() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+            var e5 = list.addEntry("e");
+
+            e2.remove();
+            e4.remove();
+            // Physical: [a, null, c, null, e], gapCount=2
+
+            list.get(1); // Partial compact → [a, c, null, null, e]
+
+            assertThat(copyUsingForEach(list)).containsExactly("a", "c", "e");
+            // After forEach: fully compacted
+            assertThat(e1.toString()).contains("@0");
+            assertThat(e3.toString()).contains("@1");
+            assertThat(e5.toString()).contains("@2");
+            assertThat(list).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("addAt compacts prefix then rotates entry into gap; all positions correct")
+        void getThenAddAt_fullCompactCorrect() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+
+            e2.remove();
+            // Physical: [a, null, c, d], gapCount=1, size=3
+
+            list.get(1); // Partial compact → [a, c, null, d]
+
+            list.add(1, "x"); // partialCompact(0): no prefix gap; slot 1 non-null → rotate c into gap at slot 2
+            assertThat(list).hasSize(4);
+            assertThat(copyUsingForEach(list)).containsExactly("a", "x", "c", "d");
+            // forEach compacts the list fully; entry positions are dense after the call.
+            assertThat(e1.toString()).contains("@0");
+            assertThat(e3.toString()).contains("@2");
+            assertThat(e4.toString()).contains("@3");
+            // gapCount is 0 after forEach; subsequent get() is direct.
+            assertThat(list.get(0)).isEqualTo("a");
+            assertThat(list.get(2)).isEqualTo("c");
+            assertThat(list.get(3)).isEqualTo("d");
+        }
+
+        @Test
+        @DisplayName("get on index >= size throws IndexOutOfBoundsException")
+        void getOutOfBounds_throwsIOOB() {
+            var list = new ElementAwareArrayList<String>();
+            list.addEntry("a");
+            var e2 = list.addEntry("b");
+            list.addEntry("c");
+
+            e2.remove();
+            // size=2
+
+            assertThatExceptionOfType(IndexOutOfBoundsException.class)
+                    .isThrownBy(() -> list.get(2));
         }
     }
 
@@ -280,7 +557,7 @@ class ElementAwareArrayListTest {
         @DisplayName("Entry getElement returns correct element")
         void entryGetElement() {
             var list = new ElementAwareArrayList<String>();
-            var entry = list.add("test");
+            var entry = list.addEntry("test");
 
             assertThat(entry.element()).isEqualTo("test");
         }
@@ -289,7 +566,7 @@ class ElementAwareArrayListTest {
         @DisplayName("Entry isRemoved returns false for active entry")
         void entryIsRemovedFalse() {
             var list = new ElementAwareArrayList<String>();
-            var entry = list.add("test");
+            var entry = list.addEntry("test");
 
             assertThat(entry.isRemoved()).isFalse();
         }
@@ -298,9 +575,9 @@ class ElementAwareArrayListTest {
         @DisplayName("Entry isRemoved returns true after removal")
         void entryIsRemovedTrue() {
             var list = new ElementAwareArrayList<String>();
-            var entry = list.add("test");
+            var entry = list.addEntry("test");
 
-            list.remove(entry);
+            entry.remove();
 
             assertThat(entry.isRemoved()).isTrue();
         }
@@ -309,7 +586,7 @@ class ElementAwareArrayListTest {
         @DisplayName("Entry toString shows element and position when active")
         void entryToStringActive() {
             var list = new ElementAwareArrayList<String>();
-            var entry = list.add("test");
+            var entry = list.addEntry("test");
 
             assertThat(entry).hasToString("test@0");
         }
@@ -318,11 +595,78 @@ class ElementAwareArrayListTest {
         @DisplayName("Entry toString shows null when removed")
         void entryToStringRemoved() {
             var list = new ElementAwareArrayList<String>();
-            var entry = list.add("test");
+            var entry = list.addEntry("test");
 
-            list.remove(entry);
+            entry.remove();
 
             assertThat(entry).hasToString("null");
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Null element support")
+    class NullElementTests {
+
+        @Test
+        @DisplayName("addEntry(null) and get(0) round-trip")
+        void addAndGet() {
+            var list = new ElementAwareArrayList<@Nullable String>();
+            list.addEntry(null);
+            assertThat(list).hasSize(1);
+            assertThat(list.getFirst()).isNull();
+        }
+
+        @Test
+        @DisplayName("forEach visits null elements")
+        void forEach() {
+            var list = new ElementAwareArrayList<@Nullable String>();
+            list.addEntry("a");
+            list.addEntry(null);
+            list.addEntry("b");
+            assertThat(copyUsingForEach(list)).containsExactly("a", null, "b");
+        }
+
+        @Test
+        @DisplayName("forEach with gaps visits null elements")
+        void forEachWithGaps() {
+            var list = new ElementAwareArrayList<@Nullable String>();
+            list.addEntry("a");
+            var e2 = list.addEntry("x");
+            list.addEntry(null);
+            list.addEntry("b");
+            e2.remove();
+            assertThat(copyUsingForEach(list)).containsExactly("a", null, "b");
+        }
+
+        @Test
+        @DisplayName("remove(Entry) of null element works")
+        void removeNullEntry() {
+            var list = new ElementAwareArrayList<@Nullable String>();
+            list.addEntry("a");
+            var nullEntry = list.addEntry(null);
+            list.addEntry("b");
+            nullEntry.remove();
+            assertThat(copyUsingForEach(list)).containsExactly("a", "b");
+        }
+
+        @Test
+        @DisplayName("iterator visits null elements")
+        void iterator() {
+            var list = new ElementAwareArrayList<@Nullable String>();
+            list.addEntry(null);
+            list.addEntry("a");
+            list.addEntry(null);
+            var result = copyUsingForEach(list);
+            assertThat(result).containsExactly(null, "a", null);
+        }
+
+        @Test
+        @DisplayName("entry.element() returns null for null element")
+        void entryElement() {
+            var list = new ElementAwareArrayList<@Nullable String>();
+            var entry = list.addEntry(null);
+            assertThat(entry.element()).isNull();
         }
 
     }
@@ -337,20 +681,16 @@ class ElementAwareArrayListTest {
             var list = new ElementAwareArrayList<Integer>();
 
             list.add(1);
-            var e2 = list.add(2);
+            var e2 = list.addEntry(2);
             list.add(3);
-            var e4 = list.add(4);
+            var e4 = list.addEntry(4);
             list.add(5);
 
-            list.remove(e2);
-            list.remove(e4);
+            e2.remove();
+            e4.remove();
 
-            assertThat(list.size()).isEqualTo(3);
-
-            var result = new ArrayList<Integer>();
-            list.forEach(result::add);
-
-            assertThat(result).containsExactly(1, 3, 5);
+            assertThat(list).hasSize(3);
+            assertThat(copyUsingForEach(list)).containsExactly(1, 3, 5);
         }
 
         @Test
@@ -358,21 +698,18 @@ class ElementAwareArrayListTest {
         void removeFromVariousPositions() {
             var list = new ElementAwareArrayList<String>();
 
-            var e1 = list.add("a");
+            var e1 = list.addEntry("a");
             list.add("b");
-            var e3 = list.add("c");
+            var e3 = list.addEntry("c");
             list.add("d");
-            var e5 = list.add("e");
+            var e5 = list.addEntry("e");
 
-            list.remove(e1); // head
-            list.remove(e3); // middle
-            list.remove(e5); // tail
+            e1.remove(); // head
+            e3.remove(); // middle
+            e5.remove(); // tail
 
-            var result = new ArrayList<String>();
-            list.forEach(result::add);
-
-            assertThat(result).containsExactly("b", "d");
-            assertThat(list.size()).isEqualTo(2);
+            assertThat(copyUsingForEach(list)).containsExactly("b", "d");
+            assertThat(list).hasSize(2);
         }
 
         @Test
@@ -380,42 +717,36 @@ class ElementAwareArrayListTest {
         void interleavedOperations() {
             var list = new ElementAwareArrayList<String>();
 
-            var e1 = list.add("1");
-            var e2 = list.add("2");
-            list.remove(e1);
+            var e1 = list.addEntry("1");
+            var e2 = list.addEntry("2");
+            e1.remove();
             list.add("3");
-            list.remove(e2);
+            e2.remove();
             list.add("4");
 
-            assertThat(list.size()).isEqualTo(2);
-
-            var result = new ArrayList<String>();
-            list.forEach(result::add);
-
-            assertThat(result).containsExactly("3", "4");
+            assertThat(list).hasSize(2);
+            assertThat(copyUsingForEach(list)).containsExactly("3", "4");
         }
 
         @Test
         @DisplayName("Large list with many gaps compacts correctly")
         void largeListWithManyGaps() {
             var list = new ElementAwareArrayList<Integer>();
-            var entries = new ArrayList<ElementAwareArrayList.Entry<Integer>>();
+            var entries = new ArrayList<ElementAwareArrayList<Integer>.Entry>();
 
             // Add 100 elements
             for (int i = 0; i < 100; i++) {
-                entries.add(list.add(i));
+                entries.add(list.addEntry(i));
             }
 
             // Remove every other element
             for (int i = 0; i < 100; i += 2) {
-                list.remove(entries.get(i));
+                entries.get(i).remove();
             }
 
-            assertThat(list.size()).isEqualTo(50);
+            assertThat(list).hasSize(50);
 
-            var result = new ArrayList<Integer>();
-            list.forEach(result::add);
-
+            var result = copyUsingForEach(list);
             assertThat(result).hasSize(50);
             for (int i = 0; i < 50; i++) {
                 assertThat(result.get(i)).isEqualTo(i * 2 + 1);
@@ -427,23 +758,19 @@ class ElementAwareArrayListTest {
         void removeAllThenAddNew() {
             var list = new ElementAwareArrayList<String>();
 
-            var e1 = list.add("old1");
-            var e2 = list.add("old2");
+            var e1 = list.addEntry("old1");
+            var e2 = list.addEntry("old2");
 
-            list.remove(e1);
-            list.remove(e2);
+            e1.remove();
+            e2.remove();
 
-            assertThat(list.isEmpty()).isTrue();
+            assertThat(list).isEmpty();
 
             list.add("new1");
             list.add("new2");
 
-            assertThat(list.size()).isEqualTo(2);
-
-            var result = new ArrayList<String>();
-            list.forEach(result::add);
-
-            assertThat(result).containsExactly("new1", "new2");
+            assertThat(list).hasSize(2);
+            assertThat(copyUsingForEach(list)).containsExactly("new1", "new2");
         }
 
         @Test
@@ -452,20 +779,14 @@ class ElementAwareArrayListTest {
             var list = new ElementAwareArrayList<String>();
 
             list.add("a");
-            var e2 = list.add("b");
+            var e2 = list.addEntry("b");
             list.add("c");
 
-            list.remove(e2);
+            e2.remove();
 
-            var result1 = new ArrayList<String>();
-            list.forEach(result1::add);
-
-            var result2 = new ArrayList<String>();
-            list.forEach(result2::add);
-
-            assertThat(result1).containsExactly("a", "c");
-            assertThat(result2).containsExactly("a", "c");
-            assertThat(list.size()).isEqualTo(2);
+            assertThat(copyUsingForEach(list)).containsExactly("a", "c");
+            assertThat(copyUsingForEach(list)).containsExactly("a", "c");
+            assertThat(list).hasSize(2);
         }
 
         @Test
@@ -473,12 +794,12 @@ class ElementAwareArrayListTest {
         void positionTrackingAfterCompaction() {
             var list = new ElementAwareArrayList<String>();
 
-            var e1 = list.add("a");
-            var e2 = list.add("b");
-            var e3 = list.add("c");
-            var e4 = list.add("d");
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
 
-            list.remove(e2);
+            e2.remove();
 
             list.forEach(s -> {
             });
@@ -488,6 +809,614 @@ class ElementAwareArrayListTest {
             assertThat(e3.toString()).contains("@1");
             assertThat(e4.toString()).contains("@2");
         }
+    }
+
+    @Nested
+    @DisplayName("add(int, Object) tests")
+    class AddAtIndexTests {
+
+        @Test
+        @DisplayName("addAt at end is equivalent to add")
+        void addAtEnd() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+
+            list.add(2, "c");
+            assertThat(list).hasSize(3);
+            assertThat(list.get(2)).isEqualTo("c");
+            assertThat(copyUsingForEach(list)).containsExactly("a", "b", "c");
+        }
+
+        @Test
+        @DisplayName("addAt at beginning shifts existing entries")
+        void addAtBeginning() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("b");
+            var e2 = list.addEntry("c");
+
+            list.add(0, "a");
+
+            assertThat(list).hasSize(3);
+            assertThat(copyUsingForEach(list)).containsExactly("a", "b", "c");
+            assertThat(e1.isRemoved()).isFalse();
+            assertThat(e2.isRemoved()).isFalse();
+        }
+
+        @Test
+        @DisplayName("addAt in middle shifts subsequent entries")
+        void addAtMiddle() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("c");
+
+            list.add(1, "b");
+
+            assertThat(list).hasSize(3);
+            assertThat(copyUsingForEach(list)).containsExactly("a", "b", "c");
+        }
+
+        @Test
+        @DisplayName("addAt partially compacts prefix then fills gap")
+        void addAtCompactsFirst() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            list.add("b");
+            var e3 = list.addEntry("c");
+
+            e1.remove();
+
+            list.add(1, "x");
+
+            assertThat(list).hasSize(3);
+            assertThat(copyUsingForEach(list)).containsExactly("b", "x", "c");
+            assertThat(e3.isRemoved()).isFalse();
+        }
+
+        @Test
+        @DisplayName("addAt fills a gap directly when the target slot is null after prefix compaction")
+        void addAtFillsGap() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+
+            e2.remove();
+            // Physical: [a@0, null, c@2, d@3], gapCount=1
+
+            list.add(1, "x");
+            // partialCompact(0): a already at slot 0, no swap; slot 1 is null → gap-fill, no shift.
+
+            assertThat(list).hasSize(4);
+            assertThat(e1.toString()).contains("@0");
+            assertThat(e3.toString()).contains("@2"); // suffix positions unchanged
+            assertThat(e4.toString()).contains("@3");
+            assertThat(copyUsingForEach(list)).containsExactly("a", "x", "c", "d");
+        }
+
+        @Test
+        @DisplayName("addAt fills a gap that prefix compaction created at the target slot")
+        void addAtFillsGapAfterPrefixCompact() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+
+            e1.remove();
+            e3.remove();
+            // Physical: [null, b@1, null, d@3], gapCount=2
+
+            list.add(1, "x");
+            // partialCompact(0): b moves from slot 1 to slot 0, slot 1 becomes null → gap-fill.
+
+            assertThat(list).hasSize(3);
+            assertThat(e2.toString()).contains("@0"); // b moved by prefix compaction
+            assertThat(e4.toString()).contains("@3"); // d position unchanged
+            assertThat(copyUsingForEach(list)).containsExactly("b", "x", "d");
+        }
+
+        @Test
+        @DisplayName("addAt rotates entries into the nearest suffix gap when target slot is non-null")
+        void addAtRotatesIntoGap() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+            var e5 = list.addEntry("e");
+
+            e4.remove();
+            // Physical: [a@0, b@1, c@2, null, e@4], gapCount=1
+
+            list.add(1, "x");
+            // partialCompact(0): no prefix gap; slot 1 non-null (b) → rotate b→2, c→3 into gap at slot 3.
+
+            assertThat(list).hasSize(5);
+            // lastElementPosition unchanged; gapCount consumed.
+            assertThat(e1.toString()).contains("@0");
+            assertThat(e2.toString()).contains("@2"); // b rotated to slot 2
+            assertThat(e3.toString()).contains("@3"); // c rotated into the former gap slot
+            assertThat(e5.toString()).contains("@4"); // e beyond the gap: untouched
+            assertThat(copyUsingForEach(list)).containsExactly("a", "x", "b", "c", "e");
+        }
+
+        @Test
+        @DisplayName("addAt with negative index throws IndexOutOfBoundsException")
+        void addAtNegativeIndex() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+
+            assertThatExceptionOfType(IndexOutOfBoundsException.class)
+                    .isThrownBy(() -> list.add(-1, "x"));
+        }
+
+        @Test
+        @DisplayName("addAt beyond size throws IndexOutOfBoundsException")
+        void addAtBeyondSize() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+
+            assertThatExceptionOfType(IndexOutOfBoundsException.class)
+                    .isThrownBy(() -> list.add(2, "x"));
+        }
+
+        @Test
+        @DisplayName("addAt beyond logical size on gappy list does not invalidate iterator")
+        void addAtBeyondLogicalSizeOnGappyList() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            var entry = list.addEntry("b");
+            list.add("c");
+            entry.remove();
+            // logical size = 2, backing size = 3
+
+            var it = list.listIterator();
+            assertThat(it.next()).isEqualTo("a");
+
+            assertThatExceptionOfType(IndexOutOfBoundsException.class)
+                    .isThrownBy(() -> list.add(3, "x"));
+            assertThatCode(() -> assertThat(it.next()).isEqualTo("c"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("addAt into empty list at index 0")
+        void addAtEmptyList() {
+            var list = new ElementAwareArrayList<String>();
+
+            list.add(0, "a");
+
+            assertThat(list).hasSize(1);
+            assertThat(list.getFirst()).isEqualTo("a");
+        }
+
+        @Test
+        @DisplayName("existing entries remain removable after addAt")
+        void existingEntriesRemovableAfterAddAt() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            list.add("c");
+            list.add(1, "b");
+            e1.remove();
+
+            assertThat(list).hasSize(2);
+            assertThat(copyUsingForEach(list)).containsExactly("b", "c");
+        }
+
+        @Test
+        @DisplayName("addAt rotate stops at nearest suffix gap, leaving farther gaps untouched")
+        void addAtRotatesIntoNearestGapMultipleGaps() {
+            var list = new ElementAwareArrayList<String>();
+            var e1 = list.addEntry("a");
+            var e2 = list.addEntry("b");
+            var e3 = list.addEntry("c");
+            var e4 = list.addEntry("d");
+            var e5 = list.addEntry("e");
+
+            e3.remove();
+            e4.remove();
+            // Physical: [a@0, b@1, null, null, e@4], gapCount=2
+
+            list.add(1, "x");
+            // partialCompact(0): no prefix gap; slot 1 non-null (b) → rotate: b→slot 2 (first null), stop.
+            // First gap (slot 2) consumed; second gap at slot 3 untouched; e@4 position unchanged.
+
+            assertThat(list).hasSize(4);
+            assertThat(e1.toString()).contains("@0");
+            assertThat(e2.toString()).contains("@2"); // b rotated into first gap
+            assertThat(e5.toString()).contains("@4"); // e beyond both gaps: untouched
+            assertThat(copyUsingForEach(list)).containsExactly("a", "x", "b", "e");
+        }
+    }
+
+    @Nested
+    @DisplayName("ListIterator tests")
+    class ListIteratorTests {
+
+        @Test
+        @DisplayName("forward iteration over gap-free list")
+        void forwardIteration() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+            list.add("c");
+
+            var it = list.listIterator();
+            assertThat(it.hasNext()).isTrue();
+            assertThat(it.next()).isEqualTo("a");
+            assertThat(it.next()).isEqualTo("b");
+            assertThat(it.next()).isEqualTo("c");
+            assertThat(it.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("backward iteration over gap-free list")
+        void backwardIteration() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+            list.add("c");
+
+            var it = list.listIterator(3);
+            assertThat(it.hasPrevious()).isTrue();
+            assertThat(it.previous()).isEqualTo("c");
+            assertThat(it.previous()).isEqualTo("b");
+            assertThat(it.previous()).isEqualTo("a");
+            assertThat(it.hasPrevious()).isFalse();
+        }
+
+        @Test
+        @DisplayName("forward iteration skips null slots")
+        void forwardWithGaps() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            var entryB = list.addEntry("b");
+            list.add("c");
+            var entryD = list.addEntry("d");
+            list.add("e");
+            entryB.remove();
+            entryD.remove();
+
+            var it = list.listIterator();
+            assertThat(it.next()).isEqualTo("a");
+            assertThat(it.next()).isEqualTo("c");
+            assertThat(it.next()).isEqualTo("e");
+            assertThat(it.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("remove after next() removes correct element, adjusts cursor")
+        void removeFwd() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+            list.add("c");
+
+            var it = list.listIterator();
+            assertThat(it.next()).isEqualTo("a");
+            it.remove();
+            assertThat(list).containsExactly("b", "c");
+            assertThat(it.hasPrevious()).isFalse();
+            assertThat(it.hasNext()).isTrue();
+            assertThat(it.next()).isEqualTo("b");
+        }
+
+        @Test
+        @DisplayName("remove after previous() removes correct element; cursor ping-pong")
+        void removeBwd() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+            list.add("c");
+
+            var it = list.listIterator();
+            it.next();
+            it.next();
+            it.next();
+            assertThat(it.previous()).isEqualTo("c");
+            it.remove();
+            assertThat(list).containsExactly("a", "b");
+            assertThat(it.hasNext()).isFalse();
+            assertThat(it.hasPrevious()).isTrue();
+            assertThat(it.previous()).isEqualTo("b");
+            assertThat(it.next()).isEqualTo("b");
+        }
+
+        @Test
+        @DisplayName("set() replaces element without invalidating concurrent iterators")
+        void set() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+
+            var it = list.listIterator();
+            var it2 = list.listIterator();
+            it.next();
+            it.set("x");
+            assertThat(list).containsExactly("x", "b");
+
+            assertThat(it2.next()).isEqualTo("x");
+        }
+
+        @Test
+        @DisplayName("add() inserts before next element; next() unaffected, previous() returns new element")
+        void addAtCursor() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+            list.add("c");
+
+            var it = list.listIterator();
+            assertThat(it.next()).isEqualTo("a");
+            it.add("x");
+            assertThat(it.next()).isEqualTo("b");
+            assertThat(it.previous()).isEqualTo("b");
+            assertThat(it.previous()).isEqualTo("x");
+            assertThat(list).containsExactly("a", "x", "b", "c");
+        }
+
+        @Test
+        @DisplayName("add() on gappy list compacts then inserts at correct logical position")
+        void addWithGaps() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            var entry = list.addEntry("b");
+            list.add("c");
+            entry.remove();
+
+            var it = list.listIterator(1);
+            it.add("x");
+            assertThat(list).containsExactly("a", "x", "c");
+        }
+
+        @Test
+        @DisplayName("next() past end throws NoSuchElementException")
+        void noSuchElement() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+
+            var it = list.listIterator();
+            it.next();
+            assertThatExceptionOfType(NoSuchElementException.class)
+                    .isThrownBy(it::next);
+        }
+
+        @Test
+        @DisplayName("external remove(Entry) causes CME on subsequent iterator call")
+        void cmeOnExternalModify() {
+            var list = new ElementAwareArrayList<String>();
+            var entry = list.addEntry("a");
+            list.add("b");
+
+            var it = list.listIterator();
+            it.next();
+            entry.remove();
+
+            assertThatExceptionOfType(ConcurrentModificationException.class)
+                    .isThrownBy(it::next);
+        }
+
+        @Test
+        @DisplayName("remove() without preceding next() or previous() throws IllegalStateException")
+        void removeWithoutNext() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+
+            var it = list.listIterator();
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(it::remove);
+        }
+
+        @Test
+        @DisplayName("listIterator(index) starts cursor after given logical position")
+        void startAtIndex() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+            list.add("c");
+
+            var it = list.listIterator(2);
+            assertThat(it.next()).isEqualTo("c");
+            assertThat(it.hasNext()).isFalse();
+
+            it = list.listIterator(2);
+            assertThat(it.previous()).isEqualTo("b");
+        }
+
+        @Test
+        @DisplayName("listIterator(index) on gappy list compacts before starting")
+        void startAtIndexWithGaps() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            var entry = list.addEntry("b");
+            list.add("c");
+            list.add("d");
+            entry.remove();
+
+            var it = list.listIterator(1);
+            assertThat(it.next()).isEqualTo("c");
+            assertThat(it.previous()).isEqualTo("c");
+            assertThat(it.previous()).isEqualTo("a");
+        }
+
+        @Test
+        @DisplayName("forward iteration through gaps then full backward traversal")
+        void forwardWithGapsThenBackward() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            var entryB = list.addEntry("b");
+            list.add("c");
+            var entryD = list.addEntry("d");
+            list.add("e");
+            entryB.remove();
+            entryD.remove();
+            // Physical: [a, null, c, null, e]; gaps never compacted during forward scan.
+
+            var it = list.listIterator();
+            assertThat(it.next()).isEqualTo("a");
+            assertThat(it.next()).isEqualTo("c");
+            assertThat(it.next()).isEqualTo("e");
+            assertThat(it.hasNext()).isFalse();
+
+            // previous() must traverse back through the uncompacted gaps.
+            assertThat(it.previous()).isEqualTo("e");
+            assertThat(it.previous()).isEqualTo("c");
+            assertThat(it.previous()).isEqualTo("a");
+            assertThat(it.hasPrevious()).isFalse();
+        }
+
+        @Test
+        @DisplayName("backward iteration from end of gappy list (gaps at head and middle)")
+        void backwardFromEndWithGaps() {
+            var list = new ElementAwareArrayList<String>();
+            var entryA = list.addEntry("a");
+            list.add("b");
+            var entryC = list.addEntry("c");
+            list.add("d");
+            entryA.remove();
+            entryC.remove();
+            // Physical: [null, b, null, d], logical: [b, d].
+
+            var it = list.listIterator(list.size());
+            assertThat(it.hasPrevious()).isTrue();
+            assertThat(it.previous()).isEqualTo("d");
+            assertThat(it.previous()).isEqualTo("b");
+            assertThat(it.hasPrevious()).isFalse();
+        }
+
+        @Test
+        @DisplayName("iterator remove on list that already has gaps")
+        void removeViaIteratorOnGappyList() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            var entryB = list.addEntry("b");
+            list.add("c");
+            list.add("d");
+            entryB.remove();
+            // Physical: [a, null, c, d], logical: [a, c, d].
+
+            var it = list.listIterator();
+            assertThat(it.next()).isEqualTo("a");
+            assertThat(it.next()).isEqualTo("c");
+            it.remove(); // removes "c" from already-gappy list
+
+            assertThat(list).hasSize(2);
+            assertThat(it.hasNext()).isTrue();
+            assertThat(it.hasPrevious()).isTrue();
+            assertThat(it.next()).isEqualTo("d");
+            assertThat(it.hasNext()).isFalse();
+            assertThat(copyUsingForEach(list)).containsExactly("a", "d");
+        }
+
+        @Test
+        @DisplayName("next-remove-next-previous cycle with pre-existing gaps")
+        void nextRemoveNextPreviousCycle() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            var entryX = list.addEntry("x");
+            list.add("b");
+            list.add("c");
+            entryX.remove();
+            // Physical: [a, null, b, c], logical: [a, b, c].
+
+            var it = list.listIterator();
+            assertThat(it.next()).isEqualTo("a");
+            assertThat(it.next()).isEqualTo("b");
+            it.remove(); // logical: [a, c]
+
+            assertThat(it.next()).isEqualTo("c");
+            assertThat(it.previous()).isEqualTo("c");
+            assertThat(it.previous()).isEqualTo("a");
+            assertThat(it.hasPrevious()).isFalse();
+            assertThat(list).containsExactly("a", "c");
+        }
+
+        @Test
+        @DisplayName("removing all elements via iterator produces no spurious CME")
+        void removeLastElementNoDoubleCme() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+            list.add("c");
+
+            var it = list.listIterator();
+            while (it.hasNext()) {
+                it.next();
+                it.remove();
+            }
+            assertThat(list).isEmpty();
+        }
+
+        @Test
+        @DisplayName("set() without preceding next() or previous() throws IllegalStateException")
+        void setWithoutNextOrPrevious() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+
+            var it = list.listIterator();
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(() -> it.set("x"));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Fail-fast behavior tests (implementation-specific)")
+    class FailFastBehaviorTests {
+
+        @Test
+        @DisplayName("listIterator fail-fast on add (implementation-specific)")
+        void cmeOnAdd() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+
+            var it = list.listIterator();
+            it.next();
+            list.add("c");
+
+            assertThatExceptionOfType(ConcurrentModificationException.class)
+                    .isThrownBy(it::next);
+        }
+
+        @Test
+        @DisplayName("listIterator fail-fast on remove(int) (implementation-specific)")
+        void cmeOnRemove() {
+            var list = new ElementAwareArrayList<String>();
+            list.add("a");
+            list.add("b");
+
+            var it = list.listIterator();
+            it.next();
+            list.removeFirst();
+
+            assertThatExceptionOfType(ConcurrentModificationException.class)
+                    .isThrownBy(it::next);
+        }
+
+        @Test
+        @DisplayName("listIterator fail-fast on remove(Entry) (implementation-specific)")
+        void cmeOnEntryRemove() {
+            var list = new ElementAwareArrayList<String>();
+            var entry = list.addEntry("a");
+            list.add("b");
+
+            var it = list.listIterator();
+            it.next();
+            entry.remove();
+
+            assertThatExceptionOfType(ConcurrentModificationException.class)
+                    .isThrownBy(it::next);
+        }
+
+    }
+
+    private static <T extends @Nullable Object> List<T> copyUsingForEach(ElementAwareArrayList<T> list) {
+        var result = new ArrayList<T>();
+        list.forEach(result::add);
+        return result;
     }
 
 }


### PR DESCRIPTION
The underlying collection is now optimized for removals, as those operations will be frequent inside group nodes. It still retains fast random access to elements, as that is required to reuse it in Neighborhoods.

The collection supports null values, and implements the full list interface; this makes it a suitable replacement to ArrayList.

Compared to ArrayList, remove() is super-fast if done via the entry. This introduces small overhead in addition and iteration, as the arrays may need to be compacted. Some operations compare equally poorly in both collections, such as additions into the middle of the array.

Note: this was co-developed with Claude code. It was reviewed by 2 different LLMs, as well as by me.