### PR TITLE
fix: seperate move and solver RandomGenerator usage

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
@@ -162,7 +162,7 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
             boolean scoreBounderEnabled, boolean isListVariable) {
         var manualEntityMimicRecorder = new ManualEntityMimicRecorder<>(sourceEntitySelector);
         var entityClassName = sourceEntitySelector.getEntityDescriptor().getEntityClass().getName();
-        var mimicSelectorId = ConfigUtils.addRandomSuffix(entityClassName, configPolicy.getRandom());
+        var mimicSelectorId = ConfigUtils.addRandomSuffix(entityClassName, configPolicy.getRandom().moveUsage());
         configPolicy.addEntityMimicRecorder(mimicSelectorId, manualEntityMimicRecorder);
         var variableDescriptorList = getGenuineVariableDescriptorList(sourceEntitySelector, isListVariable);
         MoveSelectorConfig<?> moveSelectorConfig = phaseConfig.getMoveSelectorConfig();

--- a/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
@@ -162,7 +162,7 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
             boolean scoreBounderEnabled, boolean isListVariable) {
         var manualEntityMimicRecorder = new ManualEntityMimicRecorder<>(sourceEntitySelector);
         var entityClassName = sourceEntitySelector.getEntityDescriptor().getEntityClass().getName();
-        var mimicSelectorId = ConfigUtils.addRandomSuffix(entityClassName, configPolicy.getRandom().moveUsage());
+        var mimicSelectorId = ConfigUtils.addRandomSuffix(entityClassName, configPolicy.getRandom().factoryUsage());
         configPolicy.addEntityMimicRecorder(mimicSelectorId, manualEntityMimicRecorder);
         var variableDescriptorList = getGenuineVariableDescriptorList(sourceEntitySelector, isListVariable);
         MoveSelectorConfig<?> moveSelectorConfig = phaseConfig.getMoveSelectorConfig();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/HeuristicConfigPolicy.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/HeuristicConfigPolicy.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadFactory;
-import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySorterManner;
 import ai.timefold.solver.core.config.heuristic.selector.value.ValueSorterManner;
@@ -23,6 +22,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.value.mimic.ValueMimicRec
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.score.trend.InitializingScoreTrend;
 import ai.timefold.solver.core.impl.solver.ClassInstanceCache;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 import ai.timefold.solver.core.impl.solver.thread.DefaultSolverThreadFactory;
 
@@ -42,7 +42,7 @@ public class HeuristicConfigPolicy<Solution_> {
     private final boolean reinitializeVariableFilterEnabled;
     private final boolean unassignedValuesAllowed;
     private final Class<? extends NearbyDistanceMeter<?, ?>> nearbyDistanceMeterClass;
-    private final RandomGenerator random;
+    private final RandomSource random;
 
     private final Map<String, EntityMimicRecorder<Solution_>> entityMimicRecorderMap = new HashMap<>();
     private final Map<String, SubListMimicRecorder<Solution_>> subListMimicRecorderMap = new HashMap<>();
@@ -118,7 +118,7 @@ public class HeuristicConfigPolicy<Solution_> {
         return nearbyDistanceMeterClass;
     }
 
-    public RandomGenerator getRandom() {
+    public RandomSource getRandom() {
         return random;
     }
 
@@ -275,7 +275,7 @@ public class HeuristicConfigPolicy<Solution_> {
         private boolean unassignedValuesAllowed = false;
 
         private Class<? extends NearbyDistanceMeter<?, ?>> nearbyDistanceMeterClass;
-        private RandomGenerator random;
+        private RandomSource random;
 
         public Builder<Solution_> withPreviewFeatureSet(Set<PreviewFeature> previewFeatureSet) {
             this.previewFeatureSet = previewFeatureSet;
@@ -308,7 +308,7 @@ public class HeuristicConfigPolicy<Solution_> {
             return this;
         }
 
-        public Builder<Solution_> withRandom(RandomGenerator random) {
+        public Builder<Solution_> withRandom(RandomSource random) {
             this.random = random;
             return this;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/AbstractSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/AbstractSelector.java
@@ -26,7 +26,7 @@ public abstract class AbstractSelector<Solution_> implements Selector<Solution_>
 
     @Override
     public void solvingStarted(SolverScope<Solution_> solverScope) {
-        workingRandom = solverScope.getWorkingRandom().moveUsage();
+        workingRandom = solverScope.getWorkingRandom().moveIteratorUsage();
         phaseLifecycleSupport.fireSolvingStarted(solverScope);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/AbstractSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/AbstractSelector.java
@@ -26,7 +26,7 @@ public abstract class AbstractSelector<Solution_> implements Selector<Solution_>
 
     @Override
     public void solvingStarted(SolverScope<Solution_> solverScope) {
-        workingRandom = solverScope.getWorkingRandom();
+        workingRandom = solverScope.getWorkingRandom().moveUsage();
         phaseLifecycleSupport.fireSolvingStarted(solverScope);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
@@ -49,7 +49,7 @@ public class UnionMoveSelectorFactory<Solution_>
                     // Add a new configuration with Nearby Selection enabled
                     moveSelectorConfigList
                             .add(nearbySelectorConfig.enableNearbySelection(configPolicy.getNearbyDistanceMeterClass(),
-                                    configPolicy.getRandom().moveUsage()));
+                                    configPolicy.getRandom().factoryUsage()));
 
                 }
             }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorFactory.java
@@ -49,7 +49,7 @@ public class UnionMoveSelectorFactory<Solution_>
                     // Add a new configuration with Nearby Selection enabled
                     moveSelectorConfigList
                             .add(nearbySelectorConfig.enableNearbySelection(configPolicy.getNearbyDistanceMeterClass(),
-                                    configPolicy.getRandom()));
+                                    configPolicy.getRandom().moveUsage()));
 
                 }
             }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveIterator.java
@@ -68,7 +68,7 @@ final class RuinRecreateMoveIterator<Solution_> extends UpcomingSelectionIterato
             }
         }
         return new SelectorBasedRuinRecreateMove<>(variableDescriptor, constructionHeuristicPhaseBuilder, solverScope,
-                selectedEntityList, affectedValueSet);
+                selectedEntityList, affectedValueSet, workingRandom.nextLong());
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelector.java
@@ -55,7 +55,7 @@ final class RuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<Solu
     public void solvingStarted(SolverScope<Solution_> solverScope) {
         super.solvingStarted(solverScope);
         this.solverScope = solverScope;
-        this.workingRandom = solverScope.getWorkingRandom().moveUsage();
+        this.workingRandom = solverScope.getWorkingRandom().moveIteratorUsage();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelector.java
@@ -55,7 +55,7 @@ final class RuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<Solu
     public void solvingStarted(SolverScope<Solution_> solverScope) {
         super.solvingStarted(solverScope);
         this.solverScope = solverScope;
-        this.workingRandom = solverScope.getWorkingRandom();
+        this.workingRandom = solverScope.getWorkingRandom().moveUsage();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelector.java
@@ -55,14 +55,12 @@ final class RuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<Solu
     public void solvingStarted(SolverScope<Solution_> solverScope) {
         super.solvingStarted(solverScope);
         this.solverScope = solverScope;
-        this.workingRandom = solverScope.getWorkingRandom().moveIteratorUsage();
     }
 
     @Override
     public void phaseEnded(AbstractPhaseScope<Solution_> phaseScope) {
         super.phaseEnded(phaseScope);
         this.solverScope = null;
-        this.workingRandom = null;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMove.java
@@ -27,18 +27,21 @@ public final class SelectorBasedRuinRecreateMove<Solution_> extends AbstractSele
     private final SolverScope<Solution_> solverScope;
     private final List<Object> ruinedEntityList;
     private final SequencedSet<Object> affectedValueSet;
+    private final long randomSeed;
 
     private Object @Nullable [] recordedNewValues;
 
     public SelectorBasedRuinRecreateMove(GenuineVariableDescriptor<Solution_> genuineVariableDescriptor,
             RuinRecreateConstructionHeuristicPhaseBuilder<Solution_> constructionHeuristicPhaseBuilder,
-            SolverScope<Solution_> solverScope, List<Object> ruinedEntityList, SequencedSet<Object> affectedValueSet) {
+            SolverScope<Solution_> solverScope, List<Object> ruinedEntityList, SequencedSet<Object> affectedValueSet,
+            long randomSeed) {
         this.genuineVariableDescriptor = genuineVariableDescriptor;
         this.ruinedEntityList = ruinedEntityList;
         this.affectedValueSet = affectedValueSet;
         this.constructionHeuristicPhaseBuilder = constructionHeuristicPhaseBuilder;
         this.solverScope = solverScope;
         this.recordedNewValues = null;
+        this.randomSeed = randomSeed;
     }
 
     @Override
@@ -66,7 +69,7 @@ public final class SelectorBasedRuinRecreateMove<Solution_> extends AbstractSele
         var nestedSolverScope = new SolverScope<Solution_>(solverScope.getClock());
         nestedSolverScope.setSolver(solverScope.getSolver());
         nestedSolverScope.setScoreDirector(innerScoreDirector);
-        nestedSolverScope.setWorkingRandom(DefaultRandomSource.seeded(0L));
+        nestedSolverScope.setWorkingRandom(DefaultRandomSource.seeded(randomSeed));
         constructionHeuristicPhase.solvingStarted(nestedSolverScope);
         constructionHeuristicPhase.solve(nestedSolverScope);
         constructionHeuristicPhase.solvingEnded(nestedSolverScope);
@@ -92,7 +95,7 @@ public final class SelectorBasedRuinRecreateMove<Solution_> extends AbstractSele
         var rebasedRuinedEntityList = rebaseList(ruinedEntityList, lookup);
         var rebasedAffectedValueSet = rebaseSet(affectedValueSet, lookup);
         return new SelectorBasedRuinRecreateMove<>(genuineVariableDescriptor, constructionHeuristicPhaseBuilder, solverScope,
-                rebasedRuinedEntityList, rebasedAffectedValueSet);
+                rebasedRuinedEntityList, rebasedAffectedValueSet, randomSeed);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMove.java
@@ -12,6 +12,7 @@ import ai.timefold.solver.core.impl.heuristic.move.AbstractSelectorBasedMove;
 import ai.timefold.solver.core.impl.move.VariableChangeRecordingScoreDirector;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.VariableDescriptorAwareScoreDirector;
+import ai.timefold.solver.core.impl.solver.random.DefaultRandomSource;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.preview.api.move.Move;
 
@@ -65,6 +66,7 @@ public final class SelectorBasedRuinRecreateMove<Solution_> extends AbstractSele
         var nestedSolverScope = new SolverScope<Solution_>(solverScope.getClock());
         nestedSolverScope.setSolver(solverScope.getSolver());
         nestedSolverScope.setScoreDirector(innerScoreDirector);
+        nestedSolverScope.setWorkingRandom(DefaultRandomSource.seeded(0L));
         constructionHeuristicPhase.solvingStarted(nestedSolverScope);
         constructionHeuristicPhase.solve(nestedSolverScope);
         constructionHeuristicPhase.solvingEnded(nestedSolverScope);

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMove.java
@@ -31,6 +31,23 @@ public final class SelectorBasedRuinRecreateMove<Solution_> extends AbstractSele
 
     private Object @Nullable [] recordedNewValues;
 
+    /**
+     * Prefer
+     * {@link #SelectorBasedRuinRecreateMove(GenuineVariableDescriptor, RuinRecreateConstructionHeuristicPhaseBuilder, SolverScope, List, SequencedSet, long)}
+     * with explicitly provided random seed.
+     *
+     * @param genuineVariableDescriptor
+     * @param constructionHeuristicPhaseBuilder
+     * @param solverScope
+     * @param ruinedEntityList
+     * @param affectedValueSet
+     */
+    public SelectorBasedRuinRecreateMove(GenuineVariableDescriptor<Solution_> genuineVariableDescriptor,
+            RuinRecreateConstructionHeuristicPhaseBuilder<Solution_> constructionHeuristicPhaseBuilder,
+            SolverScope<Solution_> solverScope, List<Object> ruinedEntityList, SequencedSet<Object> affectedValueSet) {
+        this(genuineVariableDescriptor, constructionHeuristicPhaseBuilder, solverScope, ruinedEntityList, affectedValueSet, 0);
+    }
+
     public SelectorBasedRuinRecreateMove(GenuineVariableDescriptor<Solution_> genuineVariableDescriptor,
             RuinRecreateConstructionHeuristicPhaseBuilder<Solution_> constructionHeuristicPhaseBuilder,
             SolverScope<Solution_> solverScope, List<Object> ruinedEntityList, SequencedSet<Object> affectedValueSet,

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
@@ -51,7 +51,7 @@ public class SwapMoveSelectorFactory<Solution_>
             if (entitySelectorConfig.getId() == null && entitySelectorConfig.getMimicSelectorRef() == null) {
                 var entityName = Objects.requireNonNull(entityDescriptor.getEntityClass().getSimpleName());
                 // We set the id to make sure the value selector will use the mimic recorder
-                entityRecorderId = ConfigUtils.addRandomSuffix(entityName, configPolicy.getRandom());
+                entityRecorderId = ConfigUtils.addRandomSuffix(entityName, configPolicy.getRandom().moveUsage());
                 entitySelectorConfig.setId(entityRecorderId);
             } else {
                 entityRecorderId = entitySelectorConfig.getId() != null ? entitySelectorConfig.getId()

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
@@ -51,7 +51,7 @@ public class SwapMoveSelectorFactory<Solution_>
             if (entitySelectorConfig.getId() == null && entitySelectorConfig.getMimicSelectorRef() == null) {
                 var entityName = Objects.requireNonNull(entityDescriptor.getEntityClass().getSimpleName());
                 // We set the id to make sure the value selector will use the mimic recorder
-                entityRecorderId = ConfigUtils.addRandomSuffix(entityName, configPolicy.getRandom().moveUsage());
+                entityRecorderId = ConfigUtils.addRandomSuffix(entityName, configPolicy.getRandom().factoryUsage());
                 entitySelectorConfig.setId(entityRecorderId);
             } else {
                 entityRecorderId = entitySelectorConfig.getId() != null ? entitySelectorConfig.getId()

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
@@ -83,7 +83,7 @@ public class ListChangeMoveSelectorFactory<Solution_>
             if (mimicSelectorConfig.getMimicSelectorRef() == null && mimicSelectorConfig.getId() == null) {
                 var variableName = Objects.requireNonNull(mimicSelectorConfig.getVariableName());
                 // We set the id to make sure the value selector will use the mimic recorder
-                entityValueRangeRecorderId = ConfigUtils.addRandomSuffix(variableName, configPolicy.getRandom().moveUsage());
+                entityValueRangeRecorderId = ConfigUtils.addRandomSuffix(variableName, configPolicy.getRandom().factoryUsage());
                 mimicSelectorConfig.setId(entityValueRangeRecorderId);
             } else {
                 entityValueRangeRecorderId =

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
@@ -83,7 +83,7 @@ public class ListChangeMoveSelectorFactory<Solution_>
             if (mimicSelectorConfig.getMimicSelectorRef() == null && mimicSelectorConfig.getId() == null) {
                 var variableName = Objects.requireNonNull(mimicSelectorConfig.getVariableName());
                 // We set the id to make sure the value selector will use the mimic recorder
-                entityValueRangeRecorderId = ConfigUtils.addRandomSuffix(variableName, configPolicy.getRandom());
+                entityValueRangeRecorderId = ConfigUtils.addRandomSuffix(variableName, configPolicy.getRandom().moveUsage());
                 mimicSelectorConfig.setId(entityValueRangeRecorderId);
             } else {
                 entityValueRangeRecorderId =

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
@@ -50,7 +50,7 @@ public class ListSwapMoveSelectorFactory<Solution_>
             if (valueSelectorConfig.getId() == null && valueSelectorConfig.getMimicSelectorRef() == null) {
                 var variableName = Objects.requireNonNull(valueSelectorConfig.getVariableName());
                 // We set the id to make sure the value selector will use the mimic recorder
-                entityValueRangeRecorderId = ConfigUtils.addRandomSuffix(variableName, configPolicy.getRandom());
+                entityValueRangeRecorderId = ConfigUtils.addRandomSuffix(variableName, configPolicy.getRandom().moveUsage());
                 valueSelectorConfig.setId(entityValueRangeRecorderId);
             } else {
                 entityValueRangeRecorderId = valueSelectorConfig.getId() != null ? valueSelectorConfig.getId()

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
@@ -50,7 +50,7 @@ public class ListSwapMoveSelectorFactory<Solution_>
             if (valueSelectorConfig.getId() == null && valueSelectorConfig.getMimicSelectorRef() == null) {
                 var variableName = Objects.requireNonNull(valueSelectorConfig.getVariableName());
                 // We set the id to make sure the value selector will use the mimic recorder
-                entityValueRangeRecorderId = ConfigUtils.addRandomSuffix(variableName, configPolicy.getRandom().moveUsage());
+                entityValueRangeRecorderId = ConfigUtils.addRandomSuffix(variableName, configPolicy.getRandom().factoryUsage());
                 valueSelectorConfig.setId(entityValueRangeRecorderId);
             } else {
                 entityValueRangeRecorderId = valueSelectorConfig.getId() != null ? valueSelectorConfig.getId()

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveIterator.java
@@ -71,7 +71,8 @@ final class ListRuinRecreateMoveIterator<Solution_> extends UpcomingSelectionIte
             }
         }
         return new SelectorBasedListRuinRecreateMove<>(listVariableStateSupply.getSourceVariableDescriptor(),
-                constructionHeuristicPhaseBuilder, solverScope, selectedValueList, affectedEntitySet);
+                constructionHeuristicPhaseBuilder, solverScope, selectedValueList, affectedEntitySet,
+                workingRandom.nextLong());
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveSelector.java
@@ -70,7 +70,7 @@ final class ListRuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<
         this.listVariableStateSupply = solverScope.getScoreDirector()
                 .getSupplyManager()
                 .demand(listVariableDescriptor.getStateDemand());
-        this.workingRandom = solverScope.getWorkingRandom();
+        this.workingRandom = solverScope.getWorkingRandom().moveUsage();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveSelector.java
@@ -70,7 +70,6 @@ final class ListRuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<
         this.listVariableStateSupply = solverScope.getScoreDirector()
                 .getSupplyManager()
                 .demand(listVariableDescriptor.getStateDemand());
-        this.workingRandom = solverScope.getWorkingRandom().moveIteratorUsage();
     }
 
     @Override
@@ -83,7 +82,6 @@ final class ListRuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<
     public void phaseEnded(AbstractPhaseScope<Solution_> phaseScope) {
         super.phaseEnded(phaseScope);
         this.solverScope = null;
-        this.workingRandom = null;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveSelector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMoveSelector.java
@@ -70,7 +70,7 @@ final class ListRuinRecreateMoveSelector<Solution_> extends GenericMoveSelector<
         this.listVariableStateSupply = solverScope.getScoreDirector()
                 .getSupplyManager()
                 .demand(listVariableDescriptor.getStateDemand());
-        this.workingRandom = solverScope.getWorkingRandom().moveUsage();
+        this.workingRandom = solverScope.getWorkingRandom().moveIteratorUsage();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
@@ -18,6 +18,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.move.generic.RuinRecreate
 import ai.timefold.solver.core.impl.move.MoveDirector;
 import ai.timefold.solver.core.impl.move.VariableChangeRecordingScoreDirector;
 import ai.timefold.solver.core.impl.score.director.VariableDescriptorAwareScoreDirector;
+import ai.timefold.solver.core.impl.solver.random.DefaultRandomSource;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.preview.api.move.Move;
 
@@ -96,6 +97,7 @@ public final class SelectorBasedListRuinRecreateMove<Solution_> extends Abstract
             var nestedSolverScope = new SolverScope<Solution_>(solverScope.getClock());
             nestedSolverScope.setSolver(solverScope.getSolver());
             nestedSolverScope.setScoreDirector(nonRecordingScoreDirector);
+            nestedSolverScope.setWorkingRandom(DefaultRandomSource.seeded(0L));
             constructionHeuristicPhase.solvingStarted(nestedSolverScope);
             constructionHeuristicPhase.solve(nestedSolverScope);
             constructionHeuristicPhase.solvingEnded(nestedSolverScope);

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
@@ -33,16 +33,19 @@ public final class SelectorBasedListRuinRecreateMove<Solution_> extends Abstract
     private final RuinRecreateConstructionHeuristicPhaseBuilder<Solution_> constructionHeuristicPhaseBuilder;
     private final SolverScope<Solution_> solverScope;
     private final Map<Object, NavigableSet<RuinedPosition>> entityToNewPositionMap;
+    private final long randomSeed;
 
     public SelectorBasedListRuinRecreateMove(ListVariableDescriptor<Solution_> listVariableDescriptor,
             RuinRecreateConstructionHeuristicPhaseBuilder<Solution_> constructionHeuristicPhaseBuilder,
-            SolverScope<Solution_> solverScope, List<Object> ruinedValueList, SequencedSet<Object> affectedEntitySet) {
+            SolverScope<Solution_> solverScope, List<Object> ruinedValueList, SequencedSet<Object> affectedEntitySet,
+            long randomSeed) {
         this.listVariableDescriptor = listVariableDescriptor;
         this.constructionHeuristicPhaseBuilder = constructionHeuristicPhaseBuilder;
         this.solverScope = solverScope;
         this.ruinedValueList = ruinedValueList;
         this.affectedEntitySet = affectedEntitySet;
         this.entityToNewPositionMap = new IdentityHashMap<>(affectedEntitySet.size());
+        this.randomSeed = randomSeed;
     }
 
     @Override
@@ -97,7 +100,7 @@ public final class SelectorBasedListRuinRecreateMove<Solution_> extends Abstract
             var nestedSolverScope = new SolverScope<Solution_>(solverScope.getClock());
             nestedSolverScope.setSolver(solverScope.getSolver());
             nestedSolverScope.setScoreDirector(nonRecordingScoreDirector);
-            nestedSolverScope.setWorkingRandom(DefaultRandomSource.seeded(0L));
+            nestedSolverScope.setWorkingRandom(DefaultRandomSource.seeded(randomSeed));
             constructionHeuristicPhase.solvingStarted(nestedSolverScope);
             constructionHeuristicPhase.solve(nestedSolverScope);
             constructionHeuristicPhase.solvingEnded(nestedSolverScope);
@@ -172,7 +175,7 @@ public final class SelectorBasedListRuinRecreateMove<Solution_> extends Abstract
                 .getSolutionDescriptor()
                 .getListVariableDescriptor();
         return new SelectorBasedListRuinRecreateMove<>(rebasedListVariableDescriptor, constructionHeuristicPhaseBuilder,
-                solverScope, rebasedRuinedValueList, rebasedAffectedEntitySet);
+                solverScope, rebasedRuinedValueList, rebasedAffectedEntitySet, randomSeed);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
@@ -35,6 +35,23 @@ public final class SelectorBasedListRuinRecreateMove<Solution_> extends Abstract
     private final Map<Object, NavigableSet<RuinedPosition>> entityToNewPositionMap;
     private final long randomSeed;
 
+    /**
+     * Prefer
+     * {@link #SelectorBasedListRuinRecreateMove(ListVariableDescriptor, RuinRecreateConstructionHeuristicPhaseBuilder, SolverScope, List, SequencedSet, long)}
+     * with explicitly provided random seed.
+     *
+     * @param listVariableDescriptor
+     * @param constructionHeuristicPhaseBuilder
+     * @param solverScope
+     * @param ruinedValueList
+     * @param affectedEntitySet
+     */
+    public SelectorBasedListRuinRecreateMove(ListVariableDescriptor<Solution_> listVariableDescriptor,
+            RuinRecreateConstructionHeuristicPhaseBuilder<Solution_> constructionHeuristicPhaseBuilder,
+            SolverScope<Solution_> solverScope, List<Object> ruinedValueList, SequencedSet<Object> affectedEntitySet) {
+        this(listVariableDescriptor, constructionHeuristicPhaseBuilder, solverScope, ruinedValueList, affectedEntitySet, 0);
+    }
+
     public SelectorBasedListRuinRecreateMove(ListVariableDescriptor<Solution_> listVariableDescriptor,
             RuinRecreateConstructionHeuristicPhaseBuilder<Solution_> constructionHeuristicPhaseBuilder,
             SolverScope<Solution_> solverScope, List<Object> ruinedValueList, SequencedSet<Object> affectedEntitySet,

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptor.java
@@ -75,7 +75,7 @@ public class SimulatedAnnealingAcceptor<Solution_> extends AbstractAcceptor<Solu
             }
             acceptChance *= acceptChanceLevel;
         }
-        return moveScope.getWorkingRandom().nextDouble() < acceptChance;
+        return moveScope.getWorkingRandom().acceptorUsage().nextDouble() < acceptChance;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
@@ -199,7 +199,7 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
             return 0.0d;
         }
         var acceptChance = 1.0d - (numerator / (double) denominator);
-        var accepted = moveScope.getWorkingRandom().nextDouble() < acceptChance;
+        var accepted = moveScope.getWorkingRandom().acceptorUsage().nextDouble() < acceptChance;
         return accepted ? acceptChance : -acceptChance;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/forager/AcceptedLocalSearchForager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/forager/AcceptedLocalSearchForager.java
@@ -121,7 +121,7 @@ public final class AcceptedLocalSearchForager<Solution_> extends AbstractLocalSe
         if (finalistList.size() == 1 || !breakTieRandomly) {
             return finalistList.get(0);
         }
-        int randomIndex = stepScope.getWorkingRandom().nextInt(finalistList.size());
+        int randomIndex = stepScope.getWorkingRandom().acceptorUsage().nextInt(finalistList.size());
         return finalistList.get(randomIndex);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/DefaultNeighborhoodTester.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/DefaultNeighborhoodTester.java
@@ -8,6 +8,7 @@ import ai.timefold.solver.core.impl.domain.solution.descriptor.DefaultPlanningSo
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.move.DefaultMoveTestContext;
 import ai.timefold.solver.core.impl.neighborhood.stream.DefaultMoveStreamFactory;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningSolutionMetaModel;
 import ai.timefold.solver.core.preview.api.move.test.MoveTester;
@@ -39,6 +40,7 @@ public final class DefaultNeighborhoodTester<Solution_>
         var moveTestContext = (DefaultMoveTestContext<Solution_>) moveTester.using(solution);
         var scoreDirector = moveTestContext.getScoreDirector();
         var solverScope = new SolverScope<Solution_>();
+        solverScope.setWorkingRandom(RandomSource.seeded(0L));
         solverScope.setScoreDirector(scoreDirector);
         repository.solvingStarted(solverScope);
         var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsBasedMoveRepository.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsBasedMoveRepository.java
@@ -73,7 +73,7 @@ public final class NeighborhoodsBasedMoveRepository<Solution_> implements MoveRe
 
     @Override
     public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
-        workingRandom = phaseScope.getWorkingRandom().moveUsage();
+        workingRandom = phaseScope.getWorkingRandom().moveIteratorUsage();
         phaseScope.getScoreDirector().setMoveRepository(this);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsBasedMoveRepository.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsBasedMoveRepository.java
@@ -73,7 +73,7 @@ public final class NeighborhoodsBasedMoveRepository<Solution_> implements MoveRe
 
     @Override
     public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
-        workingRandom = phaseScope.getWorkingRandom();
+        workingRandom = phaseScope.getWorkingRandom().moveUsage();
         phaseScope.getScoreDirector().setMoveRepository(this);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractMoveScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractMoveScope.java
@@ -1,11 +1,10 @@
 package ai.timefold.solver.core.impl.phase.scope;
 
-import java.util.random.RandomGenerator;
-
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.preview.api.move.Move;
 
 /**
@@ -66,7 +65,7 @@ public abstract class AbstractMoveScope<Solution_> {
         return getStepScope().getWorkingSolution();
     }
 
-    public RandomGenerator getWorkingRandom() {
+    public RandomSource getWorkingRandom() {
         return getStepScope().getWorkingRandom();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractPhaseScope.java
@@ -1,7 +1,5 @@
 package ai.timefold.solver.core.impl.phase.scope;
 
-import java.util.random.RandomGenerator;
-
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.solver.event.EventProducerId;
@@ -9,6 +7,7 @@ import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.PhaseTermination;
 import ai.timefold.solver.core.preview.api.move.Move;
@@ -239,7 +238,7 @@ public abstract class AbstractPhaseScope<Solution_> {
         innerScoreDirector.assertShadowVariablesAreNotStale(workingScore, completedAction);
     }
 
-    public RandomGenerator getWorkingRandom() {
+    public RandomSource getWorkingRandom() {
         return getSolverScope().getWorkingRandom();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractStepScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/scope/AbstractStepScope.java
@@ -1,12 +1,11 @@
 package ai.timefold.solver.core.impl.phase.scope;
 
-import java.util.random.RandomGenerator;
-
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.move.MoveDirector;
 import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
@@ -66,7 +65,7 @@ public abstract class AbstractStepScope<Solution_> {
         return getPhaseScope().getWorkingSolution();
     }
 
-    public RandomGenerator getWorkingRandom() {
+    public RandomSource getWorkingRandom() {
         return getPhaseScope().getWorkingRandom();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/AbstractSolver.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/AbstractSolver.java
@@ -14,7 +14,7 @@ import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleSupport;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.solver.event.SolverEventSupport;
-import ai.timefold.solver.core.impl.solver.random.DelegatingSplittableRandomGenerator;
+import ai.timefold.solver.core.impl.solver.random.DefaultRandomSource;
 import ai.timefold.solver.core.impl.solver.recaller.BestSolutionRecaller;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.UniversalTermination;
@@ -131,16 +131,16 @@ public abstract class AbstractSolver<Solution_> implements Solver<Solution_> {
         globalTermination.stepStarted(stepScope);
         // To ensure reproducibility even when the number of random calls is not deterministic,
         // split the random at step start.
-        var delegatingRandom = ((DelegatingSplittableRandomGenerator) stepScope.getWorkingRandom());
-        savedRandom = delegatingRandom.getDelegate();
-        delegatingRandom.setDelegate(delegatingRandom.split());
+        var delegatingRandom = ((DefaultRandomSource) stepScope.getWorkingRandom());
+        savedRandom = delegatingRandom.sourceRandom().getDelegate();
+        delegatingRandom.restoreState(delegatingRandom.saveState());
         // Do not propagate to phases; the active phase does that for itself and they should not propagate further.
     }
 
     public void stepEnded(AbstractStepScope<Solution_> stepScope) {
         // Restore from the split random
-        var delegatingRandom = ((DelegatingSplittableRandomGenerator) stepScope.getWorkingRandom());
-        delegatingRandom.setDelegate(Objects.requireNonNull(savedRandom));
+        var delegatingRandom = ((DefaultRandomSource) stepScope.getWorkingRandom());
+        delegatingRandom.restoreState(Objects.requireNonNull(savedRandom));
         bestSolutionRecaller.stepEnded(stepScope);
         phaseLifecycleSupport.fireStepEnded(stepScope);
         globalTermination.stepEnded(stepScope);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/AbstractSolver.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/AbstractSolver.java
@@ -132,7 +132,7 @@ public abstract class AbstractSolver<Solution_> implements Solver<Solution_> {
         // To ensure reproducibility even when the number of random calls is not deterministic,
         // split the random at step start.
         var delegatingRandom = ((DefaultRandomSource) stepScope.getWorkingRandom());
-        savedRandom = delegatingRandom.sourceRandom().getDelegate();
+        savedRandom = delegatingRandom.moveRandom().getDelegate();
         delegatingRandom.restoreState(delegatingRandom.saveState());
         // Do not propagate to phases; the active phase does that for itself and they should not propagate further.
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolver.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolver.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.common.PlanningId;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
@@ -18,6 +17,7 @@ import ai.timefold.solver.core.config.solver.monitoring.SolverMetric;
 import ai.timefold.solver.core.impl.phase.Phase;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.recaller.BestSolutionRecaller;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.BasicPlumbingTermination;
@@ -39,7 +39,7 @@ import io.micrometer.core.instrument.Tags;
 public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
 
     protected final EnvironmentMode environmentMode;
-    protected final Supplier<RandomGenerator> randomFactory;
+    protected final Supplier<RandomSource> randomFactory;
     protected final BasicPlumbingTermination<Solution_> basicPlumbingTermination;
     protected final AtomicBoolean solving = new AtomicBoolean(false);
     protected final SolverScope<Solution_> solverScope;
@@ -49,7 +49,7 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
     // Constructors and simple getters/setters
     // ************************************************************************
 
-    public DefaultSolver(EnvironmentMode environmentMode, Supplier<RandomGenerator> randomFactory,
+    public DefaultSolver(EnvironmentMode environmentMode, Supplier<RandomSource> randomFactory,
             BestSolutionRecaller<Solution_> bestSolutionRecaller, BasicPlumbingTermination<Solution_> basicPlumbingTermination,
             UniversalTermination<Solution_> termination, List<Phase<Solution_>> phaseList,
             SolverScope<Solution_> solverScope, String moveThreadCountDescription) {
@@ -66,7 +66,7 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
         return environmentMode;
     }
 
-    public RandomGenerator getRandomGenerator() {
+    public RandomSource getRandomSource() {
         return randomFactory.get();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -37,7 +37,8 @@ import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactoryFactory;
 import ai.timefold.solver.core.impl.solver.change.DefaultProblemChangeDirector;
-import ai.timefold.solver.core.impl.solver.random.DelegatingSplittableRandomGenerator;
+import ai.timefold.solver.core.impl.solver.random.DefaultRandomSource;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.recaller.BestSolutionRecaller;
 import ai.timefold.solver.core.impl.solver.recaller.BestSolutionRecallerFactory;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
@@ -212,14 +213,14 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
         return scoreDirectorFactoryFactory.buildScoreDirectorFactory(environmentMode, solutionDescriptor);
     }
 
-    public Supplier<RandomGenerator> buildRandomSupplier(EnvironmentMode environmentMode_) {
+    public Supplier<RandomSource> buildRandomSupplier(EnvironmentMode environmentMode_) {
         var randomSeed_ = solverConfig.getRandomSeed();
         if (randomSeed_ == null && environmentMode_ != EnvironmentMode.NON_REPRODUCIBLE) {
             randomSeed_ = DEFAULT_RANDOM_SEED;
         } else if (randomSeed_ == null) {
             randomSeed_ = RandomGenerator.getDefault().nextLong();
         }
-        return DelegatingSplittableRandomGenerator.getSupplier(randomSeed_);
+        return DefaultRandomSource.seededSupplier(randomSeed_);
     }
 
     public List<Phase<Solution_>> buildPhaseList(HeuristicConfigPolicy<Solution_> configPolicy,

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/random/DefaultRandomSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/random/DefaultRandomSource.java
@@ -5,8 +5,9 @@ import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.solver.AbstractSolver;
 
-public record DefaultRandomSource(DelegatingSplittableRandomGenerator sourceRandom,
-        DelegatingSplittableRandomGenerator splitRandom) implements RandomSource {
+public record DefaultRandomSource(DelegatingSplittableRandomGenerator moveRandom,
+        DelegatingSplittableRandomGenerator factoryRandom,
+        DelegatingSplittableRandomGenerator acceptorRandom) implements RandomSource {
     /**
      * Return a supplier of {@link DefaultRandomSource} with the specified
      * seed with the seed included in {@link Object#toString()}.
@@ -32,33 +33,41 @@ public record DefaultRandomSource(DelegatingSplittableRandomGenerator sourceRand
     }
 
     public static DefaultRandomSource seeded(long seed) {
-        var sourceRandom = new DelegatingSplittableRandomGenerator(seed);
-        var splitRandom = new DelegatingSplittableRandomGenerator(seed, sourceRandom.split());
-        return new DefaultRandomSource(sourceRandom, splitRandom);
+        var moveRandom = new DelegatingSplittableRandomGenerator(seed);
+        var factoryRandom = new DelegatingSplittableRandomGenerator(seed, moveRandom.split());
+        var acceptorRandom = new DelegatingSplittableRandomGenerator(seed, moveRandom.split());
+        return new DefaultRandomSource(moveRandom, factoryRandom, acceptorRandom);
     }
 
     public DefaultRandomSource split() {
-        var newSourceRandom = new DelegatingSplittableRandomGenerator(sourceRandom.getSeed(), sourceRandom.split());
-        var newSplitRandom = new DelegatingSplittableRandomGenerator(sourceRandom.getSeed(), newSourceRandom.split());
-        return new DefaultRandomSource(newSourceRandom, newSplitRandom);
+        var newMoveRandom = new DelegatingSplittableRandomGenerator(moveRandom.getSeed(), moveRandom.split());
+        var newFactoryRandom = new DelegatingSplittableRandomGenerator(moveRandom.getSeed(), newMoveRandom.split());
+        var newAcceptorRandom = new DelegatingSplittableRandomGenerator(moveRandom.getSeed(), newMoveRandom.split());
+        return new DefaultRandomSource(newMoveRandom, newFactoryRandom, newAcceptorRandom);
     }
 
     public RandomGenerator.SplittableGenerator saveState() {
-        return sourceRandom.split();
+        return moveRandom.split();
     }
 
     public void restoreState(RandomGenerator.SplittableGenerator newSourceRandom) {
-        sourceRandom.setDelegate(newSourceRandom);
-        splitRandom.setDelegate(newSourceRandom.split());
+        moveRandom.setDelegate(newSourceRandom);
+        factoryRandom.setDelegate(newSourceRandom.split());
+        acceptorRandom.setDelegate(newSourceRandom.split());
     }
 
     @Override
-    public RandomGenerator moveUsage() {
-        return sourceRandom;
+    public RandomGenerator moveIteratorUsage() {
+        return moveRandom;
+    }
+
+    @Override
+    public RandomGenerator factoryUsage() {
+        return factoryRandom;
     }
 
     @Override
     public RandomGenerator acceptorUsage() {
-        return splitRandom;
+        return acceptorRandom;
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/random/DefaultRandomSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/random/DefaultRandomSource.java
@@ -1,0 +1,64 @@
+package ai.timefold.solver.core.impl.solver.random;
+
+import java.util.function.Supplier;
+import java.util.random.RandomGenerator;
+
+import ai.timefold.solver.core.impl.solver.AbstractSolver;
+
+public record DefaultRandomSource(DelegatingSplittableRandomGenerator sourceRandom,
+        DelegatingSplittableRandomGenerator splitRandom) implements RandomSource {
+    /**
+     * Return a supplier of {@link DefaultRandomSource} with the specified
+     * seed with the seed included in {@link Object#toString()}.
+     * <p>
+     * Required so the {@link RandomGenerator} is created in the thread {@link AbstractSolver#solve}
+     * is called.
+     *
+     * @param seed The seed to use for the {@link RandomGenerator}.
+     * @return A supplier include the seed in its {@link Object#toString()}
+     */
+    public static Supplier<RandomSource> seededSupplier(long seed) {
+        return new Supplier<>() {
+            @Override
+            public RandomSource get() {
+                return seeded(seed);
+            }
+
+            @Override
+            public String toString() {
+                return "seed %d".formatted(seed);
+            }
+        };
+    }
+
+    public static DefaultRandomSource seeded(long seed) {
+        var sourceRandom = new DelegatingSplittableRandomGenerator(seed);
+        var splitRandom = new DelegatingSplittableRandomGenerator(seed, sourceRandom.split());
+        return new DefaultRandomSource(sourceRandom, splitRandom);
+    }
+
+    public DefaultRandomSource split() {
+        var newSourceRandom = new DelegatingSplittableRandomGenerator(sourceRandom.getSeed(), sourceRandom.split());
+        var newSplitRandom = new DelegatingSplittableRandomGenerator(sourceRandom.getSeed(), newSourceRandom.split());
+        return new DefaultRandomSource(newSourceRandom, newSplitRandom);
+    }
+
+    public RandomGenerator.SplittableGenerator saveState() {
+        return sourceRandom.split();
+    }
+
+    public void restoreState(RandomGenerator.SplittableGenerator newSourceRandom) {
+        sourceRandom.setDelegate(newSourceRandom);
+        splitRandom.setDelegate(newSourceRandom.split());
+    }
+
+    @Override
+    public RandomGenerator moveUsage() {
+        return sourceRandom;
+    }
+
+    @Override
+    public RandomGenerator acceptorUsage() {
+        return splitRandom;
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/random/DelegatingSplittableRandomGenerator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/random/DelegatingSplittableRandomGenerator.java
@@ -1,11 +1,9 @@
 package ai.timefold.solver.core.impl.solver.random;
 
 import java.util.SplittableRandom;
-import java.util.function.Supplier;
 import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector;
-import ai.timefold.solver.core.impl.solver.AbstractSolver;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -155,30 +153,6 @@ public final class DelegatingSplittableRandomGenerator implements RandomGenerato
     public void nextBytes(byte[] bytes) {
         assertIsOwnedByCurrentThread();
         delegate.nextBytes(bytes);
-    }
-
-    /**
-     * Return a supplier of {@link DelegatingSplittableRandomGenerator} with the specified
-     * seed with the seed included in {@link Object#toString()}.
-     * <p>
-     * Required so the {@link RandomGenerator} is created in the thread {@link AbstractSolver#solve}
-     * is called.
-     *
-     * @param seed The seed to use for the {@link RandomGenerator}.
-     * @return A supplier include the seed in its {@link Object#toString()}
-     */
-    public static Supplier<RandomGenerator> getSupplier(long seed) {
-        return new Supplier<>() {
-            @Override
-            public RandomGenerator get() {
-                return new DelegatingSplittableRandomGenerator(seed);
-            }
-
-            @Override
-            public String toString() {
-                return "seed %d".formatted(seed);
-            }
-        };
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/random/RandomSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/random/RandomSource.java
@@ -1,0 +1,35 @@
+package ai.timefold.solver.core.impl.solver.random;
+
+import java.util.random.RandomGenerator;
+
+public interface RandomSource {
+    /**
+     * Creates a new {@link RandomSource} from a given seed.
+     *
+     * @param seed Controls the random sequence generated.
+     *
+     * @return A new {@link RandomSource} from a given seed.
+     */
+    static RandomSource seeded(long seed) {
+        return DefaultRandomSource.seeded(seed);
+    }
+
+    /**
+     * Used by {@link ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector}
+     * and other components.
+     *
+     * @return A {@link RandomGenerator} instance that advances the source
+     *         {@link RandomGenerator} state.
+     */
+    RandomGenerator moveUsage();
+
+    /**
+     * Used by {@link ai.timefold.solver.core.impl.localsearch.decider.acceptor.Acceptor}
+     * and other components inbetween move generation.
+     *
+     * @return A {@link RandomGenerator} instance that does not advance the source
+     *         {@link RandomGenerator} state (and hence, any usage does not affect
+     *         reproducibility).
+     */
+    RandomGenerator acceptorUsage();
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/random/RandomSource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/random/RandomSource.java
@@ -2,6 +2,25 @@ package ai.timefold.solver.core.impl.solver.random;
 
 import java.util.random.RandomGenerator;
 
+import ai.timefold.solver.core.impl.localsearch.decider.acceptor.Acceptor;
+import ai.timefold.solver.core.impl.neighborhood.MoveRepository;
+import ai.timefold.solver.core.impl.solver.AbstractSolver;
+
+/**
+ * Provide access to a {@link RandomGenerator}. Random state
+ * is reset each step in {@link AbstractSolver#stepStarted} and
+ * {@link AbstractSolver#stepEnded}. As such, it does not matter
+ * how many random calls is performed in a step, provided usage
+ * of the {@link RandomGenerator} is fully deterministic.
+ * <br/>
+ * Moves and acceptors use different {@link RandomGenerator} since
+ * an acceptor is called when a move has been evaluated, and
+ * in a multithreaded context, we can generate moves while waiting
+ * for a prior move to be evaluated. Thus, if they used the same
+ * {@link RandomGenerator}, the moves generated would not be deterministic,
+ * since sometimes there will be another random call since an earlier move was
+ * evaluated, and sometimes there won't be.
+ */
 public interface RandomSource {
     /**
      * Creates a new {@link RandomSource} from a given seed.
@@ -15,21 +34,23 @@ public interface RandomSource {
     }
 
     /**
-     * Used by {@link ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector}
-     * and other components.
+     * Used by {@link MoveRepository} and other components for generating moves.
      *
-     * @return A {@link RandomGenerator} instance that advances the source
-     *         {@link RandomGenerator} state.
+     * @return A {@link RandomGenerator} exclusively used for generating moves.
      */
-    RandomGenerator moveUsage();
+    RandomGenerator moveIteratorUsage();
 
     /**
-     * Used by {@link ai.timefold.solver.core.impl.localsearch.decider.acceptor.Acceptor}
-     * and other components inbetween move generation.
+     * Used by factories before solving starts.
      *
-     * @return A {@link RandomGenerator} instance that does not advance the source
-     *         {@link RandomGenerator} state (and hence, any usage does not affect
-     *         reproducibility).
+     * @return A {@link RandomGenerator} exclusively used by factories.
+     */
+    RandomGenerator factoryUsage();
+
+    /**
+     * Used by {@link Acceptor} and other components inbetween move generation.
+     *
+     * @return A {@link RandomGenerator} exclusively used by acceptors.
      */
     RandomGenerator acceptorUsage();
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/scope/SolverScope.java
@@ -12,7 +12,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.random.RandomGenerator;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
@@ -27,7 +26,8 @@ import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.AbstractSolver;
 import ai.timefold.solver.core.impl.solver.change.DefaultProblemChangeDirector;
 import ai.timefold.solver.core.impl.solver.monitoring.ScoreLevels;
-import ai.timefold.solver.core.impl.solver.random.DelegatingSplittableRandomGenerator;
+import ai.timefold.solver.core.impl.solver.random.DefaultRandomSource;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.termination.PhaseTermination;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
@@ -50,7 +50,7 @@ public class SolverScope<Solution_> {
     private Set<SolverMetric> solverMetricSet = Collections.emptySet();
     private Tags monitoringTags;
     private int startingSolverCount;
-    private RandomGenerator workingRandom;
+    private RandomSource workingRandom;
     private InnerScoreDirector<Solution_, ?> scoreDirector;
     private AbstractSolver<Solution_> solver;
     private DefaultProblemChangeDirector<Solution_> problemChangeDirector;
@@ -143,11 +143,11 @@ public class SolverScope<Solution_> {
         this.startingSolverCount = startingSolverCount;
     }
 
-    public RandomGenerator getWorkingRandom() {
+    public RandomSource getWorkingRandom() {
         return workingRandom;
     }
 
-    public void setWorkingRandom(RandomGenerator workingRandom) {
+    public void setWorkingRandom(RandomSource workingRandom) {
         this.workingRandom = workingRandom;
     }
 
@@ -354,9 +354,8 @@ public class SolverScope<Solution_> {
         childThreadSolverScope.solverMetricSet = solverMetricSet;
         childThreadSolverScope.startingSolverCount = startingSolverCount;
         // Experiments show that this trick to attain reproducibility doesn't break uniform distribution
-        var delegatingRandom = (DelegatingSplittableRandomGenerator) workingRandom;
-        childThreadSolverScope.workingRandom =
-                new DelegatingSplittableRandomGenerator(delegatingRandom.getSeed(), delegatingRandom.split());
+        var delegatingRandom = (DefaultRandomSource) workingRandom;
+        childThreadSolverScope.workingRandom = delegatingRandom.split();
         childThreadSolverScope.scoreDirector = scoreDirector.createChildThreadScoreDirector(childThreadType);
         childThreadSolverScope.startingSystemTimeMillis.set(startingSystemTimeMillis.get());
         resetAtomicLongTimeMillis(childThreadSolverScope.endingSystemTimeMillis);

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolverManagerTest.java
@@ -4,6 +4,7 @@ import static ai.timefold.solver.core.api.solver.SolverStatus.NOT_SOLVING;
 import static ai.timefold.solver.core.api.solver.SolverStatus.SOLVING_ACTIVE;
 import static ai.timefold.solver.core.api.solver.SolverStatus.SOLVING_SCHEDULED;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertSolutionInitialized;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
@@ -584,7 +585,7 @@ class SolverManagerTest {
         try (var solverManager = createDefaultSolverManager(solverConfig)) {
             var problem = PlannerTestUtils.generateTestdataSolution("s1");
 
-            SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+            SolverScope<TestdataSolution> solverScope = mockSolverScope();
             doReturn(50L).when(solverScope).calculateTimeMillisSpentUpToNow();
 
             var solverJob = (DefaultSolverJob<TestdataSolution>) solverManager.solve(1L, problem);
@@ -613,7 +614,7 @@ class SolverManagerTest {
         try (var solverManager = createDefaultSolverManager(solverConfig)) {
             var problem = PlannerTestUtils.generateTestdataSolution("s1");
 
-            SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+            SolverScope<TestdataSolution> solverScope = mockSolverScope();
             doReturn(50L).when(solverScope).calculateTimeMillisSpentUpToNow();
 
             // Override spent limit to 100 milliseconds

--- a/core/src/test/java/ai/timefold/solver/core/config/solver/EnvironmentModeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/config/solver/EnvironmentModeTest.java
@@ -186,14 +186,14 @@ class EnvironmentModeTest {
     }
 
     private void assertReproducibility(Solver<TestdataSolution> solver1, Solver<TestdataSolution> solver2) {
-        assertGeneratingSameNumbers(((DefaultSolver<TestdataSolution>) solver1).getRandomSource().moveUsage(),
-                ((DefaultSolver<TestdataSolution>) solver2).getRandomSource().moveUsage());
+        assertGeneratingSameNumbers(((DefaultSolver<TestdataSolution>) solver1).getRandomSource().moveIteratorUsage(),
+                ((DefaultSolver<TestdataSolution>) solver2).getRandomSource().moveIteratorUsage());
         assertSameScoreSeries(solver1, solver2);
     }
 
     private void assertNonReproducibility(Solver<TestdataSolution> solver1, Solver<TestdataSolution> solver2) {
-        assertGeneratingDifferentNumbers(((DefaultSolver<TestdataSolution>) solver1).getRandomSource().moveUsage(),
-                ((DefaultSolver<TestdataSolution>) solver2).getRandomSource().moveUsage());
+        assertGeneratingDifferentNumbers(((DefaultSolver<TestdataSolution>) solver1).getRandomSource().moveIteratorUsage(),
+                ((DefaultSolver<TestdataSolution>) solver2).getRandomSource().moveIteratorUsage());
         assertDifferentScoreSeries(solver1, solver2);
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/config/solver/EnvironmentModeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/config/solver/EnvironmentModeTest.java
@@ -186,14 +186,14 @@ class EnvironmentModeTest {
     }
 
     private void assertReproducibility(Solver<TestdataSolution> solver1, Solver<TestdataSolution> solver2) {
-        assertGeneratingSameNumbers(((DefaultSolver<TestdataSolution>) solver1).getRandomGenerator(),
-                ((DefaultSolver<TestdataSolution>) solver2).getRandomGenerator());
+        assertGeneratingSameNumbers(((DefaultSolver<TestdataSolution>) solver1).getRandomSource().moveUsage(),
+                ((DefaultSolver<TestdataSolution>) solver2).getRandomSource().moveUsage());
         assertSameScoreSeries(solver1, solver2);
     }
 
     private void assertNonReproducibility(Solver<TestdataSolution> solver1, Solver<TestdataSolution> solver2) {
-        assertGeneratingDifferentNumbers(((DefaultSolver<TestdataSolution>) solver1).getRandomGenerator(),
-                ((DefaultSolver<TestdataSolution>) solver2).getRandomGenerator());
+        assertGeneratingDifferentNumbers(((DefaultSolver<TestdataSolution>) solver1).getRandomSource().moveUsage(),
+                ((DefaultSolver<TestdataSolution>) solver2).getRandomSource().moveUsage());
         assertDifferentScoreSeries(solver1, solver2);
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.constructionheuristic.placer.entity;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfIterator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,7 +35,7 @@ class PooledEntityPlacerTest {
 
         var placer = new PooledEntityPlacer<>(null, null, moveSelector);
 
-        var solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         placer.solvingStarted(solverScope);
 
         var phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.constructionheuristic.placer.entity;
 
 import static ai.timefold.solver.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertEntityPlacement;
 import static ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -57,7 +58,7 @@ class QueuedEntityPlacerFactoryTest {
                 new QueuedEntityPlacerFactory<TestdataMultiVarSolution>(placerConfig)
                         .buildEntityPlacer(configPolicy);
 
-        SolverScope<TestdataMultiVarSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataMultiVarSolution> solverScope = mockSolverScope();
         entityPlacer.solvingStarted(solverScope);
         AbstractPhaseScope<TestdataMultiVarSolution> phaseScope = mock(AbstractPhaseScope.class);
         when(phaseScope.getSolverScope()).thenReturn(solverScope);

--- a/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerTest.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.constructionheuristic.placer.entity;
 import static ai.timefold.solver.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertEntityPlacement;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfIterator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -53,7 +54,7 @@ class QueuedEntityPlacerTest {
                 new ChangeMoveSelector<>(new MimicReplayingEntitySelector<>(recordingEntitySelector), valueSelector, false);
         var placer = new QueuedEntityPlacer<>(null, null, recordingEntitySelector, Collections.singletonList(moveSelector));
 
-        var solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         placer.solvingStarted(solverScope);
 
         var phaseScopeA = mock(AbstractPhaseScope.class);
@@ -130,7 +131,7 @@ class QueuedEntityPlacerTest {
         var placer =
                 new QueuedEntityPlacer<>(null, null, recordingEntitySelector, moveSelectorList);
 
-        var solverScope = mock(SolverScope.class);
+        SolverScope<TestdataMultiVarSolution> solverScope = mockSolverScope();
         placer.solvingStarted(solverScope);
 
         var phaseScopeA = mock(AbstractPhaseScope.class);
@@ -201,7 +202,7 @@ class QueuedEntityPlacerTest {
         var placer = new QueuedEntityPlacer<>(null, null, recordingEntitySelector,
                 Collections.singletonList(moveSelector));
 
-        var solverScope = mock(SolverScope.class);
+        SolverScope<TestdataMultiVarSolution> solverScope = mockSolverScope();
         placer.solvingStarted(solverScope);
 
         var phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.constructionheuristic.placer.entity;
 
 import static ai.timefold.solver.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertValuePlacement;
 import static ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,6 +19,7 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.ValueRangeManager;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
@@ -36,7 +38,8 @@ class QueuedValuePlacerFactoryTest {
                 new QueuedValuePlacerFactory<TestdataSolution>(config)
                         .buildEntityPlacer(buildHeuristicConfigPolicy());
 
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
+        when(solverScope.getWorkingRandom()).thenReturn(mock(RandomSource.class));
         placer.solvingStarted(solverScope);
         AbstractPhaseScope<TestdataSolution> phaseScope = mock(AbstractPhaseScope.class);
         when(phaseScope.getSolverScope()).thenReturn(solverScope);

--- a/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.constructionheuristic.placer.entity;
 
 import static ai.timefold.solver.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertValuePlacement;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,7 +50,7 @@ class QueuedValuePlacerTest {
                 new MimicReplayingValueSelector<>(recordingValueSelector), false);
         var placer = new QueuedValuePlacer<>(null, null, recordingValueSelector, moveSelector);
 
-        var solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         placer.solvingStarted(solverScope);
 
         var phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/HeuristicConfigPolicyTestUtils.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/HeuristicConfigPolicyTestUtils.java
@@ -6,6 +6,7 @@ import ai.timefold.solver.core.config.heuristic.selector.entity.EntitySorterMann
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import ai.timefold.solver.core.impl.solver.ClassInstanceCache;
+import ai.timefold.solver.core.impl.solver.random.MockRandomSource;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 
 public final class HeuristicConfigPolicyTestUtils {
@@ -24,7 +25,7 @@ public final class HeuristicConfigPolicyTestUtils {
                     EntitySorterManner entitySorterManner) {
         return new HeuristicConfigPolicy.Builder<Solution_>()
                 .withEnvironmentMode(EnvironmentMode.PHASE_ASSERT)
-                .withRandom(new Random())
+                .withRandom(new MockRandomSource(new Random(0)))
                 .withSolutionDescriptor(solutionDescriptor)
                 .withClassInstanceCache(ClassInstanceCache.create())
                 .withEntitySorterManner(entitySorterManner)

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/SelectorTestUtils.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/SelectorTestUtils.java
@@ -28,6 +28,7 @@ import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListener;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.impl.solver.random.MockRandomSource;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.preview.api.move.Move;
 
@@ -219,7 +220,7 @@ public class SelectorTestUtils {
             Selector<Solution_>... selectors) {
         SolverScope<Solution_> solverScope = new SolverScope<>();
         solverScope.setScoreDirector(scoreDirector);
-        solverScope.setWorkingRandom(random);
+        solverScope.setWorkingRandom(new MockRandomSource(random));
         listener.solvingStarted(solverScope);
         if (selectors != null) {
             for (var selector : selectors) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/FromSolutionEntitySelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/FromSolutionEntitySelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.entity;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfEntitySelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCodesOfNeverEndingOfEntitySelector;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -10,14 +11,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 import ai.timefold.solver.core.testutil.PlannerTestUtils;
@@ -54,7 +53,7 @@ class FromSolutionEntitySelectorTest {
         when(scoreDirector.isWorkingEntityListDirty(7L)).thenReturn(false);
         FromSolutionEntitySelector entitySelector = new FromSolutionEntitySelector(entityDescriptor, cacheType, false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         entitySelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -124,7 +123,7 @@ class FromSolutionEntitySelectorTest {
         FromSolutionEntitySelector entitySelector = new FromSolutionEntitySelector(entityDescriptor,
                 SelectionCacheType.JUST_IN_TIME, false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         entitySelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -220,9 +219,9 @@ class FromSolutionEntitySelectorTest {
         when(scoreDirector.isWorkingEntityListDirty(7L)).thenReturn(false);
         FromSolutionEntitySelector entitySelector = new FromSolutionEntitySelector(entityDescriptor, cacheType, true);
 
-        Random workingRandom = new TestRandom(1, 0, 0, 2, 1, 2, 2, 1, 0);
+        var workingRandom = new TestRandom(1, 0, 0, 2, 1, 2, 2, 1, 0);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         when(solverScope.getScoreDirector()).thenReturn(scoreDirector);
         entitySelector.solvingStarted(solverScope);
@@ -280,9 +279,9 @@ class FromSolutionEntitySelectorTest {
         FromSolutionEntitySelector entitySelector = new FromSolutionEntitySelector(entityDescriptor,
                 SelectionCacheType.JUST_IN_TIME, true);
 
-        Random workingRandom = new TestRandom(1, 0, 0, 2, 1, 2, 2, 1, 0);
+        var workingRandom = new TestRandom(1, 0, 0, 2, 1, 2, 2, 1, 0);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         when(solverScope.getScoreDirector()).thenReturn(scoreDirector);
         entitySelector.solvingStarted(solverScope);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/CachingEntitySelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/CachingEntitySelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.entity.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfEntitySelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
@@ -15,7 +16,6 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.iterator.CachedLis
 import ai.timefold.solver.core.impl.heuristic.selector.entity.EntitySelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 
 import org.junit.jupiter.api.Test;
@@ -38,26 +38,26 @@ class CachingEntitySelectorTest {
     }
 
     public void runOriginalSelection(SelectionCacheType cacheType, int timesCalled) {
-        EntitySelector childEntitySelector = SelectorTestUtils.mockEntitySelector(TestdataEntity.class,
+        var childEntitySelector = SelectorTestUtils.mockEntitySelector(TestdataEntity.class,
                 new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3"));
 
-        CachingEntitySelector entitySelector = new CachingEntitySelector(childEntitySelector, cacheType, false);
+        var entitySelector = new CachingEntitySelector(childEntitySelector, cacheType, false);
         verify(childEntitySelector, times(1)).isNeverEnding();
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         entitySelector.solvingStarted(solverScope);
 
-        AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
+        var phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
         entitySelector.phaseStarted(phaseScopeA);
 
-        AbstractStepScope stepScopeA1 = mock(AbstractStepScope.class);
+        var stepScopeA1 = mock(AbstractStepScope.class);
         when(stepScopeA1.getPhaseScope()).thenReturn(phaseScopeA);
         entitySelector.stepStarted(stepScopeA1);
         assertAllCodesOfEntitySelector(entitySelector, "e1", "e2", "e3");
         entitySelector.stepEnded(stepScopeA1);
 
-        AbstractStepScope stepScopeA2 = mock(AbstractStepScope.class);
+        var stepScopeA2 = mock(AbstractStepScope.class);
         when(stepScopeA2.getPhaseScope()).thenReturn(phaseScopeA);
         entitySelector.stepStarted(stepScopeA2);
         assertAllCodesOfEntitySelector(entitySelector, "e1", "e2", "e3");
@@ -65,23 +65,23 @@ class CachingEntitySelectorTest {
 
         entitySelector.phaseEnded(phaseScopeA);
 
-        AbstractPhaseScope phaseScopeB = mock(AbstractPhaseScope.class);
+        var phaseScopeB = mock(AbstractPhaseScope.class);
         when(phaseScopeB.getSolverScope()).thenReturn(solverScope);
         entitySelector.phaseStarted(phaseScopeB);
 
-        AbstractStepScope stepScopeB1 = mock(AbstractStepScope.class);
+        var stepScopeB1 = mock(AbstractStepScope.class);
         when(stepScopeB1.getPhaseScope()).thenReturn(phaseScopeB);
         entitySelector.stepStarted(stepScopeB1);
         assertAllCodesOfEntitySelector(entitySelector, "e1", "e2", "e3");
         entitySelector.stepEnded(stepScopeB1);
 
-        AbstractStepScope stepScopeB2 = mock(AbstractStepScope.class);
+        var stepScopeB2 = mock(AbstractStepScope.class);
         when(stepScopeB2.getPhaseScope()).thenReturn(phaseScopeB);
         entitySelector.stepStarted(stepScopeB2);
         assertAllCodesOfEntitySelector(entitySelector, "e1", "e2", "e3");
         entitySelector.stepEnded(stepScopeB2);
 
-        AbstractStepScope stepScopeB3 = mock(AbstractStepScope.class);
+        var stepScopeB3 = mock(AbstractStepScope.class);
         when(stepScopeB3.getPhaseScope()).thenReturn(phaseScopeB);
         entitySelector.stepStarted(stepScopeB3);
         assertAllCodesOfEntitySelector(entitySelector, "e1", "e2", "e3");

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntitySelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/FilteringEntitySelectorTest.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.entity.decorator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfEntitySelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfOrderedEntitySelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -15,7 +16,6 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.Selectio
 import ai.timefold.solver.core.impl.heuristic.selector.entity.EntitySelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 
@@ -71,7 +71,7 @@ class FilteringEntitySelectorTest {
             entitySelector = new CachingEntitySelector(entitySelector, cacheType, false);
         }
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         entitySelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/ProbabilityEntitySelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/ProbabilityEntitySelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.entity.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCode;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
@@ -11,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Iterator;
-import java.util.Random;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.impl.heuristic.selector.SelectorTestUtils;
@@ -19,7 +19,6 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.Selectio
 import ai.timefold.solver.core.impl.heuristic.selector.entity.EntitySelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 import ai.timefold.solver.core.testutil.PlannerTestUtils;
@@ -52,14 +51,14 @@ class ProbabilityEntitySelectorTest {
         EntitySelector entitySelector = new ProbabilityEntitySelector(childEntitySelector, SelectionCacheType.STEP,
                 probabilityWeightFactory);
 
-        Random workingRandom = new TestRandom(
+        var workingRandom = new TestRandom(
                 1222.0 / 1234.0,
                 111.0 / 1234.0,
                 0.0,
                 1230.0 / 1234.0,
                 1199.0 / 1234.0);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         entitySelector.solvingStarted(solverScope);
         AbstractPhaseScope phaseScopeA = PlannerTestUtils.delegatingPhaseScope(solverScope);
@@ -118,7 +117,7 @@ class ProbabilityEntitySelectorTest {
         };
         ProbabilityEntitySelector entitySelector = new ProbabilityEntitySelector(childEntitySelector, SelectionCacheType.STEP,
                 probabilityWeightFactory);
-        entitySelector.constructCache(mock(SolverScope.class));
+        entitySelector.constructCache(mockSolverScope());
         assertThat(entitySelector.getSize()).isEqualTo(4);
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/SelectedCountLimitEntitySelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/SelectedCountLimitEntitySelectorTest.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.entity.decorator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfEntitySelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfIterator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -27,7 +28,7 @@ class SelectedCountLimitEntitySelectorTest {
                 new TestdataEntity("e5"));
         EntitySelector entitySelector = new SelectedCountLimitEntitySelector(childEntitySelector, true, 3L);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         entitySelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -85,7 +86,7 @@ class SelectedCountLimitEntitySelectorTest {
                 new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3"));
         EntitySelector entitySelector = new SelectedCountLimitEntitySelector(childEntitySelector, true, 5L);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         entitySelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/SortingEntitySelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/decorator/SortingEntitySelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.entity.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfEntitySelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.doReturn;
@@ -55,7 +56,7 @@ class SortingEntitySelectorTest {
                 new SortingEntitySelector(childEntitySelector, cacheType,
                         new TestdataObjectSorter<TestdataSolution, TestdataEntity>());
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         InnerScoreDirector<?, ?> scoreDirector = mock(InnerScoreDirector.class);
         doReturn(scoreDirector).when(solverScope).getScoreDirector();
         doReturn(new TestdataSolution()).when(scoreDirector).getWorkingSolution();

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/mimic/MimicReplayingEntitySelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/mimic/MimicReplayingEntitySelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.entity.mimic;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCode;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -11,10 +12,8 @@ import static org.mockito.Mockito.when;
 import java.util.Iterator;
 
 import ai.timefold.solver.core.impl.heuristic.selector.SelectorTestUtils;
-import ai.timefold.solver.core.impl.heuristic.selector.entity.EntitySelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 
 import org.junit.jupiter.api.Test;
@@ -23,22 +22,22 @@ class MimicReplayingEntitySelectorTest {
 
     @Test
     void originalSelection() {
-        EntitySelector childEntitySelector = SelectorTestUtils.mockEntitySelector(TestdataEntity.class,
+        var childEntitySelector = SelectorTestUtils.mockEntitySelector(TestdataEntity.class,
                 new TestdataEntity("e1"), new TestdataEntity("e2"), new TestdataEntity("e3"));
 
-        MimicRecordingEntitySelector recordingEntitySelector = new MimicRecordingEntitySelector(childEntitySelector);
-        MimicReplayingEntitySelector replayingEntitySelector = new MimicReplayingEntitySelector(recordingEntitySelector);
+        var recordingEntitySelector = new MimicRecordingEntitySelector(childEntitySelector);
+        var replayingEntitySelector = new MimicReplayingEntitySelector(recordingEntitySelector);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         recordingEntitySelector.solvingStarted(solverScope);
         replayingEntitySelector.solvingStarted(solverScope);
 
-        AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
+        var phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
         recordingEntitySelector.phaseStarted(phaseScopeA);
         replayingEntitySelector.phaseStarted(phaseScopeA);
 
-        AbstractStepScope stepScopeA1 = mock(AbstractStepScope.class);
+        var stepScopeA1 = mock(AbstractStepScope.class);
         when(stepScopeA1.getPhaseScope()).thenReturn(phaseScopeA);
         recordingEntitySelector.stepStarted(stepScopeA1);
         replayingEntitySelector.stepStarted(stepScopeA1);
@@ -46,7 +45,7 @@ class MimicReplayingEntitySelectorTest {
         recordingEntitySelector.stepEnded(stepScopeA1);
         replayingEntitySelector.stepEnded(stepScopeA1);
 
-        AbstractStepScope stepScopeA2 = mock(AbstractStepScope.class);
+        var stepScopeA2 = mock(AbstractStepScope.class);
         when(stepScopeA2.getPhaseScope()).thenReturn(phaseScopeA);
         recordingEntitySelector.stepStarted(stepScopeA2);
         replayingEntitySelector.stepStarted(stepScopeA2);
@@ -57,12 +56,12 @@ class MimicReplayingEntitySelectorTest {
         recordingEntitySelector.phaseEnded(phaseScopeA);
         replayingEntitySelector.phaseEnded(phaseScopeA);
 
-        AbstractPhaseScope phaseScopeB = mock(AbstractPhaseScope.class);
+        var phaseScopeB = mock(AbstractPhaseScope.class);
         when(phaseScopeB.getSolverScope()).thenReturn(solverScope);
         recordingEntitySelector.phaseStarted(phaseScopeB);
         replayingEntitySelector.phaseStarted(phaseScopeB);
 
-        AbstractStepScope stepScopeB1 = mock(AbstractStepScope.class);
+        var stepScopeB1 = mock(AbstractStepScope.class);
         when(stepScopeB1.getPhaseScope()).thenReturn(phaseScopeB);
         recordingEntitySelector.stepStarted(stepScopeB1);
         replayingEntitySelector.stepStarted(stepScopeB1);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/pillar/DefaultPillarSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/entity/pillar/DefaultPillarSelectorTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Random;
 
 import ai.timefold.solver.core.api.score.SimpleScore;
 import ai.timefold.solver.core.config.heuristic.selector.entity.pillar.SubPillarConfigPolicy;
@@ -105,7 +104,7 @@ class DefaultPillarSelectorTest {
         doReturn(solutionDescriptor).when(scoreDirector).getSolutionDescriptor();
         doReturn(VariableListenerSupport.create(scoreDirector)).when(scoreDirector).getSupplyManager();
 
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = PlannerTestUtils.mockSolverScope();
         doReturn(scoreDirector).when(solverScope).getScoreDirector();
         return solverScope;
     }
@@ -260,7 +259,7 @@ class DefaultPillarSelectorTest {
 
         // nextInt pattern: pillarIndex, subPillarSize, element 0, element 1, element 2, ...
         // Expected pillar cache: [b, d], [c, e, f]
-        Random workingRandom = new TestRandom(
+        var workingRandom = new TestRandom(
                 1, 0, 0, 0, // [c, e]
                 0, 0, 0, 0); // [b, d]
 
@@ -307,7 +306,7 @@ class DefaultPillarSelectorTest {
 
         // nextInt pattern: pillarIndex, subPillarSize, subPillarStartingIndex
         // Expected pillar cache: [a], [b, d], [c, e, f]
-        Random workingRandom = new TestRandom(
+        var workingRandom = new TestRandom(
                 1, 1, // [b, d]
                 2, 2, // [c, e, f]
                 2, 1, 1, // [c, e, f]

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/list/ElementDestinationSelectorTest.java
@@ -46,6 +46,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.value.mimic.ManualValueMi
 import ai.timefold.solver.core.impl.heuristic.selector.value.mimic.MimicReplayingValueSelector;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.impl.solver.random.MockRandomSource;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.preview.api.domain.metamodel.ElementPosition;
 import ai.timefold.solver.core.testdomain.TestdataValue;
@@ -371,7 +372,7 @@ class ElementDestinationSelectorTest {
 
         var solverScope = new SolverScope<TestdataPinnedUnassignedValuesListSolution>();
         solverScope.setScoreDirector(scoreDirector);
-        solverScope.setWorkingRandom(random);
+        solverScope.setWorkingRandom(new MockRandomSource(random));
         var entitySelector = new FromSolutionEntitySelector<>(
                 solutionDescriptor.findEntityDescriptorOrFail(TestdataPinnedUnassignedValuesListEntity.class),
                 SelectionCacheType.PHASE, true);
@@ -415,7 +416,7 @@ class ElementDestinationSelectorTest {
         solverScope.setScoreDirector(scoreDirector);
         // This needs to use a real Random instance, otherwise the test never covers the situation where
         // the random value of 1 needs to be produced to get to the entity.
-        solverScope.setWorkingRandom(new Random(0));
+        solverScope.setWorkingRandom(new MockRandomSource(new Random(0)));
         var entitySelector = new FromSolutionEntitySelector<>(
                 solutionDescriptor.findEntityDescriptorOrFail(TestdataAllowsUnassignedValuesListEntity.class),
                 SelectionCacheType.PHASE, true);
@@ -467,7 +468,7 @@ class ElementDestinationSelectorTest {
 
         var solverScope = new SolverScope<TestdataPinnedWithIndexListSolution>();
         solverScope.setScoreDirector(scoreDirector);
-        solverScope.setWorkingRandom(random);
+        solverScope.setWorkingRandom(new MockRandomSource(random));
         selector.solvingStarted(solverScope);
         selector.phaseStarted(new LocalSearchPhaseScope<>(solverScope, 0));
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorTest.java
@@ -5,6 +5,7 @@ import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfMov
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertEmptyNeverEndingMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -49,12 +50,12 @@ class CartesianProductMoveSelectorTest {
         CartesianProductMoveSelector moveSelector = new CartesianProductMoveSelector(childMoveSelectorList,
                 ignoreEmptyChildIterators, false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
-        AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
+        var phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
         moveSelector.phaseStarted(phaseScopeA);
-        AbstractStepScope stepScopeA1 = mock(AbstractStepScope.class);
+        var stepScopeA1 = mock(AbstractStepScope.class);
         when(stepScopeA1.getPhaseScope()).thenReturn(phaseScopeA);
         moveSelector.stepStarted(stepScopeA1);
 
@@ -115,7 +116,7 @@ class CartesianProductMoveSelectorTest {
         CartesianProductMoveSelector moveSelector = new CartesianProductMoveSelector(childMoveSelectorList,
                 ignoreEmptyChildIterators, false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
@@ -159,7 +160,7 @@ class CartesianProductMoveSelectorTest {
         CartesianProductMoveSelector moveSelector = new CartesianProductMoveSelector(childMoveSelectorList,
                 ignoreEmptyChildIterators, false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
@@ -200,7 +201,7 @@ class CartesianProductMoveSelectorTest {
         CartesianProductMoveSelector moveSelector = new CartesianProductMoveSelector(childMoveSelectorList,
                 ignoreEmptyChildIterators, false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
@@ -243,7 +244,7 @@ class CartesianProductMoveSelectorTest {
         CartesianProductMoveSelector moveSelector = new CartesianProductMoveSelector(childMoveSelectorList,
                 ignoreEmptyChildIterators, true);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
@@ -280,7 +281,7 @@ class CartesianProductMoveSelectorTest {
         CartesianProductMoveSelector moveSelector = new CartesianProductMoveSelector(childMoveSelectorList,
                 ignoreEmptyChildIterators, true);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
@@ -324,7 +325,7 @@ class CartesianProductMoveSelectorTest {
         CartesianProductMoveSelector moveSelector = new CartesianProductMoveSelector(childMoveSelectorList,
                 ignoreEmptyChildIterators, true);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
@@ -363,7 +364,7 @@ class CartesianProductMoveSelectorTest {
         CartesianProductMoveSelector moveSelector = new CartesianProductMoveSelector(childMoveSelectorList,
                 ignoreEmptyChildIterators, true);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
@@ -424,7 +425,7 @@ class CartesianProductMoveSelectorTest {
         MoveSelector moveSelector = new CartesianProductMoveSelector(moveSelectorList,
                 ignoreEmptyChildIterators, false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -490,7 +491,7 @@ class CartesianProductMoveSelectorTest {
         MoveSelector moveSelector = new CartesianProductMoveSelector(moveSelectorList,
                 ignoreEmptyChildIterators, true);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/UnionMoveSelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.composite;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,7 +11,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import ai.timefold.solver.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import ai.timefold.solver.core.impl.heuristic.move.SelectorBasedDummyMove;
@@ -37,7 +37,7 @@ class UnionMoveSelectorTest {
         UnionMoveSelector<TestdataSolution> moveSelector =
                 new UnionMoveSelector<>(childMoveSelectorList, false);
 
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope<TestdataSolution> phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
@@ -64,7 +64,7 @@ class UnionMoveSelectorTest {
         UnionMoveSelector<TestdataSolution> moveSelector =
                 new UnionMoveSelector<>(childMoveSelectorList, false);
 
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope<TestdataSolution> phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
@@ -97,13 +97,13 @@ class UnionMoveSelectorTest {
                 new UnionMoveSelector<>(childMoveSelectorList, true,
                         new FixedSelectorProbabilityWeightFactory<>(fixedProbabilityWeightMap));
 
-        Random workingRandom = new TestRandom(
+        var workingRandom = new TestRandom(
                 1.0 / 1020.0,
                 1019.0 / 1020.0,
                 1000.0 / 1020.0,
                 0.0,
                 999.0 / 1020.0);
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope<TestdataSolution> phaseScopeA = PlannerTestUtils.delegatingPhaseScope(solverScope);
@@ -131,8 +131,8 @@ class UnionMoveSelectorTest {
         UnionMoveSelector<TestdataSolution> moveSelector =
                 new UnionMoveSelector<>(childMoveSelectorList, true, null);
 
-        Random workingRandom = new TestRandom(0, 1, 1, 0, 0);
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        var workingRandom = new TestRandom(0, 1, 1, 0, 0);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope<TestdataSolution> phaseScopeA = PlannerTestUtils.delegatingPhaseScope(solverScope);
@@ -159,9 +159,9 @@ class UnionMoveSelectorTest {
         UnionMoveSelector<TestdataSolution> moveSelector =
                 new UnionMoveSelector<>(childMoveSelectorList, true, null);
 
-        Random workingRandom = new TestRandom(1);
+        var workingRandom = new TestRandom(1);
 
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope<TestdataSolution> phaseScopeA = PlannerTestUtils.delegatingPhaseScope(solverScope);
@@ -192,9 +192,9 @@ class UnionMoveSelectorTest {
                 new UnionMoveSelector<>(childMoveSelectorList, true,
                         new FixedSelectorProbabilityWeightFactory<>(fixedProbabilityWeightMap));
 
-        Random workingRandom = new TestRandom(1);
+        var workingRandom = new TestRandom(1);
 
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope<TestdataSolution> phaseScopeA = PlannerTestUtils.delegatingPhaseScope(solverScope);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/CachingMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/CachingMoveSelectorTest.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.decorator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,7 +15,6 @@ import ai.timefold.solver.core.impl.heuristic.selector.SelectorTestUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testutil.PlannerTestUtils;
 import ai.timefold.solver.core.testutil.TestRandom;
 
@@ -44,7 +44,7 @@ class CachingMoveSelectorTest {
         CachingMoveSelector moveSelector = new CachingMoveSelector(childMoveSelector, cacheType, false);
         verify(childMoveSelector, times(1)).isNeverEnding();
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -120,7 +120,7 @@ class CachingMoveSelectorTest {
 
         TestRandom workingRandom = new TestRandom(1, 0, 2);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         moveSelector.solvingStarted(solverScope);
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -18,7 +19,6 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.Selectio
 import ai.timefold.solver.core.impl.heuristic.selector.move.MoveSelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.BasicPlumbingTermination;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 
@@ -77,20 +77,20 @@ class FilteringMoveSelectorTest {
             moveSelector = new CachingMoveSelector(moveSelector, cacheType, false);
         }
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
-        AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
+        var phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
         moveSelector.phaseStarted(phaseScopeA);
 
-        AbstractStepScope stepScopeA1 = mock(AbstractStepScope.class);
+        var stepScopeA1 = mock(AbstractStepScope.class);
         when(stepScopeA1.getPhaseScope()).thenReturn(phaseScopeA);
         moveSelector.stepStarted(stepScopeA1);
         assertAllCodesOfMoveSelector(moveSelector, (cacheType.isNotCached() ? 4L : 3L), "a1", "a2", "a4");
         moveSelector.stepEnded(stepScopeA1);
 
-        AbstractStepScope stepScopeA2 = mock(AbstractStepScope.class);
+        var stepScopeA2 = mock(AbstractStepScope.class);
         when(stepScopeA2.getPhaseScope()).thenReturn(phaseScopeA);
         moveSelector.stepStarted(stepScopeA2);
         assertAllCodesOfMoveSelector(moveSelector, (cacheType.isNotCached() ? 4L : 3L), "a1", "a2", "a4");
@@ -98,23 +98,23 @@ class FilteringMoveSelectorTest {
 
         moveSelector.phaseEnded(phaseScopeA);
 
-        AbstractPhaseScope phaseScopeB = mock(AbstractPhaseScope.class);
+        var phaseScopeB = mock(AbstractPhaseScope.class);
         when(phaseScopeB.getSolverScope()).thenReturn(solverScope);
         moveSelector.phaseStarted(phaseScopeB);
 
-        AbstractStepScope stepScopeB1 = mock(AbstractStepScope.class);
+        var stepScopeB1 = mock(AbstractStepScope.class);
         when(stepScopeB1.getPhaseScope()).thenReturn(phaseScopeB);
         moveSelector.stepStarted(stepScopeB1);
         assertAllCodesOfMoveSelector(moveSelector, (cacheType.isNotCached() ? 4L : 3L), "a1", "a2", "a4");
         moveSelector.stepEnded(stepScopeB1);
 
-        AbstractStepScope stepScopeB2 = mock(AbstractStepScope.class);
+        var stepScopeB2 = mock(AbstractStepScope.class);
         when(stepScopeB2.getPhaseScope()).thenReturn(phaseScopeB);
         moveSelector.stepStarted(stepScopeB2);
         assertAllCodesOfMoveSelector(moveSelector, (cacheType.isNotCached() ? 4L : 3L), "a1", "a2", "a4");
         moveSelector.stepEnded(stepScopeB2);
 
-        AbstractStepScope stepScopeB3 = mock(AbstractStepScope.class);
+        var stepScopeB3 = mock(AbstractStepScope.class);
         when(stepScopeB3.getPhaseScope()).thenReturn(phaseScopeB);
         moveSelector.stepStarted(stepScopeB3);
         assertAllCodesOfMoveSelector(moveSelector, (cacheType.isNotCached() ? 4L : 3L), "a1", "a2", "a4");

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/ProbabilityMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/ProbabilityMoveSelectorTest.java
@@ -2,12 +2,10 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
-import static org.mockito.Mockito.mock;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.util.Random;
 
 import ai.timefold.solver.core.config.heuristic.selector.common.SelectionCacheType;
 import ai.timefold.solver.core.impl.heuristic.move.SelectorBasedDummyMove;
@@ -49,14 +47,14 @@ class ProbabilityMoveSelectorTest {
         MoveSelector<TestdataSolution> moveSelector = new ProbabilityMoveSelector<>(childMoveSelector,
                 SelectionCacheType.STEP, probabilityWeightFactory);
 
-        Random workingRandom = new TestRandom(
+        var workingRandom = new TestRandom(
                 1222.0 / 1234.0,
                 111.0 / 1234.0,
                 0.0,
                 1230.0 / 1234.0,
                 1199.0 / 1234.0);
 
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         moveSelector.solvingStarted(solverScope);
         AbstractPhaseScope<TestdataSolution> phaseScopeA = PlannerTestUtils.delegatingPhaseScope(solverScope);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/SelectedCountLimitMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/SelectedCountLimitMoveSelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,22 +24,22 @@ class SelectedCountLimitMoveSelectorTest {
         MoveSelector childMoveSelector = SelectorTestUtils.mockMoveSelector(
                 new SelectorBasedDummyMove("a1"), new SelectorBasedDummyMove("a2"), new SelectorBasedDummyMove("a3"),
                 new SelectorBasedDummyMove("a4"), new SelectorBasedDummyMove("a5"));
-        MoveSelector moveSelector = new SelectedCountLimitMoveSelector(childMoveSelector, 3L);
+        var moveSelector = new SelectedCountLimitMoveSelector(childMoveSelector, 3L);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
-        AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
+        var phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
         moveSelector.phaseStarted(phaseScopeA);
 
-        AbstractStepScope stepScopeA1 = mock(AbstractStepScope.class);
+        var stepScopeA1 = mock(AbstractStepScope.class);
         when(stepScopeA1.getPhaseScope()).thenReturn(phaseScopeA);
         moveSelector.stepStarted(stepScopeA1);
         assertAllCodesOfMoveSelector(moveSelector, "a1", "a2", "a3");
         moveSelector.stepEnded(stepScopeA1);
 
-        AbstractStepScope stepScopeA2 = mock(AbstractStepScope.class);
+        var stepScopeA2 = mock(AbstractStepScope.class);
         when(stepScopeA2.getPhaseScope()).thenReturn(phaseScopeA);
         moveSelector.stepStarted(stepScopeA2);
         assertAllCodesOfMoveSelector(moveSelector, "a1", "a2", "a3");
@@ -46,23 +47,23 @@ class SelectedCountLimitMoveSelectorTest {
 
         moveSelector.phaseEnded(phaseScopeA);
 
-        AbstractPhaseScope phaseScopeB = mock(AbstractPhaseScope.class);
+        var phaseScopeB = mock(AbstractPhaseScope.class);
         when(phaseScopeB.getSolverScope()).thenReturn(solverScope);
         moveSelector.phaseStarted(phaseScopeB);
 
-        AbstractStepScope stepScopeB1 = mock(AbstractStepScope.class);
+        var stepScopeB1 = mock(AbstractStepScope.class);
         when(stepScopeB1.getPhaseScope()).thenReturn(phaseScopeB);
         moveSelector.stepStarted(stepScopeB1);
         assertAllCodesOfMoveSelector(moveSelector, "a1", "a2", "a3");
         moveSelector.stepEnded(stepScopeB1);
 
-        AbstractStepScope stepScopeB2 = mock(AbstractStepScope.class);
+        var stepScopeB2 = mock(AbstractStepScope.class);
         when(stepScopeB2.getPhaseScope()).thenReturn(phaseScopeB);
         moveSelector.stepStarted(stepScopeB2);
         assertAllCodesOfMoveSelector(moveSelector, "a1", "a2", "a3");
         moveSelector.stepEnded(stepScopeB2);
 
-        AbstractStepScope stepScopeB3 = mock(AbstractStepScope.class);
+        var stepScopeB3 = mock(AbstractStepScope.class);
         when(stepScopeB3.getPhaseScope()).thenReturn(phaseScopeB);
         moveSelector.stepStarted(stepScopeB3);
         assertAllCodesOfMoveSelector(moveSelector, "a1", "a2", "a3");
@@ -83,7 +84,7 @@ class SelectedCountLimitMoveSelectorTest {
                 new SelectorBasedDummyMove("a1"), new SelectorBasedDummyMove("a2"), new SelectorBasedDummyMove("a3"));
         MoveSelector moveSelector = new SelectedCountLimitMoveSelector(childMoveSelector, 5L);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/ShufflingMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/ShufflingMoveSelectorTest.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.move.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
-import static org.mockito.Mockito.mock;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,7 +44,7 @@ class ShufflingMoveSelectorTest {
         verify(childMoveSelector, times(1)).isNeverEnding();
 
         TestRandom workingRandom = new TestRandom(2, 0);
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
         moveSelector.solvingStarted(solverScope);
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/SortingMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/decorator/SortingMoveSelectorTest.java
@@ -4,6 +4,7 @@ import static ai.timefold.solver.core.impl.heuristic.HeuristicConfigPolicyTestUt
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfMoveSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
 import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockScoreDirector;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -81,8 +82,8 @@ class SortingMoveSelectorTest {
                 moveSelectorFactory.buildBaseMoveSelector(buildHeuristicConfigPolicy(), SelectionCacheType.PHASE, false);
 
         var scoreDirector = mockScoreDirector(TestdataSolution.buildSolutionDescriptor());
-        var solverScope = mock(SolverScope.class);
-        when(solverScope.getScoreDirector()).thenReturn(scoreDirector);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
+        when(solverScope.getScoreDirector()).thenReturn((InnerScoreDirector) scoreDirector);
         moveSelector.solvingStarted(solverScope);
 
         var phaseScope = mock(AbstractPhaseScope.class);
@@ -103,7 +104,7 @@ class SortingMoveSelectorTest {
         MoveSelector moveSelector =
                 new SortingMoveSelector(childMoveSelector, cacheType, new CodeAssertableSorter<SelectorBasedDummyMove>());
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         InnerScoreDirector<?, ?> scoreDirector = mock(InnerScoreDirector.class);
         doReturn(scoreDirector).when(solverScope).getScoreDirector();
         doReturn(new TestdataSolution()).when(scoreDirector).getWorkingSolution();

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMoveTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.move.generic;
 
 import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockRebasingScoreDirector;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.mock;
@@ -11,7 +12,6 @@ import java.util.List;
 import java.util.Set;
 
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 import ai.timefold.solver.core.testdomain.TestdataValue;
@@ -47,7 +47,7 @@ class SelectorBasedRuinRecreateMoveTest {
                 });
 
         var move = new SelectorBasedRuinRecreateMove<TestdataSolution>(mock(GenuineVariableDescriptor.class),
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), Arrays.asList(e1, e2, e3),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), Arrays.asList(e1, e2, e3),
                 new LinkedHashSet(Set.of(v1, v2)));
         var rebasedMove = move.rebase(destinationScoreDirector.getMoveDirector());
 
@@ -70,25 +70,25 @@ class SelectorBasedRuinRecreateMoveTest {
 
         var descriptor = mock(GenuineVariableDescriptor.class);
         var move = new SelectorBasedRuinRecreateMove<TestdataSolution>(descriptor,
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e1),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
                 new LinkedHashSet<>(Set.of(v1)));
         var sameMove = new SelectorBasedRuinRecreateMove<TestdataSolution>(descriptor,
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e1),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
                 new LinkedHashSet<>(Set.of(v1)));
         assertThat(move).isEqualTo(sameMove);
 
         var differentMove = new SelectorBasedRuinRecreateMove<TestdataSolution>(descriptor,
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e1),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
                 new LinkedHashSet<>(Set.of(v2)));
         assertThat(move).isNotEqualTo(differentMove);
 
         var anotherDifferentMove = new SelectorBasedRuinRecreateMove<TestdataSolution>(descriptor,
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e2),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e2),
                 new LinkedHashSet<>(Set.of(v1)));
         assertThat(move).isNotEqualTo(anotherDifferentMove);
 
         var yetAnotherDifferentMove = new SelectorBasedRuinRecreateMove<TestdataSolution>(mock(GenuineVariableDescriptor.class),
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e1),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
                 new LinkedHashSet<>(Set.of(v1)));
         assertThat(move).isNotEqualTo(yetAnotherDifferentMove);
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SelectorBasedRuinRecreateMoveTest.java
@@ -48,7 +48,7 @@ class SelectorBasedRuinRecreateMoveTest {
 
         var move = new SelectorBasedRuinRecreateMove<TestdataSolution>(mock(GenuineVariableDescriptor.class),
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), Arrays.asList(e1, e2, e3),
-                new LinkedHashSet(Set.of(v1, v2)));
+                new LinkedHashSet(Set.of(v1, v2)), 0L);
         var rebasedMove = move.rebase(destinationScoreDirector.getMoveDirector());
 
         assertSoftly(softly -> {
@@ -71,25 +71,25 @@ class SelectorBasedRuinRecreateMoveTest {
         var descriptor = mock(GenuineVariableDescriptor.class);
         var move = new SelectorBasedRuinRecreateMove<TestdataSolution>(descriptor,
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
-                new LinkedHashSet<>(Set.of(v1)));
+                new LinkedHashSet<>(Set.of(v1)), 0L);
         var sameMove = new SelectorBasedRuinRecreateMove<TestdataSolution>(descriptor,
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
-                new LinkedHashSet<>(Set.of(v1)));
+                new LinkedHashSet<>(Set.of(v1)), 0L);
         assertThat(move).isEqualTo(sameMove);
 
         var differentMove = new SelectorBasedRuinRecreateMove<TestdataSolution>(descriptor,
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
-                new LinkedHashSet<>(Set.of(v2)));
+                new LinkedHashSet<>(Set.of(v2)), 0L);
         assertThat(move).isNotEqualTo(differentMove);
 
         var anotherDifferentMove = new SelectorBasedRuinRecreateMove<TestdataSolution>(descriptor,
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e2),
-                new LinkedHashSet<>(Set.of(v1)));
+                new LinkedHashSet<>(Set.of(v1)), 0L);
         assertThat(move).isNotEqualTo(anotherDifferentMove);
 
         var yetAnotherDifferentMove = new SelectorBasedRuinRecreateMove<TestdataSolution>(mock(GenuineVariableDescriptor.class),
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
-                new LinkedHashSet<>(Set.of(v1)));
+                new LinkedHashSet<>(Set.of(v1)), 0L);
         assertThat(move).isNotEqualTo(yetAnotherDifferentMove);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/SwapMoveSelectorTest.java
@@ -9,6 +9,7 @@ import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfMov
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCodesOfNeverEndingIterableSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
 import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockScoreDirector;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -54,7 +55,7 @@ class SwapMoveSelectorTest {
         SwapMoveSelector moveSelector = new SwapMoveSelector(entitySelector, entitySelector,
                 entitySelector.getEntityDescriptor().getGenuineVariableDescriptorList(), false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -111,7 +112,7 @@ class SwapMoveSelectorTest {
         SwapMoveSelector moveSelector = new SwapMoveSelector(entitySelector, entitySelector,
                 entitySelector.getEntityDescriptor().getGenuineVariableDescriptorList(), false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -174,7 +175,7 @@ class SwapMoveSelectorTest {
         SwapMoveSelector moveSelector = new SwapMoveSelector(leftEntitySelector, rightEntitySelector,
                 leftEntitySelector.getEntityDescriptor().getGenuineVariableDescriptorList(), false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -291,7 +292,7 @@ class SwapMoveSelectorTest {
         SwapMoveSelector moveSelector = new SwapMoveSelector(leftEntitySelector, rightEntitySelector,
                 leftEntitySelector.getEntityDescriptor().getGenuineVariableDescriptorList(), false);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         moveSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SelectorBasedListRuinRecreateMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SelectorBasedListRuinRecreateMoveTest.java
@@ -50,7 +50,7 @@ class SelectorBasedListRuinRecreateMoveTest {
 
         var move = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(mock(ListVariableDescriptor.class),
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), Arrays.asList(v1, v2),
-                new LinkedHashSet<>(Set.of(e1, e2, e3)));
+                new LinkedHashSet<>(Set.of(e1, e2, e3)), 0L);
         var rebasedMove = move.rebase(destinationScoreDirector.getMoveDirector());
 
         assertSoftly(softly -> {
@@ -73,26 +73,26 @@ class SelectorBasedListRuinRecreateMoveTest {
         var descriptor = mock(ListVariableDescriptor.class);
         var move = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(descriptor,
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
-                new LinkedHashSet<>(Set.of(v1)));
+                new LinkedHashSet<>(Set.of(v1)), 0L);
         var sameMove = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(descriptor,
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
-                new LinkedHashSet<>(Set.of(v1)));
+                new LinkedHashSet<>(Set.of(v1)), 0L);
         assertThat(move).isEqualTo(sameMove);
 
         var differentMove = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(descriptor,
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
-                new LinkedHashSet<>(Set.of(v2)));
+                new LinkedHashSet<>(Set.of(v2)), 0L);
         assertThat(move).isNotEqualTo(differentMove);
 
         var anotherDifferentMove = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(descriptor,
                 mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e2),
-                new LinkedHashSet<>(Set.of(v1)));
+                new LinkedHashSet<>(Set.of(v1)), 0L);
         assertThat(move).isNotEqualTo(anotherDifferentMove);
 
         var yetAnotherDifferentMove =
                 new SelectorBasedListRuinRecreateMove<TestdataListSolution>(mock(ListVariableDescriptor.class),
                         mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
-                        new LinkedHashSet<>(Set.of(v1)));
+                        new LinkedHashSet<>(Set.of(v1)), 0L);
         assertThat(move).isNotEqualTo(yetAnotherDifferentMove);
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SelectorBasedListRuinRecreateMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SelectorBasedListRuinRecreateMoveTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.move.generic.list;
 
 import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockRebasingScoreDirector;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.mock;
@@ -13,7 +14,6 @@ import java.util.Set;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.heuristic.selector.move.generic.RuinRecreateConstructionHeuristicPhaseBuilder;
 import ai.timefold.solver.core.impl.heuristic.selector.move.generic.list.ruin.SelectorBasedListRuinRecreateMove;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.list.TestdataListEntity;
 import ai.timefold.solver.core.testdomain.list.TestdataListSolution;
 import ai.timefold.solver.core.testdomain.list.TestdataListValue;
@@ -49,7 +49,7 @@ class SelectorBasedListRuinRecreateMoveTest {
                 });
 
         var move = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(mock(ListVariableDescriptor.class),
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), Arrays.asList(v1, v2),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), Arrays.asList(v1, v2),
                 new LinkedHashSet<>(Set.of(e1, e2, e3)));
         var rebasedMove = move.rebase(destinationScoreDirector.getMoveDirector());
 
@@ -72,26 +72,26 @@ class SelectorBasedListRuinRecreateMoveTest {
 
         var descriptor = mock(ListVariableDescriptor.class);
         var move = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(descriptor,
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e1),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
                 new LinkedHashSet<>(Set.of(v1)));
         var sameMove = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(descriptor,
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e1),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
                 new LinkedHashSet<>(Set.of(v1)));
         assertThat(move).isEqualTo(sameMove);
 
         var differentMove = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(descriptor,
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e1),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
                 new LinkedHashSet<>(Set.of(v2)));
         assertThat(move).isNotEqualTo(differentMove);
 
         var anotherDifferentMove = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(descriptor,
-                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e2),
+                mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e2),
                 new LinkedHashSet<>(Set.of(v1)));
         assertThat(move).isNotEqualTo(anotherDifferentMove);
 
         var yetAnotherDifferentMove =
                 new SelectorBasedListRuinRecreateMove<TestdataListSolution>(mock(ListVariableDescriptor.class),
-                        mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mock(SolverScope.class), List.of(e1),
+                        mock(RuinRecreateConstructionHeuristicPhaseBuilder.class), mockSolverScope(), List.of(e1),
                         new LinkedHashSet<>(Set.of(v1)));
         assertThat(move).isNotEqualTo(yetAnotherDifferentMove);
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/IterableFromSolutionPropertyValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/IterableFromSolutionPropertyValueSelectorTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.value;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelector;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -13,7 +14,6 @@ import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.ValueRangeManager;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 import ai.timefold.solver.core.testdomain.TestdataValue;
@@ -45,7 +45,7 @@ class IterableFromSolutionPropertyValueSelectorTest {
         var solution = new TestdataSolution();
         solution.setValueList(List.of(new TestdataValue("jan"), new TestdataValue("feb"), new TestdataValue("mar"),
                 new TestdataValue("apr"), new TestdataValue("may"), new TestdataValue("jun")));
-        var solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         InnerScoreDirector<?, ?> scoreDirector = mock(InnerScoreDirector.class);
         doReturn(scoreDirector).when(solverScope).getScoreDirector();
         doReturn(solution).when(scoreDirector).getWorkingSolution();

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/CachingValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/CachingValueSelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.value.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -43,7 +44,7 @@ class CachingValueSelectorTest {
         IterableValueSelector valueSelector = new CachingValueSelector(childValueSelector, cacheType, false);
         verify(childValueSelector, times(1)).isNeverEnding();
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueRangeSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueRangeSelectorTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.heuristic.selector.value.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelector;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -64,7 +65,7 @@ class FilteringValueRangeSelectorTest {
         var secondEntity = new TestdataListEntityProvidingEntity("e2", List.of(apr, may, jun));
         solution.setEntityList(List.of(firstEntity, secondEntity));
 
-        var solverScope = mock(SolverScope.class);
+        SolverScope<TestdataListEntityProvidingSolution> solverScope = mockSolverScope();
         InnerScoreDirector<?, ?> scoreDirector = mock(InnerScoreDirector.class);
         doReturn(scoreDirector).when(solverScope).getScoreDirector();
         doReturn(solution).when(scoreDirector).getWorkingSolution();

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/FilteringValueSelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.value.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelectorForEntity;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,7 +32,7 @@ class FilteringValueSelectorTest {
         SelectionFilter<TestdataSolution, TestdataValue> filter = (scoreDirector, value) -> !value.getCode().equals("v3");
         ValueSelector valueSelector = new FilteringValueSelector(childValueSelector, filter);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/IterableFilteringValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/IterableFilteringValueSelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.value.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -12,7 +13,6 @@ import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.Selectio
 import ai.timefold.solver.core.impl.heuristic.selector.value.IterableValueSelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 import ai.timefold.solver.core.testdomain.TestdataValue;
@@ -30,20 +30,20 @@ class IterableFilteringValueSelectorTest {
         SelectionFilter<TestdataSolution, TestdataValue> filter = (scoreDirector, value) -> !value.getCode().equals("v3");
         IterableValueSelector valueSelector = new IterableFilteringValueSelector(childValueSelector, filter);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
-        AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
+        var phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
         valueSelector.phaseStarted(phaseScopeA);
 
-        AbstractStepScope stepScopeA1 = mock(AbstractStepScope.class);
+        var stepScopeA1 = mock(AbstractStepScope.class);
         when(stepScopeA1.getPhaseScope()).thenReturn(phaseScopeA);
         valueSelector.stepStarted(stepScopeA1);
         assertAllCodesOfValueSelector(valueSelector, 4L, "v1", "v2", "v4");
         valueSelector.stepEnded(stepScopeA1);
 
-        AbstractStepScope stepScopeA2 = mock(AbstractStepScope.class);
+        var stepScopeA2 = mock(AbstractStepScope.class);
         when(stepScopeA2.getPhaseScope()).thenReturn(phaseScopeA);
         valueSelector.stepStarted(stepScopeA2);
         assertAllCodesOfValueSelector(valueSelector, 4L, "v1", "v2", "v4");
@@ -51,23 +51,23 @@ class IterableFilteringValueSelectorTest {
 
         valueSelector.phaseEnded(phaseScopeA);
 
-        AbstractPhaseScope phaseScopeB = mock(AbstractPhaseScope.class);
+        var phaseScopeB = mock(AbstractPhaseScope.class);
         when(phaseScopeB.getSolverScope()).thenReturn(solverScope);
         valueSelector.phaseStarted(phaseScopeB);
 
-        AbstractStepScope stepScopeB1 = mock(AbstractStepScope.class);
+        var stepScopeB1 = mock(AbstractStepScope.class);
         when(stepScopeB1.getPhaseScope()).thenReturn(phaseScopeB);
         valueSelector.stepStarted(stepScopeB1);
         assertAllCodesOfValueSelector(valueSelector, 4L, "v1", "v2", "v4");
         valueSelector.stepEnded(stepScopeB1);
 
-        AbstractStepScope stepScopeB2 = mock(AbstractStepScope.class);
+        var stepScopeB2 = mock(AbstractStepScope.class);
         when(stepScopeB2.getPhaseScope()).thenReturn(phaseScopeB);
         valueSelector.stepStarted(stepScopeB2);
         assertAllCodesOfValueSelector(valueSelector, 4L, "v1", "v2", "v4");
         valueSelector.stepEnded(stepScopeB2);
 
-        AbstractStepScope stepScopeB3 = mock(AbstractStepScope.class);
+        var stepScopeB3 = mock(AbstractStepScope.class);
         when(stepScopeB3.getPhaseScope()).thenReturn(phaseScopeB);
         valueSelector.stepStarted(stepScopeB3);
         assertAllCodesOfValueSelector(valueSelector, 4L, "v1", "v2", "v4");

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/IterableFromEntityPropertyValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/IterableFromEntityPropertyValueSelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.value.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfIterator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelector;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -52,7 +53,7 @@ class IterableFromEntityPropertyValueSelectorTest {
         var secondEntity = new TestdataEntityProvidingEntity();
         secondEntity.setValueRange(List.of(new TestdataValue("apr"), new TestdataValue("may"), new TestdataValue("jun")));
         solution.setEntityList(List.of(firstEntity, secondEntity));
-        var solverScope = mock(SolverScope.class);
+        SolverScope<TestdataEntityProvidingSolution> solverScope = mockSolverScope();
         InnerScoreDirector<?, ?> scoreDirector = mock(InnerScoreDirector.class);
         doReturn(scoreDirector).when(solverScope).getScoreDirector();
         doReturn(solution).when(scoreDirector).getWorkingSolution();

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/ReinitializeVariableValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/ReinitializeVariableValueSelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.value.decorator;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelectorForEntity;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
@@ -37,7 +38,7 @@ class ReinitializeVariableValueSelectorTest {
 
         ValueSelector valueSelector = new ReinitializeVariableValueSelector(childValueSelector);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -101,7 +102,7 @@ class ReinitializeVariableValueSelectorTest {
 
         ValueSelector valueSelector = new ReinitializeVariableValueSelector(childValueSelector);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/SelectedCountLimitValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/SelectedCountLimitValueSelectorTest.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.value.decorator;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelectorForEntity;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,22 +28,22 @@ class SelectedCountLimitValueSelectorTest {
                 TestdataValue.class, "value",
                 new TestdataValue("v1"), new TestdataValue("v2"), new TestdataValue("v3"), new TestdataValue("v4"),
                 new TestdataValue("v5"));
-        IterableValueSelector valueSelector = new SelectedCountLimitValueSelector(childValueSelector, 3L);
+        var valueSelector = new SelectedCountLimitValueSelector(childValueSelector, 3L);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
-        AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
+        var phaseScopeA = mock(AbstractPhaseScope.class);
         when(phaseScopeA.getSolverScope()).thenReturn(solverScope);
         valueSelector.phaseStarted(phaseScopeA);
 
-        AbstractStepScope stepScopeA1 = mock(AbstractStepScope.class);
+        var stepScopeA1 = mock(AbstractStepScope.class);
         when(stepScopeA1.getPhaseScope()).thenReturn(phaseScopeA);
         valueSelector.stepStarted(stepScopeA1);
         assertAllCodesOfValueSelector(valueSelector, "v1", "v2", "v3");
         valueSelector.stepEnded(stepScopeA1);
 
-        AbstractStepScope stepScopeA2 = mock(AbstractStepScope.class);
+        var stepScopeA2 = mock(AbstractStepScope.class);
         when(stepScopeA2.getPhaseScope()).thenReturn(phaseScopeA);
         valueSelector.stepStarted(stepScopeA2);
         assertAllCodesOfValueSelector(valueSelector, "v1", "v2", "v3");
@@ -50,23 +51,23 @@ class SelectedCountLimitValueSelectorTest {
 
         valueSelector.phaseEnded(phaseScopeA);
 
-        AbstractPhaseScope phaseScopeB = mock(AbstractPhaseScope.class);
+        var phaseScopeB = mock(AbstractPhaseScope.class);
         when(phaseScopeB.getSolverScope()).thenReturn(solverScope);
         valueSelector.phaseStarted(phaseScopeB);
 
-        AbstractStepScope stepScopeB1 = mock(AbstractStepScope.class);
+        var stepScopeB1 = mock(AbstractStepScope.class);
         when(stepScopeB1.getPhaseScope()).thenReturn(phaseScopeB);
         valueSelector.stepStarted(stepScopeB1);
         assertAllCodesOfValueSelector(valueSelector, "v1", "v2", "v3");
         valueSelector.stepEnded(stepScopeB1);
 
-        AbstractStepScope stepScopeB2 = mock(AbstractStepScope.class);
+        var stepScopeB2 = mock(AbstractStepScope.class);
         when(stepScopeB2.getPhaseScope()).thenReturn(phaseScopeB);
         valueSelector.stepStarted(stepScopeB2);
         assertAllCodesOfValueSelector(valueSelector, "v1", "v2", "v3");
         valueSelector.stepEnded(stepScopeB2);
 
-        AbstractStepScope stepScopeB3 = mock(AbstractStepScope.class);
+        var stepScopeB3 = mock(AbstractStepScope.class);
         when(stepScopeB3.getPhaseScope()).thenReturn(phaseScopeB);
         valueSelector.stepStarted(stepScopeB3);
         assertAllCodesOfValueSelector(valueSelector, "v1", "v2", "v3");
@@ -88,7 +89,7 @@ class SelectedCountLimitValueSelectorTest {
                 new TestdataValue("v1"), new TestdataValue("v2"), new TestdataValue("v3"));
         IterableValueSelector valueSelector = new SelectedCountLimitValueSelector(childValueSelector, 5L);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -149,7 +150,7 @@ class SelectedCountLimitValueSelectorTest {
                 new TestdataValue("v5"));
         ValueSelector valueSelector = new SelectedCountLimitValueSelector(childValueSelector, 3L);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);
@@ -209,7 +210,7 @@ class SelectedCountLimitValueSelectorTest {
                 new TestdataValue("v1"), new TestdataValue("v2"), new TestdataValue("v3"));
         ValueSelector valueSelector = new SelectedCountLimitValueSelector(childValueSelector, 5L);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        SolverScope solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope phaseScopeA = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/UnassignedListValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/decorator/UnassignedListValueSelectorTest.java
@@ -6,6 +6,7 @@ import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfIte
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelector;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertAllCodesOfValueSelectorForEntity;
 import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockScoreDirector;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,7 +48,7 @@ class UnassignedListValueSelectorTest {
                 mockIterableValueSelector(getListVariableDescriptor(scoreDirector), v1, v2, v3, v4, v5);
         var valueSelector = new UnassignedListValueSelector<>(childValueSelector);
 
-        SolverScope<TestdataListSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataListSolution> solverScope = mockSolverScope();
         valueSelector.solvingStarted(solverScope);
 
         AbstractPhaseScope<TestdataListSolution> phaseScope = mock(AbstractPhaseScope.class);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/mimic/MimicReplayingValueSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/value/mimic/MimicReplayingValueSelectorTest.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.heuristic.selector.value.mimic;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCode;
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -14,7 +15,6 @@ import ai.timefold.solver.core.impl.heuristic.selector.SelectorTestUtils;
 import ai.timefold.solver.core.impl.heuristic.selector.value.IterableValueSelector;
 import ai.timefold.solver.core.impl.phase.scope.AbstractPhaseScope;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataValue;
 
@@ -31,7 +31,7 @@ class MimicReplayingValueSelectorTest {
         MimicRecordingValueSelector recordingValueSelector = new MimicRecordingValueSelector(childValueSelector);
         MimicReplayingValueSelector replayingValueSelector = new MimicReplayingValueSelector(recordingValueSelector);
 
-        SolverScope solverScope = mock(SolverScope.class);
+        var solverScope = mockSolverScope();
         recordingValueSelector.solvingStarted(solverScope);
         replayingValueSelector.solvingStarted(solverScope);
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/composite/CompositeAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/composite/CompositeAcceptorTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.localsearch.decider.acceptor.composite;
 
 import static ai.timefold.solver.core.testutil.PlannerAssert.verifyPhaseLifecycle;
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -22,7 +23,7 @@ class CompositeAcceptorTest {
 
     @Test
     void phaseLifecycle() {
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         LocalSearchPhaseScope<TestdataSolution> phaseScope = mock(LocalSearchPhaseScope.class);
         LocalSearchStepScope<TestdataSolution> stepScope = mock(LocalSearchStepScope.class);
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/size/EntityRatioTabuSizeStrategyTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/size/EntityRatioTabuSizeStrategyTest.java
@@ -1,12 +1,11 @@
 package ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu.size;
 
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
-import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +13,7 @@ class EntityRatioTabuSizeStrategyTest {
 
     @Test
     <Solution_> void tabuSize() {
-        var phaseScope = new LocalSearchPhaseScope<Solution_>(mock(SolverScope.class), 0);
+        var phaseScope = new LocalSearchPhaseScope<Solution_>(mockSolverScope(), 0);
         when(phaseScope.getWorkingEntityCount()).thenReturn(100);
         var stepScope = new LocalSearchStepScope<>(phaseScope);
         assertThat(new EntityRatioTabuSizeStrategy<Solution_>(0.1).determineTabuSize(stepScope)).isEqualTo(10);

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/forager/AcceptedLocalSearchForagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/forager/AcceptedLocalSearchForagerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.EnumSet;
-import java.util.Random;
 
 import ai.timefold.solver.core.api.score.SimpleScore;
 import ai.timefold.solver.core.config.localsearch.decider.forager.LocalSearchPickEarlyType;
@@ -218,7 +217,7 @@ class AcceptedLocalSearchForagerTest {
         when(scoreDirector.getSolutionDescriptor()).thenReturn(TestdataSolution.buildSolutionDescriptor());
         when(scoreDirector.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
         solverScope.setScoreDirector(scoreDirector);
-        Random workingRandom = new TestRandom(1, 1);
+        var workingRandom = new TestRandom(1, 1);
         solverScope.setWorkingRandom(workingRandom);
         solverScope.setInitializedBestScore(SimpleScore.of(-10));
         solverScope.setSolverMetricSet(EnumSet.of(SolverMetric.MOVE_EVALUATION_COUNT));

--- a/core/src/test/java/ai/timefold/solver/core/impl/move/MoveDirectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/move/MoveDirectorTest.java
@@ -1558,7 +1558,7 @@ class MoveDirectorTest {
         var ephemeralMoveDirector = moveDirector.ephemeral();
         var move = new SelectorBasedListRuinRecreateMove<TestdataListSolution>(listVariableDescriptor,
                 ruinRecreateConstructionHeuristicPhaseBuilder, new SolverScope<>(), List.of(v1),
-                new LinkedHashSet<>(Set.of(e1)));
+                new LinkedHashSet<>(Set.of(e1)), 0L);
         move.execute(ephemeralMoveDirector);
         var undoMove = (RecordedUndoMove<TestdataListSolution>) ephemeralMoveDirector.createUndoMove();
         // e1 must be analyzed at the beginning of the move execution
@@ -1610,7 +1610,8 @@ class MoveDirectorTest {
         when(ruinRecreateConstructionHeuristicPhaseBuilder.build()).thenReturn(constructionHeuristicPhase);
         var ephemeralMoveDirector = moveDirector.ephemeral();
         var move = new SelectorBasedRuinRecreateMove<TestdataSolution>(genuineVariableDescriptor,
-                ruinRecreateConstructionHeuristicPhaseBuilder, mainSolverScope, List.of(v1), new LinkedHashSet<>(Set.of(e1)));
+                ruinRecreateConstructionHeuristicPhaseBuilder, mainSolverScope, List.of(v1), new LinkedHashSet<>(Set.of(e1)),
+                0L);
         move.execute(ephemeralMoveDirector);
         // Not using the main solver scope
         verify(constructionHeuristicPhase, times(0)).solve(mainSolverScope);

--- a/core/src/test/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsTest.java
@@ -29,6 +29,7 @@ import ai.timefold.solver.core.impl.score.director.easy.EasyScoreDirectorFactory
 import ai.timefold.solver.core.impl.score.director.stream.BavetConstraintStreamScoreDirectorFactory;
 import ai.timefold.solver.core.impl.solver.AbstractSolver;
 import ai.timefold.solver.core.impl.solver.event.SolverEventSupport;
+import ai.timefold.solver.core.impl.solver.random.MockRandomSource;
 import ai.timefold.solver.core.impl.solver.recaller.BestSolutionRecaller;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.solver.termination.PhaseTermination;
@@ -99,7 +100,7 @@ class NeighborhoodsTest {
         bestSolutionRecaller.setSolverEventSupport(solverEventSupport);
         var solverScope = new SolverScope<TestdataSolution>();
         solverScope.setSolver(solver);
-        solverScope.setWorkingRandom(new Random());
+        solverScope.setWorkingRandom(new MockRandomSource(new Random(0)));
         solverScope.setScoreDirector(scoreDirector);
         solverScope.setBestScore(score);
         solverScope.setBestSolution(scoreDirector.cloneSolution(solution));

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactoryTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactoryTest.java
@@ -115,9 +115,9 @@ class DefaultSolverFactoryTest {
                 .withRandomSeed(123456L);
         var defaultSolverFactory = new DefaultSolverFactory<TestdataSolution>(solverConfig);
         var randomGenerator = (DelegatingSplittableRandomGenerator) defaultSolverFactory
-                .buildRandomSupplier(EnvironmentMode.PHASE_ASSERT).get().moveUsage();
+                .buildRandomSupplier(EnvironmentMode.PHASE_ASSERT).get().moveIteratorUsage();
         var otherRandomGenerator =
-                (DelegatingSplittableRandomGenerator) RandomSource.seeded(solverConfig.getRandomSeed()).moveUsage();
+                (DelegatingSplittableRandomGenerator) RandomSource.seeded(solverConfig.getRandomSeed()).moveIteratorUsage();
         assertThat(randomGenerator.getSeed()).isEqualTo(otherRandomGenerator.getSeed());
         assertThat(otherRandomGenerator.nextLong()).isEqualTo(randomGenerator.nextLong());
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactoryTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactoryTest.java
@@ -13,6 +13,7 @@ import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescripto
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 import ai.timefold.solver.core.impl.solver.DefaultSolverTest.DummyEasyScoreCalculator;
 import ai.timefold.solver.core.impl.solver.random.DelegatingSplittableRandomGenerator;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.testdomain.TestdataConstraintProvider;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
@@ -113,10 +114,10 @@ class DefaultSolverFactoryTest {
                 .withEasyScoreCalculatorClass(DummyEasyScoreCalculator.class)
                 .withRandomSeed(123456L);
         var defaultSolverFactory = new DefaultSolverFactory<TestdataSolution>(solverConfig);
-        DelegatingSplittableRandomGenerator randomGenerator = (DelegatingSplittableRandomGenerator) defaultSolverFactory
-                .buildRandomSupplier(EnvironmentMode.PHASE_ASSERT).get();
-        DelegatingSplittableRandomGenerator otherRandomGenerator =
-                new DelegatingSplittableRandomGenerator(solverConfig.getRandomSeed());
+        var randomGenerator = (DelegatingSplittableRandomGenerator) defaultSolverFactory
+                .buildRandomSupplier(EnvironmentMode.PHASE_ASSERT).get().moveUsage();
+        var otherRandomGenerator =
+                (DelegatingSplittableRandomGenerator) RandomSource.seeded(solverConfig.getRandomSeed()).moveUsage();
         assertThat(randomGenerator.getSeed()).isEqualTo(otherRandomGenerator.getSeed());
         assertThat(otherRandomGenerator.nextLong()).isEqualTo(randomGenerator.nextLong());
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -1452,9 +1452,6 @@ class DefaultSolverTest {
                 "a1");
         assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("b2", "a2");
 
-        // assertThat(solution.getEntities().getFirst().getValues()).map(TestdataConcurrentValue::getId).containsExactly("b2","a1");
-        //assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("b1", "a2");
-
         assertThat(solution.getScore()).isEqualTo(HardSoftScore.of(0, -240));
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.random.RandomGenerator;
@@ -1408,12 +1409,15 @@ class DefaultSolverTest {
     }
 
     @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
     void solveStaleDeclarativeShadows() {
         // Solver config
         var solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataConcurrentSolution.class, TestdataConcurrentEntity.class, TestdataConcurrentValue.class)
                 .withEasyScoreCalculatorClass(null)
-                .withConstraintProviderClass(TestdataConcurrentConstraintProvider.class);
+                .withConstraintProviderClass(TestdataConcurrentConstraintProvider.class)
+                .withPhases(new LocalSearchPhaseConfig().withTerminationConfig(new TerminationConfig()
+                        .withBestScoreFeasible(true)));
 
         var e1 = new TestdataConcurrentEntity("e1");
         var e2 = new TestdataConcurrentEntity("e2");
@@ -1442,9 +1446,12 @@ class DefaultSolverTest {
 
         var solution = PlannerTestUtils.solve(solverConfig, problem);
 
-        assertThat(solution.getEntities().getFirst().getValues()).map(TestdataConcurrentValue::getId).containsExactly("b2",
-                "a1");
-        assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("b1", "a2");
+        assertThat(solution.getEntities().getFirst().getValues()).map(TestdataConcurrentValue::getId).containsExactly("a2",
+                "b1");
+        assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("a1", "b2");
+
+        // assertThat(solution.getEntities().getFirst().getValues()).map(TestdataConcurrentValue::getId).containsExactly("b2","a1");
+        //assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("b1", "a2");
 
         assertThat(solution.getScore()).isEqualTo(HardSoftScore.of(0, -240));
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -16,7 +16,6 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.random.RandomGenerator;
@@ -1409,8 +1408,11 @@ class DefaultSolverTest {
     }
 
     @Test
-    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    @Timeout(60)
     void solveStaleDeclarativeShadows() {
+        // Timeout is necessary since we use best score feasible as changes to random affect
+        // the step count to get to a feasible solution, and if we somehow broke LS so it never
+        // find a feasible solution, it would run forever otherwise.
         // Solver config
         var solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataConcurrentSolution.class, TestdataConcurrentEntity.class, TestdataConcurrentValue.class)
@@ -1446,9 +1448,9 @@ class DefaultSolverTest {
 
         var solution = PlannerTestUtils.solve(solverConfig, problem);
 
-        assertThat(solution.getEntities().getFirst().getValues()).map(TestdataConcurrentValue::getId).containsExactly("a2",
-                "b1");
-        assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("a1", "b2");
+        assertThat(solution.getEntities().getFirst().getValues()).map(TestdataConcurrentValue::getId).containsExactly("b1",
+                "a1");
+        assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("b2", "a2");
 
         // assertThat(solution.getEntities().getFirst().getValues()).map(TestdataConcurrentValue::getId).containsExactly("b2","a1");
         //assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("b1", "a2");

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/SolverMetricsIT.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/SolverMetricsIT.java
@@ -787,7 +787,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         var phaseConfig = new LocalSearchPhaseConfig();
-        phaseConfig.setTerminationConfig(new TerminationConfig().withScoreCalculationCountLimit(10L));
+        phaseConfig.setTerminationConfig(new TerminationConfig().withStepCountLimit(20));
         solverConfig.withPhases(phaseConfig)
                 .withMonitoringConfig(new MonitoringConfig().withSolverMetricList(List.of(SolverMetric.MOVE_COUNT_PER_TYPE)));
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/random/MockRandomSource.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/random/MockRandomSource.java
@@ -4,7 +4,12 @@ import java.util.random.RandomGenerator;
 
 public record MockRandomSource(RandomGenerator source) implements RandomSource {
     @Override
-    public RandomGenerator moveUsage() {
+    public RandomGenerator moveIteratorUsage() {
+        return source;
+    }
+
+    @Override
+    public RandomGenerator factoryUsage() {
         return source;
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/random/MockRandomSource.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/random/MockRandomSource.java
@@ -1,0 +1,15 @@
+package ai.timefold.solver.core.impl.solver.random;
+
+import java.util.random.RandomGenerator;
+
+public record MockRandomSource(RandomGenerator source) implements RandomSource {
+    @Override
+    public RandomGenerator moveUsage() {
+        return source;
+    }
+
+    @Override
+    public RandomGenerator acceptorUsage() {
+        return source;
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/AndCompositeTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/AndCompositeTerminationTest.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.solver.termination;
 
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.mock;
@@ -21,7 +22,7 @@ class AndCompositeTerminationTest extends AbstractCompositeTerminationTest {
         SolverTermination<TestdataSolution> termination1 = mock(MockableSolverTermination.class);
         SolverTermination<TestdataSolution> termination2 = mock(MockableSolverTermination.class);
         SolverTermination<TestdataSolution> compositeTermination = new AndCompositeTermination<>(termination1, termination2);
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
 
         when(termination1.isSolverTerminated(solverScope)).thenReturn(false);
         when(termination2.isSolverTerminated(solverScope)).thenReturn(false);
@@ -98,7 +99,7 @@ class AndCompositeTerminationTest extends AbstractCompositeTerminationTest {
         SolverTermination<TestdataSolution> termination1 = mock(MockableSolverTermination.class);
         SolverTermination<TestdataSolution> termination2 = mock(MockableSolverTermination.class);
         SolverTermination<TestdataSolution> compositeTermination = new AndCompositeTermination<>(termination1, termination2);
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/BestScoreFeasibleTerminationTest.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.solver.termination;
 
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.doReturn;
@@ -24,7 +25,7 @@ class BestScoreFeasibleTerminationTest {
         ScoreDefinition<?> scoreDefinition = mock(ScoreDefinition.class);
         when(scoreDefinition.getFeasibleLevelsSize()).thenReturn(1);
         SolverTermination<TestdataSolution> termination = new BestScoreFeasibleTermination<>(scoreDefinition, new double[] {});
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         when(solverScope.getScoreDefinition()).thenReturn(new HardSoftScoreDefinition());
         doReturn(HardSoftScore.of(-100, -100)).when(solverScope).getStartingInitializedScore();
         when(solverScope.isBestSolutionInitialized()).thenReturn(true);

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/BestScoreTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/BestScoreTerminationTest.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.solver.termination;
 
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.doReturn;
@@ -29,7 +30,7 @@ class BestScoreTerminationTest {
         ScoreDefinition<SimpleScore> scoreDefinition = mock(ScoreDefinition.class);
         when(scoreDefinition.getLevelsSize()).thenReturn(1);
         var termination = new BestScoreTermination<TestdataSolution>(scoreDefinition, SimpleScore.of(-1000), new double[] {});
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         when(solverScope.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
         when(solverScope.isBestSolutionInitialized()).thenReturn(true);
         doReturn(SimpleScore.of(-1100)).when(solverScope).getStartingInitializedScore();

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/MoveCountTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/MoveCountTerminationTest.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.solver.termination;
 
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.data.Offset.offset;
@@ -18,7 +19,7 @@ class MoveCountTerminationTest {
     void phaseTermination() {
         var termination = new MoveCountTermination<TestdataSolution>(4);
         var phaseScope = Mockito.mock(AbstractPhaseScope.class);
-        var moveScope = Mockito.mock(SolverScope.class);
+        var moveScope = mockSolverScope();
         when(phaseScope.getSolverScope()).thenReturn(moveScope);
 
         when(moveScope.getMoveEvaluationCount()).thenReturn(0L);
@@ -44,7 +45,7 @@ class MoveCountTerminationTest {
     @Test
     void solverTermination() {
         var termination = new MoveCountTermination<TestdataSolution>(4);
-        var solverScope = Mockito.mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
 
         when(solverScope.getMoveEvaluationCount()).thenReturn(0L);
         assertThat(termination.isSolverTerminated(solverScope)).isFalse();

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/OrCompositeTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/OrCompositeTerminationTest.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.solver.termination;
 
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.mock;
@@ -22,7 +23,7 @@ class OrCompositeTerminationTest extends AbstractCompositeTerminationTest {
         SolverTermination<TestdataSolution> termination2 = mock(MockableSolverTermination.class);
         SolverTermination<TestdataSolution> compositeTermination =
                 new OrCompositeTermination<>(Arrays.asList(termination1, termination2));
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
 
         when(termination1.isSolverTerminated(solverScope)).thenReturn(false);
         when(termination2.isSolverTerminated(solverScope)).thenReturn(false);
@@ -100,7 +101,7 @@ class OrCompositeTerminationTest extends AbstractCompositeTerminationTest {
         SolverTermination<TestdataSolution> termination2 = mock(MockableSolverTermination.class);
         SolverTermination<TestdataSolution> compositeTermination =
                 new OrCompositeTermination<>(Arrays.asList(termination1, termination2));
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/ScoreCalculationCountTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/ScoreCalculationCountTerminationTest.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.solver.termination;
 
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.doReturn;
@@ -19,7 +20,7 @@ class ScoreCalculationCountTerminationTest {
     @Test
     void solveTermination() {
         SolverTermination<TestdataSolution> termination = new ScoreCalculationCountTermination<>(1000L);
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
         InnerScoreDirector<TestdataSolution, SimpleScore> scoreDirector = mock(InnerScoreDirector.class);
         doReturn(scoreDirector).when(solverScope).getScoreDirector();
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTerminationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/termination/TimeMillisSpentTerminationTest.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.solver.termination;
 
+import static ai.timefold.solver.core.testutil.PlannerTestUtils.mockSolverScope;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.mock;
@@ -16,7 +17,7 @@ class TimeMillisSpentTerminationTest {
     @Test
     void solveTermination() {
         SolverTermination<TestdataSolution> termination = new TimeMillisSpentTermination<>(1000L);
-        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        SolverScope<TestdataSolution> solverScope = mockSolverScope();
 
         when(solverScope.calculateTimeMillisSpentUpToNow()).thenReturn(0L);
         assertThat(termination.isSolverTerminated(solverScope)).isFalse();

--- a/core/src/test/java/ai/timefold/solver/core/testutil/PlannerTestUtils.java
+++ b/core/src/test/java/ai/timefold/solver/core/testutil/PlannerTestUtils.java
@@ -37,6 +37,7 @@ import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.easy.EasyScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.trend.InitializingScoreTrend;
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
@@ -215,6 +216,16 @@ public final class PlannerTestUtils {
     // ************************************************************************
     // Scope helpers
     // ************************************************************************
+
+    /**
+     * Returns a mock {@link SolverScope} with {@link SolverScope#getWorkingRandom()} returning a mock random.
+     */
+    @SuppressWarnings("unchecked")
+    public static <Solution_> SolverScope<Solution_> mockSolverScope() {
+        var out = mock(SolverScope.class);
+        when(out.getWorkingRandom()).thenReturn(mock(RandomSource.class));
+        return (SolverScope<Solution_>) out;
+    }
 
     /**
      * Returns {@link AbstractPhaseScope} instance that will delegate to {@link SolverScope#getWorkingRandom()}.

--- a/core/src/test/java/ai/timefold/solver/core/testutil/TestRandom.java
+++ b/core/src/test/java/ai/timefold/solver/core/testutil/TestRandom.java
@@ -221,7 +221,12 @@ public final class TestRandom extends Random implements RandomSource {
     }
 
     @Override
-    public RandomGenerator moveUsage() {
+    public RandomGenerator moveIteratorUsage() {
+        return this;
+    }
+
+    @Override
+    public RandomGenerator factoryUsage() {
         return this;
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/testutil/TestRandom.java
+++ b/core/src/test/java/ai/timefold/solver/core/testutil/TestRandom.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
+
+import ai.timefold.solver.core.impl.solver.random.RandomSource;
 
 /**
  * On the later JDKs, it is no longer possible to mock {@link Random} to return custom sequences.
@@ -23,7 +26,7 @@ import java.util.stream.Stream;
  * we need to be able to reset the same random to start running a new sequence of numbers.
  * That is what {@link #reset(int...)} et al. are for.
  */
-public final class TestRandom extends Random {
+public final class TestRandom extends Random implements RandomSource {
 
     private BigDecimal[] toReturn;
     private int returnCount = 0;
@@ -217,4 +220,13 @@ public final class TestRandom extends Random {
         lastRequestedIntBound = null;
     }
 
+    @Override
+    public RandomGenerator moveUsage() {
+        return this;
+    }
+
+    @Override
+    public RandomGenerator acceptorUsage() {
+        return this;
+    }
 }


### PR DESCRIPTION
Before, some foragers and acceptors used the same RandomGenerator as moves, which can affect reproducibility when multithreading is used.

Now, foragers and acceptors use their own independent random.