### PR TITLE
chore: unassign if solution is inconsistent

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
+import java.util.List;
+
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.supply.Supply;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
@@ -36,5 +38,9 @@ public final class DefaultShadowVariableSession<Solution_> implements Supply {
 
     public boolean updateVariables() {
         return graph.updateChanged();
+    }
+
+    public List<Object> getInconsistentEntities() {
+        return graph.getInconsistentEntities();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -6,6 +6,8 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.function.IntFunction;
 
+import ai.timefold.solver.core.impl.util.LinkedIdentityHashSet;
+
 import org.jspecify.annotations.NonNull;
 
 final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableReferenceGraph<Solution_, BitSet> {
@@ -70,5 +72,21 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
     public void setUnknownInconsistencyValues() {
         graph.commitChanges(changeTracker);
         affectedEntitiesUpdater.setUnknownInconsistencyValues();
+    }
+
+    @Override
+    public List<Object> getInconsistentEntities() {
+        var out = new LinkedIdentityHashSet<>();
+        var graphTrackingInconsistentEntities = new DefaultTopologicalOrderGraph(this.nodeTopologicalOrders.length);
+        graph.forEachEdge(graphTrackingInconsistentEntities::addEdge);
+        graphTrackingInconsistentEntities.commitChanges(new BitSet());
+        var loopedComponentList = graphTrackingInconsistentEntities.getLoopedComponentList();
+        for (var loopedComponent : loopedComponentList) {
+            for (var nodeId : loopedComponent) {
+                var node = this.nodeList.get(nodeId);
+                out.add(node.entity());
+            }
+        }
+        return new ArrayList<>(out);
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
@@ -1,5 +1,8 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
+import java.util.Collections;
+import java.util.List;
+
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 final class EmptyVariableReferenceGraph implements VariableReferenceGraph {
@@ -20,6 +23,11 @@ final class EmptyVariableReferenceGraph implements VariableReferenceGraph {
     @Override
     public void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity) {
         // No need to do anything.
+    }
+
+    @Override
+    public List<Object> getInconsistentEntities() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -1,6 +1,8 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.BitSet;
+import java.util.Collections;
+import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Spliterators;
 import java.util.function.IntFunction;
@@ -105,5 +107,10 @@ public final class FixedVariableReferenceGraph<Solution_>
         }
         isChanged.clear();
         return true;
+    }
+
+    @Override
+    public List<Object> getInconsistentEntities() {
+        return Collections.emptyList();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -134,6 +135,11 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
         if (!isUpdating && monitoredSourceVariableSet.contains(variableReference) && monitoredEntityClass.isInstance(entity)) {
             changedEntities.add(entity);
         }
+    }
+
+    @Override
+    public List<Object> getInconsistentEntities() {
+        return Collections.emptyList();
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
+import java.util.List;
+
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 public sealed interface VariableReferenceGraph
@@ -34,4 +36,5 @@ public sealed interface VariableReferenceGraph
      */
     void afterVariableChanged(VariableMetaModel<?, ?, ?> variableReference, Object entity);
 
+    List<Object> getInconsistentEntities();
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
@@ -374,6 +374,14 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
         return true;
     }
 
+    public List<Object> getInconsistentEntities() {
+        if (shadowVariableSession == null) {
+            throw new IllegalStateException(
+                    "The shadowVariableSession is null. A solution without shadow variables cannot be inconsistent.");
+        }
+        return shadowVariableSession.getInconsistentEntities();
+    }
+
     /**
      * Triggers all cascading update shadow variable user-logic.
      */

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
@@ -377,7 +377,7 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
     public List<Object> getInconsistentEntities() {
         if (shadowVariableSession == null) {
             throw new IllegalStateException(
-                    "The shadowVariableSession is null. A solution without shadow variables cannot be inconsistent.");
+                    "Impossible state: The shadowVariableSession is null. A solution without shadow variables cannot be inconsistent.");
         }
         return shadowVariableSession.getInconsistentEntities();
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -344,6 +344,45 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         // Do nothing
     }
 
+    public void unassignInconsistentEntities() {
+        var inconsistentEntities = variableListenerSupport.getInconsistentEntities();
+        if (listVariableStateSupply != null) {
+            var listVariableDescriptor = listVariableStateSupply.getSourceVariableDescriptor();
+            var listElementClass = listVariableStateSupply.getSourceVariableDescriptor().getElementType();
+            for (var inconsistentEntity : inconsistentEntities) {
+                if (listElementClass.isInstance(inconsistentEntity)) {
+                    var inverse = Objects.requireNonNull(listVariableStateSupply.getInverseSingleton(inconsistentEntity));
+                    int index = Objects.requireNonNull(listVariableStateSupply.getIndex(inconsistentEntity));
+                    beforeListVariableElementUnassigned(listVariableDescriptor, inconsistentEntity);
+                    beforeListVariableChanged(listVariableDescriptor, inverse, index, index + 1);
+                    listVariableDescriptor.removeElement(inverse, index);
+                    afterListVariableChanged(listVariableDescriptor, inverse, index, index);
+                    afterListVariableElementUnassigned(listVariableDescriptor, inconsistentEntity);
+                    triggerVariableListeners();
+                }
+                // Unassign any normal @PlanningVariable on the entity too
+                unassignPlainEntity(inconsistentEntity);
+            }
+        } else {
+            for (var inconsistentEntity : inconsistentEntities) {
+                unassignPlainEntity(inconsistentEntity);
+            }
+        }
+    }
+
+    private void unassignPlainEntity(Object inconsistentEntity) {
+        var entityDescriptor = getSolutionDescriptor().findEntityDescriptor(inconsistentEntity.getClass());
+        if (entityDescriptor == null) {
+            throw new IllegalStateException("Object (%s) is not an entity but is inconsistent".formatted(inconsistentEntity));
+        }
+        for (var genuineVariableDescriptor : entityDescriptor.getGenuineVariableDescriptorList()) {
+            beforeVariableChanged(genuineVariableDescriptor, inconsistentEntity);
+            genuineVariableDescriptor.setValue(inconsistentEntity, null);
+            afterVariableChanged(genuineVariableDescriptor, inconsistentEntity);
+        }
+        triggerVariableListeners();
+    }
+
     @Override
     public void setMoveRepository(@Nullable MoveRepository<Solution_> moveRepository) {
         if (this.moveRepository == moveRepository) { // Prevent double initialization

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -355,8 +355,9 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
                     int index = Objects.requireNonNull(listVariableStateSupply.getIndex(inconsistentEntity));
 
                     if (listVariableDescriptor.isElementPinned(Objects.requireNonNull(workingSolution), inverse, index)) {
-                        throw new IllegalStateException(
-                                "Entity (%s) is pinned but is involved in a dependency loop".formatted(inconsistentEntity));
+                        throw new IllegalStateException("""
+                                Entity (%s) is pinned while involved in a dependency loop.
+                                This creates an unresolvable inconsistency.""".formatted(inconsistentEntity));
                     }
 
                     beforeListVariableElementUnassigned(listVariableDescriptor, inconsistentEntity);
@@ -379,12 +380,14 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     private void unassignPlainEntity(Object inconsistentEntity) {
         var entityDescriptor = getSolutionDescriptor().findEntityDescriptor(inconsistentEntity.getClass());
         if (entityDescriptor == null) {
-            throw new IllegalStateException("Object (%s) is not an entity but is inconsistent".formatted(inconsistentEntity));
+            throw new IllegalStateException(
+                    "Impossible state: Object (%s) is not an entity but is inconsistent".formatted(inconsistentEntity));
         }
         if (entityDescriptor.isGenuine()
                 && !entityDescriptor.isMovable(Objects.requireNonNull(workingSolution), inconsistentEntity)) {
-            throw new IllegalStateException(
-                    "Entity (%s) is pinned but is involved in a dependency loop".formatted(inconsistentEntity));
+            throw new IllegalStateException("""
+                    Entity (%s) is pinned while involved in a dependency loop.
+                    This creates an unresolvable inconsistency.""".formatted(inconsistentEntity));
         }
         for (var genuineVariableDescriptor : entityDescriptor.getGenuineVariableDescriptorList()) {
             beforeVariableChanged(genuineVariableDescriptor, inconsistentEntity);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -353,6 +353,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
                 if (listElementClass.isInstance(inconsistentEntity)) {
                     var inverse = Objects.requireNonNull(listVariableStateSupply.getInverseSingleton(inconsistentEntity));
                     int index = Objects.requireNonNull(listVariableStateSupply.getIndex(inconsistentEntity));
+
+                    if (listVariableDescriptor.isElementPinned(Objects.requireNonNull(workingSolution), inverse, index)) {
+                        throw new IllegalStateException(
+                                "Entity (%s) is pinned but is involved in a dependency loop".formatted(inconsistentEntity));
+                    }
+
                     beforeListVariableElementUnassigned(listVariableDescriptor, inconsistentEntity);
                     beforeListVariableChanged(listVariableDescriptor, inverse, index, index + 1);
                     listVariableDescriptor.removeElement(inverse, index);
@@ -374,6 +380,11 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         var entityDescriptor = getSolutionDescriptor().findEntityDescriptor(inconsistentEntity.getClass());
         if (entityDescriptor == null) {
             throw new IllegalStateException("Object (%s) is not an entity but is inconsistent".formatted(inconsistentEntity));
+        }
+        if (entityDescriptor.isGenuine()
+                && !entityDescriptor.isMovable(Objects.requireNonNull(workingSolution), inconsistentEntity)) {
+            throw new IllegalStateException(
+                    "Entity (%s) is pinned but is involved in a dependency loop".formatted(inconsistentEntity));
         }
         for (var genuineVariableDescriptor : entityDescriptor.getGenuineVariableDescriptorList()) {
             beforeVariableChanged(genuineVariableDescriptor, inconsistentEntity);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -170,6 +170,8 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
 
     boolean ignoreInconsistentSolutions();
 
+    void unassignInconsistentEntities();
+
     /**
      * @return never null
      */
@@ -363,5 +365,4 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
     void beforeProblemFactRemoved(Object problemFact);
 
     void afterProblemFactRemoved(Object problemFact);
-
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -60,7 +60,8 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
             scoreDirector.unassignInconsistentEntities();
             innerScore = scoreDirector.calculateScore();
             if (innerScore.isInvalid()) {
-                throw new IllegalStateException("The initial solution passed to the solver is inconsistent even after unassigning involved entities.");
+                throw new IllegalStateException(
+                        "The initial solution passed to the solver is inconsistent even after unassigning involved entities.");
             }
         }
         var score = innerScore.raw();

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -11,6 +11,9 @@ import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.solver.event.SolverEventSupport;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Remembers the {@link PlanningSolution best solution} that a {@link Solver} encounters.
  *
@@ -18,6 +21,7 @@ import ai.timefold.solver.core.impl.solver.scope.SolverScope;
  */
 public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapter<Solution_> {
 
+    private static final Logger log = LoggerFactory.getLogger(BestSolutionRecaller.class);
     protected boolean assertInitialScoreFromScratch = false;
     protected boolean assertShadowVariablesAreNotStale = false;
     protected boolean assertBestScoreIsUnmodified = false;
@@ -44,16 +48,20 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
     // Worker methods
     // ************************************************************************
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
+    @SuppressWarnings("unchecked")
     public void solvingStarted(SolverScope<Solution_> solverScope) {
         // Starting bestSolution is already set by Solver.solve(Solution)
         var scoreDirector = solverScope.getScoreDirector();
+        @SuppressWarnings("rawtypes")
         InnerScore innerScore = scoreDirector.calculateScore();
         if (innerScore.isInvalid()) {
-            throw new IllegalStateException(
-                    "The initial solution passed to the solver (%s) is invalid because it has dependency loops."
-                            .formatted(solverScope.getWorkingSolution()));
+            log.warn("The initial solution passed to the solver is inconsistent. Unassigning involved entities.");
+            scoreDirector.unassignInconsistentEntities();
+            innerScore = scoreDirector.calculateScore();
+            if (innerScore.isInvalid()) {
+                throw new IllegalStateException("The initial solution passed to the solver is inconsistent even after unassigning involved entities.");
+            }
         }
         var score = innerScore.raw();
         solverScope.setBestScore(innerScore);

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -1454,7 +1454,7 @@ class DefaultSolverTest {
     }
 
     @Test
-    void solveWhenIgnoringInconsistentSolutionsThrowsIfInitialSolutionInconsistent() {
+    void solveWhenIgnoringInconsistentSolutionsUnassignsIfInitialSolutionInconsistent() {
         // Solver config
         var solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataDependencyNoInconsistentFieldSolution.class, TestdataDependencyNoInconsistentFieldEntity.class,
@@ -1462,7 +1462,63 @@ class DefaultSolverTest {
                 .withEasyScoreCalculatorClass(null)
                 .withConstraintProviderClass(TestdataDependencyNoInconsistentFieldConstraintProvider.class)
                 .withPhases(new CustomPhaseConfig()
-                        .withCustomPhaseCommands(command -> {}));
+                        .withCustomPhaseCommands(command -> {
+                        }));
+
+        var e1 = new TestdataDependencyNoInconsistentFieldEntity("a");
+        var e2 = new TestdataDependencyNoInconsistentFieldEntity("b");
+
+        var a1 = new TestdataDependencyNoInconsistentFieldValue("a1");
+        var a2 = new TestdataDependencyNoInconsistentFieldValue("a2");
+        var b1 = new TestdataDependencyNoInconsistentFieldValue("b1");
+        var b2 = new TestdataDependencyNoInconsistentFieldValue("b2");
+
+        a2.setDependencies(List.of(a1));
+        b2.setDependencies(List.of(b1));
+
+        e1.setValues(List.of(b2, b1));
+        e2.setValues(List.of(a1, a2));
+
+        var entities = List.of(e1, e2);
+        var values = List.of(a1, a2, b1, b2);
+
+        var problem = new TestdataDependencyNoInconsistentFieldSolution();
+
+        problem.setEntities(entities);
+        problem.setValues(values);
+
+        var solution = PlannerTestUtils.solve(solverConfig, problem, false);
+        assertThat(solution.getEntities().getFirst().getValues()).isEmpty();
+        assertThat(solution.getEntities().getLast().getValues()).hasSize(2);
+
+        var sE2 = solution.getEntities().getLast();
+
+        var sA1 = solution.getValues().get(0);
+        var sA2 = solution.getValues().get(1);
+        var sB1 = solution.getValues().get(2);
+        var sB2 = solution.getValues().get(3);
+
+        assertThat(sA1.getEntity()).isEqualTo(sE2);
+        assertThat(sA1.getPreviousValue()).isNull();
+
+        assertThat(sA2.getEntity()).isEqualTo(sE2);
+        assertThat(sA2.getPreviousValue()).isEqualTo(sA1);
+
+        assertThat(sB1.getEntity()).isNull();
+        assertThat(sB1.getPreviousValue()).isNull();
+
+        assertThat(sB2.getEntity()).isNull();
+        assertThat(sB2.getPreviousValue()).isNull();
+    }
+
+    @Test
+    void solveWhenIgnoringInconsistentSolutionsThrowsIfInconsistentEntityPinned() {
+        // Solver config
+        var solverConfig = PlannerTestUtils.buildSolverConfig(
+                TestdataDependencyNoInconsistentFieldSolution.class, TestdataDependencyNoInconsistentFieldEntity.class,
+                TestdataDependencyNoInconsistentFieldValue.class)
+                .withEasyScoreCalculatorClass(null)
+                .withConstraintProviderClass(TestdataDependencyNoInconsistentFieldConstraintProvider.class);
 
         var e1 = new TestdataDependencyNoInconsistentFieldEntity("a");
         var e2 = new TestdataDependencyNoInconsistentFieldEntity("b");
@@ -1481,31 +1537,16 @@ class DefaultSolverTest {
         var entities = List.of(e1, e2);
         var values = List.of(a1, a2, b1, b2);
 
+        e1.setPinnedToIndex(1);
+
         var problem = new TestdataDependencyNoInconsistentFieldSolution();
 
         problem.setEntities(entities);
         problem.setValues(values);
 
-        var solution = PlannerTestUtils.solve(solverConfig, problem, false);
-        assertThat(solution.getEntities().getFirst().getValues().isEmpty());
-        assertThat(solution.getEntities().getLast().getValues().isEmpty());
-
-        var sA1 = solution.getValues().get(0);
-        var sA2 = solution.getValues().get(1);
-        var sB1 = solution.getValues().get(2);
-        var sB2 = solution.getValues().get(3);
-
-        assertThat(sA1.getEntity()).isNull();
-        assertThat(sA1.getPreviousValue()).isNull();
-
-        assertThat(sA2.getEntity()).isNull();
-        assertThat(sA2.getPreviousValue()).isNull();
-
-        assertThat(sB1.getEntity()).isNull();
-        assertThat(sB1.getPreviousValue()).isNull();
-
-        assertThat(sB2.getEntity()).isNull();
-        assertThat(sB2.getPreviousValue()).isNull();
+        assertThatCode(() -> PlannerTestUtils.solve(solverConfig, problem, false))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContainingAll("Entity", "b2", "is pinned but is involved in a dependency loop");
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -1460,7 +1460,9 @@ class DefaultSolverTest {
                 TestdataDependencyNoInconsistentFieldSolution.class, TestdataDependencyNoInconsistentFieldEntity.class,
                 TestdataDependencyNoInconsistentFieldValue.class)
                 .withEasyScoreCalculatorClass(null)
-                .withConstraintProviderClass(TestdataDependencyNoInconsistentFieldConstraintProvider.class);
+                .withConstraintProviderClass(TestdataDependencyNoInconsistentFieldConstraintProvider.class)
+                .withPhases(new CustomPhaseConfig()
+                        .withCustomPhaseCommands(command -> {}));
 
         var e1 = new TestdataDependencyNoInconsistentFieldEntity("a");
         var e2 = new TestdataDependencyNoInconsistentFieldEntity("b");
@@ -1484,10 +1486,26 @@ class DefaultSolverTest {
         problem.setEntities(entities);
         problem.setValues(values);
 
-        // TODO: Verify the values were unassigned instead
-        assertThatCode(() -> PlannerTestUtils.solve(solverConfig, problem)).isInstanceOf(IllegalStateException.class)
-                .hasMessageContainingAll("The initial solution passed to the solver",
-                        "is invalid because it has dependency loops");
+        var solution = PlannerTestUtils.solve(solverConfig, problem, false);
+        assertThat(solution.getEntities().getFirst().getValues().isEmpty());
+        assertThat(solution.getEntities().getLast().getValues().isEmpty());
+
+        var sA1 = solution.getValues().get(0);
+        var sA2 = solution.getValues().get(1);
+        var sB1 = solution.getValues().get(2);
+        var sB2 = solution.getValues().get(3);
+
+        assertThat(sA1.getEntity()).isNull();
+        assertThat(sA1.getPreviousValue()).isNull();
+
+        assertThat(sA2.getEntity()).isNull();
+        assertThat(sA2.getPreviousValue()).isNull();
+
+        assertThat(sB1.getEntity()).isNull();
+        assertThat(sB1.getPreviousValue()).isNull();
+
+        assertThat(sB2.getEntity()).isNull();
+        assertThat(sB2.getPreviousValue()).isNull();
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -1546,7 +1546,7 @@ class DefaultSolverTest {
 
         assertThatCode(() -> PlannerTestUtils.solve(solverConfig, problem, false))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContainingAll("Entity", "b2", "is pinned but is involved in a dependency loop");
+                .hasMessageContainingAll("Entity", "b2", "while involved in a dependency loop");
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/shadow/no_inconsistent_field/TestdataDependencyNoInconsistentFieldEntity.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import ai.timefold.solver.core.api.domain.common.PlanningId;
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPinToIndex;
 import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
 
 @PlanningEntity
@@ -16,6 +17,9 @@ public class TestdataDependencyNoInconsistentFieldEntity {
 
     @PlanningListVariable
     List<TestdataDependencyNoInconsistentFieldValue> values;
+
+    @PlanningPinToIndex
+    int pinnedToIndex;
 
     LocalDateTime startTime;
 
@@ -55,6 +59,14 @@ public class TestdataDependencyNoInconsistentFieldEntity {
 
     public void setStartTime(LocalDateTime startTime) {
         this.startTime = startTime;
+    }
+
+    public int getPinnedToIndex() {
+        return pinnedToIndex;
+    }
+
+    public void setPinnedToIndex(int pinnedToIndex) {
+        this.pinnedToIndex = pinnedToIndex;
     }
 
     @Override


### PR DESCRIPTION
Depends on https://github.com/TimefoldAI/timefold-solver/pull/2396

Unassigns any entities/values involved in dependency loops at solve start. Throws if any of those entities/values are pinned.