### PR TITLE
fix: do not log successful model deploy response as error

### DIFF
--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/DeployModelMojo.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/DeployModelMojo.java
@@ -132,7 +132,6 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
                                     "Model %s (%s) has been successfully deployed into platform %s with registration key %s",
                                     modelDescriptor.get("name").asText(), modelDescriptor.get("id").asText(), platformUrl,
                                     key));
-                    printErrorInfo(response);
                 } else if (response.statusCode() >= 409) {
                     if (getPropertyOrParameter(PROP_MODEL_OVERWRITE, overwrite)) {
 
@@ -147,7 +146,6 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
                                     "Model %s (%s) has been successfully updated on platform %s with registration key %s",
                                     modelDescriptor.get("name").asText(), modelDescriptor.get("id").asText(), platformUrl,
                                     key));
-                            printErrorInfo(response);
                         } else {
                             throw new IllegalStateException(
                                     "Model deployment (override) failed with " + response.statusCode() + " status code");


### PR DESCRIPTION
## Problem

When deploying or updating a model via the Maven plugin, `DeployModelMojo` called `printErrorInfo(response)` on the **success** branches. This logged the platform's success response body at `[ERROR]` level even though the deployment succeeded — confusing users into thinking something failed when it did not.

Reported in Slack: a successful `timefold:deploy` printed the full model JSON response prefixed with `[ERROR]` right after `BUILD SUCCESS`.

## Fix

Removed the `printErrorInfo(response)` calls from the deploy and update success branches. `printErrorInfo` is now only invoked on the genuine failure branch (non-2xx/3xx, non-409 responses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)