### PR TITLE
ci: allow unsafe PR checkout in downstream build workflow

### DIFF
--- a/.github/workflows/downstream_build.yml
+++ b/.github/workflows/downstream_build.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           path: ./timefold-solver
           ref: ${{ inputs.head_sha }}
-          # "approval_required" + PR-level maintainer approval ensures that the PR is from a trusted source.
+          # Safety note: allow-unsafe-pr-checkout is only safe when the calling workflow gates untrusted PRs via "approval_required" (environment approval) and keeps job permissions minimal.
           allow-unsafe-pr-checkout: true
 
       # Clone timefold-solver-enterprise

--- a/.github/workflows/downstream_build.yml
+++ b/.github/workflows/downstream_build.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           path: ./timefold-solver
           ref: ${{ inputs.head_sha }}
+          # "approval_required" + PR-level maintainer approval ensures that the PR is from a trusted source.
+          allow-unsafe-pr-checkout: true
 
       # Clone timefold-solver-enterprise
       # Need to check for stale repo, since GitHub is not aware of the build chain and therefore doesn't automate it.


### PR DESCRIPTION
Enable unsafe PR checkout for timefold-solver.