### PR TITLE
perf: perform shadow variable update exactly once

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
@@ -16,7 +16,7 @@ import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet_> implements VariableReferenceGraph
+public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeTracker_> implements VariableReferenceGraph
         permits DefaultVariableReferenceGraph, FixedVariableReferenceGraph {
 
     // These structures are immutable.
@@ -28,9 +28,13 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
 
     // These structures are mutable.
     protected final DynamicLinearProbeNonNegativeIntCounter[] edgeCount;
-    protected final ChangeSet_ changeSet;
+    protected final ChangeTracker_ changeTracker;
     protected final TopologicalOrderGraph graph;
 
+    /**
+     * True if we are currently doing a declarative shadow variable update,
+     * false otherwise.
+     */
     protected boolean isUpdating;
 
     AbstractVariableReferenceGraph(VariableReferenceGraphBuilder<Solution_> outerGraph,
@@ -51,7 +55,7 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
         nodeTopologicalOrders = buildNodeTopologicalOrderArray(graph, nodeList.size());
 
         var visited = Collections.newSetFromMap(new IdentityHashMap<>());
-        changeSet = createChangeSet(instanceCount);
+        changeTracker = createChangeTracker(instanceCount);
         for (var instance : nodeList) {
             var entity = instance.entity();
             if (visited.add(entity)) {
@@ -67,8 +71,22 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
         }
     }
 
+    /**
+     * As specified by {@link VariableReferenceGraph#updateChanged()}.
+     *
+     * @implNote {@link #updateChanged()} sets {{@link #isUpdating}} to true
+     *           so {@link #beforeVariableChanged(VariableMetaModel, Object)}
+     *           and {@link #afterVariableChanged(VariableMetaModel, Object)}
+     *           can short circuit.
+     */
     abstract void innerUpdateChanged();
 
+    /**
+     * Called when any non-declarative source variable for the
+     * given {@link GraphNode} changes.
+     *
+     * @param changed The graph node that has a non-declarative source variable that changed.
+     */
     abstract void markChanged(GraphNode<Solution_> changed);
 
     @Override
@@ -88,7 +106,14 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
         return out;
     }
 
-    protected abstract ChangeSet_ createChangeSet(int instanceCount);
+    /**
+     * Create the data structure used by {@link #markChanged(GraphNode)}.
+     * Used in the constructor when constructing the initial graph.
+     *
+     * @param instanceCount The number of nodes in the graph
+     * @return The data structure used for tracking.
+     */
+    protected abstract ChangeTracker_ createChangeTracker(int instanceCount);
 
     public final @Nullable GraphNode<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity) {
         var map = variableReferenceToContainingNodeMap.get(variableId);

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
@@ -31,8 +31,11 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
     protected final ChangeSet_ changeSet;
     protected final TopologicalOrderGraph graph;
 
+    protected boolean isUpdating;
+
     AbstractVariableReferenceGraph(VariableReferenceGraphBuilder<Solution_> outerGraph,
             IntFunction<TopologicalOrderGraph> graphCreator) {
+        isUpdating = false;
         nodeList = List.copyOf(outerGraph.nodeList);
         var instanceCount = nodeList.size();
         // Often the maps are a singleton; we improve performance by actually making it so.
@@ -64,6 +67,17 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
         }
     }
 
+    abstract void innerUpdateChanged();
+
+    abstract void markChanged(GraphNode<Solution_> changed);
+
+    @Override
+    public final void updateChanged() {
+        isUpdating = true;
+        innerUpdateChanged();
+        isUpdating = false;
+    }
+
     private BaseTopologicalOrderGraph.NodeTopologicalOrder[] buildNodeTopologicalOrderArray(BaseTopologicalOrderGraph graph,
             int graphSize) {
         var out = new BaseTopologicalOrderGraph.NodeTopologicalOrder[graphSize];
@@ -76,7 +90,7 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
 
     protected abstract ChangeSet_ createChangeSet(int instanceCount);
 
-    public @Nullable GraphNode<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity) {
+    public final @Nullable GraphNode<Solution_> lookupOrNull(VariableMetaModel<?, ?, ?> variableId, Object entity) {
         var map = variableReferenceToContainingNodeMap.get(variableId);
         if (map == null) {
             return null;
@@ -84,7 +98,7 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
         return map.get(entity);
     }
 
-    public void addEdge(@NonNull GraphNode<Solution_> from, @NonNull GraphNode<Solution_> to) {
+    public final void addEdge(@NonNull GraphNode<Solution_> from, @NonNull GraphNode<Solution_> to) {
         var fromNodeId = from.graphNodeId();
         var toNodeId = to.graphNodeId();
         if (fromNodeId == toNodeId) {
@@ -99,7 +113,7 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
         markChanged(to);
     }
 
-    public void removeEdge(@NonNull GraphNode<Solution_> from, @NonNull GraphNode<Solution_> to) {
+    public final void removeEdge(@NonNull GraphNode<Solution_> from, @NonNull GraphNode<Solution_> to) {
         var fromNodeId = from.graphNodeId();
         var toNodeId = to.graphNodeId();
         if (fromNodeId == toNodeId) {
@@ -114,10 +128,13 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
         markChanged(to);
     }
 
-    abstract void markChanged(GraphNode<Solution_> changed);
-
     @Override
-    public void beforeVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
+    public final void beforeVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
+        if (isUpdating) {
+            // If we are updating, then the variable that changed is a declarative shadow variable;
+            // We don't need to check for graph modifications/track changes when we are updating, so skip
+            return;
+        }
         if (variableReference.entity().type().isInstance(entity)) {
             processEntity(variableReferenceToBeforeProcessor.getOrDefault(variableReference, Collections.emptyList()), entity);
         }
@@ -135,7 +152,12 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeSet
     }
 
     @Override
-    public void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
+    public final void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
+        if (isUpdating) {
+            // If we are updating, then the variable that changed is a declarative shadow variable;
+            // We don't need to check for graph modifications/track changes when we are updating, so skip
+            return;
+        }
         if (variableReference.entity().type().isInstance(entity)) {
             var node = lookupOrNull(variableReference, entity);
             if (node != null) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultTopologicalOrderGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultTopologicalOrderGraph.java
@@ -84,10 +84,9 @@ public class DefaultTopologicalOrderGraph implements TopologicalOrderGraph {
 
     @Override
     public PrimitiveIterator.OfInt nodeForwardEdges(int fromNode) {
-        return componentMap.get(fromNode).stream()
-                .flatMap(member -> forwardEdges[member].stream())
+        return forwardEdges[fromNode].stream()
                 .mapToInt(Integer::intValue)
-                .distinct().iterator();
+                .iterator();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -46,12 +46,12 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
     }
 
     @Override
-    public void markChanged(@NonNull GraphNode<Solution_> node) {
+    void markChanged(@NonNull GraphNode<Solution_> node) {
         changeSet.set(node.graphNodeId());
     }
 
     @Override
-    public void updateChanged() {
+    void innerUpdateChanged() {
         if (changeSet.isEmpty()) {
             return;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -41,29 +41,29 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
     }
 
     @Override
-    protected BitSet createChangeSet(int instanceCount) {
+    protected BitSet createChangeTracker(int instanceCount) {
         return new BitSet(instanceCount);
     }
 
     @Override
     void markChanged(@NonNull GraphNode<Solution_> node) {
-        changeSet.set(node.graphNodeId());
+        changeTracker.set(node.graphNodeId());
     }
 
     @Override
     void innerUpdateChanged() {
-        if (changeSet.isEmpty()) {
+        if (changeTracker.isEmpty()) {
             return;
         }
-        graph.commitChanges(changeSet);
-        affectedEntitiesUpdater.accept(changeSet);
+        graph.commitChanges(changeTracker);
+        affectedEntitiesUpdater.accept(changeTracker);
     }
 
     /**
      * See {@link ConsistencyTracker#setUnknownConsistencyFromEntityShadowVariablesInconsistent}
      */
     public void setUnknownInconsistencyValues() {
-        graph.commitChanges(changeSet);
+        graph.commitChanges(changeTracker);
         affectedEntitiesUpdater.setUnknownInconsistencyValues();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -2,7 +2,9 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.BitSet;
 import java.util.PriorityQueue;
+import java.util.Spliterators;
 import java.util.function.IntFunction;
+import java.util.stream.StreamSupport;
 
 import org.jspecify.annotations.NonNull;
 
@@ -11,6 +13,7 @@ public final class FixedVariableReferenceGraph<Solution_>
     // These are immutable
     private final ChangedVariableNotifier<Solution_> changedVariableNotifier;
     private final BitSet isChanged;
+    private final int[][] cachedComponentForwardEdges;
     // These are mutable
     private boolean isFinalized = false;
 
@@ -18,6 +21,7 @@ public final class FixedVariableReferenceGraph<Solution_>
             IntFunction<TopologicalOrderGraph> graphCreator) {
         super(outerGraph, graphCreator);
         isChanged = new BitSet(nodeList.size());
+        cachedComponentForwardEdges = new int[nodeList.size()][];
         graph.commitChanges(isChanged);
         isChanged.clear();
         isFinalized = true;
@@ -26,6 +30,11 @@ public final class FixedVariableReferenceGraph<Solution_>
         // each node to changed.
         changedVariableNotifier = outerGraph.changedVariableNotifier;
         for (var node = 0; node < nodeList.size(); node++) {
+            var finalNode = node;
+            cachedComponentForwardEdges[node] = StreamSupport
+                    .intStream(() -> Spliterators.spliterator(graph.nodeForwardEdges(finalNode), 0, 0),
+                            0, false)
+                    .toArray();
             changeSet.add(nodeTopologicalOrders[node]);
             var variableReference = nodeList.get(node).variableReferences().get(0);
             var entityConsistencyState = variableReference.entityConsistencyState();
@@ -84,8 +93,7 @@ public final class FixedVariableReferenceGraph<Solution_>
             for (var shadowVariableReference : shadowVariableReferences) {
                 var isVariableChanged = shadowVariableReference.updateIfChanged(entity, changedVariableNotifier);
                 if (isVariableChanged) {
-                    for (var iterator = graph.nodeForwardEdges(changedNode.nodeId()); iterator.hasNext();) {
-                        var nextNode = iterator.next();
+                    for (var nextNode : cachedComponentForwardEdges[changedNode.nodeId()]) {
                         if (visited.get(nextNode)) {
                             continue;
                         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -10,15 +10,16 @@ public final class FixedVariableReferenceGraph<Solution_>
         extends AbstractVariableReferenceGraph<Solution_, PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder>> {
     // These are immutable
     private final ChangedVariableNotifier<Solution_> changedVariableNotifier;
-
+    private final BitSet isChanged;
     // These are mutable
     private boolean isFinalized = false;
 
     public FixedVariableReferenceGraph(VariableReferenceGraphBuilder<Solution_> outerGraph,
             IntFunction<TopologicalOrderGraph> graphCreator) {
         super(outerGraph, graphCreator);
-        // We don't use a bit set to store changes, so pass a one-use instance
-        graph.commitChanges(new BitSet(nodeList.size()));
+        isChanged = new BitSet(nodeList.size());
+        graph.commitChanges(isChanged);
+        isChanged.clear();
         isFinalized = true;
 
         // Now that we know the topological order of nodes, add
@@ -51,16 +52,20 @@ public final class FixedVariableReferenceGraph<Solution_>
     }
 
     @Override
-    public void markChanged(@NonNull GraphNode<Solution_> node) {
+    void markChanged(@NonNull GraphNode<Solution_> node) {
         // Before the graph is finalized, ignore changes, since
         // we don't know the topological order yet
         if (isFinalized) {
-            changeSet.add(nodeTopologicalOrders[node.graphNodeId()]);
+            var nodeId = node.graphNodeId();
+            if (!isChanged.get(nodeId)) {
+                changeSet.add(nodeTopologicalOrders[nodeId]);
+                isChanged.set(nodeId);
+            }
         }
     }
 
     @Override
-    public void updateChanged() {
+    void innerUpdateChanged() {
         BitSet visited;
         if (!changeSet.isEmpty()) {
             visited = new BitSet(nodeList.size());
@@ -90,5 +95,6 @@ public final class FixedVariableReferenceGraph<Solution_>
                 }
             }
         }
+        isChanged.clear();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -35,7 +35,7 @@ public final class FixedVariableReferenceGraph<Solution_>
                     .intStream(() -> Spliterators.spliterator(graph.nodeForwardEdges(finalNode), 0, 0),
                             0, false)
                     .toArray();
-            changeSet.add(nodeTopologicalOrders[node]);
+            changeTracker.add(nodeTopologicalOrders[node]);
             var variableReference = nodeList.get(node).variableReferences().get(0);
             var entityConsistencyState = variableReference.entityConsistencyState();
             if (variableReference.groupEntities() != null) {
@@ -56,7 +56,7 @@ public final class FixedVariableReferenceGraph<Solution_>
     }
 
     @Override
-    protected PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder> createChangeSet(int instanceCount) {
+    protected PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder> createChangeTracker(int instanceCount) {
         return new PriorityQueue<>(instanceCount);
     }
 
@@ -67,7 +67,7 @@ public final class FixedVariableReferenceGraph<Solution_>
         if (isFinalized) {
             var nodeId = node.graphNodeId();
             if (!isChanged.get(nodeId)) {
-                changeSet.add(nodeTopologicalOrders[nodeId]);
+                changeTracker.add(nodeTopologicalOrders[nodeId]);
                 isChanged.set(nodeId);
             }
         }
@@ -76,17 +76,17 @@ public final class FixedVariableReferenceGraph<Solution_>
     @Override
     void innerUpdateChanged() {
         BitSet visited;
-        if (!changeSet.isEmpty()) {
+        if (!changeTracker.isEmpty()) {
             visited = new BitSet(nodeList.size());
-            visited.set(changeSet.peek().nodeId());
+            visited.set(changeTracker.peek().nodeId());
         } else {
             return;
         }
 
         // NOTE: This assumes the user did not add any fixed loops to
         // their graph (i.e. have two variables ALWAYS depend on one-another).
-        while (!changeSet.isEmpty()) {
-            var changedNode = changeSet.poll();
+        while (!changeTracker.isEmpty()) {
+            var changedNode = changeTracker.poll();
             var entityVariable = nodeList.get(changedNode.nodeId());
             var entity = entityVariable.entity();
             var shadowVariableReferences = entityVariable.variableReferences();
@@ -98,7 +98,7 @@ public final class FixedVariableReferenceGraph<Solution_>
                             continue;
                         }
                         visited.set(nextNode);
-                        changeSet.add(nodeTopologicalOrders[nextNode]);
+                        changeTracker.add(nodeTopologicalOrders[nextNode]);
                     }
                 }
             }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
@@ -21,6 +22,7 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
     private final ChangedVariableNotifier<Solution_> changedVariableNotifier;
     private final List<Object> changedEntities;
     private final Class<?> monitoredEntityClass;
+    private final Map<Object, Object> keyToLastProcessedObject;
     private final boolean canTerminateEarly;
     private boolean isUpdating;
 
@@ -36,6 +38,7 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
         sortedVariableUpdaterInfos = new VariableUpdaterInfo[sortedDeclarativeShadowVariableDescriptors.size()];
         monitoredSourceVariableSet = new HashSet<>();
         changedEntities = new ArrayList<>();
+        keyToLastProcessedObject = new IdentityHashMap<>();
         isUpdating = false;
 
         this.canTerminateEarly = canTerminateEarly;
@@ -80,17 +83,17 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
     public void updateChanged() {
         isUpdating = true;
         changedEntities.sort(topologicalOrderComparator);
-        var processed = new IdentityHashMap<>();
         for (var changedEntity : changedEntities) {
             var key = keyFunction.apply(changedEntity);
-            var lastProcessed = processed.get(key);
+            var lastProcessed = keyToLastProcessedObject.get(key);
             if (lastProcessed == null || topologicalOrderComparator.compare(lastProcessed, changedEntity) < 0) {
                 lastProcessed = updateChanged(changedEntity);
-                processed.put(key, lastProcessed);
+                keyToLastProcessedObject.put(key, lastProcessed);
             }
         }
         isUpdating = false;
         changedEntities.clear();
+        keyToLastProcessedObject.clear();
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -5,10 +5,31 @@ import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 public sealed interface VariableReferenceGraph
         permits AbstractVariableReferenceGraph, EmptyVariableReferenceGraph, SingleDirectionalParentVariableReferenceGraph {
 
+    /**
+     * Update all declarative {@link ai.timefold.solver.core.api.domain.variable.ShadowVariable} that has
+     * a source that was changed in either {@link #beforeVariableChanged(VariableMetaModel, Object)} or
+     * {@link #afterVariableChanged(VariableMetaModel, Object)}.
+     * <p>
+     * Called after all {@link ai.timefold.solver.core.impl.domain.variable.VariableListener} are
+     * triggered. Declarative {@link ai.timefold.solver.core.api.domain.variable.ShadowVariable}
+     * are guaranteed to be the last variables to update.
+     */
     void updateChanged();
 
+    /**
+     * Called before the variable corresponding to the {@link VariableMetaModel} on the given entity changes.
+     *
+     * @param variableReference The variable to be changed.
+     * @param entity The entity that has the variable.
+     */
     void beforeVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity);
 
+    /**
+     * Called after the variable corresponding to the {@link VariableMetaModel} on the given entity changes.
+     *
+     * @param variableReference The variable that changed.
+     * @param entity The entity that has the variable.
+     */
     void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity);
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/FollowerValuesShadowVariableTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/declarative/FollowerValuesShadowVariableTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
@@ -17,6 +18,7 @@ import ai.timefold.solver.core.testdomain.shadow.follower.TestdataFollowerSoluti
 import ai.timefold.solver.core.testdomain.shadow.follower.TestdataLeaderEntity;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class FollowerValuesShadowVariableTest {
     @Test
@@ -88,6 +90,46 @@ class FollowerValuesShadowVariableTest {
         assertThat(followerA3.getValue()).isEqualTo(value1);
         assertThat(followerB1.getValue()).isEqualTo(value2);
         assertThat(followerB2.getValue()).isEqualTo(value2);
+    }
+
+    @Test
+    void testUpdateOnce() {
+        var leaderA = new TestdataLeaderEntity("A");
+        var leaderB = new TestdataLeaderEntity("B");
+        var leaderC = new TestdataLeaderEntity("C");
+
+        var followerA1 = Mockito.spy(new TestdataFollowerEntity("A1", leaderA));
+        var followerA2 = Mockito.spy(new TestdataFollowerEntity("A2", leaderA));
+        var followerA3 = Mockito.spy(new TestdataFollowerEntity("A3", leaderA));
+
+        var followerB1 = Mockito.spy(new TestdataFollowerEntity("B1", leaderB));
+        var followerB2 = Mockito.spy(new TestdataFollowerEntity("B2", leaderB));
+
+        var value1 = new TestdataValue("1");
+        var value2 = new TestdataValue("2");
+
+        var solution = new TestdataFollowerSolution("Solution",
+                List.of(leaderA, leaderB, leaderC),
+                List.of(followerA1, followerA2, followerA3,
+                        followerB1, followerB2),
+                List.of(value1, value2));
+
+        var solutionMetamodel = TestdataFollowerSolution.buildMetaModel();
+        var variableMetamodel = solutionMetamodel.genuineEntity(TestdataLeaderEntity.class)
+                .basicVariable("value", TestdataValue.class);
+        var context = MoveTester.build(solutionMetamodel)
+                .using(solution);
+
+        Mockito.reset(followerA1, followerA2, followerA3, followerB1, followerB2);
+        context.execute(Moves.change(variableMetamodel, leaderA, value1));
+
+        for (var entity : List.of(followerA1)) {
+            verify(entity, Mockito.times(1)).valueSupplier();
+        }
+
+        for (var entity : List.of(followerA2, followerA3, followerB1, followerB2)) {
+            verify(entity, Mockito.never()).valueSupplier();
+        }
     }
 
 }


### PR DESCRIPTION
There were a couple of inefficiently discovered

- When a declarative shadow variable changes, it goes through the same plumbing as other variables. This is wasteful, since by definition, declarative shadow variables cannot affect the structure of the graph, and the graphs already modify the queues directly.

- When group alignment is used in a fixed graph, the same entity's update might be called multiple times. This is because the change set is a priority queue, which allows duplicate elements.

Now:

- We shortcut before/after variable change to return immediately if the graph is currently updating

- For fixed graphs, we have a seperate bitset to ensure the same node cannot be added to the changed queue multiple times.