### PR TITLE
chore: upgrade to quarkus 3.35.1

### DIFF
--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -21,7 +21,7 @@
     <!-- Dependencies -->
     <!-- ************************************************************************ -->
     <version.ch.qos.logback>1.5.32</version.ch.qos.logback>
-    <version.io.quarkus>3.34.5</version.io.quarkus>
+    <version.io.quarkus>3.35.1</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.logging.log4j>2.25.4</version.org.apache.logging.log4j>
     <version.org.assertj>3.27.7</version.org.assertj>

--- a/quarkus-integration/quarkus/devui-integration-test/src/test/java/ai/timefold/solver/quarkus/it/devui/TimefoldDevUITest.java
+++ b/quarkus-integration/quarkus/devui-integration-test/src/test/java/ai/timefold/solver/quarkus/it/devui/TimefoldDevUITest.java
@@ -73,20 +73,20 @@ public class TimefoldDevUITest extends DevUIJsonRPCTest {
         JsonNode configResponse = super.executeJsonRPCMethod("getConfig");
         String solverConfig = configResponse.get("config").get("default").asText();
         assertThat(solverConfig).isEqualToIgnoringWhitespace(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                        + "<!--Properties that can be set at runtime are not included-->\n"
-                        + "<solver>\n"
-                        + "  <solutionClass>" + TestdataStringLengthShadowSolution.class.getCanonicalName()
-                        + "</solutionClass>\n"
-                        + "  <entityClass>" + TestdataStringLengthShadowEntity.class.getCanonicalName() + "</entityClass>\n"
-                        + "  <scoreDirectorFactory>\n"
-                        + "    <constraintProviderClass>" + TestdataStringLengthConstraintProvider.class.getCanonicalName()
-                        + "</constraintProviderClass>\n"
-                        + "  </scoreDirectorFactory>\n"
-                        + "  <termination>\n"
-                        + "    <bestScoreLimit>0hard/5soft</bestScoreLimit>\n"
-                        + "  </termination>\n"
-                        + "</solver>");
+                """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <!--Properties that can be set at runtime are not included-->
+                        <solver>
+                          <solutionClass>%s</solutionClass>
+                          <entityClass>%s</entityClass>
+                          <scoreDirectorFactory>
+                            <constraintProviderClass>%s</constraintProviderClass>
+                          </scoreDirectorFactory>
+                          <termination />
+                        </solver>""".formatted(
+                        TestdataStringLengthShadowSolution.class.getCanonicalName(),
+                        TestdataStringLengthShadowEntity.class.getCanonicalName(),
+                        TestdataStringLengthConstraintProvider.class.getCanonicalName()));
     }
 
     @Test

--- a/quarkus-integration/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus-integration/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,6 @@
 ---
 name: "Timefold Solver"
+artifact: "ai.timefold.solver:timefold-solver-quarkus:999-SNAPSHOT"
 metadata:
   keywords:
     - "timefold"

--- a/quarkus-integration/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus-integration/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,5 @@
 ---
 name: "Timefold Solver"
-artifact: "ai.timefold.solver:timefold-solver-quarkus:999-SNAPSHOT"
 metadata:
   keywords:
     - "timefold"


### PR DESCRIPTION
- Termination is a runtime property, so per the XML comment, it should of never been included inside the XML.
- From the test logs, an error was happening when the quarkus-extension.yaml did not have "artifact", but that error did not affect the build and the fix should work without it.