### PR TITLE
perf: Support reusing the best solution instead of cloning in LS

### DIFF
--- a/core/src/build/revapi-differences.json
+++ b/core/src/build/revapi-differences.json
@@ -44,6 +44,17 @@
           "old": "field ai.timefold.solver.core.config.heuristic.selector.move.generic.AbstractPillarMoveSelectorConfig<Config_ extends ai.timefold.solver.core.config.heuristic.selector.move.generic.AbstractPillarMoveSelectorConfig<Config_>>.subPillarSequenceComparatorClass",
           "new": "field ai.timefold.solver.core.config.heuristic.selector.move.generic.AbstractPillarMoveSelectorConfig<Config_ extends ai.timefold.solver.core.config.heuristic.selector.move.generic.AbstractPillarMoveSelectorConfig<Config_>>.subPillarSequenceComparatorClass",
           "justification": "Internal protected fields; safe."
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.attributeValueChanged",
+          "old": "class ai.timefold.solver.core.config.solver.SolverConfig",
+          "new": "class ai.timefold.solver.core.config.solver.SolverConfig",
+          "annotationType": "jakarta.xml.bind.annotation.XmlType",
+          "attribute": "propOrder",
+          "oldValue": "{\"enablePreviewFeatureSet\", \"environmentMode\", \"daemon\", \"randomSeed\", \"moveThreadCount\", \"moveThreadBufferSize\", \"threadFactoryClass\", \"monitoringConfig\", \"solutionClass\", \"entityClassList\", \"scoreDirectorFactoryConfig\", \"terminationConfig\", \"nearbyDistanceMeterClass\", \"phaseConfigList\"}",
+          "newValue": "{\"enablePreviewFeatureSet\", \"environmentMode\", \"daemon\", \"randomSeed\", \"moveThreadCount\", \"moveThreadBufferSize\", \"threadFactoryClass\", \"monitoringConfig\", \"solutionClass\", \"entityClassList\", \"scoreDirectorFactoryConfig\", \"terminationConfig\", \"nearbyDistanceMeterClass\", \"phaseConfigList\", \"reuseBestSolution\"}",
+          "justification": "add support for reusing the best solution"
         }
       ]
     }

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/SolverConfig.java
@@ -73,6 +73,7 @@ import org.jspecify.annotations.Nullable;
         "terminationConfig",
         "nearbyDistanceMeterClass",
         "phaseConfigList",
+        "reuseBestSolution",
 })
 public final class SolverConfig extends AbstractConfig<SolverConfig> {
 
@@ -247,6 +248,8 @@ public final class SolverConfig extends AbstractConfig<SolverConfig> {
 
     @XmlElement(name = "monitoring")
     private MonitoringConfig monitoringConfig = null;
+
+    private Boolean reuseBestSolution = null;
 
     // ************************************************************************
     // Constructors and simple getters/setters
@@ -448,6 +451,14 @@ public final class SolverConfig extends AbstractConfig<SolverConfig> {
         this.monitoringConfig = monitoringConfig;
     }
 
+    public @Nullable Boolean getReuseBestSolution() {
+        return reuseBestSolution;
+    }
+
+    public void setReuseBestSolution(@Nullable Boolean reuseBestSolution) {
+        this.reuseBestSolution = reuseBestSolution;
+    }
+
     // ************************************************************************
     // With methods
     // ************************************************************************
@@ -600,6 +611,11 @@ public final class SolverConfig extends AbstractConfig<SolverConfig> {
         return this;
     }
 
+    public @NonNull SolverConfig withReuseBestSolution(@NonNull Boolean reuseBestSolution) {
+        this.reuseBestSolution = reuseBestSolution;
+        return this;
+    }
+
     // ************************************************************************
     // Smart getters
     // ************************************************************************
@@ -677,6 +693,7 @@ public final class SolverConfig extends AbstractConfig<SolverConfig> {
                 inheritedConfig.nearbyDistanceMeterClass);
         phaseConfigList = ConfigUtils.inheritMergeableListConfig(phaseConfigList, inheritedConfig.getPhaseConfigList());
         monitoringConfig = ConfigUtils.inheritConfig(monitoringConfig, inheritedConfig.getMonitoringConfig());
+        reuseBestSolution = ConfigUtils.inheritOverwritableProperty(reuseBestSolution, inheritedConfig.getReuseBestSolution());
         return this;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
+++ b/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.enterprise;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -47,6 +48,7 @@ import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchTotal;
 import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.DefaultSolverFactory;
+import ai.timefold.solver.core.impl.solver.recaller.ReusingBestSolutionUpdater;
 import ai.timefold.solver.core.impl.solver.termination.PhaseTermination;
 import ai.timefold.solver.core.impl.solver.termination.SolverTermination;
 import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningSolutionMetaModel;
@@ -210,6 +212,8 @@ public interface TimefoldSolverEnterpriseService {
                     Function<In_, @Nullable Out_> propositionFunction,
                     ScoreAnalysisFetchPolicy fetchPolicy);
 
+    <Solution_> ReusingBestSolutionUpdater<Solution_> buildReusingBestSolutionUpdater(ReadWriteLock readWriteLock);
+
     enum Feature {
         MULTITHREADED_SOLVING("Multi-threaded solving", "remove moveThreadCount from solver configuration"),
         PARTITIONED_SEARCH("Partitioned search", "remove partitioned search phase from solver configuration"),
@@ -219,7 +223,8 @@ public interface TimefoldSolverEnterpriseService {
                 "remove multistageMoveSelector and/or listMultistageMoveSelector from the solver configuration"),
         CONSTRAINT_PROFILING("Constraint profiling", "remove constraintStreamProfilingEnabled from the solver configuration"),
         SCORE_ANALYSIS("Score analysis", "do not use SolutionManager's analyze() method"),
-        RECOMMENDATIONS("Recommendations", "do not use SolutionManager's recommendAssignment() method");
+        RECOMMENDATIONS("Recommendations", "do not use SolutionManager's recommendAssignment() method"),
+        REUSE_BEST_SOLUTION("Reuse best solution", "remove reuseBestSolution from solver configuration");
 
         private final String name;
         private final String workaround;

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/HeuristicConfigPolicy.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/HeuristicConfigPolicy.java
@@ -43,6 +43,7 @@ public class HeuristicConfigPolicy<Solution_> {
     private final boolean unassignedValuesAllowed;
     private final Class<? extends NearbyDistanceMeter<?, ?>> nearbyDistanceMeterClass;
     private final RandomGenerator random;
+    private final boolean reuseBestSolution;
 
     private final Map<String, EntityMimicRecorder<Solution_>> entityMimicRecorderMap = new HashMap<>();
     private final Map<String, SubListMimicRecorder<Solution_>> subListMimicRecorderMap = new HashMap<>();
@@ -64,6 +65,7 @@ public class HeuristicConfigPolicy<Solution_> {
         this.unassignedValuesAllowed = builder.unassignedValuesAllowed;
         this.nearbyDistanceMeterClass = builder.nearbyDistanceMeterClass;
         this.random = builder.random;
+        this.reuseBestSolution = builder.reuseBestSolution;
     }
 
     public EnvironmentMode getEnvironmentMode() {
@@ -122,6 +124,10 @@ public class HeuristicConfigPolicy<Solution_> {
         return random;
     }
 
+    public boolean isReuseBestSolution() {
+        return reuseBestSolution;
+    }
+
     // ************************************************************************
     // Builder methods
     // ************************************************************************
@@ -138,7 +144,8 @@ public class HeuristicConfigPolicy<Solution_> {
                 .withInitializingScoreTrend(initializingScoreTrend)
                 .withSolutionDescriptor(solutionDescriptor)
                 .withClassInstanceCache(classInstanceCache)
-                .withLogIndentation(logIndentation);
+                .withLogIndentation(logIndentation)
+                .withReuseBestSolution(reuseBestSolution);
     }
 
     public HeuristicConfigPolicy<Solution_> copyConfigPolicy() {
@@ -276,6 +283,7 @@ public class HeuristicConfigPolicy<Solution_> {
 
         private Class<? extends NearbyDistanceMeter<?, ?>> nearbyDistanceMeterClass;
         private RandomGenerator random;
+        private boolean reuseBestSolution = false;
 
         public Builder<Solution_> withPreviewFeatureSet(Set<PreviewFeature> previewFeatureSet) {
             this.previewFeatureSet = previewFeatureSet;
@@ -350,6 +358,11 @@ public class HeuristicConfigPolicy<Solution_> {
 
         public Builder<Solution_> withUnassignedValuesAllowed(boolean unassignedValuesAllowed) {
             this.unassignedValuesAllowed = unassignedValuesAllowed;
+            return this;
+        }
+
+        public Builder<Solution_> withReuseBestSolution(boolean reuseBestSolution) {
+            this.reuseBestSolution = reuseBestSolution;
             return this;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -121,7 +121,8 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
         stepScope.getScoreDirector().executeMove(step);
         predictWorkingStepScore(stepScope, step);
         var solver = stepScope.getPhaseScope().getSolverScope().getSolver();
-        solver.getBestSolutionRecaller().processWorkingSolutionDuringStep(stepScope);
+        solver.getBestSolutionRecaller().processWorkingSolutionDuringStep(stepScope,
+                stepScope.getPhaseScope().getAcceptedMoveList());
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
@@ -169,7 +169,8 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
         var moveThreadCount = configPolicy.getMoveThreadCount();
         var environmentMode = configPolicy.getEnvironmentMode();
         var decider = moveThreadCount == null
-                ? new LocalSearchDecider<>(configPolicy.getLogIndentation(), termination, moveRepository, acceptor, forager)
+                ? new LocalSearchDecider<>(configPolicy.getLogIndentation(), termination, moveRepository, acceptor, forager,
+                        configPolicy.isReuseBestSolution())
                 : TimefoldSolverEnterpriseService.loadOrFail(TimefoldSolverEnterpriseService.Feature.MULTITHREADED_SOLVING)
                         .buildLocalSearch(moveThreadCount, termination, moveRepository, acceptor, forager, environmentMode,
                                 configPolicy);

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/LocalSearchDecider.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/LocalSearchDecider.java
@@ -30,17 +30,20 @@ public class LocalSearchDecider<Solution_> {
     protected final MoveRepository<Solution_> moveRepository;
     protected final Acceptor<Solution_> acceptor;
     protected final LocalSearchForager<Solution_> forager;
+    protected final boolean reuseBestSolution;
 
     protected boolean assertMoveScoreFromScratch = false;
     protected boolean assertExpectedUndoMoveScore = false;
 
     public LocalSearchDecider(String logIndentation, PhaseTermination<Solution_> termination,
-            MoveRepository<Solution_> moveRepository, Acceptor<Solution_> acceptor, LocalSearchForager<Solution_> forager) {
+            MoveRepository<Solution_> moveRepository, Acceptor<Solution_> acceptor, LocalSearchForager<Solution_> forager,
+            boolean reuseBestSolution) {
         this.logIndentation = logIndentation;
         this.termination = termination;
         this.moveRepository = moveRepository;
         this.acceptor = acceptor;
         this.forager = forager;
+        this.reuseBestSolution = reuseBestSolution;
     }
 
     public Termination<Solution_> getTermination() {
@@ -137,6 +140,9 @@ public class LocalSearchDecider<Solution_> {
                 stepScope.setStepString(step.toString());
             }
             stepScope.setScore(pickedMoveScope.getScore());
+            if (reuseBestSolution) {
+                stepScope.getPhaseScope().addAcceptedMove(step);
+            }
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/scope/LocalSearchPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/scope/LocalSearchPhaseScope.java
@@ -1,8 +1,12 @@
 package ai.timefold.solver.core.impl.localsearch.scope;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.preview.api.move.Move;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
@@ -10,6 +14,7 @@ import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 public final class LocalSearchPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
 
     private LocalSearchStepScope<Solution_> lastCompletedStepScope;
+    private final List<Move<Solution_>> acceptedMoveList = new ArrayList<>();
 
     public LocalSearchPhaseScope(SolverScope<Solution_> solverScope, int phaseIndex) {
         super(solverScope, phaseIndex);
@@ -24,6 +29,14 @@ public final class LocalSearchPhaseScope<Solution_> extends AbstractPhaseScope<S
 
     public void setLastCompletedStepScope(LocalSearchStepScope<Solution_> lastCompletedStepScope) {
         this.lastCompletedStepScope = lastCompletedStepScope;
+    }
+
+    public List<Move<Solution_>> getAcceptedMoveList() {
+        return acceptedMoveList;
+    }
+
+    public void addAcceptedMove(Move<Solution_> move) {
+        acceptedMoveList.add(move);
     }
 
     // ************************************************************************

--- a/core/src/main/java/ai/timefold/solver/core/impl/move/MoveTesterScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/move/MoveTesterScoreDirectorFactory.java
@@ -9,7 +9,7 @@ import ai.timefold.solver.core.impl.score.director.AbstractScoreDirectorFactory;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-final class MoveTesterScoreDirectorFactory<Solution_, Score_ extends Score<Score_>>
+public final class MoveTesterScoreDirectorFactory<Solution_, Score_ extends Score<Score_>>
         extends AbstractScoreDirectorFactory<Solution_, Score_, MoveTesterScoreDirectorFactory<Solution_, Score_>> {
 
     public MoveTesterScoreDirectorFactory(SolutionDescriptor<Solution_> solutionDescriptor, EnvironmentMode environmentMode) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/ConsumerSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/ConsumerSupport.java
@@ -5,6 +5,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -66,33 +68,36 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
     }
 
     void consumeIntermediateBestSolution(Solution_ solution, EventProducerId producerId,
-            BooleanSupplier isEveryProblemChangeProcessed) {
+            BooleanSupplier isEveryProblemChangeProcessed, Lock lock) {
         /*
          * If the bestSolutionConsumer is not provided, the best solution is still set for the purpose of recording
          * problem changes.
          */
         bestSolutionHolder.set(solution, producerId, isEveryProblemChangeProcessed);
         if (bestSolutionConsumer != null) {
-            tryConsumeWaitingIntermediateBestSolution();
+            tryConsumeWaitingIntermediateBestSolution(lock);
         }
     }
 
     // Called both on the Solver thread and the Consumer thread.
-    private void tryConsumeWaitingIntermediateBestSolution() {
+    private void tryConsumeWaitingIntermediateBestSolution(Lock lock) {
         if (bestSolutionHolder.isEmpty()) {
             return; // There is no best solution to consume.
         }
         if (activeConsumption.tryAcquire()) {
-            scheduleIntermediateBestSolutionConsumption()
+            scheduleIntermediateBestSolutionConsumption(lock)
                     .whenCompleteAsync((solution, throwable) -> {
                         activeConsumption.release();
-                        tryConsumeWaitingIntermediateBestSolution();
+                        tryConsumeWaitingIntermediateBestSolution(lock);
                     }, consumerExecutor);
         }
     }
 
-    private CompletableFuture<Void> scheduleIntermediateBestSolutionConsumption() {
+    private CompletableFuture<Void> scheduleIntermediateBestSolutionConsumption(Lock lock) {
         return CompletableFuture.runAsync(() -> {
+            // If reuse best solution is enabled, this will block if the best solution
+            // is currently being updated.
+            lock.lock();
             var bestSolutionContainingProblemChanges = bestSolutionHolder.take();
             if (bestSolutionContainingProblemChanges != null) {
                 try {
@@ -107,6 +112,7 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
                     bestSolutionContainingProblemChanges.completeProblemChangesExceptionally(throwable);
                 }
             }
+            lock.unlock();
         }, consumerExecutor);
     }
 
@@ -175,7 +181,7 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
         // Situation:
         // The consumer is consuming the last but one best solution. The final best solution is waiting for the consumer.
         if (bestSolutionConsumer != null) {
-            scheduleIntermediateBestSolutionConsumption();
+            scheduleIntermediateBestSolutionConsumption(new ReentrantLock());
         }
         scheduleFinalBestSolutionConsumption(solution)
                 .whenComplete((unused, throwable) -> releaseAll());

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -132,7 +132,8 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
         solverScope.setProblemChangeDirector(new DefaultProblemChangeDirector<>(castScoreDirector));
 
         var moveThreadCount = resolveMoveThreadCount(true);
-        var bestSolutionRecaller = BestSolutionRecallerFactory.create().<Solution_> buildBestSolutionRecaller(environmentMode);
+        var bestSolutionRecaller = BestSolutionRecallerFactory.create().<Solution_> buildBestSolutionRecaller(environmentMode,
+                solverConfig.getReuseBestSolution());
         var randomFactory = buildRandomSupplier(environmentMode);
         var previewFeaturesEnabled = solverConfig.getEnablePreviewFeatureSet();
 
@@ -157,6 +158,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
                 .withInitializingScoreTrend(scoreDirectorFactory.getInitializingScoreTrend())
                 .withSolutionDescriptor(solutionDescriptor)
                 .withClassInstanceCache(ClassInstanceCache.create())
+                .withReuseBestSolution(Objects.requireNonNullElse(solverConfig.getReuseBestSolution(), false))
                 .build();
         var basicPlumbingTermination = new BasicPlumbingTermination<Solution_>(isDaemon);
         var termination = buildTermination(basicPlumbingTermination, configPolicy, configOverride);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverJob.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -33,6 +34,7 @@ import ai.timefold.solver.core.impl.phase.PossiblyInitializingPhase;
 import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListenerAdapter;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.score.director.ValueRangeManager;
+import ai.timefold.solver.core.impl.solver.event.LockableSolverEventListener;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.SolverTermination;
 
@@ -138,7 +140,7 @@ public final class DefaultSolverJob<Solution_> implements SolverJob<Solution_>, 
             solver.addPhaseLifecycleListener(new FirstInitializedSolutionPhaseLifecycleListener(currentConsumerSupport));
             // add a phase lifecycle listener once when the solver starts its execution
             solver.addPhaseLifecycleListener(new StartSolverJobPhaseLifecycleListener(currentConsumerSupport));
-            solver.addEventListener(this::onBestSolutionChangedEvent);
+            solver.addEventListener(new BestSolutionChangedEventListener());
             final var finalBestSolution = solver.solve(problem);
             currentConsumerSupport.consumeFinalBestSolution(finalBestSolution);
             return finalBestSolution;
@@ -159,20 +161,6 @@ public final class DefaultSolverJob<Solution_> implements SolverJob<Solution_>, 
             }
             solvingTerminated();
         }
-    }
-
-    private void onBestSolutionChangedEvent(BestSolutionChangedEvent<Solution_> bestSolutionChangedEvent) {
-        var currentConsumerSupport = consumerSupport.get();
-        if (currentConsumerSupport == null) { // We set this, we should only set it once and before any event is emitted.
-            throw new IllegalStateException(
-                    """
-                            Impossible state: Asked to consume a best solution changed event for problemId (%s), but the consumer is not set.
-                            This means the solver job did not start properly or has already been terminated. This is likely a bug.
-                            Please report this issue to Timefold with details on how to reproduce it."""
-                            .formatted(problemId));
-        }
-        currentConsumerSupport.consumeIntermediateBestSolution(bestSolutionChangedEvent.getNewBestSolution(),
-                bestSolutionChangedEvent.getProducerId(), bestSolutionChangedEvent::isEveryProblemChangeProcessed);
     }
 
     private void solvingTerminated() {
@@ -441,6 +429,25 @@ public final class DefaultSolverJob<Solution_> implements SolverJob<Solution_>, 
         @Override
         public void solvingStarted(SolverScope<Solution_> solverScope) {
             consumerSupport.consumeStartSolverJob(solverScope.getWorkingSolution());
+        }
+    }
+
+    private class BestSolutionChangedEventListener implements LockableSolverEventListener<Solution_> {
+
+        @Override
+        public void bestSolutionChanged(BestSolutionChangedEvent<Solution_> bestSolutionChangedEvent, Lock lock) {
+            var currentConsumerSupport = consumerSupport.get();
+            if (currentConsumerSupport == null) { // We set this, we should only set it once and before any event is emitted.
+                throw new IllegalStateException(
+                        """
+                                Impossible state: Asked to consume a best solution changed event for problemId (%s), but the consumer is not set.
+                                This means the solver job did not start properly or has already been terminated. This is likely a bug.
+                                Please report this issue to Timefold with details on how to reproduce it."""
+                                .formatted(problemId));
+            }
+            currentConsumerSupport.consumeIntermediateBestSolution(bestSolutionChangedEvent.getNewBestSolution(),
+                    bestSolutionChangedEvent.getProducerId(), bestSolutionChangedEvent::isEveryProblemChangeProcessed,
+                    lock);
         }
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/event/LockableSolverEventListener.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/event/LockableSolverEventListener.java
@@ -1,0 +1,16 @@
+package ai.timefold.solver.core.impl.solver.event;
+
+import java.util.concurrent.locks.Lock;
+
+import ai.timefold.solver.core.api.solver.event.BestSolutionChangedEvent;
+import ai.timefold.solver.core.api.solver.event.SolverEventListener;
+
+import org.jspecify.annotations.NonNull;
+
+public interface LockableSolverEventListener<Solution_> extends SolverEventListener<Solution_> {
+    default void bestSolutionChanged(@NonNull BestSolutionChangedEvent<Solution_> event) {
+        throw new UnsupportedOperationException();
+    }
+
+    void bestSolutionChanged(@NonNull BestSolutionChangedEvent<Solution_> event, @NonNull Lock lock);
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/event/SolverEventSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/event/SolverEventSupport.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.solver.event;
 
+import java.util.concurrent.locks.Lock;
+
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.solver.Solver;
 import ai.timefold.solver.core.api.solver.event.EventProducerId;
@@ -20,7 +22,7 @@ public class SolverEventSupport<Solution_> extends AbstractEventSupport<SolverEv
     }
 
     public void fireBestSolutionChanged(SolverScope<Solution_> solverScope, EventProducerId eventProducerId,
-            Solution_ newBestSolution) {
+            Solution_ newBestSolution, Lock readLock) {
         var it = getEventListeners().iterator();
         var timeMillisSpent = solverScope.getBestSolutionTimeMillisSpent();
         var bestScore = solverScope.getBestScore();
@@ -28,7 +30,12 @@ public class SolverEventSupport<Solution_> extends AbstractEventSupport<SolverEv
             var event =
                     new DefaultBestSolutionChangedEvent<>(solver, eventProducerId, timeMillisSpent, newBestSolution, bestScore);
             do {
-                it.next().bestSolutionChanged(event);
+                var eventListener = it.next();
+                if (eventListener instanceof LockableSolverEventListener<Solution_> lockableSolverEventListener) {
+                    lockableSolverEventListener.bestSolutionChanged(event, readLock);
+                } else {
+                    eventListener.bestSolutionChanged(event);
+                }
             } while (it.hasNext());
         }
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -1,15 +1,23 @@
 package ai.timefold.solver.core.impl.solver.recaller;
 
+import java.util.List;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.solver.Solver;
 import ai.timefold.solver.core.api.solver.event.EventProducerId;
+import ai.timefold.solver.core.enterprise.TimefoldSolverEnterpriseService;
 import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListenerAdapter;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.solver.event.SolverEventSupport;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.preview.api.move.Move;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * Remembers the {@link PlanningSolution best solution} that a {@link Solver} encounters.
@@ -21,8 +29,10 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
     protected boolean assertInitialScoreFromScratch = false;
     protected boolean assertShadowVariablesAreNotStale = false;
     protected boolean assertBestScoreIsUnmodified = false;
-
+    protected boolean reuseBestSolution = false;
     protected SolverEventSupport<Solution_> solverEventSupport;
+    protected ReusingBestSolutionUpdater<Solution_> reusingBestSolutionUpdater;
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
 
     public void setAssertInitialScoreFromScratch(boolean assertInitialScoreFromScratch) {
         this.assertInitialScoreFromScratch = assertInitialScoreFromScratch;
@@ -34,6 +44,19 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
 
     public void setAssertBestScoreIsUnmodified(boolean assertBestScoreIsUnmodified) {
         this.assertBestScoreIsUnmodified = assertBestScoreIsUnmodified;
+    }
+
+    public void setReuseBestSolution(boolean reuseBestSolution) {
+        this.reuseBestSolution = reuseBestSolution;
+        if (reuseBestSolution) {
+            reusingBestSolutionUpdater = TimefoldSolverEnterpriseService
+                    .loadOrFail(TimefoldSolverEnterpriseService.Feature.REUSE_BEST_SOLUTION)
+                    .buildReusingBestSolutionUpdater(readWriteLock);
+        }
+    }
+
+    public boolean isReuseBestSolution() {
+        return reuseBestSolution;
     }
 
     public void setSolverEventSupport(SolverEventSupport<Solution_> solverEventSupport) {
@@ -79,7 +102,15 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
         updateBestSolutionWithoutFiring(solverScope, stepScope.getScore(), newBestSolution);
     }
 
-    public <Score_ extends Score<Score_>> void processWorkingSolutionDuringStep(AbstractStepScope<Solution_> stepScope) {
+    public void processWorkingSolutionDuringStep(AbstractStepScope<Solution_> stepScope) {
+        processWorkingSolutionDuringStep(stepScope, null);
+    }
+
+    /**
+     * Return true if best solution was updated
+     */
+    public <Score_ extends Score<Score_>> void processWorkingSolutionDuringStep(AbstractStepScope<Solution_> stepScope,
+            @Nullable List<Move<Solution_>> acceptedMoveList) {
         var phaseScope = stepScope.getPhaseScope();
         var score = stepScope.<Score_> getScore();
         var solverScope = phaseScope.getSolverScope();
@@ -87,10 +118,16 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
         stepScope.setBestScoreImproved(bestScoreImproved);
         if (bestScoreImproved) {
             phaseScope.setBestSolutionStepIndex(stepScope.getStepIndex());
-            var newBestSolution = stepScope.cloneWorkingSolution();
-            var innerScore = buildInnerScore(solverScope.getSolutionDescriptor().<Score_> getScore(newBestSolution),
-                    stepScope.getScoreDirector().getWorkingInitScore(), true);
-            updateBestSolutionAndFire(solverScope, phaseScope, innerScore, newBestSolution);
+            if (reuseBestSolution && acceptedMoveList != null) {
+                updateBestSolutionAndFire(solverScope, phaseScope, score, acceptedMoveList);
+            } else {
+                var newBestSolution = stepScope.cloneWorkingSolution();
+                // Can this be removed? Seems to be the same as score?
+                var innerScore =
+                        buildInnerScore(solverScope.getSolutionDescriptor().<Score_> getScore(newBestSolution),
+                                stepScope.getScoreDirector().getWorkingInitScore(), true);
+                updateBestSolutionAndFire(solverScope, phaseScope, innerScore, newBestSolution);
+            }
         } else if (assertBestScoreIsUnmodified) {
             solverScope.assertScoreFromScratch(solverScope.getBestSolution());
         }
@@ -98,6 +135,11 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
 
     public <Score_ extends Score<Score_>> void processWorkingSolutionDuringMove(InnerScore<Score_> moveScore,
             AbstractStepScope<Solution_> stepScope) {
+        processWorkingSolutionDuringMove(moveScore, stepScope, null);
+    }
+
+    public <Score_ extends Score<Score_>> void processWorkingSolutionDuringMove(InnerScore<Score_> moveScore,
+            AbstractStepScope<Solution_> stepScope, @Nullable List<Move<Solution_>> acceptedMoveList) {
         var phaseScope = stepScope.getPhaseScope();
         var solverScope = phaseScope.getSolverScope();
         var bestScoreImproved = moveScore.compareTo(solverScope.getBestScore()) > 0;
@@ -105,16 +147,18 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
         // stepScope.getBestScoreImproved() is initialized on false before the first call here
         if (bestScoreImproved) {
             stepScope.setBestScoreImproved(bestScoreImproved);
-        }
-        if (bestScoreImproved) {
             phaseScope.setBestSolutionStepIndex(stepScope.getStepIndex());
-            var newBestSolution = solverScope.getScoreDirector().cloneWorkingSolution();
-            // The solution for mixed models can generate a partially solved solution,
-            // as the complete solution will only be achieved when all variable types are assigned.
-            updateBestSolutionAndFire(solverScope, phaseScope,
-                    buildInnerScore(moveScore.raw(), solverScope.getScoreDirector().getWorkingInitScore(),
-                            solverScope.getScoreDirector().getSolutionDescriptor().hasBothBasicAndListVariables()),
-                    newBestSolution);
+            // Can this be removed? Seems to be the same as moveScore?
+            var innerScore = buildInnerScore(moveScore.raw(), solverScope.getScoreDirector().getWorkingInitScore(),
+                    solverScope.getScoreDirector().getSolutionDescriptor().hasBothBasicAndListVariables());
+            if (reuseBestSolution && acceptedMoveList != null) {
+                updateBestSolutionAndFire(solverScope, phaseScope, innerScore, acceptedMoveList);
+            } else {
+                var newBestSolution = solverScope.getScoreDirector().cloneWorkingSolution();
+                // The solution for mixed models can generate a partially solved solution,
+                // as the complete solution will only be achieved when all variable types are assigned.
+                updateBestSolutionAndFire(solverScope, phaseScope, innerScore, newBestSolution);
+            }
         } else if (assertBestScoreIsUnmodified) {
             solverScope.assertScoreFromScratch(solverScope.getBestSolution());
         }
@@ -122,14 +166,16 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
 
     public void updateBestSolutionAndFire(SolverScope<Solution_> solverScope, AbstractPhaseScope<Solution_> phaseScope) {
         updateBestSolutionWithoutFiring(solverScope);
-        solverEventSupport.fireBestSolutionChanged(solverScope, phaseScope.getPhaseId(), solverScope.getBestSolution());
+        solverEventSupport.fireBestSolutionChanged(solverScope, phaseScope.getPhaseId(), solverScope.getBestSolution(),
+                readWriteLock.readLock());
     }
 
     public void updateBestSolutionAndFireIfInitialized(SolverScope<Solution_> solverScope,
             EventProducerId eventProducerId) {
         updateBestSolutionWithoutFiring(solverScope);
         if (solverScope.isBestSolutionInitialized()) {
-            solverEventSupport.fireBestSolutionChanged(solverScope, eventProducerId, solverScope.getBestSolution());
+            solverEventSupport.fireBestSolutionChanged(solverScope, eventProducerId, solverScope.getBestSolution(),
+                    readWriteLock.readLock());
         }
     }
 
@@ -137,7 +183,17 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
             InnerScore<?> bestScore,
             Solution_ bestSolution) {
         updateBestSolutionWithoutFiring(solverScope, bestScore, bestSolution);
-        solverEventSupport.fireBestSolutionChanged(solverScope, phaseScope.getPhaseId(), bestSolution);
+        solverEventSupport.fireBestSolutionChanged(solverScope, phaseScope.getPhaseId(), bestSolution,
+                readWriteLock.readLock());
+    }
+
+    private <Score_ extends Score<Score_>> void updateBestSolutionAndFire(SolverScope<Solution_> solverScope,
+            AbstractPhaseScope<Solution_> phaseScope,
+            InnerScore<Score_> score, List<Move<Solution_>> acceptedMoveList) {
+        reusingBestSolutionUpdater.updateReusingBestSolution(solverScope, score, acceptedMoveList);
+        updateBestSolutionWithoutFiring(solverScope, score, reusingBestSolutionUpdater.getBestSolution());
+        solverEventSupport.fireBestSolutionChanged(solverScope, phaseScope.getPhaseId(),
+                reusingBestSolutionUpdater.getBestSolution(), readWriteLock.readLock());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecallerFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecallerFactory.java
@@ -8,12 +8,16 @@ public class BestSolutionRecallerFactory {
         return new BestSolutionRecallerFactory();
     }
 
-    public <Solution_> BestSolutionRecaller<Solution_> buildBestSolutionRecaller(EnvironmentMode environmentMode) {
+    public <Solution_> BestSolutionRecaller<Solution_> buildBestSolutionRecaller(EnvironmentMode environmentMode,
+            Boolean reuseBestSolution) {
         BestSolutionRecaller<Solution_> bestSolutionRecaller = new BestSolutionRecaller<>();
         if (environmentMode.isFullyAsserted()) {
             bestSolutionRecaller.setAssertInitialScoreFromScratch(true);
             bestSolutionRecaller.setAssertShadowVariablesAreNotStale(true);
             bestSolutionRecaller.setAssertBestScoreIsUnmodified(true);
+        }
+        if (reuseBestSolution != null && reuseBestSolution) {
+            bestSolutionRecaller.setReuseBestSolution(true);
         }
         return bestSolutionRecaller;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/ReusingBestSolutionUpdater.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/ReusingBestSolutionUpdater.java
@@ -1,0 +1,16 @@
+package ai.timefold.solver.core.impl.solver.recaller;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
+import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.preview.api.move.Move;
+
+public interface ReusingBestSolutionUpdater<Solution_> {
+    <Score_ extends Score<Score_>> void updateReusingBestSolution(SolverScope<Solution_> solverScope,
+            InnerScore<Score_> score,
+            List<Move<Solution_>> movesSinceLastBestSolutionList);
+
+    Solution_ getBestSolution();
+}

--- a/core/src/main/resources/solver.xsd
+++ b/core/src/main/resources/solver.xsd
@@ -50,6 +50,8 @@
             <xs:element name="partitionedSearch" type="tns:partitionedSearchPhaseConfig"/>
                       
           </xs:choice>
+                    
+          <xs:element minOccurs="0" name="reuseBestSolution" type="xs:boolean"/>
                   
         </xs:sequence>
               

--- a/core/src/test/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsTest.java
@@ -75,7 +75,7 @@ class NeighborhoodsTest {
                 .buildAcceptor(heuristicConfigPolicy);
         var forager = LocalSearchForagerFactory
                 .<TestdataSolution> create(new LocalSearchForagerConfig().withAcceptedCountLimit(1)).buildForager();
-        var localSearchDecider = new LocalSearchDecider<>("", termination, moveRepository, acceptor, forager);
+        var localSearchDecider = new LocalSearchDecider<>("", termination, moveRepository, acceptor, forager, false);
         var localSearchPhase = new DefaultLocalSearchPhase.Builder<>(0, "", termination, localSearchDecider).build();
 
         // Generates a solution whose entities' values are all set to the second value.

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/ConsumerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/ConsumerSupportTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 import ai.timefold.solver.core.api.solver.Solver;
@@ -139,6 +140,7 @@ class ConsumerSupportTest {
     }
 
     private void consumeIntermediateBestSolution(TestdataSolution bestSolution) {
-        consumerSupport.consumeIntermediateBestSolution(bestSolution, EventProducerId.constructionHeuristic(0), () -> true);
+        consumerSupport.consumeIntermediateBestSolution(bestSolution, EventProducerId.constructionHeuristic(0), () -> true,
+                new ReentrantLock());
     }
 }

--- a/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/TimefoldRecorder.java
+++ b/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/TimefoldRecorder.java
@@ -140,6 +140,8 @@ public class TimefoldRecorder {
                 .ifPresent(solverConfig::setMoveThreadCount);
         maybeSolverRuntimeConfig.flatMap(SolverRuntimeConfig::randomSeed)
                 .ifPresent(solverConfig::setRandomSeed);
+        maybeSolverRuntimeConfig.flatMap(SolverRuntimeConfig::reuseBestSolution)
+                .ifPresent(solverConfig::setReuseBestSolution);
         maybeSolverRuntimeConfig.flatMap(config -> config.termination().diminishedReturns())
                 .ifPresent(diminishedReturnsConfig -> setDiminishedReturns(solverConfig, diminishedReturnsConfig));
     }

--- a/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/config/SolverRuntimeConfig.java
+++ b/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/config/SolverRuntimeConfig.java
@@ -47,4 +47,16 @@ public interface SolverRuntimeConfig {
      * Configuration of the random seed.
      */
     Optional<Long> randomSeed();
+
+    /**
+     * Enable reusing the best solution instance in events, improving performance.
+     * When enabled, the same best solution instance is reused and modified by the
+     * solver whenever the best solution changes. When enabled, ensure the best solution
+     * instance and entities are not saved outside the event handler.
+     * Defaults to "false".
+     * <p>
+     * Note: this setting is only available in Timefold Solver
+     * <a href="https://timefold.ai/docs/timefold-solver/latest/commercial-editions/commercial-editions">Enterprise Edition</a>.
+     */
+    Optional<Boolean> reuseBestSolution();
 }

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverAutoConfiguration.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverAutoConfiguration.java
@@ -312,6 +312,9 @@ public class TimefoldSolverAutoConfiguration
         if (solverProperties.getRandomSeed() != null) {
             solverConfig.setRandomSeed(solverProperties.getRandomSeed());
         }
+        if (solverProperties.getReuseBestSolution() != null) {
+            solverConfig.setReuseBestSolution(solverProperties.getReuseBestSolution());
+        }
         applyTerminationProperties(solverConfig, solverProperties.getTermination());
     }
 

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperties.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperties.java
@@ -66,6 +66,8 @@ public class SolverProperties {
      */
     private Long randomSeed;
 
+    private Boolean reuseBestSolution;
+
     @NestedConfigurationProperty
     private TerminationProperties termination;
 
@@ -143,6 +145,14 @@ public class SolverProperties {
 
     public void setRandomSeed(Long randomSeed) {
         this.randomSeed = randomSeed;
+    }
+
+    public Boolean getReuseBestSolution() {
+        return reuseBestSolution;
+    }
+
+    public void setReuseBestSolution(Boolean reuseBestSolution) {
+        this.reuseBestSolution = reuseBestSolution;
     }
 
     public TerminationProperties getTermination() {

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperty.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/config/SolverProperty.java
@@ -47,6 +47,8 @@ public enum SolverProperty {
             SolverProperties::setConstraintStreamAutomaticNodeSharing,
             value -> Boolean.valueOf(value.toString())),
     RANDOM_SEED("random-seed", SolverProperties::setRandomSeed, value -> Long.parseLong(value.toString())),
+    REUSE_BEST_SOLUTION("reuse-best-solution", SolverProperties::setReuseBestSolution,
+            value -> Boolean.parseBoolean(value.toString())),
     TERMINATION("termination", SolverProperties::setTermination, value -> {
         if (value instanceof TerminationProperties terminationProperties) {
             return terminationProperties;

--- a/tools/benchmark/src/main/resources/benchmark.xsd
+++ b/tools/benchmark/src/main/resources/benchmark.xsd
@@ -375,6 +375,9 @@
                                   
           
           </xs:choice>
+                              
+          
+          <xs:element minOccurs="0" name="reuseBestSolution" type="xs:boolean"/>
                             
         
         </xs:sequence>


### PR DESCRIPTION
Currently the working solution is cloned when ever a new best solution is found. This is slow and create additional memory pressure on giant datasets, since each entity must be cloned.

This adds a new SolverConfig property, `reuseBestSolution`, which will reuse the initial best solution clone in local search. When enabled, local search keep track of moves used in each step, which are then used to update the best solution instance.

A read-write lock is used to allow reading the best solution safely outside the solver thread. This read-write lock is automatically used for SolverManager events.

Since the same instance is reused, when this feature is enabled, users should ensure the solution and entities are not saved outside the event handler.