### PR TITLE
fix: Remove logging config for solver.service category

### DIFF
--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/TimefoldLoggingConfigProcessor.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/TimefoldLoggingConfigProcessor.java
@@ -24,8 +24,5 @@ public class TimefoldLoggingConfigProcessor {
                 new RunTimeConfigurationDefaultBuildItem("quarkus.log.handler.file.solver.filter", "solver-log-filter"));
         runtimeConfigBuildProducer.produce(
                 new RunTimeConfigurationDefaultBuildItem("quarkus.log.category.\"ai.timefold.solver\".handlers", "solver"));
-        runtimeConfigBuildProducer.produce(
-                new RunTimeConfigurationDefaultBuildItem("quarkus.log.category.\"ai.timefold.solver.service\".handlers",
-                        "solver"));
     }
 }


### PR DESCRIPTION
Removed logging configuration for 'ai.timefold.solver.service' category.
Fixes: https://sandbox.timefold.dev/dc6f4fa5-5f53-4f00-abac-464a6fca24d7/models/field-service-routing/v1/runs/f97b67f6-d9bb-4b14-bb37-e58a8e3f6aa3/log