### PR TITLE
Fail build when timefold.application.version is missing

### DIFF
--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/TimefoldModelDescriptorProcessor.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/TimefoldModelDescriptorProcessor.java
@@ -511,6 +511,14 @@ class TimefoldModelDescriptorProcessor {
         }
     }
 
+    protected static void validateApplicationVersion(String version) {
+        if (version == null || version.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "The application version is missing. Set the '" + APPLICATION_VERSION_PROPERTY
+                            + "' property (e.g. in application.properties) so the build can proceed.");
+        }
+    }
+
     private void generateModelDescriptor(String modelId, String model, OpenAPI openAPI,
             Path outputDirectory,
             Optional<ClassInfo> restResource,
@@ -529,8 +537,10 @@ class TimefoldModelDescriptorProcessor {
         descriptor.setModel(model);
         descriptor.setName(
                 config.getOptionalValue(APPLICATION_NAME_PROPERTY, String.class).orElse(openAPI.getInfo().getTitle()));
-        descriptor.setVersion(
-                config.getOptionalValue(APPLICATION_VERSION_PROPERTY, String.class).orElse(openAPI.getInfo().getVersion()));
+        String applicationVersion =
+                config.getOptionalValue(APPLICATION_VERSION_PROPERTY, String.class).orElse(openAPI.getInfo().getVersion());
+        validateApplicationVersion(applicationVersion);
+        descriptor.setVersion(applicationVersion);
         descriptor.setResourceType(getResourceTypeFromRestResource(restResource));
         descriptor.setDescription(config.getOptionalValue(APPLICATION_DESCRIPTION_PROPERTY, String.class)
                 .orElse(openAPI.getInfo().getDescription()));

--- a/service/quarkus/deployment/src/test/java/ai/timefold/solver/service/quarkus/deployment/ApplicationVersionValidationTest.java
+++ b/service/quarkus/deployment/src/test/java/ai/timefold/solver/service/quarkus/deployment/ApplicationVersionValidationTest.java
@@ -1,0 +1,36 @@
+package ai.timefold.solver.service.quarkus.deployment;
+
+import static ai.timefold.solver.service.quarkus.deployment.TimefoldModelDescriptorProcessor.validateApplicationVersion;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ApplicationVersionValidationTest {
+
+    @Test
+    void validVersionDoesNotThrow() {
+        assertThatCode(() -> validateApplicationVersion("v1")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void nullVersionThrows() {
+        assertThatThrownBy(() -> validateApplicationVersion(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("timefold.application.version");
+    }
+
+    @Test
+    void emptyVersionThrows() {
+        assertThatThrownBy(() -> validateApplicationVersion(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("timefold.application.version");
+    }
+
+    @Test
+    void blankVersionThrows() {
+        assertThatThrownBy(() -> validateApplicationVersion("   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("timefold.application.version");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2393. The Timefold service currently builds successfully even when the mandatory `timefold.application.version` property is not provided. The resolved version silently falls through to a null/blank value at the `descriptor.setVersion(...)` call site in the Quarkus build-time processor, and the missing value only surfaces later as a vague runtime error.

This change adds a static `validateApplicationVersion(String)` check in `TimefoldModelDescriptorProcessor`, mirroring the existing `validateModelId(String)`. The resolved version is now validated inside `generateModelDescriptor` before it is set on the descriptor, so the build fails fast with a clear, actionable message naming the missing `timefold.application.version` property.

## Why this matters

It aligns with the project Constitution's "Fail Fast" and "Understandable Error Messages" principles, and matches the maintainer's note on the issue that validation should be improved so a missing mandatory property does not slip through to runtime. The scope is intentionally limited to the named `timefold.application.version` property rather than the open-ended set of other properties mentioned in passing on the issue.

## Testing

Added `ApplicationVersionValidationTest`, mirroring `ModelNameValidationTest` and using AssertJ assertions per the Constitution. It covers the happy path (non-blank version passes) and the null, empty, and blank/whitespace cases (each throws `IllegalArgumentException` whose message names `timefold.application.version`). Run locally:

```
./mvnw -pl service/quarkus/deployment -am -Dtest=ApplicationVersionValidationTest test
```

All 4 tests pass.

Fixes #2393
