### PR TITLE
fix: invert the probability of acceptance in fading tabu

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AcceptorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AcceptorFactory.java
@@ -54,7 +54,7 @@ public class AcceptorFactory<Solution_> {
                 .collect(Collectors.toList());
 
         if (acceptorList.size() == 1) {
-            return acceptorList.get(0);
+            return acceptorList.getFirst();
         } else if (acceptorList.size() > 1) {
             return new CompositeAcceptor<>(acceptorList);
         } else {
@@ -134,14 +134,12 @@ public class AcceptorFactory<Solution_> {
     private Optional<ValueTabuAcceptor<Solution_>> buildValueTabuAcceptor(HeuristicConfigPolicy<Solution_> configPolicy) {
         if (acceptorTypeListsContainsAcceptorType(AcceptorType.VALUE_TABU)
                 || acceptorConfig.getValueTabuSize() != null || acceptorConfig.getFadingValueTabuSize() != null) {
+            if (acceptorConfig.getValueTabuSize() == null && acceptorConfig.getFadingValueTabuSize() == null) {
+                throw new IllegalArgumentException(
+                        "The acceptorType (%s) requires either valueTabuSize or fadingValueTabuSize to be configured."
+                                .formatted(AcceptorType.VALUE_TABU));
+            }
             var acceptor = new ValueTabuAcceptor<Solution_>(configPolicy.getLogIndentation());
-            if (acceptorConfig.getValueTabuSize() != null) {
-                acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getValueTabuSize()));
-            }
-            if (acceptorConfig.getFadingValueTabuSize() != null) {
-                acceptor.setFadingTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getFadingValueTabuSize()));
-            }
-
             if (acceptorConfig.getValueTabuSize() != null) {
                 acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getValueTabuSize()));
             }
@@ -159,6 +157,11 @@ public class AcceptorFactory<Solution_> {
     private Optional<MoveTabuAcceptor<Solution_>> buildMoveTabuAcceptor(HeuristicConfigPolicy<Solution_> configPolicy) {
         if (acceptorTypeListsContainsAcceptorType(AcceptorType.MOVE_TABU)
                 || acceptorConfig.getMoveTabuSize() != null || acceptorConfig.getFadingMoveTabuSize() != null) {
+            if (acceptorConfig.getMoveTabuSize() == null && acceptorConfig.getFadingMoveTabuSize() == null) {
+                throw new IllegalArgumentException(
+                        "The acceptorType (%s) requires either moveTabuSize or fadingMoveTabuSize to be configured."
+                                .formatted(AcceptorType.MOVE_TABU));
+            }
             var acceptor = new MoveTabuAcceptor<Solution_>(configPolicy.getLogIndentation());
             if (acceptorConfig.getMoveTabuSize() != null) {
                 acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getMoveTabuSize()));

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AcceptorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AcceptorFactory.java
@@ -17,6 +17,7 @@ import ai.timefold.solver.core.impl.localsearch.decider.acceptor.lateacceptance.
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.lateacceptance.LateAcceptanceAcceptor;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.simulatedannealing.SimulatedAnnealingAcceptor;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.stepcountinghillclimbing.StepCountingHillClimbingAcceptor;
+import ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu.AbstractTabuAcceptor;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu.EntityTabuAcceptor;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu.MoveTabuAcceptor;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu.ValueTabuAcceptor;
@@ -58,11 +59,10 @@ public class AcceptorFactory<Solution_> {
         } else if (acceptorList.size() > 1) {
             return new CompositeAcceptor<>(acceptorList);
         } else {
-            throw new IllegalArgumentException(
-                    "The acceptor does not specify any acceptorType (" + acceptorConfig.getAcceptorTypeList()
-                            + ") or other acceptor property.\n"
-                            + "For a good starting values,"
-                            + " see the docs section \"Which optimization algorithms should I use?\".");
+            throw new IllegalArgumentException("""
+                    The acceptor does not specify any acceptorType (%s) or other acceptor property.
+                    For good starting values, see the docs section "Which optimization algorithms should I use?"."""
+                    .formatted(acceptorConfig.getAcceptorTypeList()));
         }
     }
 
@@ -94,34 +94,35 @@ public class AcceptorFactory<Solution_> {
     }
 
     private Optional<EntityTabuAcceptor<Solution_>> buildEntityTabuAcceptor(HeuristicConfigPolicy<Solution_> configPolicy) {
+        var entityTabuSize = acceptorConfig.getEntityTabuSize();
+        var entityTabuRatio = acceptorConfig.getEntityTabuRatio();
+        var fadingEntityTabuSize = acceptorConfig.getFadingEntityTabuSize();
+        var fadingEntityTabuRatio = acceptorConfig.getFadingEntityTabuRatio();
         if (acceptorTypeListsContainsAcceptorType(AcceptorType.ENTITY_TABU)
-                || acceptorConfig.getEntityTabuSize() != null || acceptorConfig.getEntityTabuRatio() != null
-                || acceptorConfig.getFadingEntityTabuSize() != null || acceptorConfig.getFadingEntityTabuRatio() != null) {
+                || entityTabuSize != null || entityTabuRatio != null
+                || fadingEntityTabuSize != null || fadingEntityTabuRatio != null) {
             var acceptor = new EntityTabuAcceptor<Solution_>(configPolicy.getLogIndentation());
-            if (acceptorConfig.getEntityTabuSize() != null) {
-                if (acceptorConfig.getEntityTabuRatio() != null) {
-                    throw new IllegalArgumentException("The acceptor cannot have both acceptorConfig.getEntityTabuSize() ("
-                            + acceptorConfig.getEntityTabuSize() + ") and acceptorConfig.getEntityTabuRatio() ("
-                            + acceptorConfig.getEntityTabuRatio() + ").");
+            if (entityTabuSize != null) {
+                if (entityTabuRatio != null) {
+                    throw new IllegalArgumentException(
+                            "The acceptor cannot have both entityTabuSize (%d) and entityTabuRatio (%f)."
+                                    .formatted(entityTabuSize, entityTabuRatio));
                 }
-                acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getEntityTabuSize()));
-            } else if (acceptorConfig.getEntityTabuRatio() != null) {
-                acceptor.setTabuSizeStrategy(new EntityRatioTabuSizeStrategy<>(acceptorConfig.getEntityTabuRatio()));
-            } else if (acceptorConfig.getFadingEntityTabuSize() == null && acceptorConfig.getFadingEntityTabuRatio() == null) {
+                acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(entityTabuSize));
+            } else if (entityTabuRatio != null) {
+                acceptor.setTabuSizeStrategy(new EntityRatioTabuSizeStrategy<>(entityTabuRatio));
+            } else if (fadingEntityTabuSize == null && fadingEntityTabuRatio == null) {
                 acceptor.setTabuSizeStrategy(new EntityRatioTabuSizeStrategy<>(0.1));
             }
-            if (acceptorConfig.getFadingEntityTabuSize() != null) {
-                if (acceptorConfig.getFadingEntityTabuRatio() != null) {
+            if (fadingEntityTabuSize != null) {
+                if (fadingEntityTabuRatio != null) {
                     throw new IllegalArgumentException(
-                            "The acceptor cannot have both acceptorConfig.getFadingEntityTabuSize() ("
-                                    + acceptorConfig.getFadingEntityTabuSize()
-                                    + ") and acceptorConfig.getFadingEntityTabuRatio() ("
-                                    + acceptorConfig.getFadingEntityTabuRatio() + ").");
+                            "The acceptor cannot have both fadingEntityTabuSize (%d) and fadingEntityTabuRatio (%f)."
+                                    .formatted(fadingEntityTabuSize, fadingEntityTabuRatio));
                 }
-                acceptor.setFadingTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getFadingEntityTabuSize()));
-            } else if (acceptorConfig.getFadingEntityTabuRatio() != null) {
-                acceptor.setFadingTabuSizeStrategy(
-                        new EntityRatioTabuSizeStrategy<>(acceptorConfig.getFadingEntityTabuRatio()));
+                acceptor.setFadingTabuSizeStrategy(new FixedTabuSizeStrategy<>(fadingEntityTabuSize));
+            } else if (fadingEntityTabuRatio != null) {
+                acceptor.setFadingTabuSizeStrategy(new EntityRatioTabuSizeStrategy<>(fadingEntityTabuRatio));
             }
             if (configPolicy.getEnvironmentMode().isFullyAsserted()) {
                 acceptor.setAssertTabuHashCodeCorrectness(true);
@@ -132,46 +133,47 @@ public class AcceptorFactory<Solution_> {
     }
 
     private Optional<ValueTabuAcceptor<Solution_>> buildValueTabuAcceptor(HeuristicConfigPolicy<Solution_> configPolicy) {
+        var valueTabuSize = acceptorConfig.getValueTabuSize();
+        var fadingValueTabuSize = acceptorConfig.getFadingValueTabuSize();
         if (acceptorTypeListsContainsAcceptorType(AcceptorType.VALUE_TABU)
-                || acceptorConfig.getValueTabuSize() != null || acceptorConfig.getFadingValueTabuSize() != null) {
-            if (acceptorConfig.getValueTabuSize() == null && acceptorConfig.getFadingValueTabuSize() == null) {
+                || valueTabuSize != null || fadingValueTabuSize != null) {
+            if (valueTabuSize == null && fadingValueTabuSize == null) {
                 throw new IllegalArgumentException(
                         "The acceptorType (%s) requires either valueTabuSize or fadingValueTabuSize to be configured."
                                 .formatted(AcceptorType.VALUE_TABU));
             }
             var acceptor = new ValueTabuAcceptor<Solution_>(configPolicy.getLogIndentation());
-            if (acceptorConfig.getValueTabuSize() != null) {
-                acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getValueTabuSize()));
-            }
-            if (acceptorConfig.getFadingValueTabuSize() != null) {
-                acceptor.setFadingTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getFadingValueTabuSize()));
-            }
-            if (configPolicy.getEnvironmentMode().isFullyAsserted()) {
-                acceptor.setAssertTabuHashCodeCorrectness(true);
-            }
+            configureFixedSizeTabuAcceptor(acceptor, configPolicy, valueTabuSize, fadingValueTabuSize);
             return Optional.of(acceptor);
         }
         return Optional.empty();
     }
 
+    private static <Solution_> void configureFixedSizeTabuAcceptor(AbstractTabuAcceptor<Solution_> acceptor,
+            HeuristicConfigPolicy<Solution_> configPolicy, Integer tabuSize, Integer fadingTabuSize) {
+        if (tabuSize != null) {
+            acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(tabuSize));
+        }
+        if (fadingTabuSize != null) {
+            acceptor.setFadingTabuSizeStrategy(new FixedTabuSizeStrategy<>(fadingTabuSize));
+        }
+        if (configPolicy.getEnvironmentMode().isFullyAsserted()) {
+            acceptor.setAssertTabuHashCodeCorrectness(true);
+        }
+    }
+
     private Optional<MoveTabuAcceptor<Solution_>> buildMoveTabuAcceptor(HeuristicConfigPolicy<Solution_> configPolicy) {
+        var moveTabuSize = acceptorConfig.getMoveTabuSize();
+        var fadingMoveTabuSize = acceptorConfig.getFadingMoveTabuSize();
         if (acceptorTypeListsContainsAcceptorType(AcceptorType.MOVE_TABU)
-                || acceptorConfig.getMoveTabuSize() != null || acceptorConfig.getFadingMoveTabuSize() != null) {
-            if (acceptorConfig.getMoveTabuSize() == null && acceptorConfig.getFadingMoveTabuSize() == null) {
+                || moveTabuSize != null || fadingMoveTabuSize != null) {
+            if (moveTabuSize == null && fadingMoveTabuSize == null) {
                 throw new IllegalArgumentException(
                         "The acceptorType (%s) requires either moveTabuSize or fadingMoveTabuSize to be configured."
                                 .formatted(AcceptorType.MOVE_TABU));
             }
             var acceptor = new MoveTabuAcceptor<Solution_>(configPolicy.getLogIndentation());
-            if (acceptorConfig.getMoveTabuSize() != null) {
-                acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getMoveTabuSize()));
-            }
-            if (acceptorConfig.getFadingMoveTabuSize() != null) {
-                acceptor.setFadingTabuSizeStrategy(new FixedTabuSizeStrategy<>(acceptorConfig.getFadingMoveTabuSize()));
-            }
-            if (configPolicy.getEnvironmentMode().isFullyAsserted()) {
-                acceptor.setAssertTabuHashCodeCorrectness(true);
-            }
+            configureFixedSizeTabuAcceptor(acceptor, configPolicy, moveTabuSize, fadingMoveTabuSize);
             return Optional.of(acceptor);
         }
         return Optional.empty();
@@ -184,9 +186,9 @@ public class AcceptorFactory<Solution_> {
             var acceptor = new SimulatedAnnealingAcceptor<Solution_>();
             if (acceptorConfig.getSimulatedAnnealingStartingTemperature() == null) {
                 // TODO Support SA without a parameter
-                throw new IllegalArgumentException("The acceptorType (" + AcceptorType.SIMULATED_ANNEALING
-                        + ") currently requires a acceptorConfig.getSimulatedAnnealingStartingTemperature() ("
-                        + acceptorConfig.getSimulatedAnnealingStartingTemperature() + ").");
+                throw new IllegalArgumentException(
+                        "The acceptorType (%s) requires non-null acceptorConfig.getSimulatedAnnealingStartingTemperature()."
+                                .formatted(AcceptorType.SIMULATED_ANNEALING));
             }
             acceptor.setStartingTemperature(
                     configPolicy.getScoreDefinition().parseScore(acceptorConfig.getSimulatedAnnealingStartingTemperature()));
@@ -224,19 +226,20 @@ public class AcceptorFactory<Solution_> {
             var acceptor = new GreatDelugeAcceptor<Solution_>();
             if (acceptorConfig.getGreatDelugeWaterLevelIncrementScore() != null) {
                 if (acceptorConfig.getGreatDelugeWaterLevelIncrementRatio() != null) {
-                    throw new IllegalArgumentException("The acceptor cannot have both a "
-                            + "acceptorConfig.getGreatDelugeWaterLevelIncrementScore() ("
-                            + acceptorConfig.getGreatDelugeWaterLevelIncrementScore()
-                            + ") and a acceptorConfig.getGreatDelugeWaterLevelIncrementRatio() ("
-                            + acceptorConfig.getGreatDelugeWaterLevelIncrementRatio() + ").");
+                    throw new IllegalArgumentException("""
+                            The acceptor cannot have both acceptorConfig.getGreatDelugeWaterLevelIncrementScore() (%s) \
+                            and acceptorConfig.getGreatDelugeWaterLevelIncrementRatio() (%s)."""
+                            .formatted(acceptorConfig.getGreatDelugeWaterLevelIncrementScore(),
+                                    acceptorConfig.getGreatDelugeWaterLevelIncrementRatio()));
                 }
                 acceptor.setWaterLevelIncrementScore(
                         configPolicy.getScoreDefinition().parseScore(acceptorConfig.getGreatDelugeWaterLevelIncrementScore()));
             } else if (acceptorConfig.getGreatDelugeWaterLevelIncrementRatio() != null) {
                 if (acceptorConfig.getGreatDelugeWaterLevelIncrementRatio() <= 0.0) {
-                    throw new IllegalArgumentException("The acceptorConfig.getGreatDelugeWaterLevelIncrementRatio() ("
-                            + acceptorConfig.getGreatDelugeWaterLevelIncrementRatio()
-                            + ") must be positive because the water level should increase.");
+                    throw new IllegalArgumentException("""
+                            The acceptorConfig.getGreatDelugeWaterLevelIncrementRatio() (%s) must be positive \
+                            because the water level should increase."""
+                            .formatted(acceptorConfig.getGreatDelugeWaterLevelIncrementRatio()));
                 }
                 acceptor.setWaterLevelIncrementRatio(acceptorConfig.getGreatDelugeWaterLevelIncrementRatio());
             } else {

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
@@ -144,7 +144,9 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
         }
         // From this point, we are guaranteed to be in a fading tabu.
         var acceptChance = calculateFadingTabuAcceptChance(tabuStepCount - workingTabuSize);
-        var accepted = moveScope.getWorkingRandom().nextDouble() < acceptChance;
+        // Only call RNG when necessary.
+        var accepted = Double.compare(acceptChance, 1.0d) >= 0
+                || (Double.compare(acceptChance, 0.0d) > 0 && moveScope.getWorkingRandom().nextDouble() < acceptChance);
         if (accepted) {
             logger.trace("{}        Proposed move ({}) is fading tabu with acceptChance ({}) and is accepted.",
                     logIndentation,

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
@@ -141,7 +141,11 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
             logger.trace("{}        Proposed move ({}) is tabu and is therefore not accepted.",
                     logIndentation, moveScope.getMove());
             return false;
+        } else if (workingFadingTabuSize == 0) {
+            // No comment as the move is not tabu; the tabu list needs to be adjusted.
+            return true;
         }
+        // From this point, we are guaranteed to be in a fading tabu.
         var acceptChance = calculateFadingTabuAcceptChance(tabuStepCount - workingTabuSize);
         var accepted = moveScope.getWorkingRandom().nextDouble() < acceptChance;
         if (accepted) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
@@ -143,14 +143,15 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
             return false;
         }
         var decision = decideFadingTabuAcceptance(moveScope, tabuStepCount - workingTabuSize);
-        if (decision.accepted()) {
+        var accepted = decision > 0;
+        if (accepted) {
             logger.trace("{}        Proposed move ({}) is fading tabu with acceptChance ({}) and is accepted.",
-                    logIndentation, moveScope.getMove(), decision.acceptChance());
+                    logIndentation, moveScope.getMove(), Math.abs(decision));
         } else {
             logger.trace("{}        Proposed move ({}) is fading tabu with acceptChance ({}) and is not accepted.",
-                    logIndentation, moveScope.getMove(), decision.acceptChance());
+                    logIndentation, moveScope.getMove(), Math.abs(decision));
         }
-        return decision.accepted();
+        return accepted;
     }
 
     private int locateMaximumTabuStepIndex(LocalSearchMoveScope<Solution_> moveScope) {
@@ -182,32 +183,24 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
 
     /**
      * @param fadingTabuStepCount {@code 0 < fadingTabuStepCount <= fadingTabuSize}
-     * @return a record with the accept chance, and the decision
+     * @return in absolute value, the accept chance;
+     *         negative signum or 0 means not accepted, positive signum means accepted.
+     *         This is hacky, but we can represent 2 things with one number
+     *         and avoid allocation new types for this multiple return.
      */
-    private FadingTabuDecision decideFadingTabuAcceptance(LocalSearchMoveScope<Solution_> moveScope, int fadingTabuStepCount) {
+    private double decideFadingTabuAcceptance(LocalSearchMoveScope<Solution_> moveScope, int fadingTabuStepCount) {
         // Invert the chance; the longer the element is in the tabu list, the higher the chance should be.
         var numerator = workingFadingTabuSize - fadingTabuStepCount;
         if (numerator <= 0) { // The inverted chance would be >= 1.
-            return FadingTabuDecision.CERTAIN;
+            return 1.0d;
         }
         var denominator = workingFadingTabuSize + 1;
         if (numerator >= denominator) { // The inverted chance would be <= 0.
-            return FadingTabuDecision.IMPOSSIBLE;
+            return 0.0d;
         }
         var acceptChance = 1.0d - (numerator / (double) denominator);
-        var accepted = Double.compare(moveScope.getWorkingRandom().nextDouble(), acceptChance) < 0;
-        return new FadingTabuDecision(acceptChance, accepted);
-    }
-
-    /**
-     * @param acceptChance 0.0 <= acceptChance <= 1.0
-     * @param accepted
-     */
-    private record FadingTabuDecision(double acceptChance, boolean accepted) {
-
-        private static final FadingTabuDecision CERTAIN = new FadingTabuDecision(1.0d, true);
-        private static final FadingTabuDecision IMPOSSIBLE = new FadingTabuDecision(0.0d, false);
-
+        var accepted = moveScope.getWorkingRandom().nextDouble() < acceptChance;
+        return accepted ? acceptChance : -acceptChance;
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
@@ -141,9 +141,6 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
             logger.trace("{}        Proposed move ({}) is tabu and is therefore not accepted.",
                     logIndentation, moveScope.getMove());
             return false;
-        } else if (workingFadingTabuSize == 0) {
-            // No comment as the move is not tabu; the tabu list needs to be adjusted.
-            return true;
         }
         // From this point, we are guaranteed to be in a fading tabu.
         var acceptChance = calculateFadingTabuAcceptChance(tabuStepCount - workingTabuSize);

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
@@ -142,21 +142,15 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
                     logIndentation, moveScope.getMove());
             return false;
         }
-        // From this point, we are guaranteed to be in a fading tabu.
-        var acceptChance = calculateFadingTabuAcceptChance(tabuStepCount - workingTabuSize);
-        // Only call RNG when necessary.
-        var accepted = Double.compare(acceptChance, 1.0d) >= 0
-                || (Double.compare(acceptChance, 0.0d) > 0 && moveScope.getWorkingRandom().nextDouble() < acceptChance);
-        if (accepted) {
+        var decision = decideFadingTabuAcceptance(moveScope, tabuStepCount - workingTabuSize);
+        if (decision.accepted()) {
             logger.trace("{}        Proposed move ({}) is fading tabu with acceptChance ({}) and is accepted.",
-                    logIndentation,
-                    moveScope.getMove(), acceptChance);
+                    logIndentation, moveScope.getMove(), decision.acceptChance());
         } else {
             logger.trace("{}        Proposed move ({}) is fading tabu with acceptChance ({}) and is not accepted.",
-                    logIndentation,
-                    moveScope.getMove(), acceptChance);
+                    logIndentation, moveScope.getMove(), decision.acceptChance());
         }
-        return accepted;
+        return decision.accepted();
     }
 
     private int locateMaximumTabuStepIndex(LocalSearchMoveScope<Solution_> moveScope) {
@@ -188,12 +182,32 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
 
     /**
      * @param fadingTabuStepCount {@code 0 < fadingTabuStepCount <= fadingTabuSize}
-     * @return {@code 0.0 < acceptChance < 1.0}
+     * @return a record with the accept chance, and the decision
      */
-    protected double calculateFadingTabuAcceptChance(int fadingTabuStepCount) {
-        // The + 1's are because acceptChance should not be 0.0 or 1.0
-        // when (fadingTabuStepCount == 0) or (fadingTabuStepCount + 1 == workingFadingTabuSize)
-        return (workingFadingTabuSize - fadingTabuStepCount) / ((double) (workingFadingTabuSize + 1));
+    private FadingTabuDecision decideFadingTabuAcceptance(LocalSearchMoveScope<Solution_> moveScope, int fadingTabuStepCount) {
+        // Invert the chance; the longer the element is in the tabu list, the higher the chance should be.
+        var numerator = workingFadingTabuSize - fadingTabuStepCount;
+        if (numerator <= 0) { // The inverted chance would be >= 1.
+            return FadingTabuDecision.CERTAIN;
+        }
+        var denominator = workingFadingTabuSize + 1;
+        if (numerator >= denominator) { // The inverted chance would be <= 0.
+            return FadingTabuDecision.IMPOSSIBLE;
+        }
+        var acceptChance = 1.0d - (numerator / (double) denominator);
+        var accepted = Double.compare(moveScope.getWorkingRandom().nextDouble(), acceptChance) < 0;
+        return new FadingTabuDecision(acceptChance, accepted);
+    }
+
+    /**
+     * @param acceptChance 0.0 <= acceptChance <= 1.0
+     * @param accepted
+     */
+    private record FadingTabuDecision(double acceptChance, boolean accepted) {
+
+        private static final FadingTabuDecision CERTAIN = new FadingTabuDecision(1.0d, true);
+        private static final FadingTabuDecision IMPOSSIBLE = new FadingTabuDecision(0.0d, false);
+
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/size/FixedTabuSizeStrategy.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/size/FixedTabuSizeStrategy.java
@@ -8,9 +8,9 @@ public final class FixedTabuSizeStrategy<Solution_> extends AbstractTabuSizeStra
 
     public FixedTabuSizeStrategy(int tabuSize) {
         this.tabuSize = tabuSize;
-        if (tabuSize < 0) {
-            throw new IllegalArgumentException("The tabuSize (" + tabuSize
-                    + ") cannot be negative.");
+        if (tabuSize < 1) {
+            throw new IllegalArgumentException("The tabuSize (%d) must be at least 1."
+                    .formatted(tabuSize));
         }
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AcceptorFactoryTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AcceptorFactoryTest.java
@@ -110,4 +110,22 @@ class AcceptorFactoryTest {
         AcceptorFactory<Solution_> badAcceptorFactory = AcceptorFactory.create(localSearchAcceptorConfig);
         assertThatIllegalStateException().isThrownBy(() -> badAcceptorFactory.buildAcceptor(heuristicConfigPolicy));
     }
+
+    @Test
+    <Solution_> void valueTabuWithoutSizes_throwsException() {
+        var config = new LocalSearchAcceptorConfig()
+                .withAcceptorTypeList(List.of(AcceptorType.VALUE_TABU));
+        var factory = AcceptorFactory.create(config);
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> factory.buildAcceptor(mock(HeuristicConfigPolicy.class)));
+    }
+
+    @Test
+    <Solution_> void moveTabuWithoutSizes_throwsException() {
+        var config = new LocalSearchAcceptorConfig()
+                .withAcceptorTypeList(List.of(AcceptorType.MOVE_TABU));
+        var factory = AcceptorFactory.create(config);
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> factory.buildAcceptor(mock(HeuristicConfigPolicy.class)));
+    }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
@@ -273,7 +273,7 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        // Step 3: fading zone, fadingCount=1, acceptChance=0.6; random=0.3 → accepted
+        // Step 3: fading zone, fadingCount=1, acceptChance=0.4; random=0.3 → accepted
         solverScope.setWorkingRandom(new TestRandom(0.3));
         var stepScope3 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e1))).isTrue();
@@ -281,15 +281,15 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope3);
         phaseScope.setLastCompletedStepScope(stepScope3);
 
-        // Step 4: fadingCount=2, acceptChance=0.4; random=0.5 → rejected
+        // Step 4: fadingCount=2, acceptChance=0.6; random=0.5 → accepted
         solverScope.setWorkingRandom(new TestRandom(0.5));
         var stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, e1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, e1))).isTrue();
         stepScope4.setStep(buildMoveScope(stepScope4, e0).getMove());
         acceptor.stepEnded(stepScope4);
         phaseScope.setLastCompletedStepScope(stepScope4);
 
-        // Step 5: fadingCount=3, acceptChance=0.2; random=0.1 → accepted
+        // Step 5: fadingCount=3, acceptChance=0.8; random=0.1 → accepted
         solverScope.setWorkingRandom(new TestRandom(0.1));
         var stepScope5 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, e1))).isTrue();
@@ -297,11 +297,11 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope5);
         phaseScope.setLastCompletedStepScope(stepScope5);
 
-        // Step 6: fadingCount=4, acceptChance=0.0; random consumed but always false
+        // Step 6: fadingCount=4, acceptChance=1.0; random not consumed and accepted
         // adjustTabuList removes e1 (tabuStepCount=6 ≥ totalTabuListSize=6)
-        solverScope.setWorkingRandom(new TestRandom(0.99));
+        solverScope.setWorkingRandom(new TestRandom(new double[0]));
         var stepScope6 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, e1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, e1))).isTrue();
         stepScope6.setStep(buildMoveScope(stepScope6, e0).getMove());
         acceptor.stepEnded(stepScope6);
         phaseScope.setLastCompletedStepScope(stepScope6);

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
@@ -14,6 +14,7 @@ import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.preview.api.move.Move;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
+import ai.timefold.solver.core.testutil.TestRandom;
 
 import org.junit.jupiter.api.Test;
 
@@ -233,6 +234,82 @@ class EntityTabuAcceptorTest {
         stepScope1.setStep(buildMoveScope(stepScope1, -20, e1).getMove());
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
+
+        acceptor.phaseEnded(phaseScope);
+    }
+
+    @Test
+    void fadingTabuSize() {
+        var acceptor = new EntityTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
+        acceptor.setFadingTabuSizeStrategy(new FixedTabuSizeStrategy<>(4));
+
+        var e0 = new TestdataEntity("e0");
+        var e1 = new TestdataEntity("e1");
+
+        var solverScope = new SolverScope<>();
+        solverScope.setInitializedBestScore(SimpleScore.ZERO);
+        solverScope.setWorkingRandom(new TestRandom(new double[0]));
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        acceptor.phaseStarted(phaseScope);
+
+        // Step 0: tabu e1 at stepIndex=0
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        stepScope0.setStep(buildMoveScope(stepScope0, e1).getMove());
+        acceptor.stepEnded(stepScope0);
+        phaseScope.setLastCompletedStepScope(stepScope0);
+
+        // Steps 1-2: hard tabu (tabuStepCount 1,2 ≤ 2) — no random consumed
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, e1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, e0))).isTrue();
+        stepScope1.setStep(buildMoveScope(stepScope1, e0).getMove());
+        acceptor.stepEnded(stepScope1);
+        phaseScope.setLastCompletedStepScope(stepScope1);
+
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, e1))).isFalse();
+        stepScope2.setStep(buildMoveScope(stepScope2, e0).getMove());
+        acceptor.stepEnded(stepScope2);
+        phaseScope.setLastCompletedStepScope(stepScope2);
+
+        // Step 3: fading zone, fadingCount=1, acceptChance=0.6; random=0.3 → accepted
+        solverScope.setWorkingRandom(new TestRandom(0.3));
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e1))).isTrue();
+        stepScope3.setStep(buildMoveScope(stepScope3, e0).getMove());
+        acceptor.stepEnded(stepScope3);
+        phaseScope.setLastCompletedStepScope(stepScope3);
+
+        // Step 4: fadingCount=2, acceptChance=0.4; random=0.5 → rejected
+        solverScope.setWorkingRandom(new TestRandom(0.5));
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, e1))).isFalse();
+        stepScope4.setStep(buildMoveScope(stepScope4, e0).getMove());
+        acceptor.stepEnded(stepScope4);
+        phaseScope.setLastCompletedStepScope(stepScope4);
+
+        // Step 5: fadingCount=3, acceptChance=0.2; random=0.1 → accepted
+        solverScope.setWorkingRandom(new TestRandom(0.1));
+        var stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, e1))).isTrue();
+        stepScope5.setStep(buildMoveScope(stepScope5, e0).getMove());
+        acceptor.stepEnded(stepScope5);
+        phaseScope.setLastCompletedStepScope(stepScope5);
+
+        // Step 6: fadingCount=4, acceptChance=0.0; random consumed but always false
+        // adjustTabuList removes e1 (tabuStepCount=6 ≥ totalTabuListSize=6)
+        solverScope.setWorkingRandom(new TestRandom(0.99));
+        var stepScope6 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, e1))).isFalse();
+        stepScope6.setStep(buildMoveScope(stepScope6, e0).getMove());
+        acceptor.stepEnded(stepScope6);
+        phaseScope.setLastCompletedStepScope(stepScope6);
+
+        // Step 7: e1 expired, no random consumed
+        solverScope.setWorkingRandom(new TestRandom(new double[0]));
+        var stepScope7 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope7, e1))).isTrue();
 
         acceptor.phaseEnded(phaseScope);
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
@@ -273,10 +273,10 @@ class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        // Step 3: fading zone, fadingCount=1, acceptChance=0.4; random=0.3 → accepted
-        solverScope.setWorkingRandom(new TestRandom(0.3));
+        // Step 3: fading zone, fadingCount=1, acceptChance=0.4; random=0.5 → rejected
+        solverScope.setWorkingRandom(new TestRandom(0.5));
         var stepScope3 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e1))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, e1))).isFalse();
         stepScope3.setStep(buildMoveScope(stepScope3, e0).getMove());
         acceptor.stepEnded(stepScope3);
         phaseScope.setLastCompletedStepScope(stepScope3);

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/MoveTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/MoveTabuAcceptorTest.java
@@ -155,7 +155,7 @@ class MoveTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        // Step 3: fadingCount=1, acceptChance=0.6; random=0.3 → accepted
+        // Step 3: fadingCount=1, acceptChance=0.4; random=0.3 → accepted
         solverScope.setWorkingRandom(new TestRandom(0.3));
         var stepScope3 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, m1))).isTrue();
@@ -163,27 +163,27 @@ class MoveTabuAcceptorTest {
         acceptor.stepEnded(stepScope3);
         phaseScope.setLastCompletedStepScope(stepScope3);
 
-        // Step 4: fadingCount=2, acceptChance=0.4; random=0.5 → rejected
+        // Step 4: fadingCount=2, acceptChance=0.6; random=0.5 → accepted
         solverScope.setWorkingRandom(new TestRandom(0.5));
         var stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, m1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, m1))).isTrue();
         stepScope4.setStep(m0);
         acceptor.stepEnded(stepScope4);
         phaseScope.setLastCompletedStepScope(stepScope4);
 
-        // Step 5: fadingCount=3, acceptChance=0.2; random=0.1 → accepted
-        solverScope.setWorkingRandom(new TestRandom(0.1));
+        // Step 5: fadingCount=3, acceptChance=0.8; random=0.9 → not accepted
+        solverScope.setWorkingRandom(new TestRandom(0.9));
         var stepScope5 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, m1))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, m1))).isFalse();
         stepScope5.setStep(m0);
         acceptor.stepEnded(stepScope5);
         phaseScope.setLastCompletedStepScope(stepScope5);
 
-        // Step 6: fadingCount=4, acceptChance=0.0; random consumed but always false
+        // Step 6: fadingCount=4, acceptChance=1.0; random not consumed but always true
         // adjustTabuList removes m1 (tabuStepCount=6 ≥ totalTabuListSize=6)
-        solverScope.setWorkingRandom(new TestRandom(0.99));
+        solverScope.setWorkingRandom(new TestRandom(new double[0]));
         var stepScope6 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, m1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, m1))).isTrue();
         stepScope6.setStep(m0);
         acceptor.stepEnded(stepScope6);
         phaseScope.setLastCompletedStepScope(stepScope6);

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/MoveTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/MoveTabuAcceptorTest.java
@@ -1,0 +1,213 @@
+package ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import ai.timefold.solver.core.api.score.SimpleScore;
+import ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu.size.FixedTabuSizeStrategy;
+import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
+import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
+import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
+import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.preview.api.move.Move;
+import ai.timefold.solver.core.testutil.TestRandom;
+
+import org.junit.jupiter.api.Test;
+
+class MoveTabuAcceptorTest {
+
+    @Test
+    void tabuSize() {
+        var acceptor = new MoveTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
+
+        var m0 = mock(Move.class);
+        var m1 = mock(Move.class);
+        var m2 = mock(Move.class);
+        var m3 = mock(Move.class);
+        var m4 = mock(Move.class);
+
+        var solverScope = new SolverScope<>();
+        solverScope.setInitializedBestScore(SimpleScore.ZERO);
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        acceptor.phaseStarted(phaseScope);
+
+        // Step 0: map is empty — all moves accepted
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, m0))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, m1))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, m2))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, m3))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope0, m4))).isTrue();
+        stepScope0.setStep(m1);
+        acceptor.stepEnded(stepScope0);
+        phaseScope.setLastCompletedStepScope(stepScope0);
+
+        // Step 1: map={m1:0}; m1 tabuStepCount=1 ≤ 2 → tabu
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, m0))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, m1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, m2))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, m3))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, m4))).isTrue();
+        stepScope1.setStep(m2);
+        acceptor.stepEnded(stepScope1);
+        phaseScope.setLastCompletedStepScope(stepScope1);
+
+        // Step 2: map={m1:0,m2:1}; both tabu
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, m0))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, m1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, m2))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, m3))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, m4))).isTrue();
+        // adjustTabuList(2,[m3]): m1 tabuStepCount=2 ≥ 2 → removed; map={m2:1,m3:2}
+        stepScope2.setStep(m3);
+        acceptor.stepEnded(stepScope2);
+        phaseScope.setLastCompletedStepScope(stepScope2);
+
+        // Step 3: map={m2:1,m3:2}; m1 expired
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, m0))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, m1))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, m2))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, m3))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, m4))).isTrue();
+        // adjustTabuList(3,[m4]): m2 tabuStepCount=2 ≥ 2 → removed; map={m3:2,m4:3}
+        stepScope3.setStep(m4);
+        acceptor.stepEnded(stepScope3);
+        phaseScope.setLastCompletedStepScope(stepScope3);
+
+        // Step 4: map={m3:2,m4:3}; m2 expired
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, m0))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, m1))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, m2))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, m3))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, m4))).isFalse();
+        stepScope4.setStep(m0);
+        acceptor.stepEnded(stepScope4);
+        phaseScope.setLastCompletedStepScope(stepScope4);
+
+        acceptor.phaseEnded(phaseScope);
+    }
+
+    @Test
+    void aspiration() {
+        var acceptor = new MoveTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
+        acceptor.setAspirationEnabled(true);
+
+        var m0 = mock(Move.class);
+        var m1 = mock(Move.class);
+
+        var solverScope = new SolverScope<>();
+        solverScope.setInitializedBestScore(SimpleScore.of(-100));
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        acceptor.phaseStarted(phaseScope);
+
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        stepScope0.setStep(m1);
+        acceptor.stepEnded(stepScope0);
+        phaseScope.setLastCompletedStepScope(stepScope0);
+
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -120, m0))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -20, m0))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -120, m1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, -20, m1))).isTrue();
+
+        acceptor.phaseEnded(phaseScope);
+    }
+
+    @Test
+    void fadingTabuSize() {
+        var acceptor = new MoveTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
+        acceptor.setFadingTabuSizeStrategy(new FixedTabuSizeStrategy<>(4));
+
+        var m0 = mock(Move.class);
+        var m1 = mock(Move.class);
+
+        var solverScope = new SolverScope<>();
+        solverScope.setInitializedBestScore(SimpleScore.ZERO);
+        solverScope.setWorkingRandom(new TestRandom(new double[0]));
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        acceptor.phaseStarted(phaseScope);
+
+        // Step 0: tabu m1 at stepIndex=0
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        stepScope0.setStep(m1);
+        acceptor.stepEnded(stepScope0);
+        phaseScope.setLastCompletedStepScope(stepScope0);
+
+        // Steps 1-2: hard tabu — no random consumed
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, m1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, m0))).isTrue();
+        stepScope1.setStep(m0);
+        acceptor.stepEnded(stepScope1);
+        phaseScope.setLastCompletedStepScope(stepScope1);
+
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, m1))).isFalse();
+        stepScope2.setStep(m0);
+        acceptor.stepEnded(stepScope2);
+        phaseScope.setLastCompletedStepScope(stepScope2);
+
+        // Step 3: fadingCount=1, acceptChance=0.6; random=0.3 → accepted
+        solverScope.setWorkingRandom(new TestRandom(0.3));
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, m1))).isTrue();
+        stepScope3.setStep(m0);
+        acceptor.stepEnded(stepScope3);
+        phaseScope.setLastCompletedStepScope(stepScope3);
+
+        // Step 4: fadingCount=2, acceptChance=0.4; random=0.5 → rejected
+        solverScope.setWorkingRandom(new TestRandom(0.5));
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, m1))).isFalse();
+        stepScope4.setStep(m0);
+        acceptor.stepEnded(stepScope4);
+        phaseScope.setLastCompletedStepScope(stepScope4);
+
+        // Step 5: fadingCount=3, acceptChance=0.2; random=0.1 → accepted
+        solverScope.setWorkingRandom(new TestRandom(0.1));
+        var stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, m1))).isTrue();
+        stepScope5.setStep(m0);
+        acceptor.stepEnded(stepScope5);
+        phaseScope.setLastCompletedStepScope(stepScope5);
+
+        // Step 6: fadingCount=4, acceptChance=0.0; random consumed but always false
+        // adjustTabuList removes m1 (tabuStepCount=6 ≥ totalTabuListSize=6)
+        solverScope.setWorkingRandom(new TestRandom(0.99));
+        var stepScope6 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, m1))).isFalse();
+        stepScope6.setStep(m0);
+        acceptor.stepEnded(stepScope6);
+        phaseScope.setLastCompletedStepScope(stepScope6);
+
+        // Step 7: m1 expired, no random consumed
+        solverScope.setWorkingRandom(new TestRandom(new double[0]));
+        var stepScope7 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope7, m1))).isTrue();
+
+        acceptor.phaseEnded(phaseScope);
+    }
+
+    private static <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+            LocalSearchStepScope<Solution_> stepScope, Move<Solution_> move) {
+        var moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
+        moveScope.setInitializedScore(SimpleScore.of(0));
+        return moveScope;
+    }
+
+    private static <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+            LocalSearchStepScope<Solution_> stepScope, int score, Move<Solution_> move) {
+        var moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
+        moveScope.setInitializedScore(SimpleScore.of(score));
+        return moveScope;
+    }
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
@@ -303,4 +303,72 @@ class ValueTabuAcceptorTest {
         acceptor.phaseEnded(phaseScope);
     }
 
+    @Test
+    void fadingTabuSize() {
+        var acceptor = new ValueTabuAcceptor<>("");
+        acceptor.setTabuSizeStrategy(new FixedTabuSizeStrategy<>(2));
+        acceptor.setFadingTabuSizeStrategy(new FixedTabuSizeStrategy<>(4));
+
+        var v0 = new TestdataValue("v0");
+        var v1 = new TestdataValue("v1");
+
+        var solverScope = new SolverScope<>();
+        solverScope.setInitializedBestScore(SimpleScore.ZERO);
+        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(new double[0]));
+        var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
+        acceptor.phaseStarted(phaseScope);
+
+        var stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        stepScope0.setStep(buildMoveScope(stepScope0, v1).getMove());
+        acceptor.stepEnded(stepScope0);
+        phaseScope.setLastCompletedStepScope(stepScope0);
+
+        var stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, v1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, v0))).isTrue();
+        stepScope1.setStep(buildMoveScope(stepScope1, v0).getMove());
+        acceptor.stepEnded(stepScope1);
+        phaseScope.setLastCompletedStepScope(stepScope1);
+
+        var stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope2, v1))).isFalse();
+        stepScope2.setStep(buildMoveScope(stepScope2, v0).getMove());
+        acceptor.stepEnded(stepScope2);
+        phaseScope.setLastCompletedStepScope(stepScope2);
+
+        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(0.3));
+        var stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v1))).isTrue();
+        stepScope3.setStep(buildMoveScope(stepScope3, v0).getMove());
+        acceptor.stepEnded(stepScope3);
+        phaseScope.setLastCompletedStepScope(stepScope3);
+
+        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(0.5));
+        var stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, v1))).isFalse();
+        stepScope4.setStep(buildMoveScope(stepScope4, v0).getMove());
+        acceptor.stepEnded(stepScope4);
+        phaseScope.setLastCompletedStepScope(stepScope4);
+
+        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(0.1));
+        var stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, v1))).isTrue();
+        stepScope5.setStep(buildMoveScope(stepScope5, v0).getMove());
+        acceptor.stepEnded(stepScope5);
+        phaseScope.setLastCompletedStepScope(stepScope5);
+
+        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(0.99));
+        var stepScope6 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, v1))).isFalse();
+        stepScope6.setStep(buildMoveScope(stepScope6, v0).getMove());
+        acceptor.stepEnded(stepScope6);
+        phaseScope.setLastCompletedStepScope(stepScope6);
+
+        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(new double[0]));
+        var stepScope7 = new LocalSearchStepScope<>(phaseScope);
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope7, v1))).isTrue();
+
+        acceptor.phaseEnded(phaseScope);
+    }
+
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
@@ -14,6 +14,7 @@ import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.preview.api.move.Move;
 import ai.timefold.solver.core.testdomain.TestdataValue;
+import ai.timefold.solver.core.testutil.TestRandom;
 
 import org.junit.jupiter.api.Test;
 
@@ -314,7 +315,7 @@ class ValueTabuAcceptorTest {
 
         var solverScope = new SolverScope<>();
         solverScope.setInitializedBestScore(SimpleScore.ZERO);
-        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(new double[0]));
+        solverScope.setWorkingRandom(new TestRandom(new double[0]));
         var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         acceptor.phaseStarted(phaseScope);
 
@@ -336,35 +337,35 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(0.3));
+        solverScope.setWorkingRandom(new TestRandom(0.3));
         var stepScope3 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v1))).isTrue();
         stepScope3.setStep(buildMoveScope(stepScope3, v0).getMove());
         acceptor.stepEnded(stepScope3);
         phaseScope.setLastCompletedStepScope(stepScope3);
 
-        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(0.5));
+        solverScope.setWorkingRandom(new TestRandom(0.5));
         var stepScope4 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, v1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, v1))).isTrue();
         stepScope4.setStep(buildMoveScope(stepScope4, v0).getMove());
         acceptor.stepEnded(stepScope4);
         phaseScope.setLastCompletedStepScope(stepScope4);
 
-        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(0.1));
+        solverScope.setWorkingRandom(new TestRandom(0.99));
         var stepScope5 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, v1))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, v1))).isFalse();
         stepScope5.setStep(buildMoveScope(stepScope5, v0).getMove());
         acceptor.stepEnded(stepScope5);
         phaseScope.setLastCompletedStepScope(stepScope5);
 
-        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(0.99));
+        solverScope.setWorkingRandom(new TestRandom(new double[0]));
         var stepScope6 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, v1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, v1))).isTrue();
         stepScope6.setStep(buildMoveScope(stepScope6, v0).getMove());
         acceptor.stepEnded(stepScope6);
         phaseScope.setLastCompletedStepScope(stepScope6);
 
-        solverScope.setWorkingRandom(new ai.timefold.solver.core.testutil.TestRandom(new double[0]));
+        solverScope.setWorkingRandom(new TestRandom(new double[0]));
         var stepScope7 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope7, v1))).isTrue();
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
@@ -319,11 +319,13 @@ class ValueTabuAcceptorTest {
         var phaseScope = new LocalSearchPhaseScope<>(solverScope, 0);
         acceptor.phaseStarted(phaseScope);
 
+        // Step 0: tabu v1 at stepIndex=0
         var stepScope0 = new LocalSearchStepScope<>(phaseScope);
         stepScope0.setStep(buildMoveScope(stepScope0, v1).getMove());
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
+        // Steps 1-2: hard tabu (tabuStepCount 1,2 ≤ 2) — no random consumed
         var stepScope1 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, v1))).isFalse();
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope1, v0))).isTrue();
@@ -337,13 +339,15 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        solverScope.setWorkingRandom(new TestRandom(0.3));
+        // Step 3: fading zone, fadingCount=1, acceptChance=0.4; random=0.5 → rejected
+        solverScope.setWorkingRandom(new TestRandom(0.5));
         var stepScope3 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v1))).isTrue();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope3, v1))).isFalse();
         stepScope3.setStep(buildMoveScope(stepScope3, v0).getMove());
         acceptor.stepEnded(stepScope3);
         phaseScope.setLastCompletedStepScope(stepScope3);
 
+        // Step 4: fading zone, fadingCount=2, acceptChance=0.6; random=0.5 → accepted
         solverScope.setWorkingRandom(new TestRandom(0.5));
         var stepScope4 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope4, v1))).isTrue();
@@ -351,13 +355,15 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope4);
         phaseScope.setLastCompletedStepScope(stepScope4);
 
-        solverScope.setWorkingRandom(new TestRandom(0.99));
+        // Step 5: fading zone, fadingCount=3, acceptChance=0.8; random=0.5 → accepted
+        solverScope.setWorkingRandom(new TestRandom(0.5));
         var stepScope5 = new LocalSearchStepScope<>(phaseScope);
-        assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, v1))).isFalse();
+        assertThat(acceptor.isAccepted(buildMoveScope(stepScope5, v1))).isTrue();
         stepScope5.setStep(buildMoveScope(stepScope5, v0).getMove());
         acceptor.stepEnded(stepScope5);
         phaseScope.setLastCompletedStepScope(stepScope5);
 
+        // Step 6: fading zone, fadingCount=4, acceptChance=1.0; random not consumed and accepted
         solverScope.setWorkingRandom(new TestRandom(new double[0]));
         var stepScope6 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope6, v1))).isTrue();
@@ -365,6 +371,7 @@ class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope6);
         phaseScope.setLastCompletedStepScope(stepScope6);
 
+        // Step 7: v1 expired, no random consumed
         solverScope.setWorkingRandom(new TestRandom(new double[0]));
         var stepScope7 = new LocalSearchStepScope<>(phaseScope);
         assertThat(acceptor.isAccepted(buildMoveScope(stepScope7, v1))).isTrue();

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/size/FixedTabuSizeStrategyTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/size/FixedTabuSizeStrategyTest.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.localsearch.decider.acceptor.tabu.size;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
 
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
@@ -14,6 +15,12 @@ class FixedTabuSizeStrategyTest {
         LocalSearchStepScope stepScope = mock(LocalSearchStepScope.class);
         assertThat(new FixedTabuSizeStrategy(5).determineTabuSize(stepScope)).isEqualTo(5);
         assertThat(new FixedTabuSizeStrategy(17).determineTabuSize(stepScope)).isEqualTo(17);
+    }
+
+    @Test
+    void invalidTabuSize() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new FixedTabuSizeStrategy<>(0));
+        assertThatIllegalArgumentException().isThrownBy(() -> new FixedTabuSizeStrategy<>(-1));
     }
 
 }


### PR DESCRIPTION
The closer the item is to becoming non-tabu, the higher should its acceptance probability be. (This has been a long-standing bug which went unnoticed.)

Also made sure that, when the chance is 0 or 1, that the RNG is not called. RNG is expensive, and it affects randomness in other places of the solver that use the same RNG.