### PR TITLE
ci: do not build solver for docs only PR

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,7 @@ on:
       - '**.md'
       - '**.adoc'
       - '*.txt'
+      - 'docs/**'
 
 jobs:
   java:

--- a/.github/workflows/pull_request_quickstarts.yml
+++ b/.github/workflows/pull_request_quickstarts.yml
@@ -18,6 +18,7 @@ on:
       - '**.md'
       - '**.adoc'
       - '*.txt'
+      - 'docs/**'
 
 jobs:
   java:

--- a/.github/workflows/pull_request_secure.yml
+++ b/.github/workflows/pull_request_secure.yml
@@ -25,6 +25,7 @@ on:
       - '.gitignore'
       - '**.md'
       - '*.txt'
+      - 'docs/**'
 
 jobs:
   # Check if the user is a member of the organization; if so, allow the PR to sail through.

--- a/.github/workflows/pull_request_secure_downstream.yml
+++ b/.github/workflows/pull_request_secure_downstream.yml
@@ -25,6 +25,7 @@ on:
       - '.gitignore'
       - '**.md'
       - '*.txt'
+      - 'docs/**'
 
 jobs:
   # Check if the user is a member of the organization; if so, allow the PR to sail through.


### PR DESCRIPTION
Currently, when doing a PR just for docs, it still builds the entire matrix of the solver.
This is highly ineffecient. This PR seeks to resolve that, by excluding PRs involving only changes in docs/