### PR TITLE
chore: improve logging

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
@@ -158,6 +158,7 @@ public class DefaultConstructionHeuristicPhase<Solution_>
         terminationStatus = TerminationStatus.NOT_TERMINATED;
         moveRepository.phaseStarted(phaseScope);
         decider.phaseStarted(phaseScope);
+        logger.debug("Construction Heuristic phase ({}) started.", phaseIndex);
     }
 
     public void stepStarted(ConstructionHeuristicStepScope<Solution_> stepScope) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhase.java
@@ -94,6 +94,7 @@ public class DefaultExhaustiveSearchPhase<Solution_> extends AbstractPhase<Solut
     private void phaseStarted(ExhaustiveSearchPhaseScope<Solution_> phaseScope) {
         super.phaseStarted(phaseScope);
         decider.phaseStarted(phaseScope);
+        logger.debug("Exhaustive Search phase ({}) started.", phaseIndex);
     }
 
     private void phaseEnded(ExhaustiveSearchPhaseScope<Solution_> phaseScope) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -135,6 +135,7 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
         super.phaseStarted(phaseScope);
         decider.phaseStarted(phaseScope);
         assertWorkingSolutionInitialized(phaseScope);
+        logger.debug("Local Search phase ({}) started.", phaseIndex);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
@@ -81,6 +81,7 @@ public final class DefaultCustomPhase<Solution_>
     public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
         super.phaseStarted(phaseScope);
         terminationStatus = TerminationStatus.NOT_TERMINATED;
+        logger.debug("Custom phase ({}) started.", phaseIndex);
     }
 
     private void doStep(CustomStepScope<Solution_> stepScope, PhaseCommand<Solution_> customPhaseCommand) {


### PR DESCRIPTION
The PR adds additional logging information at the DEBUG level:

```
11:05:45.487 DEBUG [pool-5-thread-1] Custom phase (1) started.
11:05:45.488 DEBUG [pool-5-thread-1]     Custom step (0), time spent (19), score (0hard/-38007850000medium/-29758913soft),     best score (0hard/-38007850000medium/-29758913soft).
11:05:45.491  INFO [pool-5-thread-1] Custom phase (1) ended: time spent (22), best score (0hard/-38007850000medium/-29758913soft), move evaluation speed (0/sec), step total (1).

11:05:45.497 DEBUG [pool-5-thread-1] Multi-Threaded Construction Heuristic Decider started, move threads (4)
11:05:45.497 DEBUG [pool-5-thread-1] Construction Heuristic phase (2) started.
11:05:45.512 DEBUG [pool-5-thread-1]     CH step (0), time spent (43), score (0hard/-37007850000medium/-29479796soft), selected move count (2), picked move (SolverVisit{id=5f093b6c, visitGroup=null} {null -> SolverVehicleShift{id=4ba8b9dc}[0]}).
...
11:05:45.628 DEBUG [pool-5-thread-1]     CH step (158), time spent (159), score (0hard/-30000medium/-4204205soft), selected move count (18), picked move (ai.timefold.solver.core.impl.heuristic.move.SelectorBasedNoChangeMove@41d4d9d7).
11:05:45.636 DEBUG [pool-5-thread-1] Multi-Threaded Construction Heuristic Decider ended
11:05:45.636  INFO [pool-5-thread-1] Construction Heuristic phase (2) ended: time spent (167), best score (0hard/-30000medium/-4204205soft), effective move evaluation speed (15209/sec), step total (159).

11:05:45.649 DEBUG [pool-5-thread-1] Distance Matrix building ended, origin size (158), maximum destination size (40).
11:05:45.653 DEBUG [pool-5-thread-1] Distance Matrix building ended, origin size (158), maximum destination size (40).
11:05:45.657 DEBUG [pool-5-thread-1] Distance Matrix building ended, origin size (158), maximum destination size (40).
11:05:45.657 DEBUG [pool-5-thread-1] Multi-Threaded Local Search Decider started, move threads (4)
11:05:45.657 DEBUG [pool-5-thread-1] Local Search phase (3) started.
11:05:45.684 DEBUG [pool-5-thread-1]     LS step (0), time spent (215), score (0hard/-30000medium/-4203148soft), new best score (0hard/-30000medium/-4203148soft), accepted/selected move count (1/38), picked move (SolverVisit{id=797fb983, visitGroup=null} {SolverVehicleShift{id=9419b027}[0]} <-> SolverVisit{id=b20ce24e, visitGroup=null} {SolverVehicleShift{id=0ed0fa07}[0]}).
...
11:06:29.208 DEBUG [pool-5-thread-1]     LS step (130677), time spent (43739), score (0hard/0medium/-3929089soft),     best score (0hard/0medium/-3929083soft), terminated prematurely after selecting 98 moves.
11:06:29.211 DEBUG [pool-5-thread-1] Multi-Threaded Local Search Decider ended
11:06:29.211  INFO [pool-5-thread-1] Local Search phase (3) ended: time spent (43742), best score (0hard/0medium/-3929083soft), effective move evaluation speed (117863/sec), step total (130678).
```