### PR TITLE
perf: improve comparison indexer

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.core.impl.bavet.common.index;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -20,21 +21,41 @@ import ai.timefold.solver.core.impl.util.ListEntry;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Backed by a sorted array while the distinct key count is small, and by a {@link TreeMap} once it isn't.
+ * <p>
+ * Most buckets stay small for the life of the solver, where a sorted array is more cache-friendly than a
+ * red-black tree; a handful of buckets in adversarial datasets may grow large, where a {@link TreeMap} remains
+ * the safer O(log n) choice. The switch from array to tree ({@link #treeify()}) is one-way: once a bucket has
+ * proven it can grow large, going back to an array on removal only reintroduces the cost of resizing/copying for
+ * a bucket that has already demonstrated it churns near or above the threshold.
+ */
 @NullMarked
 final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         implements Indexer<T> {
+
+    private static final int ARRAY_THRESHOLD = 32;
+    private static final int INITIAL_ARRAY_CAPACITY = 4;
 
     private final KeyUnpacker<Key_> keyUnpacker;
     private final Supplier<Indexer<T>> downstreamIndexerSupplier;
     private final boolean reverseOrder;
     private final boolean hasOrEquals;
-    private final NavigableMap<Key_, Indexer<T>> comparisonMap;
+
+    private boolean belowThreshold;
+    // Below threshold: keys[0..size) sorted ascending (regardless of reverseOrder), indexers[0..size) parallel to it.
+    private Key_[] keys;
+    private Indexer<T>[] indexers;
+    private int size;
+    // Allocated lazily by treeify(); non-null exactly when !belowThreshold.
+    private @Nullable NavigableMap<Key_, Indexer<T>> comparisonMap;
 
     /**
      * @param comparisonJoinerType the type of comparison to use
      * @param keyUnpacker determines if it immediately goes to a {@link LeafIndexer} or if it uses a {@link CompositeKey}.
      * @param downstreamIndexerSupplier the supplier of the downstream indexer
      */
+    @SuppressWarnings("unchecked")
     public ComparisonIndexer(JoinerType comparisonJoinerType, KeyUnpacker<?> keyUnpacker,
             Supplier<Indexer<T>> downstreamIndexerSupplier) {
         this.keyUnpacker = Objects.requireNonNull((KeyUnpacker<Key_>) keyUnpacker);
@@ -46,33 +67,88 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
                 comparisonJoinerType == JoinerType.GREATER_THAN || comparisonJoinerType == JoinerType.GREATER_THAN_OR_EQUAL;
         this.hasOrEquals = comparisonJoinerType == JoinerType.GREATER_THAN_OR_EQUAL
                 || comparisonJoinerType == JoinerType.LESS_THAN_OR_EQUAL;
-        this.comparisonMap = reverseOrder ? new TreeMap<>(Comparator.reverseOrder()) : new TreeMap<>();
+        this.belowThreshold = true;
+        this.keys = (Key_[]) new Comparable[INITIAL_ARRAY_CAPACITY];
+        this.indexers = (Indexer<T>[]) new Indexer[INITIAL_ARRAY_CAPACITY];
     }
 
     @Override
     public ListEntry<T> put(Object compositeKey, T tuple) {
         var indexKey = keyUnpacker.apply(compositeKey);
+        var downstreamIndexer = belowThreshold ? putArray(indexKey) : putTree(indexKey);
+        return downstreamIndexer.put(compositeKey, tuple);
+    }
+
+    private Indexer<T> putTree(Key_ indexKey) {
         // Avoids computeIfAbsent in order to not create lambdas on the hot path.
         var downstreamIndexer = comparisonMap.get(indexKey);
         if (downstreamIndexer == null) {
             downstreamIndexer = downstreamIndexerSupplier.get();
             comparisonMap.put(indexKey, downstreamIndexer);
         }
-        return downstreamIndexer.put(compositeKey, tuple);
+        return downstreamIndexer;
+    }
+
+    private Indexer<T> putArray(Key_ indexKey) {
+        var searchResult = Arrays.binarySearch(keys, 0, size, indexKey);
+        if (searchResult >= 0) {
+            return indexers[searchResult];
+        }
+        var downstreamIndexer = downstreamIndexerSupplier.get();
+        insertIntoArrays(-(searchResult + 1), indexKey, downstreamIndexer);
+        if (size > ARRAY_THRESHOLD) {
+            treeify();
+        }
+        return downstreamIndexer;
+    }
+
+    private void insertIntoArrays(int insertionPoint, Key_ indexKey, Indexer<T> downstreamIndexer) {
+        if (size == keys.length) {
+            var newCapacity = keys.length * 2;
+            keys = Arrays.copyOf(keys, newCapacity);
+            indexers = Arrays.copyOf(indexers, newCapacity);
+        }
+        var shiftCount = size - insertionPoint;
+        if (shiftCount > 0) {
+            System.arraycopy(keys, insertionPoint, keys, insertionPoint + 1, shiftCount);
+            System.arraycopy(indexers, insertionPoint, indexers, insertionPoint + 1, shiftCount);
+        }
+        keys[insertionPoint] = indexKey;
+        indexers[insertionPoint] = downstreamIndexer;
+        size++;
+    }
+
+    private void treeify() {
+        NavigableMap<Key_, Indexer<T>> newComparisonMap =
+                reverseOrder ? new TreeMap<>(Comparator.reverseOrder()) : new TreeMap<>();
+        for (var i = 0; i < size; i++) {
+            newComparisonMap.put(keys[i], indexers[i]);
+        }
+        comparisonMap = newComparisonMap;
+        belowThreshold = false;
+        // Arrays are left populated (harmless: bounded size, elements stay reachable via comparisonMap anyway).
     }
 
     @Override
     public void remove(Object compositeKey, ListEntry<T> entry) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var downstreamIndexer = getDownstreamIndexer(compositeKey, indexKey, entry);
+        if (belowThreshold) {
+            removeArray(compositeKey, indexKey, entry);
+        } else {
+            removeTree(compositeKey, indexKey, entry);
+        }
+    }
+
+    private void removeTree(Object compositeKey, Key_ indexKey, ListEntry<T> entry) {
+        var downstreamIndexer = getDownstreamIndexerTree(compositeKey, indexKey, entry);
         downstreamIndexer.remove(compositeKey, entry);
         if (downstreamIndexer.isRemovable()) {
             comparisonMap.remove(indexKey);
         }
     }
 
-    private Indexer<T> getDownstreamIndexer(Object compositeKey, Key_ indexerKey, ListEntry<T> entry) {
-        var downstreamIndexer = comparisonMap.get(indexerKey);
+    private Indexer<T> getDownstreamIndexerTree(Object compositeKey, Key_ indexKey, ListEntry<T> entry) {
+        var downstreamIndexer = comparisonMap.get(indexKey);
         if (downstreamIndexer == null) {
             throw new IllegalStateException(
                     "Impossible state: the tuple (%s) with composite key (%s) doesn't exist in the indexer %s."
@@ -81,16 +157,43 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         return downstreamIndexer;
     }
 
+    private void removeArray(Object compositeKey, Key_ indexKey, ListEntry<T> entry) {
+        var searchResult = Arrays.binarySearch(keys, 0, size, indexKey);
+        if (searchResult < 0) {
+            throw new IllegalStateException(
+                    "Impossible state: the tuple (%s) with composite key (%s) doesn't exist in the indexer %s."
+                            .formatted(entry, compositeKey, this));
+        }
+        var downstreamIndexer = indexers[searchResult];
+        downstreamIndexer.remove(compositeKey, entry);
+        if (downstreamIndexer.isRemovable()) {
+            removeFromArrays(searchResult);
+        }
+    }
+
+    private void removeFromArrays(int index) {
+        var shiftCount = size - index - 1;
+        if (shiftCount > 0) {
+            System.arraycopy(keys, index + 1, keys, index, shiftCount);
+            System.arraycopy(indexers, index + 1, indexers, index, shiftCount);
+        }
+        size--;
+    }
+
     @Override
     public int size(Object compositeKey) {
+        return belowThreshold ? sizeArray(compositeKey) : sizeTree(compositeKey);
+    }
+
+    private int sizeTree(Object compositeKey) {
         return switch (comparisonMap.size()) {
             case 0 -> 0;
-            case 1 -> sizeSingleIndexer(compositeKey);
-            default -> sizeManyIndexers(compositeKey);
+            case 1 -> sizeSingleIndexerTree(compositeKey);
+            default -> sizeManyIndexersTree(compositeKey);
         };
     }
 
-    private int sizeSingleIndexer(Object compositeKey) {
+    private int sizeSingleIndexerTree(Object compositeKey) {
         var indexKey = keyUnpacker.apply(compositeKey);
         var entry = comparisonMap.firstEntry();
         return boundaryReached(entry.getKey(), indexKey) ? 0 : entry.getValue().size(compositeKey);
@@ -109,7 +212,7 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         return false;
     }
 
-    private int sizeManyIndexers(Object compositeKey) {
+    private int sizeManyIndexersTree(Object compositeKey) {
         var indexKey = keyUnpacker.apply(compositeKey);
         var size = 0;
         for (var entry : comparisonMap.entrySet()) {
@@ -122,18 +225,44 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         return size;
     }
 
+    private int sizeArray(Object compositeKey) {
+        if (size == 0) {
+            return 0;
+        }
+        var indexKey = keyUnpacker.apply(compositeKey);
+        var total = 0;
+        var i = arrayStart();
+        var step = arrayStep();
+        while (i >= 0 && i < size) {
+            if (boundaryReached(keys[i], indexKey)) {
+                break;
+            }
+            total += indexers[i].size(compositeKey);
+            i += step;
+        }
+        return total;
+    }
+
     @Override
     public void forEach(Object compositeKey, Consumer<T> tupleConsumer) {
+        if (belowThreshold) {
+            forEachArray(compositeKey, tupleConsumer);
+        } else {
+            forEachTree(compositeKey, tupleConsumer);
+        }
+    }
+
+    private void forEachTree(Object compositeKey, Consumer<T> tupleConsumer) {
         switch (comparisonMap.size()) {
             case 0 -> {
                 /* Nothing to do. */
             }
-            case 1 -> forEachSingleIndexer(compositeKey, tupleConsumer);
-            default -> forEachManyIndexers(compositeKey, tupleConsumer);
+            case 1 -> forEachSingleIndexerTree(compositeKey, tupleConsumer);
+            default -> forEachManyIndexersTree(compositeKey, tupleConsumer);
         }
     }
 
-    private void forEachSingleIndexer(Object compositeKey, Consumer<T> tupleConsumer) {
+    private void forEachSingleIndexerTree(Object compositeKey, Consumer<T> tupleConsumer) {
         var indexKey = keyUnpacker.apply(compositeKey);
         var entry = comparisonMap.firstEntry();
         if (!boundaryReached(entry.getKey(), indexKey)) {
@@ -142,7 +271,7 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         }
     }
 
-    private void forEachManyIndexers(Object compositeKey, Consumer<T> tupleConsumer) {
+    private void forEachManyIndexersTree(Object compositeKey, Consumer<T> tupleConsumer) {
         var indexKey = keyUnpacker.apply(compositeKey);
         for (var entry : comparisonMap.entrySet()) {
             if (boundaryReached(entry.getKey(), indexKey)) {
@@ -153,16 +282,37 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         }
     }
 
+    private void forEachArray(Object compositeKey, Consumer<T> tupleConsumer) {
+        if (size == 0) {
+            return;
+        }
+        var indexKey = keyUnpacker.apply(compositeKey);
+        var i = arrayStart();
+        var step = arrayStep();
+        while (i >= 0 && i < size) {
+            if (boundaryReached(keys[i], indexKey)) {
+                return;
+            }
+            // Boundary condition not yet reached; include the indexer in the range.
+            indexers[i].forEach(compositeKey, tupleConsumer);
+            i += step;
+        }
+    }
+
     @Override
     public Iterator<T> iterator(Object queryCompositeKey) {
+        return belowThreshold ? iteratorArray(queryCompositeKey) : iteratorTree(queryCompositeKey);
+    }
+
+    private Iterator<T> iteratorTree(Object queryCompositeKey) {
         return switch (comparisonMap.size()) {
             case 0 -> Collections.emptyIterator();
-            case 1 -> iteratorSingleIndexer(queryCompositeKey);
+            case 1 -> iteratorSingleIndexerTree(queryCompositeKey);
             default -> new DefaultIterator(queryCompositeKey);
         };
     }
 
-    private Iterator<T> iteratorSingleIndexer(Object compositeKey) {
+    private Iterator<T> iteratorSingleIndexerTree(Object compositeKey) {
         var indexKey = keyUnpacker.apply(compositeKey);
         var entry = comparisonMap.firstEntry();
         if (boundaryReached(entry.getKey(), indexKey)) {
@@ -172,12 +322,22 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         return entry.getValue().iterator(compositeKey);
     }
 
+    private Iterator<T> iteratorArray(Object queryCompositeKey) {
+        return size == 0 ? Collections.emptyIterator() : new DefaultIterator(queryCompositeKey);
+    }
+
     @Override
     public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom) {
         return createRandomIterator(queryCompositeKey, workingRandom, null);
     }
 
     private Iterator<T> createRandomIterator(Object queryCompositeKey, RandomGenerator workingRandom,
+            @Nullable Predicate<T> filter) {
+        return belowThreshold ? createRandomIteratorArray(queryCompositeKey, workingRandom, filter)
+                : createRandomIteratorTree(queryCompositeKey, workingRandom, filter);
+    }
+
+    private Iterator<T> createRandomIteratorTree(Object queryCompositeKey, RandomGenerator workingRandom,
             @Nullable Predicate<T> filter) {
         return switch (comparisonMap.size()) {
             case 0 -> Collections.emptyIterator();
@@ -206,6 +366,19 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         };
     }
 
+    private Iterator<T> createRandomIteratorArray(Object queryCompositeKey, RandomGenerator workingRandom,
+            @Nullable Predicate<T> filter) {
+        if (size == 0) {
+            return Collections.emptyIterator();
+        }
+        if (filter == null) {
+            return new RandomIterator(queryCompositeKey, indexer -> indexer.randomIterator(queryCompositeKey, workingRandom));
+        } else {
+            return new RandomIterator(queryCompositeKey,
+                    indexer -> indexer.randomIterator(queryCompositeKey, workingRandom, filter));
+        }
+    }
+
     @Override
     public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter) {
         return createRandomIterator(queryCompositeKey, workingRandom, filter);
@@ -213,19 +386,35 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
 
     @Override
     public boolean isRemovable() {
-        return comparisonMap.isEmpty();
+        return belowThreshold ? size == 0 : comparisonMap.isEmpty();
     }
 
     @Override
     public String toString() {
-        return "size = " + comparisonMap.size();
+        return "size = " + (belowThreshold ? size : comparisonMap.size());
+    }
+
+    /**
+     * Below threshold, keys are always stored ascending regardless of {@link #reverseOrder}; only the scan
+     * direction changes, so that array mode reproduces the same iteration order the tree mode's
+     * reverse-ordered {@link TreeMap} produces today.
+     */
+    private int arrayStart() {
+        return reverseOrder ? size - 1 : 0;
+    }
+
+    private int arrayStep() {
+        return reverseOrder ? -1 : 1;
     }
 
     private class DefaultIterator implements Iterator<T> {
 
         private final Key_ indexKey;
         private final Function<Indexer<T>, Iterator<T>> downstreamIteratorFunction;
-        private final Iterator<Map.Entry<Key_, Indexer<T>>> indexerIterator = comparisonMap.entrySet().iterator();
+        // Tree mode: entries pulled from here. Array mode: this is null and the cursor fields are used instead.
+        private final @Nullable Iterator<Map.Entry<Key_, Indexer<T>>> indexerIterator;
+        private int arrayCursor;
+        private final int arrayStep;
         protected @Nullable Iterator<T> downstreamIterator = null;
         private @Nullable T next = null;
 
@@ -237,6 +426,15 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         protected DefaultIterator(Object queryCompositeKey, Function<Indexer<T>, Iterator<T>> downstreamIteratorFunction) {
             this.indexKey = keyUnpacker.apply(queryCompositeKey);
             this.downstreamIteratorFunction = downstreamIteratorFunction;
+            if (belowThreshold) {
+                this.indexerIterator = null;
+                this.arrayCursor = arrayStart();
+                this.arrayStep = arrayStep();
+            } else {
+                this.indexerIterator = comparisonMap.entrySet().iterator();
+                this.arrayCursor = 0;
+                this.arrayStep = 0;
+            }
         }
 
         @Override
@@ -248,13 +446,30 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
                 next = downstreamIterator.next();
                 return true;
             }
-            while (indexerIterator.hasNext()) {
-                var entry = indexerIterator.next();
-                if (boundaryReached(entry.getKey(), indexKey)) {
+            if (indexerIterator != null) {
+                while (indexerIterator.hasNext()) {
+                    var entry = indexerIterator.next();
+                    if (boundaryReached(entry.getKey(), indexKey)) {
+                        return false;
+                    }
+                    // Boundary condition not yet reached; include the indexer in the range.
+                    downstreamIterator = downstreamIteratorFunction.apply(entry.getValue());
+                    if (downstreamIterator.hasNext()) {
+                        next = downstreamIterator.next();
+                        return true;
+                    }
+                }
+                return false;
+            }
+            while (arrayCursor >= 0 && arrayCursor < size) {
+                var key = keys[arrayCursor];
+                var indexer = indexers[arrayCursor];
+                arrayCursor += arrayStep;
+                if (boundaryReached(key, indexKey)) {
                     return false;
                 }
                 // Boundary condition not yet reached; include the indexer in the range.
-                downstreamIterator = downstreamIteratorFunction.apply(entry.getValue());
+                downstreamIterator = downstreamIteratorFunction.apply(indexer);
                 if (downstreamIterator.hasNext()) {
                     next = downstreamIterator.next();
                     return true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
@@ -1,14 +1,10 @@
 package ai.timefold.solver.core.impl.bavet.common.index;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -21,34 +17,15 @@ import ai.timefold.solver.core.impl.util.ListEntry;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-/**
- * Backed by a sorted array while the distinct key count is small, and by a {@link TreeMap} once it isn't.
- * <p>
- * Most buckets stay small for the life of the solver, where a sorted array is more cache-friendly than a
- * red-black tree; a handful of buckets in adversarial datasets may grow large, where a {@link TreeMap} remains
- * the safer O(log n) choice. The switch from array to tree ({@link #treeify()}) is one-way: once a bucket has
- * proven it can grow large, going back to an array on removal only reintroduces the cost of resizing/copying for
- * a bucket that has already demonstrated it churns near or above the threshold.
- */
 @NullMarked
 final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         implements Indexer<T> {
-
-    private static final int ARRAY_THRESHOLD = 32;
-    private static final int INITIAL_ARRAY_CAPACITY = 4;
 
     private final KeyUnpacker<Key_> keyUnpacker;
     private final Supplier<Indexer<T>> downstreamIndexerSupplier;
     private final boolean reverseOrder;
     private final boolean hasOrEquals;
-
-    private boolean belowThreshold;
-    // Below threshold: keys[0..size) sorted ascending (regardless of reverseOrder), indexers[0..size) parallel to it.
-    private Key_[] keys;
-    private Indexer<T>[] indexers;
-    private int size;
-    // Allocated lazily by treeify(); non-null exactly when !belowThreshold.
-    private @Nullable NavigableMap<Key_, Indexer<T>> comparisonMap;
+    private final ScalingNavigableMap<Key_, Indexer<T>> comparisonMap;
 
     /**
      * @param comparisonJoinerType the type of comparison to use
@@ -67,88 +44,29 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
                 comparisonJoinerType == JoinerType.GREATER_THAN || comparisonJoinerType == JoinerType.GREATER_THAN_OR_EQUAL;
         this.hasOrEquals = comparisonJoinerType == JoinerType.GREATER_THAN_OR_EQUAL
                 || comparisonJoinerType == JoinerType.LESS_THAN_OR_EQUAL;
-        this.belowThreshold = true;
-        this.keys = (Key_[]) new Comparable[INITIAL_ARRAY_CAPACITY];
-        this.indexers = (Indexer<T>[]) new Indexer[INITIAL_ARRAY_CAPACITY];
+        var comparator = reverseOrder ? Comparator.<Key_> reverseOrder() : null;
+        this.comparisonMap = new ScalingNavigableMap<>(comparator);
     }
 
     @Override
     public ListEntry<T> put(Object compositeKey, T tuple) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var downstreamIndexer = belowThreshold ? putArray(indexKey) : putTree(indexKey);
+        var downstreamIndexer = comparisonMap.getOrCreate(indexKey, downstreamIndexerSupplier);
         return downstreamIndexer.put(compositeKey, tuple);
-    }
-
-    private Indexer<T> putTree(Key_ indexKey) {
-        // Avoids computeIfAbsent in order to not create lambdas on the hot path.
-        var downstreamIndexer = comparisonMap.get(indexKey);
-        if (downstreamIndexer == null) {
-            downstreamIndexer = downstreamIndexerSupplier.get();
-            comparisonMap.put(indexKey, downstreamIndexer);
-        }
-        return downstreamIndexer;
-    }
-
-    private Indexer<T> putArray(Key_ indexKey) {
-        var searchResult = Arrays.binarySearch(keys, 0, size, indexKey);
-        if (searchResult >= 0) {
-            return indexers[searchResult];
-        }
-        var downstreamIndexer = downstreamIndexerSupplier.get();
-        insertIntoArrays(-(searchResult + 1), indexKey, downstreamIndexer);
-        if (size > ARRAY_THRESHOLD) {
-            treeify();
-        }
-        return downstreamIndexer;
-    }
-
-    private void insertIntoArrays(int insertionPoint, Key_ indexKey, Indexer<T> downstreamIndexer) {
-        if (size == keys.length) {
-            var newCapacity = keys.length * 2;
-            keys = Arrays.copyOf(keys, newCapacity);
-            indexers = Arrays.copyOf(indexers, newCapacity);
-        }
-        var shiftCount = size - insertionPoint;
-        if (shiftCount > 0) {
-            System.arraycopy(keys, insertionPoint, keys, insertionPoint + 1, shiftCount);
-            System.arraycopy(indexers, insertionPoint, indexers, insertionPoint + 1, shiftCount);
-        }
-        keys[insertionPoint] = indexKey;
-        indexers[insertionPoint] = downstreamIndexer;
-        size++;
-    }
-
-    private void treeify() {
-        NavigableMap<Key_, Indexer<T>> newComparisonMap =
-                reverseOrder ? new TreeMap<>(Comparator.reverseOrder()) : new TreeMap<>();
-        for (var i = 0; i < size; i++) {
-            newComparisonMap.put(keys[i], indexers[i]);
-        }
-        comparisonMap = newComparisonMap;
-        belowThreshold = false;
-        // Arrays are left populated (harmless: bounded size, elements stay reachable via comparisonMap anyway).
     }
 
     @Override
     public void remove(Object compositeKey, ListEntry<T> entry) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        if (belowThreshold) {
-            removeArray(compositeKey, indexKey, entry);
-        } else {
-            removeTree(compositeKey, indexKey, entry);
-        }
-    }
-
-    private void removeTree(Object compositeKey, Key_ indexKey, ListEntry<T> entry) {
-        var downstreamIndexer = getDownstreamIndexerTree(compositeKey, indexKey, entry);
+        var downstreamIndexer = getDownstreamIndexer(compositeKey, indexKey, entry);
         downstreamIndexer.remove(compositeKey, entry);
         if (downstreamIndexer.isRemovable()) {
             comparisonMap.remove(indexKey);
         }
     }
 
-    private Indexer<T> getDownstreamIndexerTree(Object compositeKey, Key_ indexKey, ListEntry<T> entry) {
-        var downstreamIndexer = comparisonMap.get(indexKey);
+    private Indexer<T> getDownstreamIndexer(Object compositeKey, Key_ indexerKey, ListEntry<T> entry) {
+        var downstreamIndexer = comparisonMap.get(indexerKey);
         if (downstreamIndexer == null) {
             throw new IllegalStateException(
                     "Impossible state: the tuple (%s) with composite key (%s) doesn't exist in the indexer %s."
@@ -157,46 +75,20 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         return downstreamIndexer;
     }
 
-    private void removeArray(Object compositeKey, Key_ indexKey, ListEntry<T> entry) {
-        var searchResult = Arrays.binarySearch(keys, 0, size, indexKey);
-        if (searchResult < 0) {
-            throw new IllegalStateException(
-                    "Impossible state: the tuple (%s) with composite key (%s) doesn't exist in the indexer %s."
-                            .formatted(entry, compositeKey, this));
-        }
-        var downstreamIndexer = indexers[searchResult];
-        downstreamIndexer.remove(compositeKey, entry);
-        if (downstreamIndexer.isRemovable()) {
-            removeFromArrays(searchResult);
-        }
-    }
-
-    private void removeFromArrays(int index) {
-        var shiftCount = size - index - 1;
-        if (shiftCount > 0) {
-            System.arraycopy(keys, index + 1, keys, index, shiftCount);
-            System.arraycopy(indexers, index + 1, indexers, index, shiftCount);
-        }
-        size--;
-    }
-
     @Override
     public int size(Object compositeKey) {
-        return belowThreshold ? sizeArray(compositeKey) : sizeTree(compositeKey);
-    }
-
-    private int sizeTree(Object compositeKey) {
         return switch (comparisonMap.size()) {
             case 0 -> 0;
-            case 1 -> sizeSingleIndexerTree(compositeKey);
-            default -> sizeManyIndexersTree(compositeKey);
+            case 1 -> sizeSingleIndexer(compositeKey);
+            default -> sizeManyIndexers(compositeKey);
         };
     }
 
-    private int sizeSingleIndexerTree(Object compositeKey) {
+    private int sizeSingleIndexer(Object compositeKey) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var entry = comparisonMap.firstEntry();
-        return boundaryReached(entry.getKey(), indexKey) ? 0 : entry.getValue().size(compositeKey);
+        var cursor = comparisonMap.cursorFromStart();
+        cursor.advance();
+        return boundaryReached(cursor.key(), indexKey) ? 0 : cursor.value().size(compositeKey);
     }
 
     private boolean boundaryReached(Key_ entryKey, Key_ indexKey) {
@@ -212,118 +104,71 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         return false;
     }
 
-    private int sizeManyIndexersTree(Object compositeKey) {
+    private int sizeManyIndexers(Object compositeKey) {
         var indexKey = keyUnpacker.apply(compositeKey);
         var size = 0;
-        for (var entry : comparisonMap.entrySet()) {
-            if (boundaryReached(entry.getKey(), indexKey)) {
+        var cursor = comparisonMap.cursorFromStart();
+        while (cursor.advance()) {
+            if (boundaryReached(cursor.key(), indexKey)) {
                 return size;
             }
             // Boundary condition not yet reached; include the indexer in the range.
-            size += entry.getValue().size(compositeKey);
+            size += cursor.value().size(compositeKey);
         }
         return size;
     }
 
-    private int sizeArray(Object compositeKey) {
-        if (size == 0) {
-            return 0;
-        }
-        var indexKey = keyUnpacker.apply(compositeKey);
-        var total = 0;
-        var i = arrayStart();
-        var step = arrayStep();
-        while (i >= 0 && i < size) {
-            if (boundaryReached(keys[i], indexKey)) {
-                break;
-            }
-            total += indexers[i].size(compositeKey);
-            i += step;
-        }
-        return total;
-    }
-
     @Override
     public void forEach(Object compositeKey, Consumer<T> tupleConsumer) {
-        if (belowThreshold) {
-            forEachArray(compositeKey, tupleConsumer);
-        } else {
-            forEachTree(compositeKey, tupleConsumer);
-        }
-    }
-
-    private void forEachTree(Object compositeKey, Consumer<T> tupleConsumer) {
         switch (comparisonMap.size()) {
             case 0 -> {
                 /* Nothing to do. */
             }
-            case 1 -> forEachSingleIndexerTree(compositeKey, tupleConsumer);
-            default -> forEachManyIndexersTree(compositeKey, tupleConsumer);
+            case 1 -> forEachSingleIndexer(compositeKey, tupleConsumer);
+            default -> forEachManyIndexers(compositeKey, tupleConsumer);
         }
     }
 
-    private void forEachSingleIndexerTree(Object compositeKey, Consumer<T> tupleConsumer) {
+    private void forEachSingleIndexer(Object compositeKey, Consumer<T> tupleConsumer) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var entry = comparisonMap.firstEntry();
-        if (!boundaryReached(entry.getKey(), indexKey)) {
+        var cursor = comparisonMap.cursorFromStart();
+        cursor.advance();
+        if (!boundaryReached(cursor.key(), indexKey)) {
             // Boundary condition not yet reached; include the indexer in the range.
-            entry.getValue().forEach(compositeKey, tupleConsumer);
+            cursor.value().forEach(compositeKey, tupleConsumer);
         }
     }
 
-    private void forEachManyIndexersTree(Object compositeKey, Consumer<T> tupleConsumer) {
+    private void forEachManyIndexers(Object compositeKey, Consumer<T> tupleConsumer) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        for (var entry : comparisonMap.entrySet()) {
-            if (boundaryReached(entry.getKey(), indexKey)) {
+        var cursor = comparisonMap.cursorFromStart();
+        while (cursor.advance()) {
+            if (boundaryReached(cursor.key(), indexKey)) {
                 return;
             }
             // Boundary condition not yet reached; include the indexer in the range.
-            entry.getValue().forEach(compositeKey, tupleConsumer);
-        }
-    }
-
-    private void forEachArray(Object compositeKey, Consumer<T> tupleConsumer) {
-        if (size == 0) {
-            return;
-        }
-        var indexKey = keyUnpacker.apply(compositeKey);
-        var i = arrayStart();
-        var step = arrayStep();
-        while (i >= 0 && i < size) {
-            if (boundaryReached(keys[i], indexKey)) {
-                return;
-            }
-            // Boundary condition not yet reached; include the indexer in the range.
-            indexers[i].forEach(compositeKey, tupleConsumer);
-            i += step;
+            cursor.value().forEach(compositeKey, tupleConsumer);
         }
     }
 
     @Override
     public Iterator<T> iterator(Object queryCompositeKey) {
-        return belowThreshold ? iteratorArray(queryCompositeKey) : iteratorTree(queryCompositeKey);
-    }
-
-    private Iterator<T> iteratorTree(Object queryCompositeKey) {
         return switch (comparisonMap.size()) {
             case 0 -> Collections.emptyIterator();
-            case 1 -> iteratorSingleIndexerTree(queryCompositeKey);
+            case 1 -> iteratorSingleIndexer(queryCompositeKey);
             default -> new DefaultIterator(queryCompositeKey);
         };
     }
 
-    private Iterator<T> iteratorSingleIndexerTree(Object compositeKey) {
+    private Iterator<T> iteratorSingleIndexer(Object compositeKey) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var entry = comparisonMap.firstEntry();
-        if (boundaryReached(entry.getKey(), indexKey)) {
+        var cursor = comparisonMap.cursorFromStart();
+        cursor.advance();
+        if (boundaryReached(cursor.key(), indexKey)) {
             return Collections.emptyIterator();
         }
         // Boundary condition not yet reached; include the indexer in the range.
-        return entry.getValue().iterator(compositeKey);
-    }
-
-    private Iterator<T> iteratorArray(Object queryCompositeKey) {
-        return size == 0 ? Collections.emptyIterator() : new DefaultIterator(queryCompositeKey);
+        return cursor.value().iterator(compositeKey);
     }
 
     @Override
@@ -333,24 +178,19 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
 
     private Iterator<T> createRandomIterator(Object queryCompositeKey, RandomGenerator workingRandom,
             @Nullable Predicate<T> filter) {
-        return belowThreshold ? createRandomIteratorArray(queryCompositeKey, workingRandom, filter)
-                : createRandomIteratorTree(queryCompositeKey, workingRandom, filter);
-    }
-
-    private Iterator<T> createRandomIteratorTree(Object queryCompositeKey, RandomGenerator workingRandom,
-            @Nullable Predicate<T> filter) {
         return switch (comparisonMap.size()) {
             case 0 -> Collections.emptyIterator();
             case 1 -> {
                 var indexKey = keyUnpacker.apply(queryCompositeKey);
-                var entry = comparisonMap.firstEntry();
-                if (boundaryReached(entry.getKey(), indexKey)) {
+                var cursor = comparisonMap.cursorFromStart();
+                cursor.advance();
+                if (boundaryReached(cursor.key(), indexKey)) {
                     yield Collections.emptyIterator();
                 } else { // Boundary condition not yet reached; include the indexer in the range.
                     if (filter == null) {
-                        yield entry.getValue().randomIterator(queryCompositeKey, workingRandom);
+                        yield cursor.value().randomIterator(queryCompositeKey, workingRandom);
                     } else {
-                        yield entry.getValue().randomIterator(queryCompositeKey, workingRandom, filter);
+                        yield cursor.value().randomIterator(queryCompositeKey, workingRandom, filter);
                     }
                 }
             }
@@ -366,19 +206,6 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         };
     }
 
-    private Iterator<T> createRandomIteratorArray(Object queryCompositeKey, RandomGenerator workingRandom,
-            @Nullable Predicate<T> filter) {
-        if (size == 0) {
-            return Collections.emptyIterator();
-        }
-        if (filter == null) {
-            return new RandomIterator(queryCompositeKey, indexer -> indexer.randomIterator(queryCompositeKey, workingRandom));
-        } else {
-            return new RandomIterator(queryCompositeKey,
-                    indexer -> indexer.randomIterator(queryCompositeKey, workingRandom, filter));
-        }
-    }
-
     @Override
     public Iterator<T> randomIterator(Object queryCompositeKey, RandomGenerator workingRandom, Predicate<T> filter) {
         return createRandomIterator(queryCompositeKey, workingRandom, filter);
@@ -386,35 +213,19 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
 
     @Override
     public boolean isRemovable() {
-        return belowThreshold ? size == 0 : comparisonMap.isEmpty();
+        return comparisonMap.isEmpty();
     }
 
     @Override
     public String toString() {
-        return "size = " + (belowThreshold ? size : comparisonMap.size());
-    }
-
-    /**
-     * Below threshold, keys are always stored ascending regardless of {@link #reverseOrder}; only the scan
-     * direction changes, so that array mode reproduces the same iteration order the tree mode's
-     * reverse-ordered {@link TreeMap} produces today.
-     */
-    private int arrayStart() {
-        return reverseOrder ? size - 1 : 0;
-    }
-
-    private int arrayStep() {
-        return reverseOrder ? -1 : 1;
+        return "size = " + comparisonMap.size();
     }
 
     private class DefaultIterator implements Iterator<T> {
 
         private final Key_ indexKey;
         private final Function<Indexer<T>, Iterator<T>> downstreamIteratorFunction;
-        // Tree mode: entries pulled from here. Array mode: this is null and the cursor fields are used instead.
-        private final @Nullable Iterator<Map.Entry<Key_, Indexer<T>>> indexerIterator;
-        private int arrayCursor;
-        private final int arrayStep;
+        private final ScalingNavigableMap.Cursor<Key_, Indexer<T>> cursor = comparisonMap.cursorFromStart();
         protected @Nullable Iterator<T> downstreamIterator = null;
         private @Nullable T next = null;
 
@@ -426,15 +237,6 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
         protected DefaultIterator(Object queryCompositeKey, Function<Indexer<T>, Iterator<T>> downstreamIteratorFunction) {
             this.indexKey = keyUnpacker.apply(queryCompositeKey);
             this.downstreamIteratorFunction = downstreamIteratorFunction;
-            if (belowThreshold) {
-                this.indexerIterator = null;
-                this.arrayCursor = arrayStart();
-                this.arrayStep = arrayStep();
-            } else {
-                this.indexerIterator = comparisonMap.entrySet().iterator();
-                this.arrayCursor = 0;
-                this.arrayStep = 0;
-            }
         }
 
         @Override
@@ -446,30 +248,12 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
                 next = downstreamIterator.next();
                 return true;
             }
-            if (indexerIterator != null) {
-                while (indexerIterator.hasNext()) {
-                    var entry = indexerIterator.next();
-                    if (boundaryReached(entry.getKey(), indexKey)) {
-                        return false;
-                    }
-                    // Boundary condition not yet reached; include the indexer in the range.
-                    downstreamIterator = downstreamIteratorFunction.apply(entry.getValue());
-                    if (downstreamIterator.hasNext()) {
-                        next = downstreamIterator.next();
-                        return true;
-                    }
-                }
-                return false;
-            }
-            while (arrayCursor >= 0 && arrayCursor < size) {
-                var key = keys[arrayCursor];
-                var indexer = indexers[arrayCursor];
-                arrayCursor += arrayStep;
-                if (boundaryReached(key, indexKey)) {
+            while (cursor.advance()) {
+                if (boundaryReached(cursor.key(), indexKey)) {
                     return false;
                 }
                 // Boundary condition not yet reached; include the indexer in the range.
-                downstreamIterator = downstreamIteratorFunction.apply(indexer);
+                downstreamIterator = downstreamIteratorFunction.apply(cursor.value());
                 if (downstreamIterator.hasNext()) {
                     next = downstreamIterator.next();
                     return true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
@@ -17,6 +17,29 @@ import ai.timefold.solver.core.impl.util.ListEntry;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * An {@link Indexer} for LT/LTE/GT/GTE joins, keyed by a single {@link Comparable} value
+ * and backed by a {@link ScalingNavigableMap} of key to downstream {@link Indexer}.
+ * <p>
+ * GT/GTE are handled by iterating the map in reverse ({@link #reverseOrder})
+ * rather than by using a reversed comparator or sub-map views,
+ * so both directions can share the same ascending, comparator-free {@link ScalingNavigableMap}
+ * and its fast, non-comparator {@code TreeMap} lookup path.
+ * {@link #boundaryReached} folds that direction, plus LTE/GTE inclusivity ({@link #hasOrEquals}),
+ * into a single check used to stop a range scan.
+ * <p>
+ * Every query operation ({@link #size}, {@link #forEach}, {@link #iterator}, {@link #randomIterator})
+ * has separate array-mode and tree-mode implementations,
+ * dispatched on {@link ScalingNavigableMap#arrayBased}.
+ * <p>
+ * This class was heavily benchmarked;
+ * it is recommended to assume that most decisions made here
+ * are performance-driven and not necessarily obvious or intuitive.
+ * Any changes should also be based on benchmarks.
+ *
+ * @param <T> the element type, see {@link Indexer}
+ * @param <Key_> the type of the comparison key, unpacked from the composite key by {@link #keyUnpacker}
+ */
 @NullMarked
 final class ComparisonIndexer<T, Key_ extends Comparable<Key_>> implements Indexer<T> {
 
@@ -124,13 +147,22 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>> implements Index
         return boundaryReached(entry.getKey(), indexKey) ? 0 : entry.getValue().size(compositeKey);
     }
 
+    /**
+     * Whether {@code entryKey}, and every key past it in iteration order, fails to match {@code indexKey}
+     * and the range scan (in {@code size}/{@code forEach}/{@code iterator}/{@code randomIterator}) should stop.
+     * <p>
+     * {@code comparisonMap} is always iterated ascending by natural order (see {@link ScalingNavigableMap});
+     * {@link #reverseOrder} instead flips the sign of the comparison here,
+     * so GT/GTE effectively scan the same ascending storage from the other end,
+     * without needing a reversed comparator or sub-map view.
+     */
     private boolean boundaryReached(Key_ entryKey, Key_ indexKey) {
         var comparison = entryKey.compareTo(indexKey);
         if (reverseOrder) {
             // Comparator matches the order of iteration of the map, so the boundary is always found from the bottom up.
             comparison = -comparison;
         }
-        if (comparison >= 0) { // Possibility of reaching the boundary condition.
+        if (comparison >= 0) {
             // Boundary condition reached when we're out of bounds entirely, or when GTE/LTE is not allowed.
             return comparison > 0 || !hasOrEquals;
         }
@@ -177,7 +209,7 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>> implements Index
     public void forEach(Object compositeKey, Consumer<T> tupleConsumer) {
         switch (comparisonMap.size()) {
             case 0 -> {
-                /* Nothing to do. */
+                // Nothing to do.
             }
             case 1 -> forEachSingleIndexer(compositeKey, tupleConsumer);
             default -> forEachManyIndexers(compositeKey, tupleConsumer);
@@ -345,6 +377,11 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>> implements Index
         return "size = " + comparisonMap.size();
     }
 
+    /**
+     * Handles both array-mode and tree-mode iteration in a single class,
+     * branching internally ({@link #advanceFromArray}/{@link #advanceFromTree})
+     * rather than splitting into two {@code Iterator} implementations behind a shared type.
+     */
     private class DefaultIterator implements Iterator<T> {
 
         private final Key_ indexKey;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -17,8 +18,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
-final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
-        implements Indexer<T> {
+final class ComparisonIndexer<T, Key_ extends Comparable<Key_>> implements Indexer<T> {
 
     private final KeyUnpacker<Key_> keyUnpacker;
     private final Supplier<Indexer<T>> downstreamIndexerSupplier;
@@ -43,7 +43,7 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
                 comparisonJoinerType == JoinerType.GREATER_THAN || comparisonJoinerType == JoinerType.GREATER_THAN_OR_EQUAL;
         this.hasOrEquals = comparisonJoinerType == JoinerType.GREATER_THAN_OR_EQUAL
                 || comparisonJoinerType == JoinerType.LESS_THAN_OR_EQUAL;
-        this.comparisonMap = new ScalingNavigableMap<>(reverseOrder);
+        this.comparisonMap = new ScalingNavigableMap<>();
     }
 
     @Override
@@ -56,21 +56,46 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
     @Override
     public void remove(Object compositeKey, ListEntry<T> entry) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var downstreamIndexer = getDownstreamIndexer(compositeKey, indexKey, entry);
+        if (comparisonMap.arrayBased) {
+            removeArray(compositeKey, indexKey, entry);
+        } else {
+            removeTree(compositeKey, indexKey, entry);
+        }
+    }
+
+    /**
+     * Looks up the entry once (comparisonMap.indexOf(), one binary search)
+     * and reuses the same index to remove it if needed,
+     * instead of a second indexOf()-equivalent lookup for the same key
+     * (as comparisonMap.remove(key) alone would do).
+     */
+    private void removeArray(Object compositeKey, Key_ indexKey, ListEntry<T> entry) {
+        var index = comparisonMap.indexOf(indexKey);
+        if (index < 0) {
+            throw notFoundError(compositeKey, entry);
+        }
+        var downstreamIndexer = comparisonMap.valueAt(index);
+        downstreamIndexer.remove(compositeKey, entry);
+        if (downstreamIndexer.isRemovable()) {
+            comparisonMap.removeAt(index);
+        }
+    }
+
+    private void removeTree(Object compositeKey, Key_ indexKey, ListEntry<T> entry) {
+        var downstreamIndexer = comparisonMap.get(indexKey);
+        if (downstreamIndexer == null) {
+            throw notFoundError(compositeKey, entry);
+        }
         downstreamIndexer.remove(compositeKey, entry);
         if (downstreamIndexer.isRemovable()) {
             comparisonMap.remove(indexKey);
         }
     }
 
-    private Indexer<T> getDownstreamIndexer(Object compositeKey, Key_ indexerKey, ListEntry<T> entry) {
-        var downstreamIndexer = comparisonMap.get(indexerKey);
-        if (downstreamIndexer == null) {
-            throw new IllegalStateException(
-                    "Impossible state: the tuple (%s) with composite key (%s) doesn't exist in the indexer %s."
-                            .formatted(entry, compositeKey, this));
-        }
-        return downstreamIndexer;
+    private IllegalStateException notFoundError(Object compositeKey, ListEntry<T> entry) {
+        return new IllegalStateException(
+                "Impossible state: the tuple (%s) with composite key (%s) doesn't exist in the indexer %s.".formatted(entry,
+                        compositeKey, this));
     }
 
     @Override
@@ -83,10 +108,20 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
     }
 
     private int sizeSingleIndexer(Object compositeKey) {
+        return comparisonMap.arrayBased ? sizeSingleIndexerArray(compositeKey) : sizeSingleIndexerTree(compositeKey);
+    }
+
+    private int sizeSingleIndexerArray(Object compositeKey) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var cursor = comparisonMap.cursorFromStart();
-        cursor.advance();
-        return boundaryReached(cursor.key(), indexKey) ? 0 : cursor.value().size(compositeKey);
+        var entryKey = comparisonMap.keyAt(0);
+        var entryValue = comparisonMap.valueAt(0);
+        return boundaryReached(entryKey, indexKey) ? 0 : entryValue.size(compositeKey);
+    }
+
+    private int sizeSingleIndexerTree(Object compositeKey) {
+        var indexKey = keyUnpacker.apply(compositeKey);
+        var entry = comparisonMap.firstEntry();
+        return boundaryReached(entry.getKey(), indexKey) ? 0 : entry.getValue().size(compositeKey);
     }
 
     private boolean boundaryReached(Key_ entryKey, Key_ indexKey) {
@@ -103,15 +138,37 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
     }
 
     private int sizeManyIndexers(Object compositeKey) {
+        return comparisonMap.arrayBased ? sizeManyIndexersArray(compositeKey) : sizeManyIndexersTree(compositeKey);
+    }
+
+    private int sizeManyIndexersArray(Object compositeKey) {
         var indexKey = keyUnpacker.apply(compositeKey);
         var size = 0;
-        var cursor = comparisonMap.cursorFromStart();
-        while (cursor.advance()) {
-            if (boundaryReached(cursor.key(), indexKey)) {
+        var arraySize = comparisonMap.size();
+        var i = reverseOrder ? arraySize - 1 : 0;
+        var step = reverseOrder ? -1 : 1;
+        while (i >= 0 && i < arraySize) {
+            if (boundaryReached(comparisonMap.keyAt(i), indexKey)) {
                 return size;
             }
             // Boundary condition not yet reached; include the indexer in the range.
-            size += cursor.value().size(compositeKey);
+            size += comparisonMap.valueAt(i).size(compositeKey);
+            i += step;
+        }
+        return size;
+    }
+
+    private int sizeManyIndexersTree(Object compositeKey) {
+        var indexKey = keyUnpacker.apply(compositeKey);
+        var size = 0;
+        var entryIterator = comparisonMap.iterator(reverseOrder);
+        while (entryIterator.hasNext()) {
+            var entry = entryIterator.next();
+            if (boundaryReached(entry.getKey(), indexKey)) {
+                return size;
+            }
+            // Boundary condition not yet reached; include the indexer in the range.
+            size += entry.getValue().size(compositeKey);
         }
         return size;
     }
@@ -128,24 +185,65 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
     }
 
     private void forEachSingleIndexer(Object compositeKey, Consumer<T> tupleConsumer) {
+        if (comparisonMap.arrayBased) {
+            forEachSingleIndexerArray(compositeKey, tupleConsumer);
+        } else {
+            forEachSingleIndexerTree(compositeKey, tupleConsumer);
+        }
+    }
+
+    private void forEachSingleIndexerArray(Object compositeKey, Consumer<T> tupleConsumer) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var cursor = comparisonMap.cursorFromStart();
-        cursor.advance();
-        if (!boundaryReached(cursor.key(), indexKey)) {
+        var entryKey = comparisonMap.keyAt(0);
+        var entryValue = comparisonMap.valueAt(0);
+        if (!boundaryReached(entryKey, indexKey)) {
             // Boundary condition not yet reached; include the indexer in the range.
-            cursor.value().forEach(compositeKey, tupleConsumer);
+            entryValue.forEach(compositeKey, tupleConsumer);
+        }
+    }
+
+    private void forEachSingleIndexerTree(Object compositeKey, Consumer<T> tupleConsumer) {
+        var indexKey = keyUnpacker.apply(compositeKey);
+        var entry = comparisonMap.firstEntry();
+        if (!boundaryReached(entry.getKey(), indexKey)) {
+            // Boundary condition not yet reached; include the indexer in the range.
+            entry.getValue().forEach(compositeKey, tupleConsumer);
         }
     }
 
     private void forEachManyIndexers(Object compositeKey, Consumer<T> tupleConsumer) {
+        if (comparisonMap.arrayBased) {
+            forEachManyIndexersArray(compositeKey, tupleConsumer);
+        } else {
+            forEachManyIndexersTree(compositeKey, tupleConsumer);
+        }
+    }
+
+    private void forEachManyIndexersArray(Object compositeKey, Consumer<T> tupleConsumer) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var cursor = comparisonMap.cursorFromStart();
-        while (cursor.advance()) {
-            if (boundaryReached(cursor.key(), indexKey)) {
+        var arraySize = comparisonMap.size();
+        var i = reverseOrder ? arraySize - 1 : 0;
+        var step = reverseOrder ? -1 : 1;
+        while (i >= 0 && i < arraySize) {
+            if (boundaryReached(comparisonMap.keyAt(i), indexKey)) {
                 return;
             }
             // Boundary condition not yet reached; include the indexer in the range.
-            cursor.value().forEach(compositeKey, tupleConsumer);
+            comparisonMap.valueAt(i).forEach(compositeKey, tupleConsumer);
+            i += step;
+        }
+    }
+
+    private void forEachManyIndexersTree(Object compositeKey, Consumer<T> tupleConsumer) {
+        var indexKey = keyUnpacker.apply(compositeKey);
+        var entryIterator = comparisonMap.iterator(reverseOrder);
+        while (entryIterator.hasNext()) {
+            var entry = entryIterator.next();
+            if (boundaryReached(entry.getKey(), indexKey)) {
+                return;
+            }
+            // Boundary condition not yet reached; include the indexer in the range.
+            entry.getValue().forEach(compositeKey, tupleConsumer);
         }
     }
 
@@ -159,14 +257,28 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
     }
 
     private Iterator<T> iteratorSingleIndexer(Object compositeKey) {
+        return comparisonMap.arrayBased ? iteratorSingleIndexerArray(compositeKey) : iteratorSingleIndexerTree(compositeKey);
+    }
+
+    private Iterator<T> iteratorSingleIndexerArray(Object compositeKey) {
         var indexKey = keyUnpacker.apply(compositeKey);
-        var cursor = comparisonMap.cursorFromStart();
-        cursor.advance();
-        if (boundaryReached(cursor.key(), indexKey)) {
+        var entryKey = comparisonMap.keyAt(0);
+        var entryValue = comparisonMap.valueAt(0);
+        if (boundaryReached(entryKey, indexKey)) {
             return Collections.emptyIterator();
         }
         // Boundary condition not yet reached; include the indexer in the range.
-        return cursor.value().iterator(compositeKey);
+        return entryValue.iterator(compositeKey);
+    }
+
+    private Iterator<T> iteratorSingleIndexerTree(Object compositeKey) {
+        var indexKey = keyUnpacker.apply(compositeKey);
+        var entry = comparisonMap.firstEntry();
+        if (boundaryReached(entry.getKey(), indexKey)) {
+            return Collections.emptyIterator();
+        }
+        // Boundary condition not yet reached; include the indexer in the range.
+        return entry.getValue().iterator(compositeKey);
     }
 
     @Override
@@ -178,20 +290,9 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
             @Nullable Predicate<T> filter) {
         return switch (comparisonMap.size()) {
             case 0 -> Collections.emptyIterator();
-            case 1 -> {
-                var indexKey = keyUnpacker.apply(queryCompositeKey);
-                var cursor = comparisonMap.cursorFromStart();
-                cursor.advance();
-                if (boundaryReached(cursor.key(), indexKey)) {
-                    yield Collections.emptyIterator();
-                } else { // Boundary condition not yet reached; include the indexer in the range.
-                    if (filter == null) {
-                        yield cursor.value().randomIterator(queryCompositeKey, workingRandom);
-                    } else {
-                        yield cursor.value().randomIterator(queryCompositeKey, workingRandom, filter);
-                    }
-                }
-            }
+            case 1 ->
+                comparisonMap.arrayBased ? randomIteratorSingleIndexerArray(queryCompositeKey, workingRandom, filter)
+                        : randomIteratorSingleIndexerTree(queryCompositeKey, workingRandom, filter);
             default -> {
                 if (filter == null) {
                     yield new RandomIterator(queryCompositeKey,
@@ -202,6 +303,31 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
                 }
             }
         };
+    }
+
+    private Iterator<T> randomIteratorSingleIndexerArray(Object queryCompositeKey, RandomGenerator workingRandom,
+            @Nullable Predicate<T> filter) {
+        var indexKey = keyUnpacker.apply(queryCompositeKey);
+        var entryKey = comparisonMap.keyAt(0);
+        var entryValue = comparisonMap.valueAt(0);
+        if (boundaryReached(entryKey, indexKey)) {
+            return Collections.emptyIterator();
+        }
+        // Boundary condition not yet reached; include the indexer in the range.
+        return filter == null ? entryValue.randomIterator(queryCompositeKey, workingRandom)
+                : entryValue.randomIterator(queryCompositeKey, workingRandom, filter);
+    }
+
+    private Iterator<T> randomIteratorSingleIndexerTree(Object queryCompositeKey, RandomGenerator workingRandom,
+            @Nullable Predicate<T> filter) {
+        var indexKey = keyUnpacker.apply(queryCompositeKey);
+        var entry = comparisonMap.firstEntry();
+        if (boundaryReached(entry.getKey(), indexKey)) {
+            return Collections.emptyIterator();
+        }
+        // Boundary condition not yet reached; include the indexer in the range.
+        return filter == null ? entry.getValue().randomIterator(queryCompositeKey, workingRandom)
+                : entry.getValue().randomIterator(queryCompositeKey, workingRandom, filter);
     }
 
     @Override
@@ -223,18 +349,29 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
 
         private final Key_ indexKey;
         private final Function<Indexer<T>, Iterator<T>> downstreamIteratorFunction;
-        private final ScalingNavigableMap.Cursor<Key_, Indexer<T>> cursor = comparisonMap.cursorFromStart();
+        // Tree mode: entries pulled from here. Array mode: this is null and the array cursor fields are used instead.
+        private final @Nullable Iterator<Map.Entry<Key_, Indexer<T>>> indexerIterator;
+        private int arrayCursor;
+        private final int arrayStep;
         protected @Nullable Iterator<T> downstreamIterator = null;
         private @Nullable T next = null;
 
         public DefaultIterator(Object queryCompositeKey) {
-            this(queryCompositeKey,
-                    downstreamIndexer -> downstreamIndexer.iterator(queryCompositeKey));
+            this(queryCompositeKey, downstreamIndexer -> downstreamIndexer.iterator(queryCompositeKey));
         }
 
         protected DefaultIterator(Object queryCompositeKey, Function<Indexer<T>, Iterator<T>> downstreamIteratorFunction) {
             this.indexKey = keyUnpacker.apply(queryCompositeKey);
             this.downstreamIteratorFunction = downstreamIteratorFunction;
+            if (comparisonMap.arrayBased) {
+                this.indexerIterator = null;
+                this.arrayCursor = reverseOrder ? comparisonMap.size() - 1 : 0;
+                this.arrayStep = reverseOrder ? -1 : 1;
+            } else {
+                this.indexerIterator = comparisonMap.iterator(reverseOrder);
+                this.arrayCursor = 0;
+                this.arrayStep = 0;
+            }
         }
 
         @Override
@@ -246,12 +383,36 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
                 next = downstreamIterator.next();
                 return true;
             }
-            while (cursor.advance()) {
-                if (boundaryReached(cursor.key(), indexKey)) {
+            return indexerIterator != null ? advanceFromTree() : advanceFromArray();
+        }
+
+        private boolean advanceFromTree() {
+            while (indexerIterator.hasNext()) {
+                var entry = indexerIterator.next();
+                if (boundaryReached(entry.getKey(), indexKey)) {
                     return false;
                 }
                 // Boundary condition not yet reached; include the indexer in the range.
-                downstreamIterator = downstreamIteratorFunction.apply(cursor.value());
+                downstreamIterator = downstreamIteratorFunction.apply(entry.getValue());
+                if (downstreamIterator.hasNext()) {
+                    next = downstreamIterator.next();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean advanceFromArray() {
+            var size = comparisonMap.size();
+            while (arrayCursor >= 0 && arrayCursor < size) {
+                var key = comparisonMap.keyAt(arrayCursor);
+                var indexer = comparisonMap.valueAt(arrayCursor);
+                arrayCursor += arrayStep;
+                if (boundaryReached(key, indexKey)) {
+                    return false;
+                }
+                // Boundary condition not yet reached; include the indexer in the range.
+                downstreamIterator = downstreamIteratorFunction.apply(indexer);
                 if (downstreamIterator.hasNext()) {
                     next = downstreamIterator.next();
                     return true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
@@ -157,11 +157,12 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>> implements Index
      * without needing a reversed comparator or sub-map view.
      */
     private boolean boundaryReached(Key_ entryKey, Key_ indexKey) {
-        var comparison = entryKey.compareTo(indexKey);
-        if (reverseOrder) {
-            // Comparator matches the order of iteration of the map, so the boundary is always found from the bottom up.
-            comparison = -comparison;
-        }
+        // Comparator matches the order of iteration of the map,
+        // so the boundary is always found from the bottom up.
+        // Swapping the compareTo() operands (rather than negating the result) sign-flips the comparison
+        // without risking overflow: -Integer.MIN_VALUE == Integer.MIN_VALUE,
+        // so negation is not safe here for a Comparable whose compareTo() can return exactly Integer.MIN_VALUE.
+        var comparison = reverseOrder ? indexKey.compareTo(entryKey) : entryKey.compareTo(indexKey);
         if (comparison >= 0) {
             // Boundary condition reached when we're out of bounds entirely, or when GTE/LTE is not allowed.
             return comparison > 0 || !hasOrEquals;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexer.java
@@ -1,7 +1,6 @@
 package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -44,8 +43,7 @@ final class ComparisonIndexer<T, Key_ extends Comparable<Key_>>
                 comparisonJoinerType == JoinerType.GREATER_THAN || comparisonJoinerType == JoinerType.GREATER_THAN_OR_EQUAL;
         this.hasOrEquals = comparisonJoinerType == JoinerType.GREATER_THAN_OR_EQUAL
                 || comparisonJoinerType == JoinerType.LESS_THAN_OR_EQUAL;
-        var comparator = reverseOrder ? Comparator.<Key_> reverseOrder() : null;
-        this.comparisonMap = new ScalingNavigableMap<>(comparator);
+        this.comparisonMap = new ScalingNavigableMap<>(reverseOrder);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -28,64 +29,60 @@ import org.jspecify.annotations.Nullable;
  * going back to an array on removal only reintroduces the cost of resizing/copying
  * for a bucket that has already demonstrated it churns near or above the threshold.
  * <p>
- * Keys and values are kept in two parallel arrays, not one interleaved array. Point lookups
- * ({@link #get}/{@link #getOrCreate}/{@link #remove}) binary-search over keys only and never touch values until a
- * match is found; a separate {@code keys} array keeps every key a search might probe packed together, instead of
- * spread across double the memory by unneeded interleaved value slots. Point lookups happen once per tuple
- * insertion/removal, more often than the full range scans that would actually benefit from key+value being
- * co-located, so this is the better default for this access pattern.
+ * Keys and values are kept in two parallel {@code Object[]} arrays.
+ * Point lookups ({@link #get}/{@link #getOrCreate}/{@link #remove}) binary-search over keys only
+ * and never touch values until a match is found;
+ * a separate {@code keys} array keeps every key a search might probe packed together,
+ * instead of spread across double the memory by unneeded interleaved value slots.
  * <p>
- * Keys are always compared/stored/built by their natural {@link Comparable} order, in both the array and the
- * {@link TreeMap}, regardless of {@code reversed} - never by an explicit {@link java.util.Comparator}. A
- * {@link TreeMap} without a comparator uses a faster lookup path internally ({@code getEntry()}, direct
- * {@code compareTo()}) than one with a comparator ({@code getEntryUsingComparator()}, extra dispatch through
- * {@code Comparator.compare()}) - since point lookups don't care about direction at all, giving them an explicit
- * comparator just to support reversed iteration would be paying that tax on every single lookup for no reason.
- * {@code reversed} only changes how {@link #cursorFromStart()} walks the entries: forward for the array (natural
- * start/step) or the tree ({@code entrySet()}), backward otherwise (reversed start/step, or
- * {@link NavigableMap#descendingMap()} - an O(1) view, not a rebuild).
+ * Keys are always compared/stored/built by their natural {@link Comparable} order,
+ * never by an explicit {@link Comparator}.
+ * A {@link TreeMap} without a comparator uses a faster lookup path internally ({@code getEntry()},
+ * direct {@code compareTo()}) than one with a comparator ({@code getEntryUsingComparator()}.
+ * <p>
+ * {@link ComparisonIndexer} branches on {@link #arrayBased} and calls {@link #keyAt}/{@link #valueAt} for range scans
+ * (plain, final-class, trivially inlined methods; benchmarked to be optimal);
+ * only the get/put/remove/treeify machinery is actually encapsulated here.
  *
- * @param <K> the key type; must be mutually comparable via {@link Comparable}
+ * @param <K> the key type
  * @param <V> the value type
  */
 @NullMarked
 final class ScalingNavigableMap<K extends Comparable<K>, V> {
 
-    // Package-private (not private) so tests in this package can read these directly
-    // instead of via reflection or a dedicated getter.
+    private static final Object[] EMPTY_ARRAY = new Object[0];
+
+    // Package-private: tests in this package read arrayBased/ARRAY_THRESHOLD
+    // The threshold was established experimentally.
     static final int ARRAY_THRESHOLD = 32;
-    private static final int INITIAL_ARRAY_CAPACITY = 4;
+    private static final int MINIMUM_ARRAY_CAPACITY = 4;
 
-    private final boolean reversed;
-
-    boolean belowThreshold = true;
-    // keys[0..size) sorted ascending by natural order (regardless of `reversed`), values[0..size) parallel to it.
-    private Object[] keys;
-    private Object[] values;
+    boolean arrayBased = true;
+    // keys[0, size) sorted ascending by natural order
+    private @Nullable Object[] keys = EMPTY_ARRAY;
+    // values[0, size) parallel to keys[]
+    private @Nullable Object[] values = EMPTY_ARRAY;
     private int size = 0;
-    // Allocated lazily by treeify(); non-null exactly when !belowThreshold. Never built with an explicit
-    // comparator - see the class javadoc for why.
-    private @Nullable TreeMap<K, V> treeMap;
+    // Allocated lazily by treeify(); non-null exactly when !arrayBased.
+    @Nullable
+    private TreeMap<K, V> treeMap;
 
-    ScalingNavigableMap(boolean reversed) {
-        this.reversed = reversed;
-        this.keys = new Object[INITIAL_ARRAY_CAPACITY];
-        this.values = new Object[INITIAL_ARRAY_CAPACITY];
+    ScalingNavigableMap() {
+        // No out-of-package instances.
     }
 
-    @SuppressWarnings("unchecked")
     @Nullable
-    V get(K key) {
-        if (belowThreshold) {
-            var index = indexOfKey(key);
-            return index >= 0 ? (V) values[index] : null;
+    public V get(K key) {
+        if (arrayBased) {
+            var index = indexOf(key);
+            return index >= 0 ? valueAt(index) : null;
         } else {
             return treeMap.get(key);
         }
     }
 
-    V getOrCreate(K key, Supplier<V> valueSupplier) {
-        return belowThreshold ? getOrCreateArray(key, valueSupplier) : getOrCreateTree(key, valueSupplier);
+    public V getOrCreate(K key, Supplier<V> valueSupplier) {
+        return arrayBased ? getOrCreateArray(key, valueSupplier) : getOrCreateTree(key, valueSupplier);
     }
 
     private V getOrCreateTree(K key, Supplier<V> valueSupplier) {
@@ -98,15 +95,14 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
         return value;
     }
 
-    @SuppressWarnings("unchecked")
     private V getOrCreateArray(K key, Supplier<V> valueSupplier) {
-        var index = indexOfKey(key);
+        var index = indexOf(key);
         if (index >= 0) {
-            return (V) values[index];
+            return valueAt(index);
         }
         var value = valueSupplier.get();
         insertIntoArray(-(index + 1), key, value);
-        if (size > ARRAY_THRESHOLD) {
+        if (size() > ARRAY_THRESHOLD) {
             treeify();
         }
         return value;
@@ -114,8 +110,9 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
 
     private void insertIntoArray(int insertionPoint, K key, V value) {
         if (size == keys.length) {
-            keys = Arrays.copyOf(keys, keys.length * 2);
-            values = Arrays.copyOf(values, values.length * 2);
+            var minSize = Math.max(keys.length * 2, MINIMUM_ARRAY_CAPACITY);
+            keys = Arrays.copyOf(keys, minSize);
+            values = Arrays.copyOf(values, minSize);
         }
         var shiftCount = size - insertionPoint;
         if (shiftCount > 0) {
@@ -127,130 +124,97 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
         size++;
     }
 
-    @SuppressWarnings("unchecked")
     private void treeify() {
         var newTreeMap = new TreeMap<K, V>();
         for (var i = 0; i < size; i++) {
-            newTreeMap.put((K) keys[i], (V) values[i]);
+            newTreeMap.put(keyAt(i), valueAt(i));
         }
         treeMap = newTreeMap;
-        belowThreshold = false;
-        Arrays.fill(keys, null);
-        Arrays.fill(values, null);
+        arrayBased = false;
+        Arrays.fill(keys, 0, size, null);
+        Arrays.fill(values, 0, size, null);
+        size = -1;
     }
 
-    void remove(K key) {
-        if (belowThreshold) {
-            removeFromArray(key);
+    /**
+     * If in array-mode, consider using {@link #removeAt(int)} instead,
+     * if the position is already known.
+     */
+    public void remove(K key) {
+        if (arrayBased) {
+            removeAt(indexOf(key));
         } else {
             treeMap.remove(key);
         }
     }
 
-    private void removeFromArray(K key) {
-        var index = indexOfKey(key);
+    /**
+     * Array-mode only.
+     * Exposed (alongside {@link #indexOf}) so a caller that already located an entry via {@link #indexOf} -
+     * typically to inspect its value first, like {@link ComparisonIndexer#remove} does -
+     * can remove it without a second, redundant binary search for the same key.
+     */
+    void removeAt(int index) {
         var shiftCount = size - index - 1;
         if (shiftCount > 0) {
             System.arraycopy(keys, index + 1, keys, index, shiftCount);
+            keys[size - 1] = null;
             System.arraycopy(values, index + 1, values, index, shiftCount);
+            values[size - 1] = null;
         }
         size--;
     }
 
-    int size() {
-        return belowThreshold ? size : treeMap.size();
+    public int size() {
+        return arrayBased ? size : treeMap.size();
     }
 
-    boolean isEmpty() {
-        return belowThreshold ? size == 0 : treeMap.isEmpty();
-    }
-
-    Cursor<K, V> cursorFromStart() {
-        if (belowThreshold) {
-            return new ArrayCursor();
-        }
-        var entryIterator = reversed ? treeMap.descendingMap().entrySet().iterator() : treeMap.entrySet().iterator();
-        return new TreeCursor<>(entryIterator);
-    }
-
-    private int indexOfKey(K key) {
-        return Arrays.binarySearch(keys, 0, size, key);
+    public boolean isEmpty() {
+        return arrayBased ? size == 0 : treeMap.isEmpty();
     }
 
     /**
-     * Variant of the iterator that allows to return two things at once,
-     * without allocating any carrier type.
-     *
-     * @param <K>
-     * @param <V>
+     * Array-mode range scans only.
      */
-    sealed interface Cursor<K, V> {
-
-        /**
-         * Moves to the next entry. Must be called before the first {@link #key()}/{@link #value()} call.
-         *
-         * @return false if there is no next entry; {@link #key()}/{@link #value()} must not be called in that case
-         */
-        boolean advance();
-
-        K key();
-
-        V value();
-
-    }
-
     @SuppressWarnings("unchecked")
-    private final class ArrayCursor implements Cursor<K, V> {
-
-        private final int step = reversed ? -1 : 1;
-        private int index = reversed ? size : -1;
-
-        @Override
-        public boolean advance() {
-            index += step;
-            return index >= 0 && index < size;
-        }
-
-        @Override
-        public K key() {
-            return (K) keys[index];
-        }
-
-        @Override
-        public V value() {
-            return (V) values[index];
-        }
-
+    @Nullable
+    K keyAt(int index) {
+        return (K) keys[index];
     }
 
-    private static final class TreeCursor<K, V> implements Cursor<K, V> {
+    /**
+     * Array-mode only.
+     */
+    @SuppressWarnings("unchecked")
+    @Nullable
+    V valueAt(int index) {
+        return (V) values[index];
+    }
 
-        private final Iterator<Map.Entry<K, V>> iterator;
-        private Map.@Nullable Entry<K, V> current;
+    /**
+     * Tree-mode only.
+     */
+    Map.Entry<K, V> firstEntry() {
+        return treeMap.firstEntry();
+    }
 
-        private TreeCursor(Iterator<Map.Entry<K, V>> iterator) {
-            this.iterator = iterator;
-        }
+    /**
+     * Tree-mode only.
+     */
+    Iterator<Map.Entry<K, V>> iterator(boolean reversed) {
+        return reversed ? treeMap.descendingMap().entrySet().iterator() : treeMap.entrySet().iterator();
+    }
 
-        @Override
-        public boolean advance() {
-            if (!iterator.hasNext()) {
-                return false;
-            }
-            current = iterator.next();
-            return true;
-        }
-
-        @Override
-        public K key() {
-            return current.getKey();
-        }
-
-        @Override
-        public V value() {
-            return current.getValue();
-        }
-
+    /**
+     * Array-mode only.
+     * Same contract as {@link Arrays#binarySearch(Object[], int, int, Object)}:
+     * the index of {@code key} if present, else {@code -(insertionPoint) - 1}.
+     * Exposed (see {@link #removeAt}) so a caller that needs both the value
+     * and, conditionally, to remove it - like {@link ComparisonIndexer#remove} -
+     * can reuse the result instead of searching for {@code key} a second time.
+     */
+    int indexOf(K key) {
+        return Arrays.binarySearch(keys, 0, size, key);
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
@@ -179,7 +179,6 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
      * Array-mode range scans only.
      */
     @SuppressWarnings("unchecked")
-    @Nullable
     K keyAt(int index) {
         return (K) keys[index];
     }
@@ -188,7 +187,6 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
      * Array-mode only.
      */
     @SuppressWarnings("unchecked")
-    @Nullable
     V valueAt(int index) {
         return (V) values[index];
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
@@ -53,8 +53,9 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
     private static final Object[] EMPTY_ARRAY = new Object[0];
 
     // Package-private: tests in this package read arrayBased/ARRAY_THRESHOLD
-    // The threshold was established experimentally.
-    static final int ARRAY_THRESHOLD = 32;
+    // The threshold was established experimentally;
+    // it was an improvement over 48, 96 only marginally better.
+    static final int ARRAY_THRESHOLD = 64;
     private static final int MINIMUM_ARRAY_CAPACITY = 4;
 
     boolean arrayBased = true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
@@ -1,0 +1,259 @@
+package ai.timefold.solver.core.impl.bavet.common.index;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An ordered {@code key -> value} structure,
+ * backed by a sorted array while the distinct key count is small,
+ * and by a {@link TreeMap} once it isn't.
+ * <p>
+ * Despite the name, this does not implement {@link NavigableMap}.
+ * It exposes only the handful of operations {@link ComparisonIndexer} needs;
+ * there is no {@code ceilingKey()}, {@code subMap()}, etc.
+ * <p>
+ * Most buckets stay small for the life of the solver,
+ * where a sorted array is more cache-friendly than a red-black tree;
+ * a handful of buckets in adversarial datasets may grow large,
+ * where a {@link TreeMap} remains the safer O(log n) choice.
+ * The switch from array to tree ({@link #treeify()}) is one-way:
+ * once a bucket has proven it can grow large,
+ * going back to an array on removal only reintroduces the cost of resizing/copying
+ * for a bucket that has already demonstrated it churns near or above the threshold.
+ * <p>
+ * Iteration always follows the {@link Comparator} given at construction,
+ * regardless of whether the backing storage is currently the array or the tree.
+ *
+ * @param <K> the key type; ordered by the {@link Comparator} given at construction
+ * @param <V> the value type
+ */
+@NullMarked
+final class ScalingNavigableMap<K, V> {
+
+    // Package-private (not private) so tests in this package can read these directly
+    // instead of via reflection or a dedicated getter.
+    static final int ARRAY_THRESHOLD = 32;
+    private static final int INITIAL_ARRAY_CAPACITY = 4;
+
+    // Null means natural (Comparable) order.
+    // Passed straight through to TreeMap's own constructor,
+    // which has a dedicated fast path for a null comparator
+    // (direct compareTo(), no indirection through Comparator.compare());
+    // supplying Comparator.naturalOrder() here instead would silently force
+    // every natural-order TreeMap onto its slower comparator-based lookup path.
+    private final @Nullable Comparator<? super K> comparator;
+
+    boolean belowThreshold = true;
+    // Interleaved: entries[2i] = key i, entries[2i + 1] = value i;
+    // sorted by comparator, ascending in iteration order.
+    private Object[] entries;
+    private int size = 0;
+    // Allocated lazily by treeify(); non-null exactly when !belowThreshold.
+    private @Nullable TreeMap<K, V> treeMap;
+
+    ScalingNavigableMap(@Nullable Comparator<? super K> comparator) {
+        this.comparator = comparator;
+        this.entries = new Object[INITIAL_ARRAY_CAPACITY * 2];
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    V get(K key) {
+        if (belowThreshold) {
+            var index = indexOfKey(key);
+            return index >= 0 ? (V) entries[index * 2 + 1] : null;
+        } else {
+            return treeMap.get(key);
+        }
+    }
+
+    V getOrCreate(K key, Supplier<V> valueSupplier) {
+        return belowThreshold ? getOrCreateArray(key, valueSupplier) : getOrCreateTree(key, valueSupplier);
+    }
+
+    private V getOrCreateTree(K key, Supplier<V> valueSupplier) {
+        // Avoids computeIfAbsent in order to not create lambdas on the hot path.
+        var value = treeMap.get(key);
+        if (value == null) {
+            value = valueSupplier.get();
+            treeMap.put(key, value);
+        }
+        return value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private V getOrCreateArray(K key, Supplier<V> valueSupplier) {
+        var index = indexOfKey(key);
+        if (index >= 0) {
+            return (V) entries[index * 2 + 1];
+        }
+        var value = valueSupplier.get();
+        insertIntoArray(-(index + 1), key, value);
+        if (size > ARRAY_THRESHOLD) {
+            treeify();
+        }
+        return value;
+    }
+
+    private void insertIntoArray(int insertionPoint, K key, V value) {
+        if (size * 2 == entries.length) {
+            entries = Arrays.copyOf(entries, entries.length * 2);
+        }
+        var shiftCount = (size - insertionPoint) * 2;
+        if (shiftCount > 0) {
+            System.arraycopy(entries, insertionPoint * 2, entries, (insertionPoint + 1) * 2, shiftCount);
+        }
+        var pos = insertionPoint * 2;
+        entries[pos] = key;
+        entries[pos + 1] = value;
+        size++;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void treeify() {
+        var newTreeMap = new TreeMap<K, V>(comparator);
+        for (var i = 0; i < size; i++) {
+            var pos = i * 2;
+            newTreeMap.put((K) entries[pos], (V) entries[pos + 1]);
+        }
+        treeMap = newTreeMap;
+        belowThreshold = false;
+        Arrays.fill(entries, null);
+    }
+
+    void remove(K key) {
+        if (belowThreshold) {
+            removeFromArray(key);
+        } else {
+            treeMap.remove(key);
+        }
+    }
+
+    private void removeFromArray(K key) {
+        var index = indexOfKey(key);
+        var shiftCount = (size - index - 1) * 2;
+        if (shiftCount > 0) {
+            System.arraycopy(entries, (index + 1) * 2, entries, index * 2, shiftCount);
+        }
+        size--;
+    }
+
+    int size() {
+        return belowThreshold ? size : treeMap.size();
+    }
+
+    boolean isEmpty() {
+        return belowThreshold ? size == 0 : treeMap.isEmpty();
+    }
+
+    Cursor<K, V> cursorFromStart() {
+        return belowThreshold ? new ArrayCursor() : new TreeCursor<>(treeMap.entrySet().iterator());
+    }
+
+    @SuppressWarnings("unchecked")
+    private int indexOfKey(K key) {
+        var low = 0;
+        var high = size - 1;
+        while (low <= high) {
+            var mid = (low + high) >>> 1;
+            var comparison = compare((K) entries[mid * 2], key);
+            if (comparison < 0) {
+                low = mid + 1;
+            } else if (comparison > 0) {
+                high = mid - 1;
+            } else {
+                return mid;
+            }
+        }
+        return -(low + 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    private int compare(K a, K b) {
+        return comparator != null ? comparator.compare(a, b) : ((Comparable<? super K>) a).compareTo(b);
+    }
+
+    /**
+     * Variant of the iterator that allows to return two things at once,
+     * without allocating any carrier type.
+     *
+     * @param <K>
+     * @param <V>
+     */
+    sealed interface Cursor<K, V> {
+
+        /**
+         * Moves to the next entry. Must be called before the first {@link #key()}/{@link #value()} call.
+         *
+         * @return false if there is no next entry; {@link #key()}/{@link #value()} must not be called in that case
+         */
+        boolean advance();
+
+        K key();
+
+        V value();
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private final class ArrayCursor implements Cursor<K, V> {
+
+        private int index = -1;
+
+        @Override
+        public boolean advance() {
+            index++;
+            return index < size;
+        }
+
+        @Override
+        public K key() {
+            return (K) entries[index * 2];
+        }
+
+        @Override
+        public V value() {
+            return (V) entries[index * 2 + 1];
+        }
+
+    }
+
+    private static final class TreeCursor<K, V> implements Cursor<K, V> {
+
+        private final Iterator<Map.Entry<K, V>> iterator;
+        private Map.@Nullable Entry<K, V> current;
+
+        private TreeCursor(Iterator<Map.Entry<K, V>> iterator) {
+            this.iterator = iterator;
+        }
+
+        @Override
+        public boolean advance() {
+            if (!iterator.hasNext()) {
+                return false;
+            }
+            current = iterator.next();
+            return true;
+        }
+
+        @Override
+        public K key() {
+            return current.getKey();
+        }
+
+        @Override
+        public V value() {
+            return current.getValue();
+        }
+
+    }
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
@@ -28,21 +28,28 @@ import org.jspecify.annotations.Nullable;
  * going back to an array on removal only reintroduces the cost of resizing/copying
  * for a bucket that has already demonstrated it churns near or above the threshold.
  * <p>
+ * Keys and values are kept in two parallel arrays, not one interleaved array. Point lookups
+ * ({@link #get}/{@link #getOrCreate}/{@link #remove}) binary-search over keys only and never touch values until a
+ * match is found; a separate {@code keys} array keeps every key a search might probe packed together, instead of
+ * spread across double the memory by unneeded interleaved value slots. Point lookups happen once per tuple
+ * insertion/removal, more often than the full range scans that would actually benefit from key+value being
+ * co-located, so this is the better default for this access pattern.
+ * <p>
  * Keys are always compared/stored/built by their natural {@link Comparable} order, in both the array and the
  * {@link TreeMap}, regardless of {@code reversed} - never by an explicit {@link java.util.Comparator}. A
  * {@link TreeMap} without a comparator uses a faster lookup path internally ({@code getEntry()}, direct
  * {@code compareTo()}) than one with a comparator ({@code getEntryUsingComparator()}, extra dispatch through
- * {@code Comparator.compare()}) - since point lookups ({@link #get}/{@link #getOrCreate}/{@link #remove}) don't
- * care about direction at all, giving them an explicit comparator just to support reversed iteration would be
- * paying that tax on every single lookup for no reason. {@code reversed} only changes how {@link #cursorFromStart()}
- * walks the entries: forward for the array (natural start/step) or the tree ({@code entrySet()}), backward
- * otherwise (reversed start/step, or {@link NavigableMap#descendingMap()} - an O(1) view, not a rebuild).
+ * {@code Comparator.compare()}) - since point lookups don't care about direction at all, giving them an explicit
+ * comparator just to support reversed iteration would be paying that tax on every single lookup for no reason.
+ * {@code reversed} only changes how {@link #cursorFromStart()} walks the entries: forward for the array (natural
+ * start/step) or the tree ({@code entrySet()}), backward otherwise (reversed start/step, or
+ * {@link NavigableMap#descendingMap()} - an O(1) view, not a rebuild).
  *
  * @param <K> the key type; must be mutually comparable via {@link Comparable}
  * @param <V> the value type
  */
 @NullMarked
-final class ScalingNavigableMap<K, V> {
+final class ScalingNavigableMap<K extends Comparable<K>, V> {
 
     // Package-private (not private) so tests in this package can read these directly
     // instead of via reflection or a dedicated getter.
@@ -52,9 +59,9 @@ final class ScalingNavigableMap<K, V> {
     private final boolean reversed;
 
     boolean belowThreshold = true;
-    // Interleaved: entries[2i] = key i, entries[2i + 1] = value i; always sorted ascending by natural order,
-    // regardless of `reversed` - only the cursor's scan direction flips, never the storage order.
-    private Object[] entries;
+    // keys[0..size) sorted ascending by natural order (regardless of `reversed`), values[0..size) parallel to it.
+    private Object[] keys;
+    private Object[] values;
     private int size = 0;
     // Allocated lazily by treeify(); non-null exactly when !belowThreshold. Never built with an explicit
     // comparator - see the class javadoc for why.
@@ -62,7 +69,8 @@ final class ScalingNavigableMap<K, V> {
 
     ScalingNavigableMap(boolean reversed) {
         this.reversed = reversed;
-        this.entries = new Object[INITIAL_ARRAY_CAPACITY * 2];
+        this.keys = new Object[INITIAL_ARRAY_CAPACITY];
+        this.values = new Object[INITIAL_ARRAY_CAPACITY];
     }
 
     @SuppressWarnings("unchecked")
@@ -70,7 +78,7 @@ final class ScalingNavigableMap<K, V> {
     V get(K key) {
         if (belowThreshold) {
             var index = indexOfKey(key);
-            return index >= 0 ? (V) entries[index * 2 + 1] : null;
+            return index >= 0 ? (V) values[index] : null;
         } else {
             return treeMap.get(key);
         }
@@ -94,7 +102,7 @@ final class ScalingNavigableMap<K, V> {
     private V getOrCreateArray(K key, Supplier<V> valueSupplier) {
         var index = indexOfKey(key);
         if (index >= 0) {
-            return (V) entries[index * 2 + 1];
+            return (V) values[index];
         }
         var value = valueSupplier.get();
         insertIntoArray(-(index + 1), key, value);
@@ -105,16 +113,17 @@ final class ScalingNavigableMap<K, V> {
     }
 
     private void insertIntoArray(int insertionPoint, K key, V value) {
-        if (size * 2 == entries.length) {
-            entries = Arrays.copyOf(entries, entries.length * 2);
+        if (size == keys.length) {
+            keys = Arrays.copyOf(keys, keys.length * 2);
+            values = Arrays.copyOf(values, values.length * 2);
         }
-        var shiftCount = (size - insertionPoint) * 2;
+        var shiftCount = size - insertionPoint;
         if (shiftCount > 0) {
-            System.arraycopy(entries, insertionPoint * 2, entries, (insertionPoint + 1) * 2, shiftCount);
+            System.arraycopy(keys, insertionPoint, keys, insertionPoint + 1, shiftCount);
+            System.arraycopy(values, insertionPoint, values, insertionPoint + 1, shiftCount);
         }
-        var pos = insertionPoint * 2;
-        entries[pos] = key;
-        entries[pos + 1] = value;
+        keys[insertionPoint] = key;
+        values[insertionPoint] = value;
         size++;
     }
 
@@ -122,12 +131,12 @@ final class ScalingNavigableMap<K, V> {
     private void treeify() {
         var newTreeMap = new TreeMap<K, V>();
         for (var i = 0; i < size; i++) {
-            var pos = i * 2;
-            newTreeMap.put((K) entries[pos], (V) entries[pos + 1]);
+            newTreeMap.put((K) keys[i], (V) values[i]);
         }
         treeMap = newTreeMap;
         belowThreshold = false;
-        Arrays.fill(entries, null);
+        Arrays.fill(keys, null);
+        Arrays.fill(values, null);
     }
 
     void remove(K key) {
@@ -140,9 +149,10 @@ final class ScalingNavigableMap<K, V> {
 
     private void removeFromArray(K key) {
         var index = indexOfKey(key);
-        var shiftCount = (size - index - 1) * 2;
+        var shiftCount = size - index - 1;
         if (shiftCount > 0) {
-            System.arraycopy(entries, (index + 1) * 2, entries, index * 2, shiftCount);
+            System.arraycopy(keys, index + 1, keys, index, shiftCount);
+            System.arraycopy(values, index + 1, values, index, shiftCount);
         }
         size--;
     }
@@ -163,22 +173,8 @@ final class ScalingNavigableMap<K, V> {
         return new TreeCursor<>(entryIterator);
     }
 
-    @SuppressWarnings("unchecked")
     private int indexOfKey(K key) {
-        var low = 0;
-        var high = size - 1;
-        while (low <= high) {
-            var mid = (low + high) >>> 1;
-            var comparison = ((Comparable<? super K>) entries[mid * 2]).compareTo(key);
-            if (comparison < 0) {
-                low = mid + 1;
-            } else if (comparison > 0) {
-                high = mid - 1;
-            } else {
-                return mid;
-            }
-        }
-        return -(low + 1);
+        return Arrays.binarySearch(keys, 0, size, key);
     }
 
     /**
@@ -217,12 +213,12 @@ final class ScalingNavigableMap<K, V> {
 
         @Override
         public K key() {
-            return (K) entries[index * 2];
+            return (K) keys[index];
         }
 
         @Override
         public V value() {
-            return (V) entries[index * 2 + 1];
+            return (V) values[index];
         }
 
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
@@ -1,7 +1,6 @@
 package ai.timefold.solver.core.impl.bavet.common.index;
 
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -29,10 +28,17 @@ import org.jspecify.annotations.Nullable;
  * going back to an array on removal only reintroduces the cost of resizing/copying
  * for a bucket that has already demonstrated it churns near or above the threshold.
  * <p>
- * Iteration always follows the {@link Comparator} given at construction,
- * regardless of whether the backing storage is currently the array or the tree.
+ * Keys are always compared/stored/built by their natural {@link Comparable} order, in both the array and the
+ * {@link TreeMap}, regardless of {@code reversed} - never by an explicit {@link java.util.Comparator}. A
+ * {@link TreeMap} without a comparator uses a faster lookup path internally ({@code getEntry()}, direct
+ * {@code compareTo()}) than one with a comparator ({@code getEntryUsingComparator()}, extra dispatch through
+ * {@code Comparator.compare()}) - since point lookups ({@link #get}/{@link #getOrCreate}/{@link #remove}) don't
+ * care about direction at all, giving them an explicit comparator just to support reversed iteration would be
+ * paying that tax on every single lookup for no reason. {@code reversed} only changes how {@link #cursorFromStart()}
+ * walks the entries: forward for the array (natural start/step) or the tree ({@code entrySet()}), backward
+ * otherwise (reversed start/step, or {@link NavigableMap#descendingMap()} - an O(1) view, not a rebuild).
  *
- * @param <K> the key type; ordered by the {@link Comparator} given at construction
+ * @param <K> the key type; must be mutually comparable via {@link Comparable}
  * @param <V> the value type
  */
 @NullMarked
@@ -43,24 +49,19 @@ final class ScalingNavigableMap<K, V> {
     static final int ARRAY_THRESHOLD = 32;
     private static final int INITIAL_ARRAY_CAPACITY = 4;
 
-    // Null means natural (Comparable) order.
-    // Passed straight through to TreeMap's own constructor,
-    // which has a dedicated fast path for a null comparator
-    // (direct compareTo(), no indirection through Comparator.compare());
-    // supplying Comparator.naturalOrder() here instead would silently force
-    // every natural-order TreeMap onto its slower comparator-based lookup path.
-    private final @Nullable Comparator<? super K> comparator;
+    private final boolean reversed;
 
     boolean belowThreshold = true;
-    // Interleaved: entries[2i] = key i, entries[2i + 1] = value i;
-    // sorted by comparator, ascending in iteration order.
+    // Interleaved: entries[2i] = key i, entries[2i + 1] = value i; always sorted ascending by natural order,
+    // regardless of `reversed` - only the cursor's scan direction flips, never the storage order.
     private Object[] entries;
     private int size = 0;
-    // Allocated lazily by treeify(); non-null exactly when !belowThreshold.
+    // Allocated lazily by treeify(); non-null exactly when !belowThreshold. Never built with an explicit
+    // comparator - see the class javadoc for why.
     private @Nullable TreeMap<K, V> treeMap;
 
-    ScalingNavigableMap(@Nullable Comparator<? super K> comparator) {
-        this.comparator = comparator;
+    ScalingNavigableMap(boolean reversed) {
+        this.reversed = reversed;
         this.entries = new Object[INITIAL_ARRAY_CAPACITY * 2];
     }
 
@@ -119,7 +120,7 @@ final class ScalingNavigableMap<K, V> {
 
     @SuppressWarnings("unchecked")
     private void treeify() {
-        var newTreeMap = new TreeMap<K, V>(comparator);
+        var newTreeMap = new TreeMap<K, V>();
         for (var i = 0; i < size; i++) {
             var pos = i * 2;
             newTreeMap.put((K) entries[pos], (V) entries[pos + 1]);
@@ -155,7 +156,11 @@ final class ScalingNavigableMap<K, V> {
     }
 
     Cursor<K, V> cursorFromStart() {
-        return belowThreshold ? new ArrayCursor() : new TreeCursor<>(treeMap.entrySet().iterator());
+        if (belowThreshold) {
+            return new ArrayCursor();
+        }
+        var entryIterator = reversed ? treeMap.descendingMap().entrySet().iterator() : treeMap.entrySet().iterator();
+        return new TreeCursor<>(entryIterator);
     }
 
     @SuppressWarnings("unchecked")
@@ -164,7 +169,7 @@ final class ScalingNavigableMap<K, V> {
         var high = size - 1;
         while (low <= high) {
             var mid = (low + high) >>> 1;
-            var comparison = compare((K) entries[mid * 2], key);
+            var comparison = ((Comparable<? super K>) entries[mid * 2]).compareTo(key);
             if (comparison < 0) {
                 low = mid + 1;
             } else if (comparison > 0) {
@@ -174,11 +179,6 @@ final class ScalingNavigableMap<K, V> {
             }
         }
         return -(low + 1);
-    }
-
-    @SuppressWarnings("unchecked")
-    private int compare(K a, K b) {
-        return comparator != null ? comparator.compare(a, b) : ((Comparable<? super K>) a).compareTo(b);
     }
 
     /**
@@ -206,12 +206,13 @@ final class ScalingNavigableMap<K, V> {
     @SuppressWarnings("unchecked")
     private final class ArrayCursor implements Cursor<K, V> {
 
-        private int index = -1;
+        private final int step = reversed ? -1 : 1;
+        private int index = reversed ? size : -1;
 
         @Override
         public boolean advance() {
-            index++;
-            return index < size;
+            index += step;
+            return index >= 0 && index < size;
         }
 
         @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
@@ -102,11 +102,12 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
         if (index >= 0) {
             return valueAt(index);
         }
+        if (size + 1 > ARRAY_THRESHOLD) {
+            treeify();
+            return getOrCreateTree(key, valueSupplier);
+        }
         var value = valueSupplier.get();
         insertIntoArray(-(index + 1), key, value);
-        if (size() > ARRAY_THRESHOLD) {
-            treeify();
-        }
         return value;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
@@ -38,7 +38,7 @@ import org.jspecify.annotations.Nullable;
  * Keys are always compared/stored/built by their natural {@link Comparable} order,
  * never by an explicit {@link Comparator}.
  * A {@link TreeMap} without a comparator uses a faster lookup path internally ({@code getEntry()},
- * direct {@code compareTo()}) than one with a comparator ({@code getEntryUsingComparator()}.
+ * direct {@code compareTo()}) than one with a comparator ({@code getEntryUsingComparator()}).
  * <p>
  * {@link ComparisonIndexer} branches on {@link #arrayBased} and calls {@link #keyAt}/{@link #valueAt} for range scans
  * (plain, final-class, trivially inlined methods; benchmarked to be optimal);
@@ -139,20 +139,25 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
     }
 
     /**
+     * No-op if {@code key} isn't present.
      * If in array-mode, consider using {@link #removeAt(int)} instead,
      * if the position is already known.
      */
     public void remove(K key) {
         if (arrayBased) {
-            removeAt(indexOf(key));
+            var index = indexOf(key);
+            if (index >= 0) {
+                removeAt(index);
+            }
         } else {
             treeMap.remove(key);
         }
     }
 
     /**
-     * Array-mode only.
-     * Exposed (alongside {@link #indexOf}) so a caller that already located an entry via {@link #indexOf} -
+     * Array-mode only. {@code index} must be a valid, currently-occupied position, as returned by
+     * a non-negative {@link #indexOf(Comparable)}.
+     * Exposed (alongside {@link #indexOf(Comparable)}) so a caller that already located an entry via {@link #indexOf} -
      * typically to inspect its value first, like {@link ComparisonIndexer#remove} does -
      * can remove it without a second, redundant binary search for the same key.
      */
@@ -160,10 +165,11 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
         var shiftCount = size - index - 1;
         if (shiftCount > 0) {
             System.arraycopy(keys, index + 1, keys, index, shiftCount);
-            keys[size - 1] = null;
             System.arraycopy(values, index + 1, values, index, shiftCount);
-            values[size - 1] = null;
         }
+        // Whether shifted or not, the last occupied slot is now stale; null it so it doesn't outlive size.
+        keys[size - 1] = null;
+        values[size - 1] = null;
         size--;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMap.java
@@ -53,8 +53,9 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
     private static final Object[] EMPTY_ARRAY = new Object[0];
 
     // Package-private: tests in this package read arrayBased/ARRAY_THRESHOLD
-    // The threshold was established experimentally;
-    // it was an improvement over 48, 96 only marginally better.
+    // Established experimentally;
+    // get/scan/churn all favor 64 over 32;
+    // pushing further to 96 or 128 only improved scan marginally, while get and churn got worse.
     static final int ARRAY_THRESHOLD = 64;
     private static final int MINIMUM_ARRAY_CAPACITY = 4;
 
@@ -210,8 +211,8 @@ final class ScalingNavigableMap<K extends Comparable<K>, V> {
      * Array-mode only.
      * Same contract as {@link Arrays#binarySearch(Object[], int, int, Object)}:
      * the index of {@code key} if present, else {@code -(insertionPoint) - 1}.
-     * Exposed (see {@link #removeAt}) so a caller that needs both the value
-     * and, conditionally, to remove it - like {@link ComparisonIndexer#remove} -
+     * Exposed (see {@link #removeAt}) so a caller that needs both the value and, conditionally, to remove it -
+     * like {@link ComparisonIndexer#remove} -
      * can reuse the result instead of searching for {@code key} a second time.
      */
     int indexOf(K key) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexerTest.java
@@ -2,9 +2,13 @@ package ai.timefold.solver.core.impl.bavet.common.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import ai.timefold.solver.core.api.score.stream.Joiners;
 import ai.timefold.solver.core.impl.bavet.bi.joiner.DefaultBiJoiner;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
+import ai.timefold.solver.core.impl.util.ListEntry;
 
 import org.junit.jupiter.api.Test;
 
@@ -87,6 +91,72 @@ class ComparisonIndexerTest extends AbstractIndexerTest {
         indexer.remove(50, entry50);
         assertThat(indexer.isRemovable()).isTrue();
         assertThat(forEachToTuples(indexer, 60)).isEmpty();
+    }
+
+    @Test
+    void treeifiesPastArrayThreshold() throws Exception {
+        // Below-threshold storage is a sorted array; crossing ARRAY_THRESHOLD must treeify without
+        // changing LESS_THAN match sets or order (see ComparisonIndexer's belowThreshold/treeify()).
+        Indexer<UniTuple<String>> indexer = new IndexerFactory<>(lessThanAge).buildIndexer(true);
+        var threshold = arrayThreshold();
+        var tuplesByAge = new LinkedHashMap<Integer, UniTuple<String>>();
+        for (var age = 0; age <= threshold; age++) { // threshold + 1 puts: crosses the threshold on the last one.
+            var tuple = newTuple("age" + age);
+            indexer.put(age, tuple);
+            tuplesByAge.put(age, tuple);
+        }
+        assertThat(isBelowThreshold(indexer)).isFalse();
+
+        // A few more puts on the tree path, to confirm it keeps working post-treeify.
+        for (var age = threshold + 1; age <= threshold + 3; age++) {
+            var tuple = newTuple("age" + age);
+            indexer.put(age, tuple);
+            tuplesByAge.put(age, tuple);
+        }
+
+        var queryAge = threshold + 10;
+        assertThat(forEachToTuples(indexer, queryAge)).containsExactlyInAnyOrderElementsOf(tuplesByAge.values());
+        assertThat(indexer.size(queryAge)).isEqualTo(tuplesByAge.size());
+
+        var midAge = threshold / 2;
+        var expectedBelowMid = tuplesByAge.entrySet().stream()
+                .filter(e -> e.getKey() < midAge)
+                .map(Map.Entry::getValue)
+                .toList();
+        assertThat(forEachToTuples(indexer, midAge)).containsExactlyInAnyOrderElementsOf(expectedBelowMid);
+        assertThat(indexer.size(midAge)).isEqualTo(expectedBelowMid.size());
+    }
+
+    @Test
+    void treeifyIsOneWayNoDemotionOnRemove() throws Exception {
+        // Once treeified, removing back below ARRAY_THRESHOLD must NOT revert to array mode.
+        Indexer<UniTuple<String>> indexer = new IndexerFactory<>(lessThanAge).buildIndexer(true);
+        var threshold = arrayThreshold();
+        var entriesByAge = new LinkedHashMap<Integer, ListEntry<UniTuple<String>>>();
+        for (var age = 0; age <= threshold; age++) { // threshold + 1 puts: crosses the threshold on the last one.
+            entriesByAge.put(age, indexer.put(age, newTuple("age" + age)));
+        }
+        assertThat(isBelowThreshold(indexer)).isFalse();
+
+        // Remove all but one entry, well below the array threshold.
+        entriesByAge.entrySet().stream()
+                .filter(e -> e.getKey() > 0)
+                .forEach(e -> indexer.remove(e.getKey(), e.getValue()));
+
+        assertThat(isBelowThreshold(indexer)).isFalse();
+        assertThat(indexer.size(threshold + 10)).isEqualTo(1);
+    }
+
+    private static int arrayThreshold() throws Exception {
+        var field = ComparisonIndexer.class.getDeclaredField("ARRAY_THRESHOLD");
+        field.setAccessible(true);
+        return field.getInt(null);
+    }
+
+    private static boolean isBelowThreshold(Indexer<?> indexer) throws Exception {
+        var field = ComparisonIndexer.class.getDeclaredField("belowThreshold");
+        field.setAccessible(true);
+        return field.getBoolean(indexer);
     }
 
     private static UniTuple<String> newTuple(String factA) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexerTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.stream.Joiners;
 import ai.timefold.solver.core.impl.bavet.bi.joiner.DefaultBiJoiner;
+import ai.timefold.solver.core.impl.bavet.common.joiner.JoinerType;
 import ai.timefold.solver.core.impl.bavet.common.tuple.UniTuple;
 import ai.timefold.solver.core.impl.util.ListEntry;
 
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.Test;
  */
 class ComparisonIndexerTest extends AbstractIndexerTest {
 
-    @SuppressWarnings("unchecked")
     private final DefaultBiJoiner<TestPerson, TestPerson> lessThanAge =
             (DefaultBiJoiner<TestPerson, TestPerson>) Joiners.lessThan(TestPerson::age);
 
@@ -145,22 +145,48 @@ class ComparisonIndexerTest extends AbstractIndexerTest {
         assertThat(indexer.size(threshold + 10)).isEqualTo(1);
     }
 
+    @Test
+    void boundaryComparisonHandlesExtremeCompareToWithoutOverflow() {
+        Indexer<UniTuple<String>> indexer =
+                new ComparisonIndexer<>(JoinerType.GREATER_THAN, KeyUnpacker.<ExtremeKey> single(),
+                        RandomAccessLeafIndexer::new);
+        var low = new ExtremeKey(1);
+        var high = new ExtremeKey(2); // low.compareTo(high) == Integer.MIN_VALUE.
+        indexer.put(low, newTuple("low"));
+
+        // low is not greater than high, nor than itself: neither query should match.
+        assertThat(forEachToTuples(indexer, high)).isEmpty();
+        assertThat(indexer.size(high)).isZero();
+        assertThat(forEachToTuples(indexer, low)).isEmpty();
+        assertThat(indexer.size(low)).isZero();
+    }
+
     private static UniTuple<String> newTuple(String factA) {
         return UniTuple.of(factA, 0);
     }
 
-    @SuppressWarnings("unchecked")
+    private record ExtremeKey(int value) implements Comparable<ExtremeKey> {
+
+        @Override
+        public int compareTo(ExtremeKey other) {
+            if (value == other.value) {
+                return 0;
+            }
+            // Deliberately extreme instead of a bounded difference,
+            // to exercise the sign-flip for GT/GTE without relying on subtraction-based compareTo() tricks elsewhere.
+            return value < other.value ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+        }
+    }
+
     private static DefaultBiJoiner<TestPerson, TestPerson> twoComparisons() {
         return (DefaultBiJoiner<TestPerson, TestPerson>) Joiners.lessThan(TestPerson::age)
                 .and(Joiners.greaterThan(TestPerson::age));
     }
 
-    @SuppressWarnings("unchecked")
     private static DefaultBiJoiner<TestPerson, TestPerson> equalGender() {
         return (DefaultBiJoiner<TestPerson, TestPerson>) Joiners.equal(TestPerson::gender);
     }
 
-    @SuppressWarnings("unchecked")
     private static DefaultBiJoiner<TestPerson, TestPerson> equalThenLessThan() {
         return (DefaultBiJoiner<TestPerson, TestPerson>) Joiners.equal(TestPerson::gender)
                 .and(Joiners.lessThan(TestPerson::age));

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexerTest.java
@@ -96,7 +96,7 @@ class ComparisonIndexerTest extends AbstractIndexerTest {
     @Test
     void treeifiesPastArrayThreshold() {
         // Below-threshold storage is a sorted array; crossing ARRAY_THRESHOLD must treeify without
-        // changing LESS_THAN match sets or order (see ScalingNavigableMap's belowThreshold/treeify()).
+        // changing LESS_THAN match sets or order (see ScalingNavigableMap's arrayBased/treeify()).
         Indexer<UniTuple<String>> indexer = new IndexerFactory<>(lessThanAge).buildIndexer(true);
         var threshold = ScalingNavigableMap.ARRAY_THRESHOLD;
         var tuplesByAge = new LinkedHashMap<Integer, UniTuple<String>>();

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ComparisonIndexerTest.java
@@ -94,18 +94,17 @@ class ComparisonIndexerTest extends AbstractIndexerTest {
     }
 
     @Test
-    void treeifiesPastArrayThreshold() throws Exception {
+    void treeifiesPastArrayThreshold() {
         // Below-threshold storage is a sorted array; crossing ARRAY_THRESHOLD must treeify without
-        // changing LESS_THAN match sets or order (see ComparisonIndexer's belowThreshold/treeify()).
+        // changing LESS_THAN match sets or order (see ScalingNavigableMap's belowThreshold/treeify()).
         Indexer<UniTuple<String>> indexer = new IndexerFactory<>(lessThanAge).buildIndexer(true);
-        var threshold = arrayThreshold();
+        var threshold = ScalingNavigableMap.ARRAY_THRESHOLD;
         var tuplesByAge = new LinkedHashMap<Integer, UniTuple<String>>();
         for (var age = 0; age <= threshold; age++) { // threshold + 1 puts: crosses the threshold on the last one.
             var tuple = newTuple("age" + age);
             indexer.put(age, tuple);
             tuplesByAge.put(age, tuple);
         }
-        assertThat(isBelowThreshold(indexer)).isFalse();
 
         // A few more puts on the tree path, to confirm it keeps working post-treeify.
         for (var age = threshold + 1; age <= threshold + 3; age++) {
@@ -128,35 +127,22 @@ class ComparisonIndexerTest extends AbstractIndexerTest {
     }
 
     @Test
-    void treeifyIsOneWayNoDemotionOnRemove() throws Exception {
-        // Once treeified, removing back below ARRAY_THRESHOLD must NOT revert to array mode.
+    void treeifyIsOneWayNoDemotionOnRemove() {
+        // Once treeified, removing back below ARRAY_THRESHOLD must still behave correctly.
+        // (The one-way-ness of the underlying switch is verified directly in ScalingNavigableMapTest.)
         Indexer<UniTuple<String>> indexer = new IndexerFactory<>(lessThanAge).buildIndexer(true);
-        var threshold = arrayThreshold();
+        var threshold = ScalingNavigableMap.ARRAY_THRESHOLD;
         var entriesByAge = new LinkedHashMap<Integer, ListEntry<UniTuple<String>>>();
         for (var age = 0; age <= threshold; age++) { // threshold + 1 puts: crosses the threshold on the last one.
             entriesByAge.put(age, indexer.put(age, newTuple("age" + age)));
         }
-        assertThat(isBelowThreshold(indexer)).isFalse();
 
         // Remove all but one entry, well below the array threshold.
         entriesByAge.entrySet().stream()
                 .filter(e -> e.getKey() > 0)
                 .forEach(e -> indexer.remove(e.getKey(), e.getValue()));
 
-        assertThat(isBelowThreshold(indexer)).isFalse();
         assertThat(indexer.size(threshold + 10)).isEqualTo(1);
-    }
-
-    private static int arrayThreshold() throws Exception {
-        var field = ComparisonIndexer.class.getDeclaredField("ARRAY_THRESHOLD");
-        field.setAccessible(true);
-        return field.getInt(null);
-    }
-
-    private static boolean isBelowThreshold(Indexer<?> indexer) throws Exception {
-        var field = ComparisonIndexer.class.getDeclaredField("belowThreshold");
-        field.setAccessible(true);
-        return field.getBoolean(indexer);
     }
 
     private static UniTuple<String> newTuple(String factA) {

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
@@ -27,6 +27,19 @@ class ScalingNavigableMapTest {
     }
 
     @Test
+    void removeIsNoOpForMissingKey() {
+        var map = new ScalingNavigableMap<Integer, String>();
+        map.getOrCreate(1, () -> "one");
+        map.getOrCreate(2, () -> "two");
+
+        map.remove(99); // Not present; must not throw.
+
+        assertThat(map.size()).isEqualTo(2);
+        assertThat(map.get(1)).isEqualTo("one");
+        assertThat(map.get(2)).isEqualTo("two");
+    }
+
+    @Test
     void arrayModeIsAlwaysAscendingRegardlessOfReversed() {
         var map = new ScalingNavigableMap<Integer, String>();
         map.getOrCreate(3, () -> "three");

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
@@ -1,0 +1,74 @@
+package ai.timefold.solver.core.impl.bavet.common.index;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ScalingNavigableMapTest {
+
+    @Test
+    void getOrCreateGetRemove() {
+        var map = new ScalingNavigableMap<Integer, String>(Comparator.naturalOrder());
+        assertThat(map.isEmpty()).isTrue();
+        assertThat(map.get(1)).isNull();
+
+        assertThat(map.getOrCreate(1, () -> "one")).isEqualTo("one");
+        assertThat(map.getOrCreate(1, () -> "should not be used")).isEqualTo("one");
+        assertThat(map.get(1)).isEqualTo("one");
+        assertThat(map.size()).isEqualTo(1);
+        assertThat(map.isEmpty()).isFalse();
+
+        map.remove(1);
+        assertThat(map.get(1)).isNull();
+        assertThat(map.isEmpty()).isTrue();
+    }
+
+    @Test
+    void iteratesInComparatorOrder() {
+        var ascending = new ScalingNavigableMap<Integer, String>(Comparator.naturalOrder());
+        ascending.getOrCreate(3, () -> "three");
+        ascending.getOrCreate(1, () -> "one");
+        ascending.getOrCreate(2, () -> "two");
+        assertThat(keysInCursorOrder(ascending)).containsExactly(1, 2, 3);
+
+        var descending = new ScalingNavigableMap<Integer, String>(Comparator.reverseOrder());
+        descending.getOrCreate(3, () -> "three");
+        descending.getOrCreate(1, () -> "one");
+        descending.getOrCreate(2, () -> "two");
+        assertThat(keysInCursorOrder(descending)).containsExactly(3, 2, 1);
+    }
+
+    @Test
+    void treeifiesPastArrayThresholdAndStaysTreeified() {
+        var map = new ScalingNavigableMap<Integer, String>(Comparator.naturalOrder());
+        for (var key = 0; key <= ScalingNavigableMap.ARRAY_THRESHOLD; key++) { // crosses the threshold on the last put
+            var value = "value" + key;
+            map.getOrCreate(key, () -> value);
+        }
+        assertThat(map.belowThreshold).isFalse();
+        assertThat(map.size()).isEqualTo(ScalingNavigableMap.ARRAY_THRESHOLD + 1);
+        assertThat(keysInCursorOrder(map)).hasSize(ScalingNavigableMap.ARRAY_THRESHOLD + 1).isSorted();
+
+        // Remove all but one key, well below the threshold: must not revert to array mode.
+        for (var key = 1; key <= ScalingNavigableMap.ARRAY_THRESHOLD; key++) {
+            map.remove(key);
+        }
+        assertThat(map.belowThreshold).isFalse();
+        assertThat(map.size()).isEqualTo(1);
+        assertThat(map.get(0)).isEqualTo("value0");
+    }
+
+    private static List<Integer> keysInCursorOrder(ScalingNavigableMap<Integer, String> map) {
+        var keys = new ArrayList<Integer>();
+        var cursor = map.cursorFromStart();
+        while (cursor.advance()) {
+            keys.add(cursor.key());
+        }
+        return keys;
+    }
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
@@ -11,7 +11,7 @@ class ScalingNavigableMapTest {
 
     @Test
     void getOrCreateGetRemove() {
-        var map = new ScalingNavigableMap<Integer, String>(false);
+        var map = new ScalingNavigableMap<Integer, String>();
         assertThat(map.isEmpty()).isTrue();
         assertThat(map.get(1)).isNull();
 
@@ -27,62 +27,69 @@ class ScalingNavigableMapTest {
     }
 
     @Test
-    void iteratesForwardOrReversed() {
-        var ascending = new ScalingNavigableMap<Integer, String>(false);
-        ascending.getOrCreate(3, () -> "three");
-        ascending.getOrCreate(1, () -> "one");
-        ascending.getOrCreate(2, () -> "two");
-        assertThat(keysInCursorOrder(ascending)).containsExactly(1, 2, 3);
-
-        var descending = new ScalingNavigableMap<Integer, String>(true);
-        descending.getOrCreate(3, () -> "three");
-        descending.getOrCreate(1, () -> "one");
-        descending.getOrCreate(2, () -> "two");
-        assertThat(keysInCursorOrder(descending)).containsExactly(3, 2, 1);
+    void arrayModeIsAlwaysAscendingRegardlessOfReversed() {
+        var map = new ScalingNavigableMap<Integer, String>();
+        map.getOrCreate(3, () -> "three");
+        map.getOrCreate(1, () -> "one");
+        map.getOrCreate(2, () -> "two");
+        assertThat(map.arrayBased).isTrue();
+        assertThat(ascendingKeys(map)).containsExactly(1, 2, 3);
+        assertThat(descendingKeys(map)).containsExactly(1, 2, 3);
     }
 
     @Test
-    void iteratesForwardOrReversedPastArrayThreshold() {
-        var ascending = new ScalingNavigableMap<Integer, String>(false);
-        var descending = new ScalingNavigableMap<Integer, String>(true);
-        for (var key = 0; key <= ScalingNavigableMap.ARRAY_THRESHOLD; key++) { // crosses the threshold on the last put
-            var value = "value" + key;
-            ascending.getOrCreate(key, () -> value);
-            descending.getOrCreate(key, () -> value);
-        }
-        assertThat(ascending.belowThreshold).isFalse();
-        assertThat(descending.belowThreshold).isFalse();
-        assertThat(keysInCursorOrder(ascending)).isSorted();
-        assertThat(keysInCursorOrder(descending)).isSortedAccordingTo((a, b) -> b - a);
-    }
-
-    @Test
-    void treeifiesPastArrayThresholdAndStaysTreeified() {
-        var map = new ScalingNavigableMap<Integer, String>(false);
+    void iteratorHonorsReversedPastArrayThreshold() {
+        var map = new ScalingNavigableMap<Integer, String>();
         for (var key = 0; key <= ScalingNavigableMap.ARRAY_THRESHOLD; key++) { // crosses the threshold on the last put
             var value = "value" + key;
             map.getOrCreate(key, () -> value);
         }
-        assertThat(map.belowThreshold).isFalse();
+        assertThat(map.arrayBased).isFalse();
+        assertThat(ascendingKeys(map)).isSorted();
+        assertThat(descendingKeys(map)).isSortedAccordingTo((a, b) -> b - a);
+    }
+
+    @Test
+    void treeifiesPastArrayThresholdAndStaysTreeified() {
+        var map = new ScalingNavigableMap<Integer, String>();
+        for (var key = 0; key <= ScalingNavigableMap.ARRAY_THRESHOLD; key++) { // crosses the threshold on the last put
+            var value = "value" + key;
+            map.getOrCreate(key, () -> value);
+        }
+        assertThat(map.arrayBased).isFalse();
         assertThat(map.size()).isEqualTo(ScalingNavigableMap.ARRAY_THRESHOLD + 1);
-        assertThat(keysInCursorOrder(map)).hasSize(ScalingNavigableMap.ARRAY_THRESHOLD + 1).isSorted();
+        assertThat(ascendingKeys(map)).hasSize(ScalingNavigableMap.ARRAY_THRESHOLD + 1).isSorted();
 
         // Remove all but one key, well below the threshold: must not revert to array mode.
         for (var key = 1; key <= ScalingNavigableMap.ARRAY_THRESHOLD; key++) {
             map.remove(key);
         }
-        assertThat(map.belowThreshold).isFalse();
+        assertThat(map.arrayBased).isFalse();
         assertThat(map.size()).isEqualTo(1);
         assertThat(map.get(0)).isEqualTo("value0");
     }
 
-    private static List<Integer> keysInCursorOrder(ScalingNavigableMap<Integer, String> map) {
+    private static List<Integer> ascendingKeys(ScalingNavigableMap<Integer, String> map) {
+        return keys(map, false);
+    }
+
+    private static List<Integer> keys(ScalingNavigableMap<Integer, String> map, boolean reversed) {
         var keys = new ArrayList<Integer>();
-        var cursor = map.cursorFromStart();
-        while (cursor.advance()) {
-            keys.add(cursor.key());
+        if (map.arrayBased) {
+            for (var i = 0; i < map.size(); i++) {
+                keys.add(map.keyAt(i));
+            }
+        } else {
+            var entryIterator = map.iterator(reversed);
+            while (entryIterator.hasNext()) {
+                keys.add(entryIterator.next().getKey());
+            }
         }
         return keys;
+    }
+
+    private static List<Integer> descendingKeys(ScalingNavigableMap<Integer, String> map) {
+        return keys(map, true);
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
@@ -3,7 +3,6 @@ package ai.timefold.solver.core.impl.bavet.common.index;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -12,7 +11,7 @@ class ScalingNavigableMapTest {
 
     @Test
     void getOrCreateGetRemove() {
-        var map = new ScalingNavigableMap<Integer, String>(Comparator.naturalOrder());
+        var map = new ScalingNavigableMap<Integer, String>(false);
         assertThat(map.isEmpty()).isTrue();
         assertThat(map.get(1)).isNull();
 
@@ -28,14 +27,14 @@ class ScalingNavigableMapTest {
     }
 
     @Test
-    void iteratesInComparatorOrder() {
-        var ascending = new ScalingNavigableMap<Integer, String>(Comparator.naturalOrder());
+    void iteratesForwardOrReversed() {
+        var ascending = new ScalingNavigableMap<Integer, String>(false);
         ascending.getOrCreate(3, () -> "three");
         ascending.getOrCreate(1, () -> "one");
         ascending.getOrCreate(2, () -> "two");
         assertThat(keysInCursorOrder(ascending)).containsExactly(1, 2, 3);
 
-        var descending = new ScalingNavigableMap<Integer, String>(Comparator.reverseOrder());
+        var descending = new ScalingNavigableMap<Integer, String>(true);
         descending.getOrCreate(3, () -> "three");
         descending.getOrCreate(1, () -> "one");
         descending.getOrCreate(2, () -> "two");
@@ -43,8 +42,23 @@ class ScalingNavigableMapTest {
     }
 
     @Test
+    void iteratesForwardOrReversedPastArrayThreshold() {
+        var ascending = new ScalingNavigableMap<Integer, String>(false);
+        var descending = new ScalingNavigableMap<Integer, String>(true);
+        for (var key = 0; key <= ScalingNavigableMap.ARRAY_THRESHOLD; key++) { // crosses the threshold on the last put
+            var value = "value" + key;
+            ascending.getOrCreate(key, () -> value);
+            descending.getOrCreate(key, () -> value);
+        }
+        assertThat(ascending.belowThreshold).isFalse();
+        assertThat(descending.belowThreshold).isFalse();
+        assertThat(keysInCursorOrder(ascending)).isSorted();
+        assertThat(keysInCursorOrder(descending)).isSortedAccordingTo((a, b) -> b - a);
+    }
+
+    @Test
     void treeifiesPastArrayThresholdAndStaysTreeified() {
-        var map = new ScalingNavigableMap<Integer, String>(Comparator.naturalOrder());
+        var map = new ScalingNavigableMap<Integer, String>(false);
         for (var key = 0; key <= ScalingNavigableMap.ARRAY_THRESHOLD; key++) { // crosses the threshold on the last put
             var value = "value" + key;
             map.getOrCreate(key, () -> value);


### PR DESCRIPTION
Introduces an alternative to `TreeMap` which, for a small amount of keys, uses a sorted array. This is a significant performance improvement (~10 % in score director benchmarks), if the number of keys stays low.