### PR TITLE
chore: make score analysis/recommendations/update fail fast on inconsistent solution

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/api/domain/variable/InconsistentSolutionException.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/variable/InconsistentSolutionException.java
@@ -1,0 +1,27 @@
+package ai.timefold.solver.core.api.domain.variable;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class InconsistentSolutionException extends RuntimeException {
+    private final Object solution;
+    private final List<Object> involvedEntityList;
+
+    public InconsistentSolutionException(String feature, Object solution, List<Object> involvedEntityList) {
+        super("The solution (%s) is inconsistent. %s requires a consistent solution.".formatted(solution, feature));
+        this.solution = solution;
+        this.involvedEntityList = involvedEntityList;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getSolution() {
+        return (T) solution;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> List<T> getInvolvedEntityList() {
+        return (List<T>) involvedEntityList;
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -343,8 +343,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         // Do nothing
     }
 
+    public List<Object> getInconsistentEntities() {
+        return shadowVariableSupport.getInconsistentEntities();
+    }
+
     public void unassignInconsistentEntities() {
-        var inconsistentEntities = shadowVariableSupport.getInconsistentEntities();
+        var inconsistentEntities = getInconsistentEntities();
         if (listVariableStateSupply != null) {
             var listVariableDescriptor = listVariableStateSupply.getSourceVariableDescriptor();
             var listElementClass = listVariableStateSupply.getSourceVariableDescriptor().getElementType();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -489,6 +489,10 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         lastVariableUpdateWasSuccessful = shadowVariableSupport.updateShadowVariables();
     }
 
+    public boolean isLastVariableUpdateWasSuccessful() {
+        return lastVariableUpdateWasSuccessful;
+    }
+
     /**
      * This function clears all listener events that have been generated without triggering any of them.
      * Using this method requires caution because clearing the event queue can lead to inconsistent states.

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -95,7 +95,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     private long calculationCount = 0L;
     protected @Nullable Solution_ workingSolution;
     private int workingInitScore = 0;
-    private boolean lastVariableUpdateWasSuccessful = true;
+    private boolean lastVariableUpdateSuccessful = true;
 
     private final boolean isStepAssertOrMore;
 
@@ -246,7 +246,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public final InnerScore<Score_> calculateScore() {
-        if (lastVariableUpdateWasSuccessful) {
+        if (lastVariableUpdateSuccessful) {
             return innerCalculateScore();
         } else {
             var invalidScore = InnerScore.invalid(getScoreDefinition().getZeroScore());
@@ -343,12 +343,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         // Do nothing
     }
 
-    public List<Object> getInconsistentEntities() {
+    public List<Object> computeInconsistentEntities() {
         return shadowVariableSupport.getInconsistentEntities();
     }
 
     public void unassignInconsistentEntities() {
-        var inconsistentEntities = getInconsistentEntities();
+        var inconsistentEntities = computeInconsistentEntities();
         if (listVariableStateSupply != null) {
             var listVariableDescriptor = listVariableStateSupply.getSourceVariableDescriptor();
             var listElementClass = listVariableStateSupply.getSourceVariableDescriptor().getElementType();
@@ -490,11 +490,11 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public void updateShadowVariables() {
-        lastVariableUpdateWasSuccessful = shadowVariableSupport.updateShadowVariables();
+        lastVariableUpdateSuccessful = shadowVariableSupport.updateShadowVariables();
     }
 
-    public boolean isLastVariableUpdateWasSuccessful() {
-        return lastVariableUpdateWasSuccessful;
+    public boolean isLastVariableUpdateSuccessful() {
+        return lastVariableUpdateSuccessful;
     }
 
     /**
@@ -509,7 +509,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public void forceUpdateShadowVariables() {
-        lastVariableUpdateWasSuccessful = shadowVariableSupport.forceUpdateAllShadowVariables(getWorkingSolution());
+        lastVariableUpdateSuccessful = shadowVariableSupport.forceUpdateAllShadowVariables(getWorkingSolution());
     }
 
     protected void setCalculatedScore(Score_ score) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -74,7 +74,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     private final @Nullable LookupManager lookUpManager;
     protected final ConstraintMatchPolicy constraintMatchPolicy;
     private boolean expectShadowVariablesInCorrectState;
-    private boolean ignoreInconsistentSolutions;
+    private final boolean ignoreInconsistentSolutions;
     private final VariableDescriptorCache<Solution_> variableDescriptorCache;
     protected final ShadowVariableSupport<Solution_> shadowVariableSupport;
     private final @Nullable SolutionTracker<Solution_> solutionTracker; // Null when tracking disabled.
@@ -110,7 +110,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         this.lookUpManager = lookUpEnabled ? new LookupManager(solutionDescriptor.getLookUpStrategyResolver()) : null;
         this.constraintMatchPolicy = builder.constraintMatchPolicy;
         this.expectShadowVariablesInCorrectState = builder.expectShadowVariablesInCorrectState;
-        this.ignoreInconsistentSolutions = builder.ignoreInconsistentSolutions;
+        this.ignoreInconsistentSolutions = !solutionDescriptor.hasAnyShadowVariablesInconsistentMember();
         this.variableDescriptorCache = new VariableDescriptorCache<>(solutionDescriptor);
         this.shadowVariableSupport = ShadowVariableSupport.create(this);
         this.shadowVariableSupport.linkShadowVariables();
@@ -524,7 +524,6 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             var childThreadScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
                     .withLookUpEnabled(lookUpEnabled)
                     .withConstraintMatchPolicy(constraintMatchPolicy)
-                    .withIgnoreInconsistentSolutions(ignoreInconsistentSolutions)
                     .buildDerived();
             // ScoreCalculationCountTermination takes into account previous phases
             // but the calculationCount of partitions is maxed, not summed.
@@ -534,7 +533,6 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             var childThreadScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
                     .withLookUpEnabled(true)
                     .withConstraintMatchPolicy(constraintMatchPolicy)
-                    .withIgnoreInconsistentSolutions(ignoreInconsistentSolutions)
                     .buildDerived();
             childThreadScoreDirector.setWorkingSolution(cloneWorkingSolution());
             return childThreadScoreDirector;
@@ -807,7 +805,6 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         // Most score directors don't need derived status; CS will override this.
         try (var uncorruptedScoreDirector = assertionScoreDirectorFactory.createScoreDirectorBuilder()
                 .withConstraintMatchPolicy(ConstraintMatchPolicy.ENABLED)
-                .withIgnoreInconsistentSolutions(ignoreInconsistentSolutions)
                 .buildDerived()) {
             uncorruptedScoreDirector.setWorkingSolution(workingSolution);
             var uncorruptedInnerScore = uncorruptedScoreDirector.calculateScore();
@@ -1006,7 +1003,6 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         protected ConstraintMatchPolicy constraintMatchPolicy = ConstraintMatchPolicy.DISABLED;
         protected boolean lookUpEnabled = false;
         protected boolean expectShadowVariablesInCorrectState = true;
-        protected boolean ignoreInconsistentSolutions = false;
 
         protected AbstractScoreDirectorBuilder(Factory_ scoreDirectorFactory) {
             this.scoreDirectorFactory = Objects.requireNonNull(scoreDirectorFactory);
@@ -1027,12 +1023,6 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         @SuppressWarnings("unchecked")
         public Builder_ withExpectShadowVariablesInCorrectState(boolean expectShadowVariablesInCorrectState) {
             this.expectShadowVariablesInCorrectState = expectShadowVariablesInCorrectState;
-            return (Builder_) this;
-        }
-
-        @SuppressWarnings("unchecked")
-        public Builder_ withIgnoreInconsistentSolutions(boolean ignoreInconsistentSolutions) {
-            this.ignoreInconsistentSolutions = ignoreInconsistentSolutions;
             return (Builder_) this;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -65,10 +65,8 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
             boolean cloneSolution) {
         var isShadowVariableUpdateEnabled = solutionUpdatePolicy.isShadowVariableUpdateEnabled();
         var nonNullSolution = Objects.requireNonNull(solution);
-        var allowsInconsistent = getScoreDirectorFactory().getSolutionDescriptor().hasAnyShadowVariablesInconsistentMember();
         try (var scoreDirector = getScoreDirectorFactory().createScoreDirectorBuilder().withLookUpEnabled(cloneSolution)
                 .withConstraintMatchPolicy(constraintMatchPolicy)
-                .withIgnoreInconsistentSolutions(!allowsInconsistent)
                 .withExpectShadowVariablesInCorrectState(!isShadowVariableUpdateEnabled).build()) {
             nonNullSolution = cloneSolution ? scoreDirector.cloneSolution(nonNullSolution) : nonNullSolution;
             if (isShadowVariableUpdateEnabled) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -51,20 +51,23 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
     @Override
     public Score_ update(Solution_ solution, SolutionUpdatePolicy solutionUpdatePolicy) {
         if (solutionUpdatePolicy == SolutionUpdatePolicy.NO_UPDATE) {
-            throw new IllegalArgumentException("Can not call " + this.getClass().getSimpleName()
-                    + ".update() with this solutionUpdatePolicy (" + solutionUpdatePolicy + ").");
+            throw new IllegalArgumentException(
+                    "Can not call %s.update() with this solutionUpdatePolicy (%s)."
+                            .formatted(this.getClass().getSimpleName(), solutionUpdatePolicy));
         }
-        return callScoreDirector(solution, solutionUpdatePolicy,
+        return callScoreDirector("Solution update", solution, solutionUpdatePolicy,
                 s -> s.getSolutionDescriptor().getScore(s.getWorkingSolution()), ConstraintMatchPolicy.DISABLED, false);
     }
 
-    private <Result_> Result_ callScoreDirector(Solution_ solution, SolutionUpdatePolicy solutionUpdatePolicy,
+    private <Result_> Result_ callScoreDirector(String feature, Solution_ solution, SolutionUpdatePolicy solutionUpdatePolicy,
             Function<InnerScoreDirector<Solution_, Score_>, Result_> function, ConstraintMatchPolicy constraintMatchPolicy,
             boolean cloneSolution) {
         var isShadowVariableUpdateEnabled = solutionUpdatePolicy.isShadowVariableUpdateEnabled();
         var nonNullSolution = Objects.requireNonNull(solution);
+        var allowsInconsistent = getScoreDirectorFactory().getSolutionDescriptor().hasAnyShadowVariablesInconsistentMember();
         try (var scoreDirector = getScoreDirectorFactory().createScoreDirectorBuilder().withLookUpEnabled(cloneSolution)
                 .withConstraintMatchPolicy(constraintMatchPolicy)
+                .withIgnoreInconsistentSolutions(!allowsInconsistent)
                 .withExpectShadowVariablesInCorrectState(!isShadowVariableUpdateEnabled).build()) {
             nonNullSolution = cloneSolution ? scoreDirector.cloneSolution(nonNullSolution) : nonNullSolution;
             if (isShadowVariableUpdateEnabled) {
@@ -82,7 +85,16 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
                         Maybe use Constraint Streams instead of Easy or Incremental score calculator?""");
             }
             if (solutionUpdatePolicy.isScoreUpdateEnabled()) {
-                scoreDirector.calculateScore();
+                var score = scoreDirector.calculateScore();
+                if (score.isInvalid()) {
+                    throw new IllegalArgumentException("""
+                            The solution (%s) is inconsistent. %s requires a consistent solution to be passed.
+                            """.formatted(solution, feature));
+                }
+            } else if (!scoreDirector.isLastVariableUpdateWasSuccessful()) {
+                throw new IllegalArgumentException("""
+                        The solution (%s) is inconsistent. %s requires a consistent solution to be passed.
+                        """.formatted(solution, feature));
             }
             return function.apply(scoreDirector);
         }
@@ -112,7 +124,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
         var enterpriseService =
                 TimefoldSolverEnterpriseService.loadOrFail(TimefoldSolverEnterpriseService.Feature.SCORE_ANALYSIS);
         var currentScore = (Score_) scoreDirectorFactory.getSolutionDescriptor().getScore(solution);
-        var analysis = callScoreDirector(solution, solutionUpdatePolicy,
+        var analysis = callScoreDirector("Solution analysis", solution, solutionUpdatePolicy,
                 scoreDirector -> enterpriseService.analyze(scoreDirector.calculateScore(),
                         scoreDirector.getConstraintMatchTotalMap(), fetchPolicy),
                 ConstraintMatchPolicy.match(fetchPolicy), false);
@@ -134,7 +146,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
             ScoreAnalysisFetchPolicy fetchPolicy) {
         var enterpriseService =
                 TimefoldSolverEnterpriseService.loadOrFail(TimefoldSolverEnterpriseService.Feature.RECOMMENDATIONS);
-        return callScoreDirector(
+        return callScoreDirector("Recommended assignment",
                 solution, SolutionUpdatePolicy.UPDATE_ALL, enterpriseService.buildRecommender(solverFactory, solution,
                         evaluatedEntityOrElement, propositionFunction, fetchPolicy),
                 ConstraintMatchPolicy.match(fetchPolicy), true);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.variable.InconsistentSolutionException;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.analysis.ScoreAnalysis;
 import ai.timefold.solver.core.api.solver.RecommendedAssignment;
@@ -87,14 +88,12 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
             if (solutionUpdatePolicy.isScoreUpdateEnabled()) {
                 var score = scoreDirector.calculateScore();
                 if (score.isInvalid()) {
-                    throw new IllegalArgumentException("""
-                            The solution (%s) is inconsistent. %s requires a consistent solution to be passed.
-                            """.formatted(solution, feature));
+                    var inconsistentEntities = scoreDirector.getInconsistentEntities();
+                    throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
                 }
             } else if (!scoreDirector.isLastVariableUpdateWasSuccessful()) {
-                throw new IllegalArgumentException("""
-                        The solution (%s) is inconsistent. %s requires a consistent solution to be passed.
-                        """.formatted(solution, feature));
+                var inconsistentEntities = scoreDirector.getInconsistentEntities();
+                throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
             }
             return function.apply(scoreDirector);
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -53,7 +53,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
     public Score_ update(Solution_ solution, SolutionUpdatePolicy solutionUpdatePolicy) {
         if (solutionUpdatePolicy == SolutionUpdatePolicy.NO_UPDATE) {
             throw new IllegalArgumentException(
-                    "Can not call %s.update() with this solutionUpdatePolicy (%s)."
+                    "Cannot call %s.update() with this solutionUpdatePolicy (%s), since it would do nothing."
                             .formatted(this.getClass().getSimpleName(), solutionUpdatePolicy));
         }
         return callScoreDirector("Solution update", solution, solutionUpdatePolicy,
@@ -86,11 +86,11 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
             if (solutionUpdatePolicy.isScoreUpdateEnabled()) {
                 var score = scoreDirector.calculateScore();
                 if (score.isInvalid()) {
-                    var inconsistentEntities = scoreDirector.getInconsistentEntities();
+                    var inconsistentEntities = scoreDirector.computeInconsistentEntities();
                     throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
                 }
-            } else if (!scoreDirector.isLastVariableUpdateWasSuccessful()) {
-                var inconsistentEntities = scoreDirector.getInconsistentEntities();
+            } else if (!scoreDirector.isLastVariableUpdateSuccessful()) {
+                var inconsistentEntities = scoreDirector.computeInconsistentEntities();
                 throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
             }
             return function.apply(scoreDirector);
@@ -121,7 +121,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
         var enterpriseService =
                 TimefoldSolverEnterpriseService.loadOrFail(TimefoldSolverEnterpriseService.Feature.SCORE_ANALYSIS);
         var currentScore = (Score_) scoreDirectorFactory.getSolutionDescriptor().getScore(solution);
-        var analysis = callScoreDirector("Solution analysis", solution, solutionUpdatePolicy,
+        var analysis = callScoreDirector("Score analysis", solution, solutionUpdatePolicy,
                 scoreDirector -> enterpriseService.analyze(scoreDirector.calculateScore(),
                         scoreDirector.getConstraintMatchTotalMap(), fetchPolicy),
                 ConstraintMatchPolicy.match(fetchPolicy), false);

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -126,7 +126,6 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
         }
         var castScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
                 .withLookUpEnabled(true) // Custom phases and problem changes may rely on lookups.
-                .withIgnoreInconsistentSolutions(!solutionDescriptor.hasAnyShadowVariablesInconsistentMember())
                 .withConstraintMatchPolicy(
                         constraintMatchEnabled ? ConstraintMatchPolicy.ENABLED : ConstraintMatchPolicy.DISABLED)
                 .build();

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
+import ai.timefold.solver.core.api.domain.variable.InconsistentSolutionException;
 import ai.timefold.solver.core.api.score.HardSoftScore;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
@@ -137,9 +138,11 @@ public class SolutionManagerTest {
         assertThat(solutionManager).isNotNull();
 
         assertThatCode(() -> solutionManager.update(inconsistentSolution))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InconsistentSolutionException.class)
                 .hasMessageContainingAll("The solution (",
-                        "is inconsistent", "Solution update", "requires a consistent solution");
+                        "is inconsistent", "Solution update", "requires a consistent solution")
+                .hasFieldOrPropertyWithValue("solution", inconsistentSolution)
+                .hasFieldOrPropertyWithValue("involvedEntityList", List.of(valueA1, valueA2));
     }
 
     private void assertShadowedListValueAllNull(SoftAssertions softly, TestdataListValueWithShadowHistory current) {
@@ -196,10 +199,12 @@ public class SolutionManagerTest {
         var solutionManager = solutionManagerSource.createSolutionManager(solverFactory);
         assertThat(solutionManager).isNotNull();
 
-        assertThatCode(() -> solutionManager.update(inconsistentSolution, SolutionUpdatePolicy.UPDATE_SHADOW_VARIABLES_ONLY))
-                .isInstanceOf(IllegalArgumentException.class)
+        assertThatCode(() -> solutionManager.update(inconsistentSolution))
+                .isInstanceOf(InconsistentSolutionException.class)
                 .hasMessageContainingAll("The solution (",
-                        "is inconsistent", "Solution update", "requires a consistent solution");
+                        "is inconsistent", "Solution update", "requires a consistent solution")
+                .hasFieldOrPropertyWithValue("solution", inconsistentSolution)
+                .hasFieldOrPropertyWithValue("involvedEntityList", List.of(valueA1, valueA2));
     }
 
     @ParameterizedTest

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -23,6 +24,10 @@ import ai.timefold.solver.core.testdomain.shadow.concurrent.TestdataConcurrentCo
 import ai.timefold.solver.core.testdomain.shadow.concurrent.TestdataConcurrentEntity;
 import ai.timefold.solver.core.testdomain.shadow.concurrent.TestdataConcurrentSolution;
 import ai.timefold.solver.core.testdomain.shadow.concurrent.TestdataConcurrentValue;
+import ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field.TestdataDependencyNoInconsistentFieldConstraintProvider;
+import ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field.TestdataDependencyNoInconsistentFieldEntity;
+import ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field.TestdataDependencyNoInconsistentFieldSolution;
+import ai.timefold.solver.core.testdomain.shadow.no_inconsistent_field.TestdataDependencyNoInconsistentFieldValue;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
@@ -113,6 +118,30 @@ public class SolutionManagerTest {
         });
     }
 
+    @ParameterizedTest
+    @EnumSource(SolutionManagerSource.class)
+    void updateInconsistent(SolutionManagerSource solutionManagerSource) {
+        var entity1 = new TestdataDependencyNoInconsistentFieldEntity("e1");
+        var valueA1 = new TestdataDependencyNoInconsistentFieldValue("a1");
+        var valueA2 = new TestdataDependencyNoInconsistentFieldValue("a2", Duration.ofHours(1L), List.of(valueA1));
+        entity1.setValues(List.of(valueA2, valueA1));
+        var inconsistentSolution =
+                new TestdataDependencyNoInconsistentFieldSolution(List.of(entity1), List.of(valueA1, valueA2));
+
+        var solverFactory = SolverFactory.create(new SolverConfig()
+                .withSolutionClass(TestdataDependencyNoInconsistentFieldSolution.class)
+                .withEntityClasses(TestdataDependencyNoInconsistentFieldEntity.class,
+                        TestdataDependencyNoInconsistentFieldValue.class)
+                .withConstraintProviderClass(TestdataDependencyNoInconsistentFieldConstraintProvider.class));
+        var solutionManager = solutionManagerSource.createSolutionManager(solverFactory);
+        assertThat(solutionManager).isNotNull();
+
+        assertThatCode(() -> solutionManager.update(inconsistentSolution))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContainingAll("The solution (",
+                        "is inconsistent", "Solution update", "requires a consistent solution");
+    }
+
     private void assertShadowedListValueAllNull(SoftAssertions softly, TestdataListValueWithShadowHistory current) {
         softly.assertThat(current.getIndex()).isNull();
         softly.assertThat(current.getEntity()).isNull();
@@ -147,6 +176,30 @@ public class SolutionManagerTest {
             softly.assertThat(solution.getScore()).isNull();
             softly.assertThat(solution.getEntityList().getFirst().getFirstShadow()).isNotNull();
         });
+    }
+
+    @ParameterizedTest
+    @EnumSource(SolutionManagerSource.class)
+    void updateOnlyShadowVariablesInconsistent(SolutionManagerSource solutionManagerSource) {
+        var entity1 = new TestdataDependencyNoInconsistentFieldEntity("e1");
+        var valueA1 = new TestdataDependencyNoInconsistentFieldValue("a1");
+        var valueA2 = new TestdataDependencyNoInconsistentFieldValue("a2", Duration.ofHours(1L), List.of(valueA1));
+        entity1.setValues(List.of(valueA2, valueA1));
+        var inconsistentSolution =
+                new TestdataDependencyNoInconsistentFieldSolution(List.of(entity1), List.of(valueA1, valueA2));
+
+        var solverFactory = SolverFactory.create(new SolverConfig()
+                .withSolutionClass(TestdataDependencyNoInconsistentFieldSolution.class)
+                .withEntityClasses(TestdataDependencyNoInconsistentFieldEntity.class,
+                        TestdataDependencyNoInconsistentFieldValue.class)
+                .withConstraintProviderClass(TestdataDependencyNoInconsistentFieldConstraintProvider.class));
+        var solutionManager = solutionManagerSource.createSolutionManager(solverFactory);
+        assertThat(solutionManager).isNotNull();
+
+        assertThatCode(() -> solutionManager.update(inconsistentSolution, SolutionUpdatePolicy.UPDATE_SHADOW_VARIABLES_ONLY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContainingAll("The solution (",
+                        "is inconsistent", "Solution update", "requires a consistent solution");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Depends on https://github.com/TimefoldAI/timefold-solver/pull/2443

Fail fast on inconsistent solution for `SolutionManager`'s `update` and `analyze` methods.