### PR TITLE
fix: make mvn verify idempotent by replacing stale enhanced OpenAPI file

### DIFF
--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/TimefoldModelDescriptorProcessor.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/TimefoldModelDescriptorProcessor.java
@@ -218,7 +218,7 @@ class TimefoldModelDescriptorProcessor {
                 // copy enhanced OpenAPI spec file to target folder for validation purpose
                 Path enhancedOpenApiPath =
                         Paths.get(out.getOutputDirectory().toString(), "timefold-model-enhanced-openapi.json");
-                Files.copy(openAPIDefinition, enhancedOpenApiPath);
+                Files.copy(openAPIDefinition, enhancedOpenApiPath, StandardCopyOption.REPLACE_EXISTING);
 
                 // check if there is JSON schema definition for the schedule operation
                 Path jsonSchemaDefinition =

--- a/service/quarkus/deployment/src/test/java/ai/timefold/solver/service/quarkus/deployment/ModelDescriptorArchiveGenerationTest.java
+++ b/service/quarkus/deployment/src/test/java/ai/timefold/solver/service/quarkus/deployment/ModelDescriptorArchiveGenerationTest.java
@@ -1,0 +1,57 @@
+package ai.timefold.solver.service.quarkus.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+
+import ai.timefold.solver.service.quarkus.deployment.builditem.ModelArchiveBuildItem;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+
+class ModelDescriptorArchiveGenerationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void replacesExistingEnhancedOpenApiDefinition() throws IOException {
+        Path modelArchivePath = tempDir.resolve("timefold");
+        Path outputDirectory = tempDir.resolve("target");
+        Path modelFilesPath = modelArchivePath.resolve("test-model_v1");
+
+        Files.createDirectories(modelFilesPath.resolve("openapi"));
+        Files.createDirectories(modelFilesPath.resolve("jsonschema"));
+        Files.createDirectories(modelFilesPath.resolve("default-config-profile"));
+        Files.createDirectories(outputDirectory);
+
+        Files.writeString(modelArchivePath.resolve("timefold-model-descriptor.json"),
+                """
+                        {
+                          "id": "test-model_v1",
+                          "imageRef": "test-image:latest"
+                        }
+                        """);
+        Files.writeString(modelFilesPath.resolve("openapi/service.json"), "{\"updated\":true}");
+        Files.writeString(modelFilesPath.resolve("jsonschema/schedule.json"), "{}");
+        Files.writeString(modelFilesPath.resolve("default-config-profile/default-config.json"), "{}");
+
+        Path enhancedOpenApiPath = outputDirectory.resolve("timefold-model-enhanced-openapi.json");
+        Files.writeString(enhancedOpenApiPath, "{\"stale\":true}");
+
+        new TimefoldModelDescriptorProcessor()
+                .generateModelDescriptorArchive(Optional.of(new ModelArchiveBuildItem(modelArchivePath)),
+                        new OutputTargetBuildItem(outputDirectory, "test", "test", false, new Properties(),
+                                Optional.empty()));
+
+        assertThat(Files.readString(enhancedOpenApiPath)).isEqualTo("{\"updated\":true}");
+        assertThat(outputDirectory.resolve("model-descriptor.zip")).exists();
+    }
+
+}


### PR DESCRIPTION
## Summary

Make the model descriptor build step idempotent so a Timefold service project can run `mvn verify` more than once. The enhanced OpenAPI spec is now copied with `StandardCopyOption.REPLACE_EXISTING`, replacing any file left over from a prior build instead of aborting.

## Why this matters

Running `mvn verify` a second time failed with `java.nio.file.FileAlreadyExistsException: target/timefold-model-enhanced-openapi.json` (issue #2392). The first build writes `timefold-model-enhanced-openapi.json` into the output directory; on the next build the file is already there and the copy aborts.

Root cause: in `service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/TimefoldModelDescriptorProcessor.java:221`, the copy inside the `generateModelDescriptorArchive` build step had no overwrite option. This is the build step in the reported stack trace. The fix mirrors the copy convention already used elsewhere in the same processor (`TimefoldModelDescriptorProcessor.java:1156` and `:1232`, both `Files.copy(..., StandardCopyOption.REPLACE_EXISTING)`). A clean build is unchanged; repeat builds are now idempotent.

## Testing

Added `ModelDescriptorArchiveGenerationTest` which drives the real `generateModelDescriptorArchive` build step with a pre-existing stale `timefold-model-enhanced-openapi.json` and asserts the file is overwritten with the current spec content and that the model descriptor archive is produced.

- `./mvnw -pl service/quarkus/deployment -am test -Dtest=ModelDescriptorArchiveGenerationTest` passes with the fix (JDK 21, Quarkus 3.36.2).
- The same test reproduces the original `FileAlreadyExistsException` when the fix is reverted, confirming it guards the regression.

Fixes #2392
