### PR TITLE
doc: remove mention of old benchmark method reference

### DIFF
--- a/docs/src/modules/ROOT/pages/using-timefold-solver/benchmarking-and-tweaking.adoc
+++ b/docs/src/modules/ROOT/pages/using-timefold-solver/benchmarking-and-tweaking.adoc
@@ -63,7 +63,7 @@ PlannerBenchmark benchmark = benchmarkFactory.buildPlannerBenchmark(dataset1, da
 benchmark.benchmark();
 ----
 
-This generates a benchmark report in `local/benchmarkReport` and shows it in your browser when it's finished.
+This generates a benchmark report in `local/benchmarkReport` when it's finished.
 The ``SolverFactory``'s solver configuration needs a termination to limit how long each dataset runs.
 To configure a different benchmark directory, pass a `File` parameter to `createFromSolverConfigXmlResource()`.
 

--- a/docs/src/modules/ROOT/pages/using-timefold-solver/benchmarking-and-tweaking.adoc
+++ b/docs/src/modules/ROOT/pages/using-timefold-solver/benchmarking-and-tweaking.adoc
@@ -60,7 +60,7 @@ VehicleRoutePlan dataset1 = ...;
 VehicleRoutePlan dataset2 = ...;
 VehicleRoutePlan dataset3 = ...;
 PlannerBenchmark benchmark = benchmarkFactory.buildPlannerBenchmark(dataset1, dataset2, dataset3);
-benchmark.benchmarkAndShowReportInBrowser();
+benchmark.benchmark();
 ----
 
 This generates a benchmark report in `local/benchmarkReport` and shows it in your browser when it's finished.
@@ -82,7 +82,7 @@ Configure it with a benchmark configuration XML file, provided as a classpath re
 PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.createFromXmlResource(
         "org/acme/vehiclerouting/benchmarkConfig.xml");
 PlannerBenchmark benchmark = benchmarkFactory.buildPlannerBenchmark();
-benchmark.benchmarkAndShowReportInBrowser();
+benchmark.benchmark();
 ----
 
 Alternatively, create a `PlannerBenchmarkFactory` programmatically from a `PlannerBenchmarkConfig`.


### PR DESCRIPTION
Was in our migration recipe, but was still mentioned in the docs. 