### PR TITLE
ci: use Solver snapshot in the downstream build

### DIFF
--- a/.github/workflows/downstream_build.yml
+++ b/.github/workflows/downstream_build.yml
@@ -111,7 +111,9 @@ jobs:
         shell: bash
         env:
           TIMEFOLD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}
-        run: mvn -B clean verify
+        run: |
+          mvn versions:update-parent -DskipResolution=true -DallowSnapshots=true -DparentVersion=999-SNAPSHOT
+          mvn -B clean verify
 
       - name: Test Summary
         uses: test-summary/action@2920bc1b1b377c787227b204af6981e8f41bbef3

--- a/service/facade/service-parent/pom.xml
+++ b/service/facade/service-parent/pom.xml
@@ -896,18 +896,6 @@
     </profile>
 
     <profile>
-      <id>solver-snapshot</id>
-      <activation>
-        <property>
-          <name>solver-snapshot</name>
-        </property>
-      </activation>
-      <properties>
-        <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
-      </properties>
-    </profile>
-
-    <profile>
       <id>quickProfile</id>
       <activation>
         <property>


### PR DESCRIPTION
Tested with a clean local maven repository.