### PR TITLE
chore: add service parent pom metadata

### DIFF
--- a/service/facade/service-parent/pom.xml
+++ b/service/facade/service-parent/pom.xml
@@ -12,6 +12,27 @@
     This module is in a preview state and thus is a subject to changes.
   </description>
 
+  <url>https://solver.timefold.ai</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:git@github.com:TimefoldAI/timefold-solver.git</connection>
+    <developerConnection>scm:git:git@github.com:TimefoldAI/timefold-solver.git</developerConnection>
+    <url>https://github.com/TimefoldAI/timefold-solver</url>
+  </scm>
+  <developers>
+    <developer>
+      <name>Timefold Community</name>
+      <organization>Timefold</organization>
+      <organizationUrl>https://timefold.ai</organizationUrl>
+    </developer>
+  </developers>
+
   <properties>
     <revision>999-SNAPSHOT</revision>
     <ai.timefold.solver.enterprise>false</ai.timefold.solver.enterprise>


### PR DESCRIPTION
Fixes the failed deploy to Maven Central:

```
Caused by: jreleaser.shadow.org.jreleaser.model.spi.deploy.DeployException: deployment 45e8da94-ac25-41cf-877d-965ddee2f92f failed
pkg:maven/ai.timefold.solver/timefold-solver-service-parent@2.2.0 Project URL is not defined
pkg:maven/ai.timefold.solver/timefold-solver-service-parent@2.2.0 License information is missing
pkg:maven/ai.timefold.solver/timefold-solver-service-parent@2.2.0 SCM URL is not defined
pkg:maven/ai.timefold.solver/timefold-solver-service-parent@2.2.0 Developers information is missing
```