### PR TITLE
fix: write generated service build artifacts to target instead of sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ local
 
 # Repository wide ignore mac DS_Store files
 .DS_Store
+
+# Generated service build artifacts that must never be committed (issue #2410)
+**/src/main/jib/timefold/diagnostic-tools.jar
+**/.flattened-pom.xml
+**/timefold-model-enhanced-openapi.json

--- a/service/facade/service-parent/pom.xml
+++ b/service/facade/service-parent/pom.xml
@@ -385,6 +385,24 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <!-- The diagnostic-tools jar is copied into src/main/jib (above) because Quarkus
+             container-image-jib only includes files from that fixed directory and it cannot be
+             relocated to target/. Remove it on clean so a stale jar from a previous enterprise build
+             is never shipped by a later non-enterprise build that skips the copy (issue #2410). -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>src/main/jib/timefold</directory>
+              <includes>
+                <include>diagnostic-tools.jar</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/service/facade/service-parent/pom.xml
+++ b/service/facade/service-parent/pom.xml
@@ -388,8 +388,9 @@
       <plugin>
         <!-- The diagnostic-tools jar is copied into src/main/jib (above) because Quarkus
              container-image-jib only includes files from that fixed directory and it cannot be
-             relocated to target/. Remove it on clean so a stale jar from a previous enterprise build
-             is never shipped by a later non-enterprise build that skips the copy (issue #2410). -->
+             relocated to target/. To make sure a stale jar from a previous enterprise build is never
+             shipped by a later build that skips the copy, delete it both on clean and at the start of
+             every build (before the copy execution in generate-resources runs) (issue #2410). -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <configuration>
@@ -402,6 +403,27 @@
             </fileset>
           </filesets>
         </configuration>
+        <executions>
+          <execution>
+            <id>delete-stale-diagnostic-tools</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <configuration>
+              <!-- Do not wipe target/ during initialize; only remove the generated jib jar. -->
+              <excludeDefaultDirectories>true</excludeDefaultDirectories>
+              <filesets>
+                <fileset>
+                  <directory>src/main/jib/timefold</directory>
+                  <includes>
+                    <include>diagnostic-tools.jar</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/service/facade/service-parent/pom.xml
+++ b/service/facade/service-parent/pom.xml
@@ -302,6 +302,10 @@
             <updatePomFile>true</updatePomFile>
             <flattenMode>resolveCiFriendliesOnly</flattenMode>
             <keepCommentsInPom>true</keepCommentsInPom>
+            <!-- Write the flattened pom under target/ instead of the module basedir, so the generated
+                 .flattened-pom.xml does not litter the source tree of models and quickstarts (issue #2410). -->
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <flattenedPomFilename>.flattened-pom.xml</flattenedPomFilename>
           </configuration>
           <executions>
             <execution>
@@ -364,6 +368,9 @@
                   <version>${version.ai.timefold.solver}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
+                  <!-- Quarkus container-image-jib only copies files from the fixed src/main/jib directory
+                       into the image, so this generated jar has to stay here. It is kept out of Git via
+                       .gitignore instead (issue #2410). -->
                   <outputDirectory>src/main/jib/timefold</outputDirectory>
                   <destFileName>diagnostic-tools.jar</destFileName>
                 </artifactItem>


### PR DESCRIPTION
## Summary

Keep the service build's generated artifacts out of the source tree. The flatten-maven-plugin now writes `.flattened-pom.xml` under `target/` instead of each module basedir, and the generated `diagnostic-tools.jar` is git-ignored and removed at the start of every build so it never gets committed or shipped stale.

## Why this matters

Issue #2410 reports that `diagnostic-tools.jar`, `.flattened-pom.xml`, and the enhanced OpenAPI spec reappear among the sources on every build and risk being checked into Git across models and quickstarts.

- In `service/facade/service-parent/pom.xml` the `flatten-maven-plugin` config now sets `outputDirectory` to `${project.build.directory}` with `flattenedPomFilename` `.flattened-pom.xml`, so the flattened pom lands in `target/`.
- The `timefold-model-enhanced-openapi.json` is already written to the build output directory by `TimefoldModelDescriptorProcessor` (`out.getOutputDirectory()`), so no producer change was needed.
- The `copy-timefold-diagnostic-tools` execution still writes to `src/main/jib/timefold` because Quarkus `container-image-jib` only includes files from that fixed directory and it cannot be pointed at `target/`. To satisfy the "must not be checked into Git" requirement, that jar is git-ignored, and `maven-clean-plugin` deletes it on `clean` and at the `initialize` phase (before the copy runs) so a stale jar from a previous enterprise build can never be packaged by a later build that skips the copy.
- A defensive `.gitignore` entry backs up all three artifact patterns.

## Testing

`mvn validate` cannot run here because it requires the `999-SNAPSHOT` solver artifacts that are not published. Validated that both edited XML files are well-formed and that the flatten-maven-plugin (`outputDirectory`, `flattenedPomFilename`) and maven-clean-plugin (`filesets`, `excludeDefaultDirectories`) options used are the documented parameters for those plugins.

Fixes #2410
