### PR TITLE
fix: R&R allows for value to be kept unassigned

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateConstructionHeuristicPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateConstructionHeuristicPhase.java
@@ -48,21 +48,21 @@ public final class RuinRecreateConstructionHeuristicPhase<Solution_>
 
     @Override
     protected void doStep(ConstructionHeuristicStepScope<Solution_> stepScope) {
-        if (!elementsToRuinSet.isEmpty()) {
+        var checkMissingElements = !elementsToRuinSet.isEmpty()
+                // The generated step may include a no-change move
+                // when it's better to keep a planning value unassigned
+                // or when there are no unpinned entities
+                && !stepScope.getStep().getPlanningEntities().isEmpty();
+        if (checkMissingElements) {
             var listVariableDescriptor = stepScope.getPhaseScope().getSolverScope().getSolutionDescriptor()
                     .getListVariableDescriptor();
-            // The generated step may include a no-change move
-            // when it's better to keep a planning value unassigned
-            // or when there are no unpinned entities
-            if (!stepScope.getStep().getPlanningEntities().isEmpty()) {
-                var entity = stepScope.getStep().getPlanningEntities().getFirst();
-                if (!elementsToRuinSet.contains(entity)) {
-                    // Sometimes, the list of elements to be ruined does not include new destinations selected by the CH.
-                    // In these cases, we need to record the element list before making any move changes
-                    // so that it can be referenced to restore the solution to its original state when undoing changes.
-                    missingUpdatedElementsMap.computeIfAbsent(entity,
-                            e -> List.copyOf(listVariableDescriptor.getValue(e)));
-                }
+            var entity = stepScope.getStep().getPlanningEntities().getFirst();
+            if (!elementsToRuinSet.contains(entity)) {
+                // Sometimes, the list of elements to be ruined does not include new destinations selected by the CH.
+                // In these cases, we need to record the element list before making any move changes
+                // so that it can be referenced to restore the solution to its original state when undoing changes.
+                missingUpdatedElementsMap.computeIfAbsent(entity,
+                        e -> List.copyOf(listVariableDescriptor.getValue(e)));
             }
         }
         super.doStep(stepScope);

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateConstructionHeuristicPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateConstructionHeuristicPhase.java
@@ -51,13 +51,18 @@ public final class RuinRecreateConstructionHeuristicPhase<Solution_>
         if (!elementsToRuinSet.isEmpty()) {
             var listVariableDescriptor = stepScope.getPhaseScope().getSolverScope().getSolutionDescriptor()
                     .getListVariableDescriptor();
-            var entity = stepScope.getStep().getPlanningEntities().iterator().next();
-            if (!elementsToRuinSet.contains(entity)) {
-                // Sometimes, the list of elements to be ruined does not include new destinations selected by the CH.
-                // In these cases, we need to record the element list before making any move changes
-                // so that it can be referenced to restore the solution to its original state when undoing changes.
-                missingUpdatedElementsMap.computeIfAbsent(entity,
-                        e -> List.copyOf(listVariableDescriptor.getValue(e)));
+            // The generated step may include a no-change move
+            // when it's better to keep a planning value unassigned
+            // or when there are no unpinned entities
+            if (!stepScope.getStep().getPlanningEntities().isEmpty()) {
+                var entity = stepScope.getStep().getPlanningEntities().getFirst();
+                if (!elementsToRuinSet.contains(entity)) {
+                    // Sometimes, the list of elements to be ruined does not include new destinations selected by the CH.
+                    // In these cases, we need to record the element list before making any move changes
+                    // so that it can be referenced to restore the solution to its original state when undoing changes.
+                    missingUpdatedElementsMap.computeIfAbsent(entity,
+                            e -> List.copyOf(listVariableDescriptor.getValue(e)));
+                }
             }
         }
         super.doStep(stepScope);

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
@@ -20,6 +20,7 @@ import ai.timefold.solver.core.impl.move.VariableChangeRecordingScoreDirector;
 import ai.timefold.solver.core.impl.score.director.VariableDescriptorAwareScoreDirector;
 import ai.timefold.solver.core.impl.solver.random.DefaultRandomSource;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
+import ai.timefold.solver.core.preview.api.domain.metamodel.PositionInList;
 import ai.timefold.solver.core.preview.api.move.Move;
 
 import org.jspecify.annotations.NullMarked;
@@ -130,10 +131,9 @@ public final class SelectorBasedListRuinRecreateMove<Solution_> extends Abstract
 
             for (var ruinedValue : ruinedValueList) {
                 // Some ruined values may be left unassigned
-                if (!listVariableStateSupply.isAssigned(ruinedValue)) {
+                if (!(listVariableStateSupply.getElementPosition(ruinedValue) instanceof PositionInList position)) {
                     continue;
                 }
-                var position = listVariableStateSupply.getElementPosition(ruinedValue).ensureAssigned();
                 entityToNewPositionMap.computeIfAbsent(position.entity(), ignored -> new TreeSet<>())
                         .add(new RuinedPosition(ruinedValue, position.index()));
                 entityToInsertedValuesMap.computeIfAbsent(position.entity(), ignored -> new ArrayList<>()).add(ruinedValue);

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/SelectorBasedListRuinRecreateMove.java
@@ -129,8 +129,11 @@ public final class SelectorBasedListRuinRecreateMove<Solution_> extends Abstract
             }
 
             for (var ruinedValue : ruinedValueList) {
-                var position = listVariableStateSupply.getElementPosition(ruinedValue)
-                        .ensureAssigned();
+                // Some ruined values may be left unassigned
+                if (!listVariableStateSupply.isAssigned(ruinedValue)) {
+                    continue;
+                }
+                var position = listVariableStateSupply.getElementPosition(ruinedValue).ensureAssigned();
                 entityToNewPositionMap.computeIfAbsent(position.entity(), ignored -> new TreeSet<>())
                         .add(new RuinedPosition(ruinedValue, position.index()));
                 entityToInsertedValuesMap.computeIfAbsent(position.entity(), ignored -> new ArrayList<>()).add(ruinedValue);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelectorTest.java
@@ -5,6 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.List;
 
+import ai.timefold.solver.core.api.score.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
 import ai.timefold.solver.core.api.solver.SolverFactory;
 import ai.timefold.solver.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.RuinRecreateMoveSelectorConfig;
@@ -21,6 +25,7 @@ import ai.timefold.solver.core.testdomain.unassignedvar.TestdataAllowsUnassigned
 import ai.timefold.solver.core.testdomain.unassignedvar.TestdataAllowsUnassignedSolution;
 import ai.timefold.solver.core.testutil.AbstractMeterTest;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.Metrics;
@@ -92,6 +97,39 @@ class RuinRecreateMoveSelectorTest extends AbstractMeterTest {
         var problem = TestdataAllowsUnassignedSolution.generateSolution(5, 30);
         var solver = SolverFactory.create(solverConfig).buildSolver();
         assertDoesNotThrow(() -> solver.solve(problem));
+    }
+
+    @Test
+    void testRuiningNoAssignedValues() {
+        var solverConfig = new SolverConfig()
+                .withEnvironmentMode(EnvironmentMode.TRACKED_FULL_ASSERT)
+                .withSolutionClass(TestdataAllowsUnassignedSolution.class)
+                .withEntityClasses(TestdataAllowsUnassignedEntity.class)
+                .withConstraintProviderClass(TestdataNoAssignedValuesListMixedConstraintProvider.class)
+                .withPhaseList(List.of(
+                        new LocalSearchPhaseConfig()
+                                .withMoveSelectorConfig(new RuinRecreateMoveSelectorConfig().withMinimumRuinedCount(3))
+                                .withTerminationConfig(new TerminationConfig()
+                                        .withStepCountLimit(1))));
+        var problem = TestdataAllowsUnassignedSolution.generateSolution(3, 3);
+        for (var i = 0; i < 3; i++) {
+            problem.getEntityList().get(i).setValue(problem.getValueList().get(i));
+        }
+        var solver = SolverFactory.create(solverConfig).buildSolver();
+        assertDoesNotThrow(() -> solver.solve(problem));
+    }
+
+    public static final class TestdataNoAssignedValuesListMixedConstraintProvider
+            implements ConstraintProvider {
+
+        @Override
+        public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory constraintFactory) {
+            return new Constraint[] {
+                    constraintFactory.forEach(TestdataAllowsUnassignedEntity.class)
+                            .penalize(SimpleScore.ONE)
+                            .asConstraint("No Assigned")
+            };
+        }
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelectorTest.java
@@ -108,15 +108,22 @@ class RuinRecreateMoveSelectorTest extends AbstractMeterTest {
                 .withConstraintProviderClass(TestdataNoAssignedValuesListMixedConstraintProvider.class)
                 .withPhaseList(List.of(
                         new LocalSearchPhaseConfig()
+                                // Since the problem has 3 planning entities, the R&R will select all of them
                                 .withMoveSelectorConfig(new RuinRecreateMoveSelectorConfig().withMinimumRuinedCount(3))
                                 .withTerminationConfig(new TerminationConfig()
                                         .withStepCountLimit(1))));
+        // The problem involves three entities and three planning values,
+        // with the initial solution assigning a value to each entity
         var problem = TestdataAllowsUnassignedSolution.generateSolution(3, 3);
         for (var i = 0; i < 3; i++) {
             problem.getEntityList().get(i).setValue(problem.getValueList().get(i));
         }
         var solver = SolverFactory.create(solverConfig).buildSolver();
-        assertDoesNotThrow(() -> solver.solve(problem));
+        // All values must remain unassigned
+        var solution = (TestdataAllowsUnassignedSolution) assertDoesNotThrow(() -> solver.solve(problem));
+        assertThat(solution.getEntityList().getFirst().getValue()).isNull();
+        assertThat(solution.getEntityList().get(1).getValue()).isNull();
+        assertThat(solution.getEntityList().get(2).getValue()).isNull();
     }
 
     public static final class TestdataNoAssignedValuesListMixedConstraintProvider

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorTest.java
@@ -175,7 +175,7 @@ class ListRuinRecreateMoveSelectorTest extends AbstractMeterTest {
         var solver = SolverFactory.create(solverConfig).buildSolver();
         var solution = (TestdataAllowsUnassignedValuesListSolution) assertDoesNotThrow(() -> solver.solve(problem));
         // Two values must remain unassigned
-        assertThat(solution.getEntityList().size()).isOne();
+        assertThat(solution.getEntityList().getFirst().getValueList()).hasSize(1);
     }
 
     public static final class TestdataOnlyOneAssignedValuesListMixedConstraintProvider

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorTest.java
@@ -154,4 +154,37 @@ class ListRuinRecreateMoveSelectorTest extends AbstractMeterTest {
         assertDoesNotThrow(() -> solver.solve(problem));
     }
 
+    @Test
+    void testRuiningOnlyOneAssignedValues() {
+        var solverConfig = new SolverConfig()
+                .withEnvironmentMode(EnvironmentMode.TRACKED_FULL_ASSERT)
+                .withSolutionClass(TestdataAllowsUnassignedValuesListSolution.class)
+                .withEntityClasses(TestdataAllowsUnassignedValuesListEntity.class,
+                        TestdataAllowsUnassignedValuesListValue.class)
+                .withConstraintProviderClass(TestdataOnlyOneAssignedValuesListMixedConstraintProvider.class)
+                .withPhaseList(List.of(
+                        new LocalSearchPhaseConfig()
+                                .withMoveSelectorConfig(new ListRuinRecreateMoveSelectorConfig().withMinimumRuinedCount(3))
+                                .withTerminationConfig(new TerminationConfig()
+                                        .withStepCountLimit(1))));
+        var problem = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(3, 1);
+        problem.getEntityList().getFirst().getValueList().addAll(problem.getValueList());
+        var solver = SolverFactory.create(solverConfig).buildSolver();
+        assertDoesNotThrow(() -> solver.solve(problem));
+    }
+
+    public static final class TestdataOnlyOneAssignedValuesListMixedConstraintProvider
+            implements ConstraintProvider {
+
+        @Override
+        public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory constraintFactory) {
+            return new Constraint[] {
+                    constraintFactory.forEach(TestdataAllowsUnassignedValuesListEntity.class)
+                            .filter(entity -> entity.getValueList().size() != 1)
+                            .penalize(SimpleScore.ONE)
+                            .asConstraint("Only One Assigned")
+            };
+        }
+    }
+
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorTest.java
@@ -164,13 +164,18 @@ class ListRuinRecreateMoveSelectorTest extends AbstractMeterTest {
                 .withConstraintProviderClass(TestdataOnlyOneAssignedValuesListMixedConstraintProvider.class)
                 .withPhaseList(List.of(
                         new LocalSearchPhaseConfig()
+                                // Since the problem has 3 planning values, the R&R will select all of them
                                 .withMoveSelectorConfig(new ListRuinRecreateMoveSelectorConfig().withMinimumRuinedCount(3))
                                 .withTerminationConfig(new TerminationConfig()
                                         .withStepCountLimit(1))));
         var problem = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(3, 1);
+        // The problem involves one entity and three planning values,
+        // with the initial solution assigning all values to that single entity
         problem.getEntityList().getFirst().getValueList().addAll(problem.getValueList());
         var solver = SolverFactory.create(solverConfig).buildSolver();
-        assertDoesNotThrow(() -> solver.solve(problem));
+        var solution = (TestdataAllowsUnassignedValuesListSolution) assertDoesNotThrow(() -> solver.solve(problem));
+        // Two values must remain unassigned
+        assertThat(solution.getEntityList().size()).isOne();
     }
 
     public static final class TestdataOnlyOneAssignedValuesListMixedConstraintProvider


### PR DESCRIPTION
This PR solves a list-ruin-and-recreate issue by enabling ruined values to stay unassigned. The issue occurs when a ruined value is preferable to keep unassigned, leading the CH to skip assignment, which then results in failure with the following:
```
[[15~17:33:45.910 ERROR [pool-5-thread-1] Solving with id (878581f7-5f74-47ad-97f2-6ade2368d592) failed: message (null): java.util.NoSuchElementException
          at java.base/java.util.Collections$EmptyIterator.next(Collections.java:4640)
          at ai.timefold.solver.core.impl.heuristic.selector.move.generic.RuinRecreateConstructionHeuristicPhase.doStep(RuinRecreateConstructionHeuristicPhase.java:54)
          at ai.timefold.solver.core.impl.constructionheuristic.DefaultConstructionHeuristicPhase.solve(DefaultConstructionHeuristicPhase.java:115)
          at ai.timefold.solver.core.impl.heuristic.selector.move.generic.list.ruin.SelectorBasedListRuinRecreateMove.execute(SelectorBasedListRuinRecreateMove.java:122)
          at ai.timefold.solver.core.impl.heuristic.move.AbstractSelectorBasedMove.execute(AbstractSelectorBasedMove.java:57)
          at ai.timefold.solver.core.impl.move.MoveDirector.execute(MoveDirector.java:413)
          at ai.timefold.solver.core.impl.move.MoveDirector.execute(MoveDirector.java:403)
          at ai.timefold.solver.core.impl.move.MoveDirector.executeTemporary(MoveDirector.java:431)
          at ai.timefold.solver.core.impl.score.director.AbstractScoreDirector.executeTemporaryMove(AbstractScoreDirector.java:362)
          at ai.timefold.solver.core.impl.score.director.InnerScoreDirector.executeTemporaryMove(InnerScoreDirector.java:136)
          at ai.timefold.solver.core.impl.localsearch.decider.LocalSearchDecider.doMove(LocalSearchDecider.java:117)
          at ai.timefold.solver.core.impl.localsearch.decider.LocalSearchDecider.decideNextStep(LocalSearchDecider.java:96)
          at ai.timefold.solver.core.impl.localsearch.DefaultLocalSearchPhase.solve(DefaultLocalSearchPhase.java:89)
          at ai.timefold.solver.core.impl.solver.AbstractSolver.runPhases(AbstractSolver.java:89)
          at ai.timefold.solver.core.impl.solver.DefaultSolver.solve(DefaultSolver.java:171)
          at ai.timefold.solver.core.impl.solver.DefaultSolverJob.call(DefaultSolverJob.java:142)
          at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
          at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
          at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
          at java.base/java.lang.Thread.run(Thread.java:1474)
```