### PR TITLE
fix: add missing config JAR to BOM

### DIFF
--- a/build/bom/pom.xml
+++ b/build/bom/pom.xml
@@ -484,6 +484,18 @@
         <classifier>sources</classifier>
       </dependency>
 
+      <dependency>
+        <groupId>ai.timefold.solver</groupId>
+        <artifactId>timefold-solver-service-config</artifactId>
+        <version>${version.ai.timefold.solver}</version>
+      </dependency>
+      <dependency>
+        <groupId>ai.timefold.solver</groupId>
+        <artifactId>timefold-solver-service-config</artifactId>
+        <version>${version.ai.timefold.solver}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
       <!-- test support -->
       <dependency>
         <groupId>ai.timefold.solver</groupId>


### PR DESCRIPTION
The JAR is used in CI to figure our docker image name and version.