### PR TITLE
fix: bring Jackson and Annotations in sync

### DIFF
--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -49,7 +49,9 @@
     <version.org.springframework.boot>4.1.0</version.org.springframework.boot>
     <version.org.wiremock>3.13.2</version.org.wiremock>
     <version.ow2.asm>9.10.1</version.ow2.asm>
+    <!-- Upgrade Jackson and its annotations together; otherwise there may be runtime errors. -->
     <version.tools.jackson>3.2.0</version.tools.jackson>
+    <version.com.fasterxml.jackson.core>2.22</version.com.fasterxml.jackson.core>
 
     <!-- ************************************************************************ -->
     <!-- Plugins -->
@@ -168,6 +170,12 @@
         <groupId>org.jspecify</groupId>
         <artifactId>jspecify</artifactId>
         <version>${version.org.jspecify}</version>
+      </dependency>
+      <!-- Quarkus may bring an outdated version, causing compatibility issues in timefold-solver-jackson. -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${version.com.fasterxml.jackson.core}</version>
       </dependency>
 
       <!-- ASM -->


### PR DESCRIPTION
This requires overriding the version of Jackson Annotations that we get from Quarkus. All tests suggest that this is a compatible release.