### PR TITLE
fix: address XXE in JaxbIO parsing

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/io/jaxb/GenericJaxbIO.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/io/jaxb/GenericJaxbIO.java
@@ -124,7 +124,7 @@ public final class GenericJaxbIO<T> {
 
     public T read(Reader reader) {
         try {
-            return (T) createUnmarshaller().unmarshal(reader);
+            return (T) createUnmarshaller().unmarshal(parseXml(reader));
         } catch (JAXBException jaxbException) {
             throw new TimefoldXmlSerializationException(ERR_MSG_READ.formatted(rootClass.getName()), jaxbException);
         }


### PR DESCRIPTION
CWE-611: createUnmarshaller().unmarshal(Reader) lets the JAXB provider build its own SAX parser with default settings — external general entities, parameter entities, and DTD loading are not disabled. An attacker who controls the XML stream can:

  - exfiltrate local files via <!ENTITY xxe SYSTEM "file:///etc/passwd">,
  - pivot to internal HTTP endpoints (SSRF) via SYSTEM "http://169.254.169.254/...",
  - trigger a "billion laughs" DoS.

This is not being used in solver code, but could have been used by users.