### PR TITLE
ci: only publish SBOM in JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,7 @@
                   <goal>makeAggregateBom</goal>
                 </goals>
                 <configuration>
+                  <outputFormat>json</outputFormat>
                   <excludeTestProject>true</excludeTestProject>
                 </configuration>
               </execution>


### PR DESCRIPTION
Saves on release file size.
Let's backport to the 2.3.x release branch.