### PR TITLE
perf: add ability to ignore inconsistent solutions

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/config/solver/PreviewFeature.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/PreviewFeature.java
@@ -21,6 +21,7 @@ public enum PreviewFeature {
 
     DIVERSIFIED_LATE_ACCEPTANCE,
     PLANNING_SOLUTION_DIFF,
+    IGNORE_INCONSISTENT_SOLUTIONS,
     /**
      * Unlike other preview features, Neighborhoods are an active research project.
      * It is intended to simplify the creation of custom moves, eventually replacing move selectors.

--- a/core/src/main/java/ai/timefold/solver/core/config/solver/PreviewFeature.java
+++ b/core/src/main/java/ai/timefold/solver/core/config/solver/PreviewFeature.java
@@ -21,7 +21,6 @@ public enum PreviewFeature {
 
     DIVERSIFIED_LATE_ACCEPTANCE,
     PLANNING_SOLUTION_DIFF,
-    IGNORE_INCONSISTENT_SOLUTIONS,
     /**
      * Unlike other preview features, Neighborhoods are an active research project.
      * It is intended to simplify the creation of custom moves, eventually replacing move selectors.

--- a/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
+++ b/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
@@ -151,7 +151,7 @@ public interface TimefoldSolverEnterpriseService {
         }
     }
 
-    TopologicalOrderGraph buildTopologyGraph(int size);
+    TopologicalOrderGraph buildTopologyGraph(int size, boolean ignoreInconsistentSolutions);
 
     /**
      * Will create new classes that apply node-sharing to the given {@link ConstraintProvider}.

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -59,6 +59,7 @@ import ai.timefold.solver.core.impl.domain.solution.cloner.FieldAccessingSolutio
 import ai.timefold.solver.core.impl.domain.solution.cloner.gizmo.GizmoSolutionCloner;
 import ai.timefold.solver.core.impl.domain.solution.cloner.gizmo.GizmoSolutionClonerFactory;
 import ai.timefold.solver.core.impl.domain.variable.declarative.DeclarativeShadowVariableDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.declarative.ShadowVariablesInconsistentVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.BasicVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
@@ -1037,6 +1038,13 @@ public final class SolutionDescriptor<Solution_> {
         return declarativeShadowVariableDescriptorList;
     }
 
+    public boolean hasAnyShadowVariablesInconsistentMember() {
+        return entityDescriptorMap.values().stream()
+                .flatMap(entityDescriptor -> entityDescriptor.getShadowVariableDescriptors().stream())
+                .anyMatch(
+                        shadowVariableDescriptor -> shadowVariableDescriptor instanceof ShadowVariablesInconsistentVariableDescriptor<Solution_>);
+    }
+
     public Stream<Object> extractAllEntitiesStream(Solution_ solution) {
         var stream = Stream.empty();
         for (var memberAccessor : entityMemberAccessorMap.values()) {
@@ -1102,5 +1110,4 @@ public final class SolutionDescriptor<Solution_> {
     public String toString() {
         return "%s(%s)".formatted(getClass().getSimpleName(), solutionClass.getName());
     }
-
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableUpdateHelper.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableUpdateHelper.java
@@ -106,7 +106,7 @@ public final class ShadowVariableUpdateHelper<Solution_> {
                             .formatted(missingShadowVariableTypeList));
         }
         // No solution, we trigger all supported events manually
-        var session = InternalShadowVariableSession.build(solutionDescriptor, entities);
+        var session = InternalShadowVariableSession.build(solutionDescriptor, false, entities);
         // Update all built-in shadow variables
         var listVariableDescriptor = solutionDescriptor.getListVariableDescriptor();
         if (listVariableDescriptor == null) {
@@ -123,12 +123,14 @@ public final class ShadowVariableUpdateHelper<Solution_> {
 
         public static <Solution_> InternalShadowVariableSession<Solution_> build(
                 SolutionDescriptor<Solution_> solutionDescriptor,
+                boolean ignoreInconsistentSolutions,
                 Object... entities) {
             return new InternalShadowVariableSession<>(solutionDescriptor,
                     DefaultShadowVariableSessionFactory.buildGraph(
                             new DefaultShadowVariableSessionFactory.GraphDescriptor<>(solutionDescriptor,
                                     ChangedVariableNotifier.empty(), entities)
-                                    .assertingNoReferencedMissingEntities()));
+                                    .assertingNoReferencedMissingEntities(),
+                            ignoreInconsistentSolutions));
         }
 
         /**
@@ -331,7 +333,7 @@ public final class ShadowVariableUpdateHelper<Solution_> {
         }
 
         @Override
-        public InnerScore<Score_> calculateScore() {
+        public InnerScore<Score_> innerCalculateScore() {
             throw new UnsupportedOperationException();
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AbstractVariableReferenceGraph.java
@@ -79,7 +79,7 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeTra
      *           and {@link #afterVariableChanged(VariableMetaModel, Object)}
      *           can short circuit.
      */
-    abstract void innerUpdateChanged();
+    abstract boolean innerUpdateChanged();
 
     /**
      * Called when any non-declarative source variable for the
@@ -90,10 +90,11 @@ public abstract sealed class AbstractVariableReferenceGraph<Solution_, ChangeTra
     abstract void markChanged(GraphNode<Solution_> changed);
 
     @Override
-    public final void updateChanged() {
+    public final boolean updateChanged() {
         isUpdating = true;
-        innerUpdateChanged();
+        var success = innerUpdateChanged();
         isUpdating = false;
+        return success;
     }
 
     private BaseTopologicalOrderGraph.NodeTopologicalOrder[] buildNodeTopologicalOrderArray(BaseTopologicalOrderGraph graph,

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
@@ -21,12 +21,16 @@ final class AffectedEntitiesUpdater<Solution_>
     // Internal state; expensive to create, therefore we reuse.
     private final LoopedTracker loopedTracker;
     private final BitSet visited;
+    private final boolean ignoreInconsistentSolutions;
     private final PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder> changeQueue;
+    private boolean consistencyProcessed;
+
 
     AffectedEntitiesUpdater(BaseTopologicalOrderGraph graph, List<GraphNode<Solution_>> nodeList,
             BaseTopologicalOrderGraph.NodeTopologicalOrder[] nodeTopologicalOrders,
             Function<Object, List<GraphNode<Solution_>>> entityToContainingNode,
-            int entityCount, ChangedVariableNotifier<Solution_> changedVariableNotifier) {
+            int entityCount, ChangedVariableNotifier<Solution_> changedVariableNotifier,
+            boolean ignoreInconsistentSolutions) {
         this.graph = graph;
         this.nodeList = nodeList;
         this.nodeTopologicalOrders = nodeTopologicalOrders;
@@ -36,6 +40,8 @@ final class AffectedEntitiesUpdater<Solution_>
                 createNodeToEntityNodes(entityCount, nodeList, entityToContainingNode));
         this.visited = new BitSet(instanceCount);
         this.changeQueue = new PriorityQueue<>(instanceCount);
+        this.ignoreInconsistentSolutions = ignoreInconsistentSolutions;
+        this.consistencyProcessed = false;
     }
 
     static <Solution_> int[][] createNodeToEntityNodes(int entityCount,
@@ -98,6 +104,7 @@ final class AffectedEntitiesUpdater<Solution_>
 
         // Prepare for the next time updateChanged() is called.
         // No need to clear changeQueue, as that already finishes empty.
+        consistencyProcessed = true;
         loopedTracker.clear();
         visited.clear();
     }
@@ -129,19 +136,22 @@ final class AffectedEntitiesUpdater<Solution_>
 
         // Do not need to update anyChanged here; the graph already marked
         // all nodes whose looped status changed for us
-        var groupEntities = shadowVariableReferences.get(0).groupEntities();
-        var groupEntityIds = entityVariable.groupEntityIds();
 
-        if (groupEntities != null) {
-            for (var i = 0; i < groupEntityIds.length; i++) {
-                var groupEntity = groupEntities[i];
-                var groupEntityId = groupEntityIds[i];
+        if (!ignoreInconsistentSolutions || !consistencyProcessed) {
+            var groupEntities = shadowVariableReferences.get(0).groupEntities();
+            var groupEntityIds = entityVariable.groupEntityIds();
+
+            if (groupEntities != null) {
+                for (var i = 0; i < groupEntityIds.length; i++) {
+                    var groupEntity = groupEntities[i];
+                    var groupEntityId = groupEntityIds[i];
+                    anyChanged |=
+                            updateLoopedStatusOfEntity(groupEntity, groupEntityId, entityConsistencyState);
+                }
+            } else {
                 anyChanged |=
-                        updateLoopedStatusOfEntity(groupEntity, groupEntityId, entityConsistencyState);
+                        updateLoopedStatusOfEntity(entity, entityVariable.entityId(), entityConsistencyState);
             }
-        } else {
-            anyChanged |=
-                    updateLoopedStatusOfEntity(entity, entityVariable.entityId(), entityConsistencyState);
         }
 
         for (var shadowVariableReference : shadowVariableReferences) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/AffectedEntitiesUpdater.java
@@ -25,7 +25,6 @@ final class AffectedEntitiesUpdater<Solution_>
     private final PriorityQueue<BaseTopologicalOrderGraph.NodeTopologicalOrder> changeQueue;
     private boolean consistencyProcessed;
 
-
     AffectedEntitiesUpdater(BaseTopologicalOrderGraph graph, List<GraphNode<Solution_>> nodeList,
             BaseTopologicalOrderGraph.NodeTopologicalOrder[] nodeTopologicalOrders,
             Function<Object, List<GraphNode<Solution_>>> entityToContainingNode,

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ConsistencyTracker.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/ConsistencyTracker.java
@@ -23,9 +23,11 @@ public record ConsistencyTracker<Solution_>(
     }
 
     public static <Solution_> ConsistencyTracker<Solution_> frozen(SolutionDescriptor<Solution_> solutionDescriptor,
+            boolean ignoreInconsistentSolutions,
             Object[] entityOrFacts) {
         var out = new ConsistencyTracker<Solution_>(true);
-        out.setUnknownConsistencyFromEntityShadowVariablesInconsistent(solutionDescriptor, entityOrFacts);
+        out.setUnknownConsistencyFromEntityShadowVariablesInconsistent(solutionDescriptor, ignoreInconsistentSolutions,
+                entityOrFacts);
         return out;
     }
 
@@ -46,6 +48,7 @@ public record ConsistencyTracker<Solution_>(
      * (regardless of its actual consistency in the graph).
      */
     void setUnknownConsistencyFromEntityShadowVariablesInconsistent(SolutionDescriptor<Solution_> solutionDescriptor,
+            boolean ignoreInconsistentSolutions,
             Object[] entityOrFacts) { // Not private so DefaultVariableReferenceGraph javadoc can reference it.
         var entities = Arrays.stream(entityOrFacts)
                 .filter(maybeEntity -> solutionDescriptor.hasEntityDescriptor(maybeEntity.getClass()))
@@ -60,7 +63,8 @@ public record ConsistencyTracker<Solution_>(
                         new DefaultShadowVariableSessionFactory.GraphDescriptor<>(solutionDescriptor,
                                 ChangedVariableNotifier.empty(), entities)
                                 .withConsistencyTracker(this)
-                                .assertingNoReferencedMissingEntities());
+                                .assertingNoReferencedMissingEntities(),
+                        ignoreInconsistentSolutions);
 
         // Graph will either be DefaultVariableReferenceGraph or EmptyVariableReferenceGraph
         // If it is empty, we don't need to do anything.
@@ -71,7 +75,7 @@ public record ConsistencyTracker<Solution_>(
 
     /**
      * If true, consistency and shadow variables are frozen and should not be updated.
-     * ConstraintVerifier creates a frozen instance via {@link #frozen(SolutionDescriptor, Object[])}.
+     * ConstraintVerifier creates a frozen instance via {@link #frozen(SolutionDescriptor, boolean, Object[])}.
      * 
      * @return true if consistency and shadow variables are frozen and should not be updated
      */

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
@@ -34,7 +34,7 @@ public final class DefaultShadowVariableSession<Solution_> implements Supply {
                 entity);
     }
 
-    public void updateVariables() {
-        graph.updateChanged();
+    public boolean updateVariables() {
+        return graph.updateChanged();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -162,29 +162,31 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         }
     }
 
-    public static <Solution_> VariableReferenceGraph buildGraph(GraphDescriptor<Solution_> graphDescriptor) {
+    public static <Solution_> VariableReferenceGraph buildGraph(GraphDescriptor<Solution_> graphDescriptor,
+            boolean ignoreInconsistentSolutions) {
         var graphStructureAndDirection = GraphStructure.determineGraphStructure(graphDescriptor.solutionDescriptor(),
                 graphDescriptor.entities());
         LOGGER.trace("Shadow variable graph structure: {}", graphStructureAndDirection);
-        return buildGraphForStructureAndDirection(graphStructureAndDirection, graphDescriptor);
+        return buildGraphForStructureAndDirection(graphStructureAndDirection, graphDescriptor, ignoreInconsistentSolutions);
     }
 
     static <Solution_> VariableReferenceGraph buildGraphForStructureAndDirection(
-            GraphStructure.GraphStructureAndDirection graphStructureAndDirection, GraphDescriptor<Solution_> graphDescriptor) {
+            GraphStructure.GraphStructureAndDirection graphStructureAndDirection, GraphDescriptor<Solution_> graphDescriptor,
+            boolean ignoreInconsistentSolutions) {
         return switch (graphStructureAndDirection.structure()) {
             case EMPTY -> EmptyVariableReferenceGraph.INSTANCE;
             case SINGLE_DIRECTIONAL_PARENT -> {
                 var scoreDirector =
                         graphDescriptor.variableReferenceGraphBuilder().changedVariableNotifier.innerScoreDirector();
                 if (scoreDirector == null) {
-                    yield buildArbitraryGraph(graphDescriptor);
+                    yield buildArbitraryGraph(graphDescriptor, ignoreInconsistentSolutions);
                 }
                 yield buildSingleDirectionalParentGraph(graphDescriptor, graphStructureAndDirection);
             }
             case ARBITRARY_SINGLE_ENTITY_AT_MOST_ONE_DIRECTIONAL_PARENT_TYPE ->
-                buildArbitrarySingleEntityGraph(graphDescriptor);
+                buildArbitrarySingleEntityGraph(graphDescriptor, ignoreInconsistentSolutions);
             case NO_DYNAMIC_EDGES, ARBITRARY ->
-                buildArbitraryGraph(graphDescriptor);
+                buildArbitraryGraph(graphDescriptor, ignoreInconsistentSolutions);
         };
     }
 
@@ -280,7 +282,8 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         };
     }
 
-    private static <Solution_> VariableReferenceGraph buildArbitraryGraph(GraphDescriptor<Solution_> graphDescriptor) {
+    private static <Solution_> VariableReferenceGraph buildArbitraryGraph(GraphDescriptor<Solution_> graphDescriptor,
+            boolean ignoreInconsistentSolutions) {
         var declarativeShadowVariableDescriptors =
                 graphDescriptor.solutionDescriptor().getDeclarativeShadowVariableDescriptors();
         var variableIdToUpdater = EntityVariableUpdaterLookup.<Solution_> entityIndependentLookup();
@@ -294,13 +297,14 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
                 graphDescriptor,
                 declarativeShadowVariableDescriptors, variableIdToUpdater);
         return buildVariableReferenceGraph(graphDescriptor, declarativeShadowVariableDescriptors,
-                declarativeShadowVariableToAliasMap);
+                declarativeShadowVariableToAliasMap, ignoreInconsistentSolutions);
     }
 
     private static <Solution_> VariableReferenceGraph buildVariableReferenceGraph(
             GraphDescriptor<Solution_> graphDescriptor,
             List<DeclarativeShadowVariableDescriptor<Solution_>> declarativeShadowVariableDescriptors,
-            Map<VariableMetaModel<?, ?, ?>, Set<VariableSourceReference>> declarativeShadowVariableToAliasMap) {
+            Map<VariableMetaModel<?, ?, ?>, Set<VariableSourceReference>> declarativeShadowVariableToAliasMap,
+            boolean ignoreInconsistentSolutions) {
         // Create variable processors for each declarative shadow variable descriptor
         for (var declarativeShadowVariable : declarativeShadowVariableDescriptors) {
             var fromVariableId = declarativeShadowVariable.getVariableMetaModel();
@@ -315,7 +319,8 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
         // Create the fixed edges in the graph
         createFixedVariableRelationEdges(graphDescriptor.variableReferenceGraphBuilder(), graphDescriptor.entities(),
                 declarativeShadowVariableDescriptors);
-        return graphDescriptor.variableReferenceGraphBuilder().build(graphDescriptor.graphCreator());
+        return graphDescriptor.variableReferenceGraphBuilder().build(graphDescriptor.graphCreator(),
+                ignoreInconsistentSolutions);
     }
 
     private record GroupVariableUpdaterInfo<Solution_>(
@@ -443,7 +448,7 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
     }
 
     private static <Solution_> VariableReferenceGraph buildArbitrarySingleEntityGraph(
-            GraphDescriptor<Solution_> graphDescriptor) {
+            GraphDescriptor<Solution_> graphDescriptor, boolean ignoreInconsistentSolutions) {
         var declarativeShadowVariableDescriptors =
                 graphDescriptor.solutionDescriptor().getDeclarativeShadowVariableDescriptors();
         // Use a dependent lookup; if an entity does not use groups, then all variables can share the same node.
@@ -475,7 +480,7 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
                 (entity, declarativeShadowVariable, variableId) -> variableIdToGroupedUpdater.get(variableId)
                         .getUpdatersForEntityVariable(entity, declarativeShadowVariable));
         return buildVariableReferenceGraph(graphDescriptor, declarativeShadowVariableDescriptors,
-                declarativeShadowVariableToAliasMap);
+                declarativeShadowVariableToAliasMap, ignoreInconsistentSolutions);
     }
 
     private static <Solution_> Map<VariableMetaModel<?, ?, ?>, Set<VariableSourceReference>> createGraphNodes(
@@ -691,18 +696,21 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
     }
 
     public DefaultShadowVariableSession<Solution_> forSolution(ConsistencyTracker<Solution_> consistencyTracker,
+            boolean ignoreInconsistentSolutions,
             Solution_ solution) {
         var entities = new ArrayList<>();
         solutionDescriptor.visitAllEntities(solution, entities::add);
-        return forEntities(consistencyTracker, entities.toArray());
+        return forEntities(consistencyTracker, ignoreInconsistentSolutions, entities.toArray());
     }
 
     public DefaultShadowVariableSession<Solution_> forEntities(ConsistencyTracker<Solution_> consistencyTracker,
+            boolean ignoreInconsistentSolutions,
             Object... entities) {
         var graph = buildGraph(
                 new GraphDescriptor<>(solutionDescriptor, ChangedVariableNotifier.of(scoreDirector), entities)
                         .withConsistencyTracker(consistencyTracker)
-                        .withGraphCreator(graphCreator));
+                        .withGraphCreator(graphCreator),
+                ignoreInconsistentSolutions);
         return new DefaultShadowVariableSession<>(graph);
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultTopologicalOrderGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultTopologicalOrderGraph.java
@@ -117,7 +117,7 @@ public class DefaultTopologicalOrderGraph implements TopologicalOrderGraph {
     }
 
     @Override
-    public void commitChanges(BitSet changed) {
+    public boolean commitChanges(BitSet changed) {
         var index = new MutableInt(1);
         var stackIndex = new MutableInt(0);
         var size = forwardEdges.length;
@@ -126,6 +126,7 @@ public class DefaultTopologicalOrderGraph implements TopologicalOrderGraph {
         var lowMap = new int[size];
         var onStackSet = new boolean[size];
         var components = new ArrayList<BitSet>();
+        var anyLooped = false;
         componentMap.clear();
 
         for (var node = 0; node < size; node++) {
@@ -139,6 +140,7 @@ public class DefaultTopologicalOrderGraph implements TopologicalOrderGraph {
             var component = components.get(i);
             var componentSize = component.cardinality();
             var isComponentLooped = componentSize != 1;
+            anyLooped |= isComponentLooped;
             var componentNodes = new ArrayList<Integer>(componentSize);
             for (var node = component.nextSetBit(0); node >= 0; node = component.nextSetBit(node + 1)) {
                 nodeIdToTopologicalOrderMap[node] = ordIndex;
@@ -159,6 +161,7 @@ public class DefaultTopologicalOrderGraph implements TopologicalOrderGraph {
                 }
             }
         }
+        return anyLooped;
     }
 
     private void strongConnect(int node, MutableInt index, MutableInt stackIndex, int[] stack,

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -11,11 +11,13 @@ import org.jspecify.annotations.NonNull;
 final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableReferenceGraph<Solution_, BitSet> {
     // These structures are mutable.
     private final AffectedEntitiesUpdater<Solution_> affectedEntitiesUpdater;
+    private final boolean ignoreInconsistentSolutions;
 
     public DefaultVariableReferenceGraph(VariableReferenceGraphBuilder<Solution_> outerGraph,
-            IntFunction<TopologicalOrderGraph> graphCreator) {
+            IntFunction<TopologicalOrderGraph> graphCreator,
+            boolean ignoreInconsistentSolutions) {
         super(outerGraph, graphCreator);
-
+        this.ignoreInconsistentSolutions = ignoreInconsistentSolutions;
         var entityToVariableReferenceMap = new IdentityHashMap<Object, List<GraphNode<Solution_>>>();
         for (var instance : nodeList) {
             if (instance.groupEntityIds() == null) {
@@ -49,12 +51,16 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
     }
 
     @Override
-    void innerUpdateChanged() {
+    boolean innerUpdateChanged() {
         if (changeTracker.isEmpty()) {
-            return;
+            return true;
         }
-        graph.commitChanges(changeTracker);
-        affectedEntitiesUpdater.accept(changeTracker);
+        if (graph.commitChanges(changeTracker) && ignoreInconsistentSolutions) {
+            return false;
+        } else {
+            affectedEntitiesUpdater.accept(changeTracker);
+            return true;
+        }
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -37,7 +37,8 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
         affectedEntitiesUpdater =
                 new AffectedEntitiesUpdater<>(graph, nodeList, nodeTopologicalOrders,
                         entityToVariableReferenceMap::get,
-                        outerGraph.entityToEntityId.size(), outerGraph.changedVariableNotifier);
+                        outerGraph.entityToEntityId.size(), outerGraph.changedVariableNotifier,
+                        ignoreInconsistentSolutions);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
@@ -7,8 +7,9 @@ final class EmptyVariableReferenceGraph implements VariableReferenceGraph {
     public static final EmptyVariableReferenceGraph INSTANCE = new EmptyVariableReferenceGraph();
 
     @Override
-    public void updateChanged() {
+    public boolean updateChanged() {
         // No need to do anything.
+        return true;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -74,13 +74,13 @@ public final class FixedVariableReferenceGraph<Solution_>
     }
 
     @Override
-    void innerUpdateChanged() {
+    boolean innerUpdateChanged() {
         BitSet visited;
         if (!changeTracker.isEmpty()) {
             visited = new BitSet(nodeList.size());
             visited.set(changeTracker.peek().nodeId());
         } else {
-            return;
+            return true;
         }
 
         // NOTE: This assumes the user did not add any fixed loops to
@@ -104,5 +104,6 @@ public final class FixedVariableReferenceGraph<Solution_>
             }
         }
         isChanged.clear();
+        return true;
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
@@ -80,7 +80,7 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
     }
 
     @Override
-    public void updateChanged() {
+    public boolean updateChanged() {
         isUpdating = true;
         changedEntities.sort(topologicalOrderComparator);
         for (var changedEntity : changedEntities) {
@@ -94,6 +94,7 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
         isUpdating = false;
         changedEntities.clear();
         keyToLastProcessedObject.clear();
+        return true;
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalOrderGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/TopologicalOrderGraph.java
@@ -9,8 +9,10 @@ public interface TopologicalOrderGraph extends BaseTopologicalOrderGraph {
      * Called when all edge modifications are queued.
      * After this method returns, {@link #getTopologicalOrder(int)}
      * must be accurate for every node in the graph.
+     *
+     * @return true if the graph has loops, false otherwise
      */
-    void commitChanges(BitSet changed);
+    boolean commitChanges(BitSet changed);
 
     /**
      * Called on graph creation to supply metadata about the graph nodes.

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -13,8 +13,10 @@ public sealed interface VariableReferenceGraph
      * Called after all {@link ai.timefold.solver.core.impl.domain.variable.VariableListener} are
      * triggered. Declarative {@link ai.timefold.solver.core.api.domain.variable.ShadowVariable}
      * are guaranteed to be the last variables to update.
+     *
+     * @return true if the update successful; false otherwise
      */
-    void updateChanged();
+    boolean updateChanged();
 
     /**
      * Called before the variable corresponding to the {@link VariableMetaModel} on the given entity changes.

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraphBuilder.java
@@ -116,7 +116,8 @@ public final class VariableReferenceGraphBuilder<Solution_> {
                 .add(consumer);
     }
 
-    public VariableReferenceGraph build(IntFunction<TopologicalOrderGraph> graphCreator) {
+    public VariableReferenceGraph build(IntFunction<TopologicalOrderGraph> graphCreator,
+            boolean ignoreInconsistentSolutions) {
         assertNoFixedLoops();
         if (nodeList.isEmpty()) {
             return EmptyVariableReferenceGraph.INSTANCE;
@@ -124,7 +125,7 @@ public final class VariableReferenceGraphBuilder<Solution_> {
         if (isGraphFixed) {
             return new FixedVariableReferenceGraph<>(this, graphCreator);
         }
-        return new DefaultVariableReferenceGraph<>(this, graphCreator);
+        return new DefaultVariableReferenceGraph<>(this, graphCreator, ignoreInconsistentSolutions);
     }
 
     public @NonNull GraphNode<Solution_> lookupOrError(VariableMetaModel<?, ?, ?> variableId, Object entity) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
@@ -57,7 +57,8 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
 
     public static <Solution_> VariableListenerSupport<Solution_> create(InnerScoreDirector<Solution_, ?> scoreDirector) {
         return new VariableListenerSupport<>(scoreDirector, new NotifiableRegistry<>(scoreDirector.getSolutionDescriptor()),
-                TimefoldSolverEnterpriseService.loadOrDefault(service -> service::buildTopologyGraph,
+                TimefoldSolverEnterpriseService.loadOrDefault(
+                        service -> size -> service.buildTopologyGraph(size, scoreDirector.ignoreInconsistentSolutions()),
                         () -> DefaultTopologicalOrderGraph::new));
     }
 
@@ -74,6 +75,7 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
     private final IntFunction<TopologicalOrderGraph> shadowVariableGraphCreator;
 
     private boolean notificationQueuesAreEmpty = true;
+    private boolean updateSuccessful = true;
     private int nextGlobalOrder = 0;
     @Nullable
     private DefaultShadowVariableSession<Solution_> shadowVariableSession = null;
@@ -253,7 +255,9 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
                     scoreDirector,
                     shadowVariableGraphCreator);
             shadowVariableSession =
-                    shadowVariableSessionFactory.forSolution(consistencyTracker, scoreDirector.getWorkingSolution());
+                    shadowVariableSessionFactory.forSolution(consistencyTracker,
+                            scoreDirector.ignoreInconsistentSolutions(),
+                            scoreDirector.getWorkingSolution());
         }
     }
 
@@ -332,12 +336,12 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
         return scoreDirector;
     }
 
-    public void triggerVariableListenersInNotificationQueues() {
+    public boolean triggerVariableListenersInNotificationQueues() {
         if (notificationQueuesAreEmpty) {
             // Shortcut in case the trigger is called multiple times in a row,
             // without any notifications inbetween.
             // This is better than trying to ensure that the situation never ever occurs.
-            return;
+            return updateSuccessful;
         }
         for (var notifiable : notifiableRegistry.getAll()) {
             notifiable.triggerAllNotifications();
@@ -352,15 +356,22 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
             listVariableChangedNotificationList.clear();
         }
         if (shadowVariableSession != null) {
-            shadowVariableSession.updateVariables();
-            // Some internal variable listeners (such as those used
-            // to check for solution corruption) might have a declarative
-            // shadow variable as a source and need to be triggered here.
-            for (var notifiable : notifiableRegistry.getAll()) {
-                notifiable.triggerAllNotifications();
+            if (shadowVariableSession.updateVariables()) {
+                // Some internal variable listeners (such as those used
+                // to check for solution corruption) might have a declarative
+                // shadow variable as a source and need to be triggered here.
+                for (var notifiable : notifiableRegistry.getAll()) {
+                    notifiable.triggerAllNotifications();
+                }
+            } else {
+                updateSuccessful = false;
+                notificationQueuesAreEmpty = true;
+                return false;
             }
         }
+        updateSuccessful = true;
         notificationQueuesAreEmpty = true;
+        return true;
     }
 
     /**
@@ -439,9 +450,9 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
      *
      * @param workingSolution working solution
      */
-    public void forceTriggerAllVariableListeners(Solution_ workingSolution) {
+    public boolean forceTriggerAllVariableListeners(Solution_ workingSolution) {
         scoreDirector.getSolutionDescriptor().visitAllEntities(workingSolution, this::simulateGenuineVariableChange);
-        triggerVariableListenersInNotificationQueues();
+        return triggerVariableListenersInNotificationQueues();
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/CompositeAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/CompositeAcceptor.java
@@ -52,6 +52,9 @@ public class CompositeAcceptor<Solution_> extends AbstractAcceptor<Solution_> {
 
     @Override
     public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
+        if (moveScope.getScore().isInvalid()) {
+            return false;
+        }
         for (Acceptor<Solution_> acceptor : acceptorList) {
             boolean accepted = acceptor.isAccepted(moveScope);
             if (!accepted) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptor.java
@@ -63,6 +63,9 @@ public class GreatDelugeAcceptor<Solution_> extends AbstractAcceptor<Solution_> 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public boolean isAccepted(LocalSearchMoveScope moveScope) {
+        if (moveScope.getScore().isInvalid()) {
+            return false;
+        }
         var moveScore = moveScope.getScore().raw();
         if (moveScore.compareTo(currentWaterLevel) >= 0) {
             return true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptor.java
@@ -10,6 +10,9 @@ public class HillClimbingAcceptor<Solution_> extends AbstractAcceptor<Solution_>
     @Override
     public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         InnerScore moveScore = moveScope.getScore();
+        if (moveScore.isInvalid()) {
+            return false;
+        }
         InnerScore lastStepScore = moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore();
         return moveScore.compareTo(lastStepScore) >= 0;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/DiversifiedLateAcceptanceAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/DiversifiedLateAcceptanceAcceptor.java
@@ -53,6 +53,9 @@ public class DiversifiedLateAcceptanceAcceptor<Solution_> extends AbstractAccept
         // The acceptance and replacement strategies are based on the work:
         // Diversified Late Acceptance Search by M. Namazi, C. Sanderson, M. A. H. Newton, M. M. A. Polash, and A. Sattar
         var moveScore = moveScope.getScore();
+        if (moveScore.isInvalid()) {
+            return false;
+        }
         var current = (InnerScore) moveScope.getStepScope().getPhaseScope()
                 .getLastCompletedStepScope().getScore();
         var previous = current;

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptor.java
@@ -50,6 +50,9 @@ public class LateAcceptanceAcceptor<Solution_> extends AbstractAcceptor<Solution
     @Override
     public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         var moveScore = (InnerScore) moveScope.getScore();
+        if (moveScore.isInvalid()) {
+            return false;
+        }
         var lateScore = getPreviousScore(lateScoreIndex);
         if (moveScore.compareTo(lateScore) >= 0) {
             return true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptor.java
@@ -57,6 +57,10 @@ public class SimulatedAnnealingAcceptor<Solution_> extends AbstractAcceptor<Solu
         // Guaranteed local search; no need for InnerScore.
         Score lastStepScore = phaseScope.getLastCompletedStepScope().getScore().raw();
         Score moveScore = moveScope.getScore().raw();
+        var thisStepInvalid = moveScope.getScore().isInvalid();
+        if (thisStepInvalid) {
+            return false;
+        }
         if (moveScore.compareTo(lastStepScore) >= 0) {
             return true;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptor.java
@@ -45,6 +45,9 @@ public class StepCountingHillClimbingAcceptor<Solution_> extends AbstractAccepto
     public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         InnerScore lastStepScore = moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore();
         InnerScore moveScore = moveScope.getScore();
+        if (moveScore.isInvalid()) {
+            return false;
+        }
         if (moveScore.compareTo(lastStepScore) >= 0) {
             return true;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
@@ -124,6 +124,10 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
 
     @Override
     public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
+        var thisStepInvalid = moveScope.getScore().isInvalid();
+        if (thisStepInvalid) {
+            return false;
+        }
         var maximumTabuStepIndex = locateMaximumTabuStepIndex(moveScope);
         if (maximumTabuStepIndex < 0) {
             // The move isn't tabu at all

--- a/core/src/main/java/ai/timefold/solver/core/impl/move/MoveTesterScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/move/MoveTesterScoreDirector.java
@@ -26,7 +26,7 @@ final class MoveTesterScoreDirector<Solution_, Score_ extends Score<Score_>>
     }
 
     @Override
-    public InnerScore<Score_> calculateScore() {
+    public InnerScore<Score_> innerCalculateScore() {
         return InnerScore.fullyAssigned(scoreDirectorFactory.getScoreDefinition().getZeroScore());
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -75,6 +75,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     private final @Nullable LookupManager lookUpManager;
     protected final ConstraintMatchPolicy constraintMatchPolicy;
     private boolean expectShadowVariablesInCorrectState;
+    private boolean ignoreInconsistentSolutions;
     private final VariableDescriptorCache<Solution_> variableDescriptorCache;
     protected final VariableListenerSupport<Solution_> variableListenerSupport;
     private final @Nullable SolutionTracker<Solution_> solutionTracker; // Null when tracking disabled.
@@ -95,6 +96,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     private long calculationCount = 0L;
     protected @Nullable Solution_ workingSolution;
     private int workingInitScore = 0;
+    private boolean lastVariableUpdateWasSuccessful = true;
 
     private final boolean isStepAssertOrMore;
 
@@ -109,6 +111,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         this.lookUpManager = lookUpEnabled ? new LookupManager(solutionDescriptor.getLookUpStrategyResolver()) : null;
         this.constraintMatchPolicy = builder.constraintMatchPolicy;
         this.expectShadowVariablesInCorrectState = builder.expectShadowVariablesInCorrectState;
+        this.ignoreInconsistentSolutions = builder.ignoreInconsistentSolutions;
         this.variableDescriptorCache = new VariableDescriptorCache<>(solutionDescriptor);
         this.variableListenerSupport = VariableListenerSupport.create(this);
         this.variableListenerSupport.linkVariableListeners();
@@ -168,6 +171,11 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     @Override
     public boolean expectShadowVariablesInCorrectState() {
         return expectShadowVariablesInCorrectState;
+    }
+
+    @Override
+    public boolean ignoreInconsistentSolutions() {
+        return ignoreInconsistentSolutions;
     }
 
     @Override
@@ -234,6 +242,19 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     // ************************************************************************
     // Complex methods
     // ************************************************************************
+
+    public abstract InnerScore<Score_> innerCalculateScore();
+
+    @Override
+    public final InnerScore<Score_> calculateScore() {
+        if (lastVariableUpdateWasSuccessful) {
+            return innerCalculateScore();
+        } else {
+            var invalidScore = InnerScore.invalid(getScoreDefinition().getZeroScore());
+            getSolutionDescriptor().setScore(workingSolution, invalidScore.raw());
+            return invalidScore;
+        }
+    }
 
     /**
      * Note: resetting the working solution does NOT substitute the calls to before/after methods of
@@ -413,7 +434,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public void triggerVariableListeners() {
-        variableListenerSupport.triggerVariableListenersInNotificationQueues();
+        lastVariableUpdateWasSuccessful = variableListenerSupport.triggerVariableListenersInNotificationQueues();
     }
 
     /**
@@ -428,7 +449,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public void forceTriggerVariableListeners() {
-        variableListenerSupport.forceTriggerAllVariableListeners(getWorkingSolution());
+        lastVariableUpdateWasSuccessful = variableListenerSupport.forceTriggerAllVariableListeners(getWorkingSolution());
     }
 
     protected void setCalculatedScore(Score_ score) {
@@ -440,15 +461,21 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     public InnerScoreDirector<Solution_, Score_> createChildThreadScoreDirector(ChildThreadType childThreadType) {
         // Most score directors don't need derived status; CS will override this.
         if (childThreadType == ChildThreadType.PART_THREAD) {
-            var childThreadScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder().withLookUpEnabled(lookUpEnabled)
-                    .withConstraintMatchPolicy(constraintMatchPolicy).buildDerived();
+            var childThreadScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
+                    .withLookUpEnabled(lookUpEnabled)
+                    .withConstraintMatchPolicy(constraintMatchPolicy)
+                    .withIgnoreInconsistentSolutions(ignoreInconsistentSolutions)
+                    .buildDerived();
             // ScoreCalculationCountTermination takes into account previous phases
             // but the calculationCount of partitions is maxed, not summed.
             childThreadScoreDirector.calculationCount = calculationCount;
             return childThreadScoreDirector;
         } else if (childThreadType == ChildThreadType.MOVE_THREAD) {
-            var childThreadScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder().withLookUpEnabled(true)
-                    .withConstraintMatchPolicy(constraintMatchPolicy).buildDerived();
+            var childThreadScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
+                    .withLookUpEnabled(true)
+                    .withConstraintMatchPolicy(constraintMatchPolicy)
+                    .withIgnoreInconsistentSolutions(ignoreInconsistentSolutions)
+                    .buildDerived();
             childThreadScoreDirector.setWorkingSolution(cloneWorkingSolution());
             return childThreadScoreDirector;
         } else {
@@ -719,7 +746,9 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         }
         // Most score directors don't need derived status; CS will override this.
         try (var uncorruptedScoreDirector = assertionScoreDirectorFactory.createScoreDirectorBuilder()
-                .withConstraintMatchPolicy(ConstraintMatchPolicy.ENABLED).buildDerived()) {
+                .withConstraintMatchPolicy(ConstraintMatchPolicy.ENABLED)
+                .withIgnoreInconsistentSolutions(ignoreInconsistentSolutions)
+                .buildDerived()) {
             uncorruptedScoreDirector.setWorkingSolution(workingSolution);
             var uncorruptedInnerScore = uncorruptedScoreDirector.calculateScore();
             if (!innerScore.equals(uncorruptedInnerScore)) {
@@ -917,6 +946,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         protected ConstraintMatchPolicy constraintMatchPolicy = ConstraintMatchPolicy.DISABLED;
         protected boolean lookUpEnabled = false;
         protected boolean expectShadowVariablesInCorrectState = true;
+        protected boolean ignoreInconsistentSolutions = false;
 
         protected AbstractScoreDirectorBuilder(Factory_ scoreDirectorFactory) {
             this.scoreDirectorFactory = Objects.requireNonNull(scoreDirectorFactory);
@@ -937,6 +967,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         @SuppressWarnings("unchecked")
         public Builder_ withExpectShadowVariablesInCorrectState(boolean expectShadowVariablesInCorrectState) {
             this.expectShadowVariablesInCorrectState = expectShadowVariablesInCorrectState;
+            return (Builder_) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Builder_ withIgnoreInconsistentSolutions(boolean ignoreInconsistentSolutions) {
+            this.ignoreInconsistentSolutions = ignoreInconsistentSolutions;
             return (Builder_) this;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScore.java
@@ -34,6 +34,10 @@ public record InnerScore<Score_ extends Score<Score_>>(Score_ raw, int unassigne
         return new InnerScore<>(score, unassignedCount);
     }
 
+    public static <Score_ extends Score<Score_>> InnerScore<Score_> invalid(Score_ zeroScore) {
+        return new InnerScore<>(zeroScore, Integer.MAX_VALUE);
+    }
+
     public InnerScore {
         Objects.requireNonNull(raw);
         if (unassignedCount < 0) {
@@ -44,6 +48,10 @@ public record InnerScore<Score_ extends Score<Score_>>(Score_ raw, int unassigne
 
     public boolean isFullyAssigned() {
         return unassignedCount == 0;
+    }
+
+    public boolean isInvalid() {
+        return unassignedCount == Integer.MAX_VALUE;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -168,6 +168,8 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
      */
     boolean expectShadowVariablesInCorrectState();
 
+    boolean ignoreInconsistentSolutions();
+
     /**
      * @return never null
      */

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/easy/EasyScoreDirector.java
@@ -44,7 +44,7 @@ public final class EasyScoreDirector<Solution_, Score_ extends Score<Score_>>
     }
 
     @Override
-    public InnerScore<Score_> calculateScore() {
+    public InnerScore<Score_> innerCalculateScore() {
         variableListenerSupport.assertNotificationQueuesAreEmpty();
         var score = easyScoreCalculator.calculateScore(workingSolution);
         setCalculatedScore(score);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/incremental/IncrementalScoreDirector.java
@@ -79,7 +79,7 @@ public final class IncrementalScoreDirector<Solution_, Score_ extends Score<Scor
     }
 
     @Override
-    public InnerScore<Score_> calculateScore() {
+    public InnerScore<Score_> innerCalculateScore() {
         variableListenerSupport.assertNotificationQueuesAreEmpty();
         var score = Objects.requireNonNull(incrementalScoreCalculator.calculateScore(),
                 () -> "The incrementalScoreCalculator (%s) must return a non-null score in the method calculateScore()."

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
@@ -71,6 +71,7 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
         solutionDescriptor.visitAllEntities(solution, entityList::add);
         variableListenerSupport.setConsistencyTracker(ConsistencyTracker.frozen(
                 getSolutionDescriptor(),
+                ignoreInconsistentSolutions(),
                 entityList.toArray()));
     }
 
@@ -89,7 +90,7 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
     }
 
     @Override
-    public InnerScore<Score_> calculateScore() {
+    public InnerScore<Score_> innerCalculateScore() {
         variableListenerSupport.assertNotificationQueuesAreEmpty();
         var score = session.calculateScore();
         setCalculatedScore(score);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirectorFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/stream/BavetConstraintStreamScoreDirectorFactory.java
@@ -85,7 +85,7 @@ public final class BavetConstraintStreamScoreDirectorFactory<Solution_, Score_ e
 
     @Override
     public AbstractScoreInliner<Score_> fireAndForget(Object... facts) {
-        var consistencyTracker = ConsistencyTracker.frozen(solutionDescriptor, facts);
+        var consistencyTracker = ConsistencyTracker.frozen(solutionDescriptor, false, facts);
         var session = newSession(null, consistencyTracker,
                 ConstraintMatchPolicy.ENABLED, true);
         Arrays.stream(facts).forEach(session::insert);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -125,9 +125,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
         }
         var castScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
                 .withLookUpEnabled(true) // Custom phases and problem changes may rely on lookups.
-                .withIgnoreInconsistentSolutions(Objects.requireNonNullElse(
-                        solverConfig.getEnablePreviewFeatureSet(), Collections.emptySet())
-                        .contains(PreviewFeature.IGNORE_INCONSISTENT_SOLUTIONS))
+                .withIgnoreInconsistentSolutions(!solutionDescriptor.hasAnyShadowVariablesInconsistentMember())
                 .withConstraintMatchPolicy(
                         constraintMatchEnabled ? ConstraintMatchPolicy.ENABLED : ConstraintMatchPolicy.DISABLED)
                 .build();

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -125,6 +125,9 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
         }
         var castScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
                 .withLookUpEnabled(true) // Custom phases and problem changes may rely on lookups.
+                .withIgnoreInconsistentSolutions(Objects.requireNonNullElse(
+                        solverConfig.getEnablePreviewFeatureSet(), Collections.emptySet())
+                        .contains(PreviewFeature.IGNORE_INCONSISTENT_SOLUTIONS))
                 .withConstraintMatchPolicy(
                         constraintMatchEnabled ? ConstraintMatchPolicy.ENABLED : ConstraintMatchPolicy.DISABLED)
                 .build();

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -50,6 +50,11 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
         // Starting bestSolution is already set by Solver.solve(Solution)
         var scoreDirector = solverScope.getScoreDirector();
         InnerScore innerScore = scoreDirector.calculateScore();
+        if (innerScore.isInvalid()) {
+            throw new IllegalStateException(
+                    "The initial solution passed to the solver (%s) is invalid because it has dependency loops."
+                            .formatted(solverScope.getWorkingSolution()));
+        }
         var score = innerScore.raw();
         solverScope.setBestScore(innerScore);
         solverScope.setBestSolutionTimeMillis(solverScope.getClock().millis());

--- a/core/src/main/resources/solver.xsd
+++ b/core/src/main/resources/solver.xsd
@@ -1461,8 +1461,6 @@
             
       <xs:enumeration value="PLANNING_SOLUTION_DIFF"/>
             
-      <xs:enumeration value="IGNORE_INCONSISTENT_SOLUTIONS"/>
-            
       <xs:enumeration value="NEIGHBORHOODS"/>
           
     </xs:restriction>

--- a/core/src/main/resources/solver.xsd
+++ b/core/src/main/resources/solver.xsd
@@ -1461,6 +1461,8 @@
             
       <xs:enumeration value="PLANNING_SOLUTION_DIFF"/>
             
+      <xs:enumeration value="IGNORE_INCONSISTENT_SOLUTIONS"/>
+            
       <xs:enumeration value="NEIGHBORHOODS"/>
           
     </xs:restriction>

--- a/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/composite/CompositeAcceptorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/composite/CompositeAcceptorTest.java
@@ -8,11 +8,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 
+import ai.timefold.solver.core.api.score.SimpleScore;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.Acceptor;
 import ai.timefold.solver.core.impl.localsearch.decider.acceptor.CompositeAcceptor;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchStepScope;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.testdomain.TestdataSolution;
 
@@ -66,6 +68,8 @@ class CompositeAcceptorTest {
             acceptorList.add(acceptor);
         }
         var acceptor = new CompositeAcceptor<>(acceptorList);
-        return acceptor.isAccepted(mock(LocalSearchMoveScope.class));
+        var moveScope = mock(LocalSearchMoveScope.class);
+        when(moveScope.getScore()).thenReturn(InnerScore.fullyAssigned(new SimpleScore(0)));
+        return acceptor.isAccepted(moveScope);
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -1449,6 +1449,87 @@ class DefaultSolverTest {
         assertThat(solution.getScore()).isEqualTo(HardSoftScore.of(0, -240));
     }
 
+    @Test
+    void solveWhenIgnoringInconsistentSolutionsThrowsIfInitialSolutionInconsistent() {
+        // Solver config
+        var solverConfig = PlannerTestUtils.buildSolverConfig(
+                TestdataConcurrentSolution.class, TestdataConcurrentEntity.class, TestdataConcurrentValue.class)
+                .withEasyScoreCalculatorClass(null)
+                .withConstraintProviderClass(TestdataConcurrentConstraintProvider.class)
+                .withPreviewFeature(PreviewFeature.IGNORE_INCONSISTENT_SOLUTIONS);
+
+        var e1 = new TestdataConcurrentEntity("e1");
+        var e2 = new TestdataConcurrentEntity("e2");
+
+        var a1 = new TestdataConcurrentValue("a1");
+        var a2 = new TestdataConcurrentValue("a2");
+        var b1 = new TestdataConcurrentValue("b1");
+        var b2 = new TestdataConcurrentValue("b2");
+
+        a1.setConcurrentValueGroup(List.of(a1, a2));
+        a2.setConcurrentValueGroup(List.of(a1, a2));
+
+        b1.setConcurrentValueGroup(List.of(b1, b2));
+        b2.setConcurrentValueGroup(List.of(b1, b2));
+
+        e1.setValues(List.of(a1, b1));
+        e2.setValues(List.of(b2, a2));
+
+        var entities = List.of(e1, e2);
+        var values = List.of(a1, a2, b1, b2);
+
+        var problem = new TestdataConcurrentSolution();
+
+        problem.setEntities(entities);
+        problem.setValues(values);
+
+        assertThatCode(() -> PlannerTestUtils.solve(solverConfig, problem)).isInstanceOf(IllegalStateException.class)
+                .hasMessageContainingAll("The initial solution passed to the solver",
+                        "is invalid because it has dependency loops");
+    }
+
+    @Test
+    void solveIgnoreInconsistent() {
+        // Solver config
+        var solverConfig = PlannerTestUtils.buildSolverConfig(
+                TestdataConcurrentSolution.class, TestdataConcurrentEntity.class, TestdataConcurrentValue.class)
+                .withEasyScoreCalculatorClass(null)
+                .withConstraintProviderClass(TestdataConcurrentConstraintProvider.class);
+
+        var e1 = new TestdataConcurrentEntity("e1");
+        var e2 = new TestdataConcurrentEntity("e2");
+
+        var a1 = new TestdataConcurrentValue("a1");
+        var a2 = new TestdataConcurrentValue("a2");
+        var b1 = new TestdataConcurrentValue("b1");
+        var b2 = new TestdataConcurrentValue("b2");
+
+        a1.setConcurrentValueGroup(List.of(a1, a2));
+        a2.setConcurrentValueGroup(List.of(a1, a2));
+
+        b1.setConcurrentValueGroup(List.of(b1, b2));
+        b2.setConcurrentValueGroup(List.of(b1, b2));
+
+        e1.setValues(List.of(a1, b2));
+        e2.setValues(List.of(a2, b1));
+
+        var entities = List.of(e1, e2);
+        var values = List.of(a1, a2, b1, b2);
+
+        var problem = new TestdataConcurrentSolution();
+
+        problem.setEntities(entities);
+        problem.setValues(values);
+
+        var solution = PlannerTestUtils.solve(solverConfig, problem);
+
+        assertThat(solution.getEntities().getFirst().getValues()).map(TestdataConcurrentValue::getId).containsExactly("a1",
+                "b2");
+        assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("a2", "b1");
+
+        assertThat(solution.getScore()).isEqualTo(HardSoftScore.of(0, -240));
+    }
+
     private static List<MoveSelectorConfig<?>> generateMovesForMixedModel() {
         // Local Search
         var allMoveSelectionConfigList = new ArrayList<MoveSelectorConfig<?>>();

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -134,6 +134,10 @@ import ai.timefold.solver.core.testdomain.shadow.inverserelation.TestdataInverse
 import ai.timefold.solver.core.testdomain.shadow.inverserelation.TestdataInverseRelationEntity;
 import ai.timefold.solver.core.testdomain.shadow.inverserelation.TestdataInverseRelationSolution;
 import ai.timefold.solver.core.testdomain.shadow.inverserelation.TestdataInverseRelationValue;
+import ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field.TestdataDependencyNoInconsistentFieldConstraintProvider;
+import ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field.TestdataDependencyNoInconsistentFieldEntity;
+import ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field.TestdataDependencyNoInconsistentFieldSolution;
+import ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field.TestdataDependencyNoInconsistentFieldValue;
 import ai.timefold.solver.core.testdomain.sort.comparator.OneValuePerEntityComparatorEasyScoreCalculator;
 import ai.timefold.solver.core.testdomain.sort.comparator.TestdataComparatorSortableEntity;
 import ai.timefold.solver.core.testdomain.sort.comparator.TestdataComparatorSortableSolution;
@@ -1453,36 +1457,34 @@ class DefaultSolverTest {
     void solveWhenIgnoringInconsistentSolutionsThrowsIfInitialSolutionInconsistent() {
         // Solver config
         var solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataConcurrentSolution.class, TestdataConcurrentEntity.class, TestdataConcurrentValue.class)
+                TestdataDependencyNoInconsistentFieldSolution.class, TestdataDependencyNoInconsistentFieldEntity.class,
+                TestdataDependencyNoInconsistentFieldValue.class)
                 .withEasyScoreCalculatorClass(null)
-                .withConstraintProviderClass(TestdataConcurrentConstraintProvider.class)
-                .withPreviewFeature(PreviewFeature.IGNORE_INCONSISTENT_SOLUTIONS);
+                .withConstraintProviderClass(TestdataDependencyNoInconsistentFieldConstraintProvider.class);
 
-        var e1 = new TestdataConcurrentEntity("e1");
-        var e2 = new TestdataConcurrentEntity("e2");
+        var e1 = new TestdataDependencyNoInconsistentFieldEntity("a");
+        var e2 = new TestdataDependencyNoInconsistentFieldEntity("b");
 
-        var a1 = new TestdataConcurrentValue("a1");
-        var a2 = new TestdataConcurrentValue("a2");
-        var b1 = new TestdataConcurrentValue("b1");
-        var b2 = new TestdataConcurrentValue("b2");
+        var a1 = new TestdataDependencyNoInconsistentFieldValue("a1");
+        var a2 = new TestdataDependencyNoInconsistentFieldValue("a2");
+        var b1 = new TestdataDependencyNoInconsistentFieldValue("b1");
+        var b2 = new TestdataDependencyNoInconsistentFieldValue("b2");
 
-        a1.setConcurrentValueGroup(List.of(a1, a2));
-        a2.setConcurrentValueGroup(List.of(a1, a2));
+        a2.setDependencies(List.of(a1));
+        b2.setDependencies(List.of(b1));
 
-        b1.setConcurrentValueGroup(List.of(b1, b2));
-        b2.setConcurrentValueGroup(List.of(b1, b2));
-
-        e1.setValues(List.of(a1, b1));
-        e2.setValues(List.of(b2, a2));
+        e1.setValues(List.of(b2, b1));
+        e2.setValues(List.of(a2, a1));
 
         var entities = List.of(e1, e2);
         var values = List.of(a1, a2, b1, b2);
 
-        var problem = new TestdataConcurrentSolution();
+        var problem = new TestdataDependencyNoInconsistentFieldSolution();
 
         problem.setEntities(entities);
         problem.setValues(values);
 
+        // TODO: Verify the values were unassigned instead
         assertThatCode(() -> PlannerTestUtils.solve(solverConfig, problem)).isInstanceOf(IllegalStateException.class)
                 .hasMessageContainingAll("The initial solution passed to the solver",
                         "is invalid because it has dependency loops");
@@ -1492,42 +1494,40 @@ class DefaultSolverTest {
     void solveIgnoreInconsistent() {
         // Solver config
         var solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataConcurrentSolution.class, TestdataConcurrentEntity.class, TestdataConcurrentValue.class)
+                TestdataDependencyNoInconsistentFieldSolution.class, TestdataDependencyNoInconsistentFieldEntity.class,
+                TestdataDependencyNoInconsistentFieldValue.class)
                 .withEasyScoreCalculatorClass(null)
-                .withConstraintProviderClass(TestdataConcurrentConstraintProvider.class);
+                .withConstraintProviderClass(TestdataDependencyNoInconsistentFieldConstraintProvider.class);
 
-        var e1 = new TestdataConcurrentEntity("e1");
-        var e2 = new TestdataConcurrentEntity("e2");
+        var e1 = new TestdataDependencyNoInconsistentFieldEntity("a");
+        var e2 = new TestdataDependencyNoInconsistentFieldEntity("b");
 
-        var a1 = new TestdataConcurrentValue("a1");
-        var a2 = new TestdataConcurrentValue("a2");
-        var b1 = new TestdataConcurrentValue("b1");
-        var b2 = new TestdataConcurrentValue("b2");
+        var a1 = new TestdataDependencyNoInconsistentFieldValue("a1");
+        var a2 = new TestdataDependencyNoInconsistentFieldValue("a2");
+        var b1 = new TestdataDependencyNoInconsistentFieldValue("b1");
+        var b2 = new TestdataDependencyNoInconsistentFieldValue("b2");
 
-        a1.setConcurrentValueGroup(List.of(a1, a2));
-        a2.setConcurrentValueGroup(List.of(a1, a2));
-
-        b1.setConcurrentValueGroup(List.of(b1, b2));
-        b2.setConcurrentValueGroup(List.of(b1, b2));
-
-        e1.setValues(List.of(a1, b2));
-        e2.setValues(List.of(a2, b1));
+        a2.setDependencies(List.of(a1));
+        b2.setDependencies(List.of(b1));
 
         var entities = List.of(e1, e2);
         var values = List.of(a1, a2, b1, b2);
 
-        var problem = new TestdataConcurrentSolution();
+        var problem = new TestdataDependencyNoInconsistentFieldSolution();
 
         problem.setEntities(entities);
         problem.setValues(values);
 
         var solution = PlannerTestUtils.solve(solverConfig, problem);
+        assertThat(solution.getScore()).isEqualTo(HardSoftScore.of(0L, -360L));
+        var solutionValues = solution.getValues();
+        var solutionA1 = solutionValues.get(0);
+        var solutionA2 = solutionValues.get(1);
+        var solutionB1 = solutionValues.get(2);
+        var solutionB2 = solutionValues.get(3);
 
-        assertThat(solution.getEntities().getFirst().getValues()).map(TestdataConcurrentValue::getId).containsExactly("a1",
-                "b2");
-        assertThat(solution.getEntities().get(1).getValues()).map(TestdataConcurrentValue::getId).containsExactly("a2", "b1");
-
-        assertThat(solution.getScore()).isEqualTo(HardSoftScore.of(0, -240));
+        assertThat(solutionA2.getStartTime()).isAfterOrEqualTo(solutionA1.getEndTime());
+        assertThat(solutionB2.getStartTime()).isAfterOrEqualTo(solutionB1.getEndTime());
     }
 
     private static List<MoveSelectorConfig<?>> generateMovesForMixedModel() {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldConstraintProvider.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldConstraintProvider.java
@@ -1,0 +1,26 @@
+package ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field;
+
+import java.time.Duration;
+
+import ai.timefold.solver.core.api.score.HardSoftScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+
+import org.jspecify.annotations.NonNull;
+
+public class TestdataDependencyNoInconsistentFieldConstraintProvider implements ConstraintProvider {
+    @Override
+    public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory constraintFactory) {
+        return new Constraint[] {
+                finishTasksAsSoonAsPossible(constraintFactory),
+        };
+    }
+
+    public Constraint finishTasksAsSoonAsPossible(@NonNull ConstraintFactory constraintFactory) {
+        return constraintFactory.forEach(TestdataDependencyNoInconsistentFieldValue.class)
+                .penalize(HardSoftScore.ONE_SOFT, t -> (int) Duration.between(t.getEntity().getStartTime(),
+                        t.getEndTime()).toMinutes())
+                .asConstraint("Finish tasks as early as possible");
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldEntity.java
@@ -1,0 +1,64 @@
+package ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.common.PlanningId;
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+
+@PlanningEntity
+public class TestdataDependencyNoInconsistentFieldEntity {
+    @PlanningId
+    String id;
+
+    @PlanningListVariable
+    List<TestdataDependencyNoInconsistentFieldValue> values;
+
+    LocalDateTime startTime;
+
+    public TestdataDependencyNoInconsistentFieldEntity() {
+        this(null, LocalDateTime.ofEpochSecond(0L, 0, ZoneOffset.UTC));
+    }
+
+    public TestdataDependencyNoInconsistentFieldEntity(String id) {
+        this(id, LocalDateTime.ofEpochSecond(0L, 0, ZoneOffset.UTC));
+    }
+
+    public TestdataDependencyNoInconsistentFieldEntity(String id, LocalDateTime startTime) {
+        this.id = id;
+        this.startTime = startTime;
+        this.values = new ArrayList<>();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<TestdataDependencyNoInconsistentFieldValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataDependencyNoInconsistentFieldValue> values) {
+        this.values = values;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataPredecessorEntity{id=%s, values=%s, startTime=%s}".formatted(id, values, startTime);
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldSolution.java
@@ -1,0 +1,68 @@
+package ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.HardSoftScore;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+@PlanningSolution
+public class TestdataDependencyNoInconsistentFieldSolution {
+    public static SolutionDescriptor<TestdataDependencyNoInconsistentFieldSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(
+                TestdataDependencyNoInconsistentFieldSolution.class, TestdataDependencyNoInconsistentFieldEntity.class,
+                TestdataDependencyNoInconsistentFieldValue.class);
+    }
+
+    @PlanningEntityCollectionProperty
+    List<TestdataDependencyNoInconsistentFieldEntity> entities;
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider
+    List<TestdataDependencyNoInconsistentFieldValue> values;
+
+    @PlanningScore
+    HardSoftScore score;
+
+    public TestdataDependencyNoInconsistentFieldSolution() {
+    }
+
+    public TestdataDependencyNoInconsistentFieldSolution(List<TestdataDependencyNoInconsistentFieldEntity> entities,
+            List<TestdataDependencyNoInconsistentFieldValue> values) {
+        this.values = values;
+        this.entities = entities;
+    }
+
+    public List<TestdataDependencyNoInconsistentFieldValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<TestdataDependencyNoInconsistentFieldValue> values) {
+        this.values = values;
+    }
+
+    public List<TestdataDependencyNoInconsistentFieldEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(
+            List<TestdataDependencyNoInconsistentFieldEntity> entities) {
+        this.entities = entities;
+    }
+
+    public HardSoftScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftScore score) {
+        this.score = score;
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataPredecessorSolution{entities=%s, values=%s, score=%s}".formatted(entities, values, score);
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldValue.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldValue.java
@@ -1,0 +1,143 @@
+package ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.common.PlanningId;
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowSources;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+
+@PlanningEntity
+public class TestdataDependencyNoInconsistentFieldValue {
+    @PlanningId
+    String id;
+    List<TestdataDependencyNoInconsistentFieldValue> dependencies;
+
+    @PreviousElementShadowVariable(sourceVariableName = "values")
+    TestdataDependencyNoInconsistentFieldValue previousValue;
+
+    @ShadowVariable(supplierName = "calculateStartTime")
+    LocalDateTime startTime;
+
+    @ShadowVariable(supplierName = "calculateEndTime")
+    LocalDateTime endTime;
+
+    @InverseRelationShadowVariable(sourceVariableName = "values")
+    TestdataDependencyNoInconsistentFieldEntity entity;
+
+    Duration duration;
+
+    public TestdataDependencyNoInconsistentFieldValue() {
+    }
+
+    public TestdataDependencyNoInconsistentFieldValue(String id) {
+        this(id, Duration.ofHours(1L), null);
+    }
+
+    public TestdataDependencyNoInconsistentFieldValue(String id, Duration duration) {
+        this(id, duration, null);
+    }
+
+    public TestdataDependencyNoInconsistentFieldValue(String id, Duration duration,
+            List<TestdataDependencyNoInconsistentFieldValue> dependencies) {
+        this.id = id;
+        this.duration = duration;
+        this.dependencies = dependencies;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<TestdataDependencyNoInconsistentFieldValue> getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(
+            List<TestdataDependencyNoInconsistentFieldValue> dependencies) {
+        this.dependencies = dependencies;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    @ShadowSources({ "dependencies[].endTime", "previousValue.endTime", "entity" })
+    public LocalDateTime calculateStartTime() {
+        LocalDateTime readyTime;
+        if (previousValue != null) {
+            readyTime = previousValue.endTime;
+        } else if (entity != null) {
+            readyTime = entity.startTime;
+        } else {
+            return null;
+        }
+
+        if (dependencies != null) {
+            for (var dependency : dependencies) {
+                if (dependency.endTime == null) {
+                    return null;
+                }
+                readyTime = readyTime.isAfter(dependency.endTime) ? readyTime : dependency.endTime;
+            }
+        }
+        return readyTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    @ShadowSources({ "startTime" })
+    public LocalDateTime calculateEndTime() {
+        if (startTime == null) {
+            return null;
+        }
+        return startTime.plus(duration);
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Duration duration) {
+        this.duration = duration;
+    }
+
+    public TestdataDependencyNoInconsistentFieldEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(TestdataDependencyNoInconsistentFieldEntity entity) {
+        this.entity = entity;
+    }
+
+    public TestdataDependencyNoInconsistentFieldValue getPreviousValue() {
+        return previousValue;
+    }
+
+    public void setPreviousValue(TestdataDependencyNoInconsistentFieldValue previousValue) {
+        this.previousValue = previousValue;
+    }
+
+    @Override
+    public String toString() {
+        return "%s{endTime=%s}".formatted(id, endTime);
+    }
+}

--- a/tools/benchmark/src/main/resources/benchmark.xsd
+++ b/tools/benchmark/src/main/resources/benchmark.xsd
@@ -2420,9 +2420,6 @@
       <xs:enumeration value="PLANNING_SOLUTION_DIFF"/>
                   
       
-      <xs:enumeration value="IGNORE_INCONSISTENT_SOLUTIONS"/>
-                  
-      
       <xs:enumeration value="NEIGHBORHOODS"/>
                 
     

--- a/tools/benchmark/src/main/resources/benchmark.xsd
+++ b/tools/benchmark/src/main/resources/benchmark.xsd
@@ -2420,6 +2420,9 @@
       <xs:enumeration value="PLANNING_SOLUTION_DIFF"/>
                   
       
+      <xs:enumeration value="IGNORE_INCONSISTENT_SOLUTIONS"/>
+                  
+      
       <xs:enumeration value="NEIGHBORHOODS"/>
                 
     


### PR DESCRIPTION
Added a new preview feature `IGNORE_INCONSISTENT_SOLUTIONS`.
When enabled, when a move causes the solution to be in an inconsistent state, that move is effectively ignored; `calculateScore` will return a score with the minimum init value possible (i.e. a score that is less than all other scores) and no shadow variables will be updated.

Technically, this potentially introduces a score trap: all inconsistent solutions get the same -infinity score. However, this doesn't seem to be a problem in the benchmarks I performed.

`TopologicalGraph#commitChanges` signature has changed to return a boolean which is true iff the graph has loops (and thus the solution inconsistent.

Benchmarks show significant improvements for Machine Job Scheduling on Enterprise.