### PR TITLE
ci: correctly replace parent version in downstream build workflow

### DIFF
--- a/.github/workflows/downstream_build.yml
+++ b/.github/workflows/downstream_build.yml
@@ -93,6 +93,10 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+          # Set the JFrog credentials that will be used for downloading the solver service parent in the downstream build.
+          server-id: timefold
+          server-username: JRELEASER_JFROG_USERNAME
+          server-password: JRELEASER_JFROG_TOKEN
 
       - name: Quickly build timefold-solver
         working-directory: ./timefold-solver

--- a/.github/workflows/downstream_build.yml
+++ b/.github/workflows/downstream_build.yml
@@ -115,6 +115,8 @@ jobs:
         shell: bash
         env:
           TIMEFOLD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}
+          JRELEASER_JFROG_USERNAME: ${{ secrets.JRELEASER_JFROG_USERNAME }}
+          JRELEASER_JFROG_TOKEN: ${{ secrets.JRELEASER_JFROG_TOKEN }}
         run: |
           mvn versions:update-parent -DskipResolution=true -DallowSnapshots=true -DparentVersion=999-SNAPSHOT
           mvn -B clean verify

--- a/.github/workflows/downstream_build.yml
+++ b/.github/workflows/downstream_build.yml
@@ -93,10 +93,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-          # Set the JFrog credentials that will be used for downloading the solver service parent in the downstream build.
-          server-id: timefold
-          server-username: JRELEASER_JFROG_USERNAME
-          server-password: JRELEASER_JFROG_TOKEN
 
       - name: Quickly build timefold-solver
         working-directory: ./timefold-solver
@@ -110,15 +106,32 @@ jobs:
           TIMEFOLD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}
         run: ./mvnw -B -Dquickly clean install
 
+      - name: Switch ${{ inputs.name }} to Solver 999-SNAPSHOT
+        working-directory: ./${{ inputs.repository }}
+        shell: bash
+        run: |
+          POM="pom.xml"
+          TARGET_VERSION="999-SNAPSHOT"
+          
+          # Replace the first <version> element (parent version) in pom.xml.
+          sed -i '0,/^\s*<version>/s|<version>[^<]*</version>|<version>'"$TARGET_VERSION"'</version>|' "$POM"
+          
+          # Verify the parent version is now TARGET_VERSION
+          ACTUAL_VERSION=$(grep -m1 '^\s*<version>' "$POM" | sed 's|.*<version>\(.*\)</version>.*|\1|')
+          
+          if [ "$ACTUAL_VERSION" = "$TARGET_VERSION" ]; then
+            exit 0
+          else
+            echo "Expected parent version $TARGET_VERSION but found $ACTUAL_VERSION" >&2
+            exit 1
+          fi
+
       - name: Build and test ${{ inputs.name }}
         working-directory: ./${{ inputs.repository }}
         shell: bash
         env:
           TIMEFOLD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}
-          JRELEASER_JFROG_USERNAME: ${{ secrets.JRELEASER_JFROG_USERNAME }}
-          JRELEASER_JFROG_TOKEN: ${{ secrets.JRELEASER_JFROG_TOKEN }}
         run: |
-          mvn versions:update-parent -DskipResolution=true -DallowSnapshots=true -DparentVersion=999-SNAPSHOT
           mvn -B clean verify
 
       - name: Test Summary

--- a/.github/workflows/pull_request_secure_downstream.yml
+++ b/.github/workflows/pull_request_secure_downstream.yml
@@ -72,9 +72,7 @@ jobs:
       name: Field Service Routing
       head_ref: ${{ github.head_ref }}
       head_sha: ${{ github.event.pull_request.head.sha }}
-    secrets:
-      JRELEASER_GITHUB_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
-      TIMEFOLD_SOLVER_CI_PROD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}
+    secrets: inherit
 
   timefold-employee-scheduling:
     needs: approval_required
@@ -84,9 +82,7 @@ jobs:
       name: Employee Scheduling
       head_ref: ${{ github.head_ref }}
       head_sha: ${{ github.event.pull_request.head.sha }}
-    secrets:
-      JRELEASER_GITHUB_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
-      TIMEFOLD_SOLVER_CI_PROD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}
+    secrets: inherit
 
   timefold-pickup-delivery-routing:
     needs: approval_required
@@ -96,6 +92,4 @@ jobs:
       name: Pickup and Delivery Routing
       head_ref: ${{ github.head_ref }}
       head_sha: ${{ github.event.pull_request.head.sha }}
-    secrets:
-      JRELEASER_GITHUB_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
-      TIMEFOLD_SOLVER_CI_PROD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}
+    secrets: inherit

--- a/.github/workflows/pull_request_secure_downstream.yml
+++ b/.github/workflows/pull_request_secure_downstream.yml
@@ -72,7 +72,9 @@ jobs:
       name: Field Service Routing
       head_ref: ${{ github.head_ref }}
       head_sha: ${{ github.event.pull_request.head.sha }}
-    secrets: inherit
+    secrets:
+      JRELEASER_GITHUB_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
+      TIMEFOLD_SOLVER_CI_PROD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}
 
   timefold-employee-scheduling:
     needs: approval_required
@@ -82,7 +84,9 @@ jobs:
       name: Employee Scheduling
       head_ref: ${{ github.head_ref }}
       head_sha: ${{ github.event.pull_request.head.sha }}
-    secrets: inherit
+    secrets:
+      JRELEASER_GITHUB_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
+      TIMEFOLD_SOLVER_CI_PROD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}
 
   timefold-pickup-delivery-routing:
     needs: approval_required
@@ -92,4 +96,6 @@ jobs:
       name: Pickup and Delivery Routing
       head_ref: ${{ github.head_ref }}
       head_sha: ${{ github.event.pull_request.head.sha }}
-    secrets: inherit
+    secrets:
+      JRELEASER_GITHUB_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
+      TIMEFOLD_SOLVER_CI_PROD_LICENSE: ${{ secrets.TIMEFOLD_SOLVER_CI_PROD_LICENSE }}


### PR DESCRIPTION
Added JFrog credentials for downloading parent pom.xml to upgrade models' version to solver snapshot.