### PR TITLE
perf(constraint-streams): improve joins by removing list entries

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractGroupNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractGroupNode.java
@@ -182,9 +182,12 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
             updateGroup(tuple, oldGroup);
             return;
         }
-        var oldUserSuppliedGroupKey = extractUserSuppliedKey(oldGroup.getGroupKey());
         var newUserSuppliedGroupKey = groupKeyFunction.apply(tuple);
-        if (Objects.equals(oldUserSuppliedGroupKey, newUserSuppliedGroupKey)) {
+        var storedKey = oldGroup.getGroupKey();
+        var sameKey = useAssertingGroupKey
+                ? Objects.equals(extractUserSuppliedKey(storedKey), newUserSuppliedGroupKey)
+                : Objects.equals(storedKey, newUserSuppliedGroupKey);
+        if (sameKey) {
             updateGroup(tuple, oldGroup);
         } else {
             if (hasCollector) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIfExistsNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIfExistsNode.java
@@ -5,9 +5,9 @@ import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleState;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
-import ai.timefold.solver.core.impl.util.ElementAwareLinkedList;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This class has two direct children: {@link AbstractIndexedIfExistsNode} and {@link AbstractUnindexedIfExistsNode}.
@@ -23,6 +23,9 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
 
     protected final boolean shouldExist;
 
+    // When isFiltering, these slots hold the head FilteringTracker of a hidden intrusive doubly-linked list
+    // (null = empty list). Links are stored in FilteringTracker's own prev/next fields — there is no list object.
+    // See FilteringTracker for the field layout.
     protected final int inputStoreIndexLeftTrackerList; // -1 if !isFiltering
     protected final int inputStoreIndexRightTrackerList; // -1 if !isFiltering
 
@@ -63,7 +66,7 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
     }
 
     protected void updateCounterLeft(ExistsCounter<LeftTuple_> counter) {
-        TupleState state = counter.state;
+        var state = counter.state;
         if (shouldExist ? counter.countRight > 0 : counter.countRight == 0) {
             // Insert or update
             switch (state) {
@@ -123,26 +126,104 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
         } // Else do not even propagate an update
     }
 
-    protected ElementAwareLinkedList<FilteringTracker<LeftTuple_>> clearRightTrackerList(UniTuple<Right_> rightTuple) {
-        ElementAwareLinkedList<FilteringTracker<LeftTuple_>> rightTrackerList =
-                rightTuple.getStore(inputStoreIndexRightTrackerList);
-        rightTrackerList.clear(tracker -> {
-            decrementCounterRight(tracker.counter);
-            tracker.removeByRight();
-        });
-        return rightTrackerList;
+    // Prepends tracker into the left tuple's hidden intrusive tracker list.
+    // The left tuple's store at inputStoreIndexLeftTrackerList holds the list head (null = empty).
+    private void linkLeft(FilteringTracker<LeftTuple_> tracker) {
+        var leftTuple = tracker.counter.leftTuple;
+        FilteringTracker<LeftTuple_> head = leftTuple.getStore(inputStoreIndexLeftTrackerList);
+        tracker.leftNext = head;
+        if (head != null) {
+            head.leftPrev = tracker;
+        }
+        leftTuple.setStore(inputStoreIndexLeftTrackerList, tracker);
     }
 
-    protected void updateCounterFromLeft(ExistsCounter<LeftTuple_> counter, UniTuple<Right_> rightTuple,
-            ElementAwareLinkedList<FilteringTracker<LeftTuple_>> leftTrackerList) {
-        if (testFiltering(counter.leftTuple, rightTuple)) {
-            counter.countRight++;
-            new FilteringTracker<>(counter, leftTrackerList, rightTuple.getStore(inputStoreIndexRightTrackerList));
+    // Prepends tracker into the right tuple's hidden intrusive tracker list.
+    // The right tuple's store at inputStoreIndexRightTrackerList holds the list head (null = empty).
+    private void linkRight(FilteringTracker<LeftTuple_> tracker) {
+        var rightTuple = tracker.rightTuple;
+        FilteringTracker<LeftTuple_> head = rightTuple.getStore(inputStoreIndexRightTrackerList);
+        tracker.rightNext = head;
+        if (head != null) {
+            head.rightPrev = tracker;
+        }
+        rightTuple.setStore(inputStoreIndexRightTrackerList, tracker);
+    }
+
+    // Splices tracker out of its right tuple's hidden list (used when clearing from the left side).
+    // Nulls the tracker's right links; if tracker is the head, updates the right tuple's slot.
+    private void removeFromRight(FilteringTracker<LeftTuple_> tracker) {
+        var prev = tracker.rightPrev;
+        var next = tracker.rightNext;
+        if (prev != null) {
+            prev.rightNext = next;
+        } else {
+            // tracker is the head of the right list; update the slot
+            tracker.rightTuple.setStore(inputStoreIndexRightTrackerList, next);
+        }
+        if (next != null) {
+            next.rightPrev = prev;
+        }
+        tracker.rightPrev = null;
+        tracker.rightNext = null;
+    }
+
+    // Splices tracker out of its left tuple's hidden list (used when clearing from the right side).
+    // Nulls the tracker's left links; if tracker is the head, updates the left tuple's slot.
+    private void removeFromLeft(FilteringTracker<LeftTuple_> tracker) {
+        var prev = tracker.leftPrev;
+        var next = tracker.leftNext;
+        if (prev != null) {
+            prev.leftNext = next;
+        } else {
+            // tracker is the head of the left list; update the slot
+            tracker.counter.leftTuple.setStore(inputStoreIndexLeftTrackerList, next);
+        }
+        if (next != null) {
+            next.leftPrev = prev;
+        }
+        tracker.leftPrev = null;
+        tracker.leftNext = null;
+    }
+
+    // Clears the left tracker list rooted at leftTuple's inputStoreIndexLeftTrackerList slot,
+    // cross-removing each tracker from its right tuple's hidden list. No-op when !isFiltering.
+    // Walk safety: removeFromRight only touches right-side links, so leftNext is stable across the call.
+    protected void clearLeftTrackerList(LeftTuple_ leftTuple) {
+        if (!isFiltering) {
+            return;
+        }
+        FilteringTracker<LeftTuple_> tracker = leftTuple.removeStore(inputStoreIndexLeftTrackerList);
+        while (tracker != null) {
+            var next = tracker.leftNext;
+            removeFromRight(tracker);
+            tracker = next;
         }
     }
 
-    protected void updateCounterFromRight(ExistsCounter<LeftTuple_> counter, UniTuple<Right_> rightTuple,
-            ElementAwareLinkedList<FilteringTracker<LeftTuple_>> rightTrackerList) {
+    // Clears the right tracker list rooted at rightTuple's inputStoreIndexRightTrackerList slot,
+    // decrementing each counter and cross-removing each tracker from its left tuple's hidden list.
+    // Walk safety: removeFromLeft only touches left-side links, so rightNext is stable across the call.
+    protected void clearRightTrackerList(UniTuple<Right_> rightTuple) {
+        FilteringTracker<LeftTuple_> tracker = rightTuple.removeStore(inputStoreIndexRightTrackerList);
+        while (tracker != null) {
+            var next = tracker.rightNext;
+            decrementCounterRight(tracker.counter);
+            removeFromLeft(tracker);
+            tracker = next;
+        }
+    }
+
+    protected void updateCounterFromLeft(ExistsCounter<LeftTuple_> counter, UniTuple<Right_> rightTuple) {
+        if (testFiltering(counter.leftTuple, rightTuple)) {
+            counter.countRight++;
+            var tracker = new FilteringTracker<>(counter, rightTuple);
+            linkLeft(tracker);
+            linkRight(tracker);
+        }
+    }
+
+    protected void updateCounterFromRight(ExistsCounter<LeftTuple_> counter, UniTuple<Right_> rightTuple) {
         var leftTuple = counter.leftTuple;
         if (!leftTuple.getState().isActive()) {
             // Assume the following scenario:
@@ -163,7 +244,9 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
         }
         if (testFiltering(leftTuple, rightTuple)) {
             incrementCounterRight(counter);
-            new FilteringTracker<>(counter, leftTuple.getStore(inputStoreIndexLeftTrackerList), rightTrackerList);
+            var tracker = new FilteringTracker<>(counter, rightTuple);
+            linkLeft(tracker);
+            linkRight(tracker);
         }
     }
 
@@ -214,24 +297,21 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
     @NullMarked
     protected static final class FilteringTracker<LeftTuple_ extends Tuple> {
 
-        final ExistsCounter<LeftTuple_> counter;
-        private final ElementAwareLinkedList.Entry<FilteringTracker<LeftTuple_>> leftTrackerEntry;
-        private final ElementAwareLinkedList.Entry<FilteringTracker<LeftTuple_>> rightTrackerEntry;
+        // A tracker is a node in TWO hidden intrusive doubly-linked lists at once:
+        // one keyed on its left tuple (counter.leftTuple) and one on its right tuple.
+        // The list heads live in the tuples' inputStoreIndexLeftTrackerList /
+        // inputStoreIndexRightTrackerList store slots (null = empty list).
+        // These fields ARE the links — no ElementAwareLinkedList or Entry is allocated.
+        final ExistsCounter<LeftTuple_> counter; // -> leftTuple, for the left-keyed list and counter decrement
+        final Tuple rightTuple; // for the right-keyed list; typed as Tuple (not UniTuple<Right_>) — only getStore/setStore needed
+        @Nullable
+        FilteringTracker<LeftTuple_> leftPrev, leftNext; // links in the left tuple's hidden list
+        @Nullable
+        FilteringTracker<LeftTuple_> rightPrev, rightNext; // links in the right tuple's hidden list
 
-        FilteringTracker(ExistsCounter<LeftTuple_> counter,
-                ElementAwareLinkedList<FilteringTracker<LeftTuple_>> leftTrackerList,
-                ElementAwareLinkedList<FilteringTracker<LeftTuple_>> rightTrackerList) {
+        FilteringTracker(ExistsCounter<LeftTuple_> counter, Tuple rightTuple) {
             this.counter = counter;
-            leftTrackerEntry = leftTrackerList.add(this);
-            rightTrackerEntry = rightTrackerList.add(this);
-        }
-
-        public void removeByLeft() {
-            rightTrackerEntry.remove();
-        }
-
-        public void removeByRight() {
-            leftTrackerEntry.remove();
+            this.rightTuple = rightTuple;
         }
 
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIndexedIfExistsNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIndexedIfExistsNode.java
@@ -14,7 +14,6 @@ import ai.timefold.solver.core.impl.bavet.common.tuple.RightTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
-import ai.timefold.solver.core.impl.util.ElementAwareLinkedList;
 import ai.timefold.solver.core.impl.util.ListEntry;
 
 import org.jspecify.annotations.Nullable;
@@ -101,10 +100,10 @@ public abstract class AbstractIndexedIfExistsNode<LeftTuple_ extends Tuple, Righ
         if (!isFiltering) {
             counter.countRight = rightSize(leftTuple, compositeKey);
         } else {
-            var leftTrackerList = new ElementAwareLinkedList<FilteringTracker<LeftTuple_>>();
+            // Trackers link themselves into the left tuple's inputStoreIndexLeftTrackerList slot.
+            // No list object is needed; the slot starts null and the first tracker becomes the head.
             forEachRightFromLeft(leftTuple, compositeKey,
-                    rightTuple -> updateCounterFromLeft(counter, rightTuple, leftTrackerList));
-            leftTuple.setStore(inputStoreIndexLeftTrackerList, leftTrackerList);
+                    rightTuple -> updateCounterFromLeft(counter, rightTuple));
         }
     }
 
@@ -136,12 +135,10 @@ public abstract class AbstractIndexedIfExistsNode<LeftTuple_ extends Tuple, Righ
                 updateUnchangedCounterLeft(counter);
             } else {
                 // Call filtering for the leftTuple and rightTuple combinations again
-                ElementAwareLinkedList<FilteringTracker<LeftTuple_>> leftTrackerList =
-                        leftTuple.getStore(inputStoreIndexLeftTrackerList);
-                leftTrackerList.clear(FilteringTracker::removeByLeft);
+                clearLeftTrackerList(leftTuple);
                 counter.countRight = 0;
                 forEachRightFromLeft(leftTuple, oldCompositeKey,
-                        rightTuple -> updateCounterFromLeft(counter, rightTuple, leftTrackerList));
+                        rightTuple -> updateCounterFromLeft(counter, rightTuple));
                 updateCounterLeft(counter);
             }
         } else {
@@ -185,14 +182,6 @@ public abstract class AbstractIndexedIfExistsNode<LeftTuple_ extends Tuple, Righ
         }
     }
 
-    private void clearLeftTrackerList(LeftTuple_ leftTuple) {
-        if (isFiltering) {
-            ElementAwareLinkedList<FilteringTracker<LeftTuple_>> leftTrackerList =
-                    leftTuple.getStore(inputStoreIndexLeftTrackerList);
-            leftTrackerList.clear(FilteringTracker::removeByLeft);
-        }
-    }
-
     private void updateIndexerLeft(Object compositeKey, ListEntry<ExistsCounter<LeftTuple_>> counterEntry, LeftTuple_ leftTuple,
             boolean keepBucket) {
         removeFromIndexerLeft(compositeKey, leftTuple, counterEntry, keepBucket);
@@ -216,10 +205,10 @@ public abstract class AbstractIndexedIfExistsNode<LeftTuple_ extends Tuple, Righ
         if (!isFiltering) {
             forEachLeftCounter(rightTuple, compositeKey, this::incrementCounterRight);
         } else {
-            var rightTrackerList = new ElementAwareLinkedList<FilteringTracker<LeftTuple_>>();
+            // Trackers link themselves into the right tuple's inputStoreIndexRightTrackerList slot.
+            // No list object is needed; the slot starts null and the first tracker becomes the head.
             forEachLeftCounter(rightTuple, compositeKey,
-                    counter -> updateCounterFromRight(counter, rightTuple, rightTrackerList));
-            rightTuple.setStore(inputStoreIndexRightTrackerList, rightTrackerList);
+                    counter -> updateCounterFromRight(counter, rightTuple));
         }
     }
 
@@ -235,9 +224,9 @@ public abstract class AbstractIndexedIfExistsNode<LeftTuple_ extends Tuple, Righ
         if (oldCompositeKey.equals(newCompositeKey)) {
             // No need for re-indexing because the index keys didn't change
             if (isFiltering) {
-                var rightTrackerList = clearRightTrackerList(rightTuple);
+                clearRightTrackerList(rightTuple);
                 forEachLeftCounter(rightTuple, oldCompositeKey,
-                        counter -> updateCounterFromRight(counter, rightTuple, rightTrackerList));
+                        counter -> updateCounterFromRight(counter, rightTuple));
             }
         } else {
             // sameBucket: equal prefix unchanged ⇒ keep & reuse the cached bucket (no top lookup, no drop/recreate).

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIndexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIndexedJoinNode.java
@@ -13,8 +13,8 @@ import ai.timefold.solver.core.impl.bavet.common.tuple.LeftTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.RightTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
+import ai.timefold.solver.core.impl.bavet.common.tuple.TupleList;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
-import ai.timefold.solver.core.impl.util.ElementAwareLinkedList;
 import ai.timefold.solver.core.impl.util.ListEntry;
 
 import org.jspecify.annotations.Nullable;
@@ -85,7 +85,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
                             .formatted(leftTuple));
         }
         var compositeKey = keysExtractorLeft.apply(leftTuple);
-        leftTuple.setStore(inputStoreIndexLeftOutTupleList, new ElementAwareLinkedList<OutTuple_>());
+        leftTuple.setStore(inputStoreIndexLeftOutTupleList, leftOutTupleListBuilder.get());
         indexAndPropagateLeft(leftTuple, compositeKey, false);
     }
 
@@ -103,7 +103,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
             // Prefer an update over retract-insert if possible
             innerUpdateLeft(leftTuple, consumer -> forEachRightMatch(leftTuple, oldCompositeKey, consumer));
         } else {
-            ElementAwareLinkedList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
+            TupleList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
             var reuseBucket = reuseBucketEligible && fusedEqualIndex.isSameBucket(oldCompositeKey, newCompositeKey);
             if (reuseBucket) {
                 // Equal prefix unchanged ⇒ same bucket: move within the cached bucket, no top lookup or drop/recreate.
@@ -168,7 +168,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        ElementAwareLinkedList<OutTuple_> outTupleListLeft = leftTuple.removeStore(inputStoreIndexLeftOutTupleList);
+        TupleList<OutTuple_> outTupleListLeft = leftTuple.removeStore(inputStoreIndexLeftOutTupleList);
         ListEntry<LeftTuple_> entry = leftTuple.removeStore(inputStoreIndexLeftEntry);
         if (useFusedEqualIndex) {
             Bucket<LeftTuple_, UniTuple<Right_>> bucket = leftTuple.removeStore(inputStoreIndexLeftBucket);
@@ -188,7 +188,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
                             .formatted(rightTuple));
         }
         var compositeKey = keysExtractorRight.apply(rightTuple);
-        rightTuple.setStore(inputStoreIndexRightOutTupleList, new ElementAwareLinkedList<OutTuple_>());
+        rightTuple.setStore(inputStoreIndexRightOutTupleList, rightOutTupleListBuilder.get());
         indexAndPropagateRight(rightTuple, compositeKey, false);
     }
 
@@ -206,7 +206,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
             // Prefer an update over retract-insert if possible
             innerUpdateRight(rightTuple, consumer -> forEachLeftMatch(rightTuple, oldCompositeKey, consumer));
         } else {
-            ElementAwareLinkedList<OutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
+            TupleList<OutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
             var reuseBucket = reuseBucketEligible && fusedEqualIndex.isSameBucket(oldCompositeKey, newCompositeKey);
             if (reuseBucket) {
                 // Equal prefix unchanged ⇒ same bucket: move within the cached bucket, no top lookup or drop/recreate.
@@ -255,7 +255,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        ElementAwareLinkedList<OutTuple_> outTupleListRight = rightTuple.removeStore(inputStoreIndexRightOutTupleList);
+        TupleList<OutTuple_> outTupleListRight = rightTuple.removeStore(inputStoreIndexRightOutTupleList);
         ListEntry<UniTuple<Right_>> entry = rightTuple.removeStore(inputStoreIndexRightEntry);
         if (useFusedEqualIndex) {
             Bucket<LeftTuple_, UniTuple<Right_>> bucket = rightTuple.removeStore(inputStoreIndexRightBucket);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractJoinNode.java
@@ -1,14 +1,15 @@
 package ai.timefold.solver.core.impl.bavet.common;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import ai.timefold.solver.core.impl.bavet.common.tuple.InOutTupleStorePositionTracker;
 import ai.timefold.solver.core.impl.bavet.common.tuple.OutTupleStorePositionTracker;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
+import ai.timefold.solver.core.impl.bavet.common.tuple.TupleList;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleState;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
-import ai.timefold.solver.core.impl.util.ElementAwareLinkedList;
 
 /**
  * This class has two direct children: {@link AbstractIndexedJoinNode} and {@link AbstractUnindexedJoinNode}.
@@ -25,10 +26,13 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     protected final int inputStoreIndexLeftOutTupleList;
     protected final int inputStoreIndexRightOutTupleList;
     private final boolean isFiltering;
-    private final int outputStoreIndexLeftOutEntry;
-    private final int outputStoreIndexRightOutEntry;
+    private final int outputStoreIndexLeftOutTupleList;
+    private final int outputStoreIndexRightOutTupleList;
     protected final OutTupleStorePositionTracker outputStoreSizeTracker;
     private final StaticPropagationQueue<OutTuple_> propagationQueue;
+
+    protected final Supplier<TupleList<OutTuple_>> leftOutTupleListBuilder;
+    protected final Supplier<TupleList<OutTuple_>> rightOutTupleListBuilder;
 
     protected AbstractJoinNode(TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, boolean isFiltering,
             InOutTupleStorePositionTracker tupleStorePositionTracker) {
@@ -36,10 +40,17 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
         this.inputStoreIndexLeftOutTupleList = tupleStorePositionTracker.reserveNextLeft();
         this.inputStoreIndexRightOutTupleList = tupleStorePositionTracker.reserveNextRight();
         this.isFiltering = isFiltering;
-        this.outputStoreIndexLeftOutEntry = tupleStorePositionTracker.reserveNextOut();
-        this.outputStoreIndexRightOutEntry = tupleStorePositionTracker.reserveNextOut();
+        this.outputStoreIndexLeftOutTupleList = tupleStorePositionTracker.reserveNextOut();
+        this.outputStoreIndexRightOutTupleList = tupleStorePositionTracker.reserveNextOut();
         this.outputStoreSizeTracker = tupleStorePositionTracker;
         this.propagationQueue = new StaticPropagationQueue<>(nextNodesTupleLifecycle);
+
+        var outputStoreIndexLeftOutPrev = tupleStorePositionTracker.reserveNextOut();
+        var outputStoreIndexLeftOutNext = tupleStorePositionTracker.reserveNextOut();
+        var outputStoreIndexRightOutPrev = tupleStorePositionTracker.reserveNextOut();
+        var outputStoreIndexRightOutNext = tupleStorePositionTracker.reserveNextOut();
+        this.leftOutTupleListBuilder = () -> new TupleList<>(outputStoreIndexLeftOutPrev, outputStoreIndexLeftOutNext);
+        this.rightOutTupleListBuilder = () -> new TupleList<>(outputStoreIndexRightOutPrev, outputStoreIndexRightOutNext);
     }
 
     @Override
@@ -57,10 +68,12 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     protected final void insertOutTuple(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple) {
         var outTuple = createOutTuple(leftTuple, rightTuple);
-        ElementAwareLinkedList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
-        outTuple.setStore(outputStoreIndexLeftOutEntry, outTupleListLeft.add(outTuple));
-        ElementAwareLinkedList<OutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
-        outTuple.setStore(outputStoreIndexRightOutEntry, outTupleListRight.add(outTuple));
+        TupleList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
+        outTupleListLeft.add(outTuple);
+        outTuple.setStore(outputStoreIndexLeftOutTupleList, outTupleListLeft);
+        TupleList<OutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
+        outTupleListRight.add(outTuple);
+        outTuple.setStore(outputStoreIndexRightOutTupleList, outTupleListRight);
         propagationQueue.insert(outTuple);
     }
 
@@ -92,10 +105,10 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     protected final void innerUpdateLeft(LeftTuple_ leftTuple, Consumer<Consumer<UniTuple<Right_>>> rightTupleConsumer) {
         // Prefer an update over retract-insert if possible
-        ElementAwareLinkedList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
+        TupleList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
         // Propagate the update for downstream filters, matchWeighers, ...
         if (!isFiltering) {
-            for (var outTuple : outTupleListLeft) {
+            for (var outTuple = outTupleListLeft.first(); outTuple != null; outTuple = outTupleListLeft.next(outTuple)) {
                 updateOutTupleLeft(outTuple, leftTuple);
             }
         } else {
@@ -117,7 +130,8 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
                 return;
             }
             rightTupleConsumer.accept(rightTuple -> processOutTupleUpdate(leftTuple, rightTuple,
-                    rightTuple.getStore(inputStoreIndexRightOutTupleList), outTupleListLeft, outputStoreIndexRightOutEntry));
+                    rightTuple.getStore(inputStoreIndexRightOutTupleList), outTupleListLeft,
+                    outputStoreIndexRightOutTupleList));
         }
     }
 
@@ -139,21 +153,21 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     protected final void innerUpdateRight(UniTuple<Right_> rightTuple, Consumer<Consumer<LeftTuple_>> leftTupleConsumer) {
         // Prefer an update over retract-insert if possible
-        ElementAwareLinkedList<OutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
+        TupleList<OutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
         if (!isFiltering) {
             // Propagate the update for downstream filters, matchWeighers, ...
-            for (var outTuple : outTupleListRight) {
+            for (var outTuple = outTupleListRight.first(); outTuple != null; outTuple = outTupleListRight.next(outTuple)) {
                 setOutTupleRightFact(outTuple, rightTuple);
                 doUpdateOutTuple(outTuple);
             }
         } else {
             leftTupleConsumer.accept(leftTuple -> processOutTupleUpdateFromLeft(leftTuple, rightTuple,
-                    leftTuple.getStore(inputStoreIndexLeftOutTupleList), outTupleListRight, outputStoreIndexLeftOutEntry));
+                    leftTuple.getStore(inputStoreIndexLeftOutTupleList), outTupleListRight, outputStoreIndexLeftOutTupleList));
         }
     }
 
     private void processOutTupleUpdateFromLeft(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple,
-            ElementAwareLinkedList<OutTuple_> outList, ElementAwareLinkedList<OutTuple_> outTupleList,
+            TupleList<OutTuple_> outList, TupleList<OutTuple_> outTupleList,
             int outputStoreIndexOutEntry) {
         if (!leftTuple.getState().isActive()) {
             // Assume the following scenario:
@@ -176,7 +190,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     }
 
     private void processOutTupleUpdate(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple,
-            ElementAwareLinkedList<OutTuple_> referenceList, ElementAwareLinkedList<OutTuple_> sourceList,
+            TupleList<OutTuple_> referenceList, TupleList<OutTuple_> sourceList,
             int outputStoreIndexOutEntry) {
         var outTuple = findOutTuple(sourceList, referenceList, outputStoreIndexOutEntry);
         if (testFiltering(leftTuple, rightTuple)) {
@@ -192,19 +206,18 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
         }
     }
 
-    private static <Tuple_ extends Tuple> Tuple_ findOutTuple(ElementAwareLinkedList<Tuple_> sourceList,
-            ElementAwareLinkedList<Tuple_> referenceList, int outputStoreIndexOutEntry) {
+    private static <Tuple_ extends Tuple> Tuple_ findOutTuple(TupleList<Tuple_> sourceList,
+            TupleList<Tuple_> referenceList, int outputStoreIndexOutEntry) {
         // Hack: the outTuple has no left/right input tuple reference, use the left/right outList reference instead.
         var item = sourceList.first();
+        // Safe: findOutTuple returns immediately on a match; the caller retracts after this call returns, not during the walk.
         while (item != null) {
             // Creating list iterators here caused major GC pressure; therefore, we iterate over the entries directly.
-            var outTuple = item.element();
-            ElementAwareLinkedList.Entry<Tuple_> outEntry = outTuple.getStore(outputStoreIndexOutEntry);
-            var outEntryList = outEntry.getList();
+            TupleList<Tuple_> outEntryList = item.getStore(outputStoreIndexOutEntry);
             if (referenceList == outEntryList) {
-                return outTuple;
+                return item;
             }
-            item = item.next();
+            item = sourceList.next(item);
         }
         return null;
     }
@@ -216,16 +229,17 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     }
 
     private void removeLeftEntry(OutTuple_ outTuple) {
-        removeEntry(outTuple, outputStoreIndexLeftOutEntry);
+        removeEntry(outTuple, outputStoreIndexLeftOutTupleList);
     }
 
     private void removeRightEntry(OutTuple_ outTuple) {
-        removeEntry(outTuple, outputStoreIndexRightOutEntry);
+        removeEntry(outTuple, outputStoreIndexRightOutTupleList);
     }
 
     private void removeEntry(OutTuple_ outTuple, int outputStoreIndex) {
-        ElementAwareLinkedList.Entry<OutTuple_> outEntry = outTuple.removeStore(outputStoreIndex);
-        outEntry.remove();
+        TupleList<OutTuple_> list = outTuple.getStore(outputStoreIndex);
+        list.remove(outTuple);
+        outTuple.setStore(outputStoreIndex, null);
     }
 
     private void propagateRetract(OutTuple_ outTuple) {
@@ -238,14 +252,14 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     }
 
     void retractOutTupleByLeft(OutTuple_ outTuple) {
-        outTuple.removeStore(outputStoreIndexLeftOutEntry); // The caller will clear the entire list in one go.
+        outTuple.setStore(outputStoreIndexLeftOutTupleList, null); // The caller will clear the entire list in one go.
         removeRightEntry(outTuple);
         propagateRetract(outTuple);
     }
 
     void retractOutTupleByRight(OutTuple_ outTuple) {
         removeLeftEntry(outTuple);
-        outTuple.removeStore(outputStoreIndexRightOutEntry); // The caller will clear the entire list in one go.
+        outTuple.setStore(outputStoreIndexRightOutTupleList, null); // The caller will clear the entire list in one go.
         propagateRetract(outTuple);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractUnindexedIfExistsNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractUnindexedIfExistsNode.java
@@ -47,11 +47,11 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends Tuple, Ri
         if (!isFiltering) {
             counter.countRight = rightTupleList.size();
         } else {
-            var leftTrackerList = new ElementAwareLinkedList<FilteringTracker<LeftTuple_>>();
+            // Trackers link themselves into the left tuple's inputStoreIndexLeftTrackerList slot.
+            // No list object is needed; the slot starts null and the first tracker becomes the head.
             for (var rightTuple : rightTupleList) {
-                updateCounterFromLeft(counter, rightTuple, leftTrackerList);
+                updateCounterFromLeft(counter, rightTuple);
             }
-            leftTuple.setStore(inputStoreIndexLeftTrackerList, leftTrackerList);
         }
         initCounterLeft(counter);
     }
@@ -71,12 +71,10 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends Tuple, Ri
             updateUnchangedCounterLeft(counter);
         } else {
             // Call filtering for the leftTuple and rightTuple combinations again
-            ElementAwareLinkedList<FilteringTracker<LeftTuple_>> leftTrackerList =
-                    leftTuple.getStore(inputStoreIndexLeftTrackerList);
-            leftTrackerList.clear(FilteringTracker::removeByLeft);
+            clearLeftTrackerList(leftTuple);
             counter.countRight = 0;
             for (var rightTuple : rightTupleList) {
-                updateCounterFromLeft(counter, rightTuple, leftTrackerList);
+                updateCounterFromLeft(counter, rightTuple);
             }
             updateCounterLeft(counter);
         }
@@ -92,11 +90,7 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends Tuple, Ri
         }
         var counter = counterEntry.element();
         counterEntry.remove();
-        if (isFiltering) {
-            ElementAwareLinkedList<FilteringTracker<LeftTuple_>> leftTrackerList =
-                    leftTuple.getStore(inputStoreIndexLeftTrackerList);
-            leftTrackerList.clear(FilteringTracker::removeByLeft);
-        }
+        clearLeftTrackerList(leftTuple);
         killCounterLeft(counter);
     }
 
@@ -111,11 +105,11 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends Tuple, Ri
         if (!isFiltering) {
             counterList.forEach(this::incrementCounterRight);
         } else {
-            var rightTrackerList = new ElementAwareLinkedList<FilteringTracker<LeftTuple_>>();
+            // Trackers link themselves into the right tuple's inputStoreIndexRightTrackerList slot.
+            // No list object is needed; the slot starts null and the first tracker becomes the head.
             for (var counter : counterList) {
-                updateCounterFromRight(counter, rightTuple, rightTrackerList);
+                updateCounterFromRight(counter, rightTuple);
             }
-            rightTuple.setStore(inputStoreIndexRightTrackerList, rightTrackerList);
         }
     }
 
@@ -128,9 +122,9 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends Tuple, Ri
             return;
         }
         if (isFiltering) {
-            var rightTrackerList = clearRightTrackerList(rightTuple);
+            clearRightTrackerList(rightTuple);
             for (var counter : counterList) {
-                updateCounterFromRight(counter, rightTuple, rightTrackerList);
+                updateCounterFromRight(counter, rightTuple);
             }
         }
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractUnindexedJoinNode.java
@@ -5,8 +5,8 @@ import ai.timefold.solver.core.impl.bavet.common.tuple.LeftTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.RightTupleLifecycle;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
+import ai.timefold.solver.core.impl.bavet.common.tuple.TupleList;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
-import ai.timefold.solver.core.impl.util.ElementAwareLinkedList;
 
 /**
  * There is a strong likelihood that any change made to this class
@@ -19,27 +19,27 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
         extends AbstractJoinNode<LeftTuple_, Right_, OutTuple_>
         implements LeftTupleLifecycle<LeftTuple_>, RightTupleLifecycle<UniTuple<Right_>> {
 
-    private final int inputStoreIndexLeftEntry;
-    private final int inputStoreIndexRightEntry;
-    private final ElementAwareLinkedList<LeftTuple_> leftTupleList = new ElementAwareLinkedList<>();
-    private final ElementAwareLinkedList<UniTuple<Right_>> rightTupleList = new ElementAwareLinkedList<>();
+    private final TupleList<LeftTuple_> leftTupleList;
+    private final TupleList<UniTuple<Right_>> rightTupleList;
 
     protected AbstractUnindexedJoinNode(TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, boolean isFiltering,
             InOutTupleStorePositionTracker tupleStorePositionTracker) {
         super(nextNodesTupleLifecycle, isFiltering, tupleStorePositionTracker);
-        this.inputStoreIndexLeftEntry = tupleStorePositionTracker.reserveNextLeft();
-        this.inputStoreIndexRightEntry = tupleStorePositionTracker.reserveNextRight();
+        this.leftTupleList = new TupleList<>(tupleStorePositionTracker.reserveNextLeft(),
+                tupleStorePositionTracker.reserveNextLeft());
+        this.rightTupleList = new TupleList<>(tupleStorePositionTracker.reserveNextRight(),
+                tupleStorePositionTracker.reserveNextRight());
     }
 
     @Override
     public final void insertLeft(LeftTuple_ leftTuple) {
-        if (leftTuple.getStore(inputStoreIndexLeftEntry) != null) {
+        if (leftTuple.getStore(inputStoreIndexLeftOutTupleList) != null) {
             throw new IllegalStateException(
                     "Impossible state: the input for the tuple (%s) was already added in the tupleStore."
                             .formatted(leftTuple));
         }
-        leftTuple.setStore(inputStoreIndexLeftEntry, leftTupleList.add(leftTuple));
-        leftTuple.setStore(inputStoreIndexLeftOutTupleList, new ElementAwareLinkedList<OutTuple_>());
+        leftTupleList.add(leftTuple);
+        leftTuple.setStore(inputStoreIndexLeftOutTupleList, leftOutTupleListBuilder.get());
         if (!leftTuple.getState().isActive()) {
             // Assume the following scenario:
             // - The join is of two entities of the same type, both filtering out unassigned.
@@ -56,14 +56,14 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
             // However, no such issue could have been reproduced; when in doubt, leave it out.
             return;
         }
-        for (var rightTuple : rightTupleList) {
+        for (var rightTuple = rightTupleList.first(); rightTuple != null; rightTuple = rightTupleList.next(rightTuple)) {
             insertOutTupleFiltered(leftTuple, rightTuple);
         }
     }
 
     @Override
     public final void updateLeft(LeftTuple_ leftTuple) {
-        if (leftTuple.getStore(inputStoreIndexLeftEntry) == null) {
+        if (leftTuple.getStore(inputStoreIndexLeftOutTupleList) == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             insertLeft(leftTuple);
             return;
@@ -73,33 +73,32 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
 
     @Override
     public final void retractLeft(LeftTuple_ leftTuple) {
-        ElementAwareLinkedList.Entry<LeftTuple_> leftEntry = leftTuple.removeStore(inputStoreIndexLeftEntry);
-        if (leftEntry == null) {
+        TupleList<OutTuple_> outTupleListLeft = leftTuple.removeStore(inputStoreIndexLeftOutTupleList);
+        if (outTupleListLeft == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        ElementAwareLinkedList<OutTuple_> outTupleListLeft = leftTuple.removeStore(inputStoreIndexLeftOutTupleList);
-        leftEntry.remove();
+        leftTupleList.remove(leftTuple);
         outTupleListLeft.clear(this::retractOutTupleByLeft);
     }
 
     @Override
     public final void insertRight(UniTuple<Right_> rightTuple) {
-        if (rightTuple.getStore(inputStoreIndexRightEntry) != null) {
+        if (rightTuple.getStore(inputStoreIndexRightOutTupleList) != null) {
             throw new IllegalStateException(
                     "Impossible state: the input for the tuple (%s) was already added in the tupleStore."
                             .formatted(rightTuple));
         }
-        rightTuple.setStore(inputStoreIndexRightEntry, rightTupleList.add(rightTuple));
-        rightTuple.setStore(inputStoreIndexRightOutTupleList, new ElementAwareLinkedList<OutTuple_>());
-        for (var leftTuple : leftTupleList) {
+        rightTupleList.add(rightTuple);
+        rightTuple.setStore(inputStoreIndexRightOutTupleList, rightOutTupleListBuilder.get());
+        for (var leftTuple = leftTupleList.first(); leftTuple != null; leftTuple = leftTupleList.next(leftTuple)) {
             insertOutTupleFilteredFromLeft(leftTuple, rightTuple);
         }
     }
 
     @Override
     public final void updateRight(UniTuple<Right_> rightTuple) {
-        if (rightTuple.getStore(inputStoreIndexRightEntry) == null) {
+        if (rightTuple.getStore(inputStoreIndexRightOutTupleList) == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             insertRight(rightTuple);
             return;
@@ -109,13 +108,12 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
 
     @Override
     public final void retractRight(UniTuple<Right_> rightTuple) {
-        ElementAwareLinkedList.Entry<UniTuple<Right_>> rightEntry = rightTuple.removeStore(inputStoreIndexRightEntry);
-        if (rightEntry == null) {
+        TupleList<OutTuple_> outTupleListRight = rightTuple.removeStore(inputStoreIndexRightOutTupleList);
+        if (outTupleListRight == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        ElementAwareLinkedList<OutTuple_> outTupleListRight = rightTuple.removeStore(inputStoreIndexRightOutTupleList);
-        rightEntry.remove();
+        rightTupleList.remove(rightTuple);
         outTupleListRight.clear(this::retractOutTupleByRight);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/TupleList.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/TupleList.java
@@ -1,0 +1,101 @@
+package ai.timefold.solver.core.impl.bavet.common.tuple;
+
+import java.util.function.Consumer;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Doubly-linked list for tuples that stores prev/next links in the tuple's own store slots.
+ * No per-element object is allocated; the join node reserves two out-slots per side for the links.
+ * One {@code TupleList} head is created per input-tuple insert (not per match).
+ *
+ * @param <T> The element type. Must be a {@link Tuple} so its store can hold the link pointers.
+ */
+@NullMarked
+public final class TupleList<T extends Tuple> {
+
+    private final int prevStoreIndex;
+    private final int nextStoreIndex;
+    private @Nullable T first;
+    private @Nullable T last;
+    private int size;
+
+    public TupleList(int prevStoreIndex, int nextStoreIndex) {
+        this.prevStoreIndex = prevStoreIndex;
+        this.nextStoreIndex = nextStoreIndex;
+    }
+
+    public void add(T tuple) {
+        tuple.setStore(prevStoreIndex, last);
+        if (first == null) {
+            first = tuple;
+        } else {
+            last.setStore(nextStoreIndex, tuple);
+        }
+        last = tuple;
+        size++;
+    }
+
+    public void remove(T tuple) {
+        T prev = tuple.removeStore(prevStoreIndex);
+        T next = tuple.removeStore(nextStoreIndex);
+        if (first == tuple) {
+            first = next;
+        } else {
+            prev.setStore(nextStoreIndex, next);
+        }
+        if (last == tuple) {
+            last = prev;
+        } else {
+            next.setStore(prevStoreIndex, prev);
+        }
+        size--;
+    }
+
+    /**
+     * Walks the list and calls the consumer for each element, then resets the head.
+     * Captures {@code next} before the consumer call in case the consumer retains the tuple.
+     * Member tuples' link slots are NOT nulled here — callers are responsible for any cleanup
+     * needed on dying out-tuples.
+     * For bulk-clear on retract this is safe: the tuples are GC'd.
+     */
+    public void clear(Consumer<T> consumer) {
+        var entry = first;
+        while (entry != null) {
+            // Extract next before the consumer, in case consumer retains/removes the entry.
+            var next = next(entry);
+            consumer.accept(entry);
+            entry = next;
+        }
+        first = null;
+        last = null;
+        size = 0;
+    }
+
+    public void forEach(Consumer<T> consumer) {
+        var entry = first;
+        while (entry != null) {
+            var next = next(entry);
+            consumer.accept(entry);
+            entry = next;
+        }
+    }
+
+    public @Nullable T first() {
+        return first;
+    }
+
+    /**
+     * Returns the element after {@code tuple} in this list, or {@code null} if it is the last.
+     * Used for iterator-free manual walks: {@code for (var t = list.first(); t != null; t = list.next(t))}.
+     */
+    public @Nullable T next(T tuple) {
+        return tuple.getStore(nextStoreIndex);
+    }
+
+    public int size() {
+        return size;
+    }
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/tuple/TupleListTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/tuple/TupleListTest.java
@@ -1,0 +1,190 @@
+package ai.timefold.solver.core.impl.bavet.common.tuple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+class TupleListTest {
+
+    private static Tuple createTuple() {
+        // Slot 0 = prevStoreIndex, slot 1 = nextStoreIndex for the list under test.
+        return UniTuple.of(2);
+    }
+
+    @Test
+    void addSingle() {
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+
+        list.add(t1);
+
+        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.first()).isEqualTo(t1);
+        assertThat(list.next(t1)).isNull();
+    }
+
+    @Test
+    void addTwo_firstAndNextCorrect() {
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+        var t2 = createTuple();
+
+        list.add(t1);
+        list.add(t2);
+
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.first()).isEqualTo(t1);
+        assertThat(list.next(t1)).isEqualTo(t2);
+        assertThat(list.next(t2)).isNull();
+    }
+
+    @Test
+    void removeFirst() {
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+        var t2 = createTuple();
+        list.add(t1);
+        list.add(t2);
+
+        list.remove(t1);
+
+        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.first()).isEqualTo(t2);
+        assertThat(list.next(t2)).isNull();
+    }
+
+    @Test
+    void removeLast() {
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+        var t2 = createTuple();
+        list.add(t1);
+        list.add(t2);
+
+        list.remove(t2);
+
+        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.first()).isEqualTo(t1);
+        assertThat(list.next(t1)).isNull();
+    }
+
+    @Test
+    void removeMiddle() {
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+        var t2 = createTuple();
+        var t3 = createTuple();
+        list.add(t1);
+        list.add(t2);
+        list.add(t3);
+
+        list.remove(t2);
+
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.first()).isEqualTo(t1);
+        assertThat(list.next(t1)).isEqualTo(t3);
+        assertThat(list.next(t3)).isNull();
+    }
+
+    @Test
+    void removeAll_emptyAfter() {
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+        list.add(t1);
+
+        list.remove(t1);
+
+        assertThat(list.size()).isEqualTo(0);
+        assertThat(list.first()).isNull();
+    }
+
+    @Test
+    void clear_callsConsumerInOrder_thenEmpty() {
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+        var t2 = createTuple();
+        list.add(t1);
+        list.add(t2);
+
+        var visited = new ArrayList<Tuple>();
+        list.clear(visited::add);
+
+        assertThat(visited).containsExactly(t1, t2);
+        assertThat(list.size()).isEqualTo(0);
+        assertThat(list.first()).isNull();
+    }
+
+    @Test
+    void clear_safeWhenConsumerRemovesFromSameList() {
+        // Verifies that pre-capturing 'next' in clear() makes it safe
+        // even if the consumer calls remove() on the same list;
+        // the walk is not corrupted.
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+        var t2 = createTuple();
+        var t3 = createTuple();
+        list.add(t1);
+        list.add(t2);
+        list.add(t3);
+
+        var visited = new ArrayList<Tuple>();
+        list.clear(tuple -> {
+            visited.add(tuple);
+            // Remove from the same list while clear() is walking;
+            // safe because clear() pre-captures next.
+            // In production, retractOutTupleByLeft removes from the *other* side's list, not this one,
+            // so this scenario is stronger than production requires.
+            if (tuple == t2) {
+                list.remove(tuple);
+            }
+        });
+
+        // All three elements are visited regardless of the mid-walk removal.
+        assertThat(visited).containsExactly(t1, t2, t3);
+        assertThat(list.size()).isEqualTo(0);
+        assertThat(list.first()).isNull();
+    }
+
+    @Test
+    void forEach_visitAllInOrder() {
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+        var t2 = createTuple();
+        var t3 = createTuple();
+        list.add(t1);
+        list.add(t2);
+        list.add(t3);
+
+        var visited = new ArrayList<Tuple>();
+        list.forEach(visited::add);
+
+        assertThat(visited).containsExactly(t1, t2, t3);
+    }
+
+    @Test
+    void emptyList_sizeZero_firstNull() {
+        var list = new TupleList<>(0, 1);
+
+        assertThat(list.size()).isEqualTo(0);
+        assertThat(list.first()).isNull();
+    }
+
+    @Test
+    void remove_nullsSlotsOnTuple() {
+        // Verify that remove clears both link slots so a removed tuple
+        // doesn't retain stale pointers (important for GC and correctness).
+        var list = new TupleList<>(0, 1);
+        var t1 = createTuple();
+        var t2 = createTuple();
+        list.add(t1);
+        list.add(t2);
+
+        list.remove(t1);
+
+        // After removal, the tuple's slots must be null.
+        assertThat(t1.<Object> getStore(0)).isNull(); // prevSlot
+        assertThat(t1.<Object> getStore(1)).isNull(); // nextSlot
+    }
+}


### PR DESCRIPTION
Turns tuples into list entries without creating an entry middleman.

This eliminates many `ElementAwareLinkedList` instances, leading to a significant GC pressure drop and resulting performance. +20 % was observed in machine reassignment.