### PR TITLE
docs: remove plus version

### DIFF
--- a/.github/workflows/release-changelog-template.md
+++ b/.github/workflows/release-changelog-template.md
@@ -13,7 +13,7 @@ _Timefold Solver Community Edition_ is an open source project, and you are more 
 For more, see [Contributing](https://github.com/TimefoldAI/timefold-solver/blob/main/CONTRIBUTING.adoc).
 
 Timefold also offers commercial editions of the solver, which include additional features such as explainability, the ability to scale out to the biggest datasets, and enterprise-grade support.
-Find out [which edition is right for you](https://licenses.timefold.ai/). 
+Find out [more about the different editions](https://licenses.timefold.ai/). 
 
 # How to use Timefold Solver
 

--- a/README.adoc
+++ b/README.adoc
@@ -63,14 +63,13 @@ For more, see link:CONTRIBUTING.md[Contributing].
 
 == Editions
 
-There are three editions of Timefold Solver:
+There are two editions of Timefold Solver:
 
 - _Timefold Solver Community Edition_,
-- _Timefold Solver Plus_
 - _Timefold Solver Enterprise_.
 
 The Community Edition (this repo) is open-source and licensed under the Apache-2.0 license.
-The latter two are non-open-source commercial offerings and require a Timefold license to run.
+The Enterprise Edition is a non-open-source commercial offering and requires a Timefold license to run.
 
 https://licenses.timefold.ai/[See which edition is right for you.]
 

--- a/docs/src/modules/ROOT/pages/commercial-editions/_only-plus-and-enterprise.adoc
+++ b/docs/src/modules/ROOT/pages/commercial-editions/_only-plus-and-enterprise.adoc
@@ -1,1 +1,0 @@
-NOTE: This feature is exclusive to xref:commercial-editions/commercial-editions.adoc[Timefold Solver Plus and Enterprise Editions.]

--- a/docs/src/modules/ROOT/pages/commercial-editions/commercial-editions.adoc
+++ b/docs/src/modules/ROOT/pages/commercial-editions/commercial-editions.adoc
@@ -1,14 +1,14 @@
-= Plus/Enterprise Editions
+= Enterprise Edition
 :page-aliases: partitioned-search/partitioned-search.adoc, \
     enterprise-edition/enterprise-edition.adoc
 :doctype: book
 :icons: font
 
-_Timefold Solver Plus_ and _Timefold Solver Enterprise_ are commercial products which offer additional features,
+_Timefold Solver Enterprise_ is a commercial product which offers additional features,
 such as xref:constraints-and-score/understanding-the-score.adoc[score analysis], xref:optimization-algorithms/move-selector-reference.adoc#nearbySelection[nearby selection] and xref:running-timefold-solver/multithreaded-solving.adoc#multithreadedIncrementalSolving[multithreaded solving].
 These features are essential to scale out to large datasets and build trust with your users.
 
-Unlike _Timefold Solver Community Edition_, these commercial editions are not open-source.
+Unlike _Timefold Solver Community Edition_, this commercial edition is not open-source.
 
 TIP: Looking for quicker time-to-value?
 Timefold offers https://docs.timefold.ai/[pre-built, fully tuned optimization models], no constraint building required.
@@ -19,37 +19,37 @@ Just plug into our API and start optimizing immediately.
 We offer free trials to everyone as well as free licenses to non-profit organizations and for academic research.
 See our https://licenses.timefold.ai/[license portal] to get your license, then follow the xref:commercial-editions/installation.adoc[installation guide] to get started.
 
-== Feature Comparison
+== Features
 
-[cols="4,^1,^1", options="header"]
+[cols="4,^1", options="header"]
 |===
-| Feature | Plus | Enterprise
+| Feature | Enterprise
 
 | xref:constraints-and-score/understanding-the-score.adoc[Score Analysis]
-| ✓ | ✓
+| ✓
 
 | xref:responding-to-change/recommendation-api.adoc#assignmentRecommendationAPI[Recommendation API]
-| ✓ | ✓
+| ✓
 
 | xref:commercial-editions/performance-improvements.adoc[Performance improvements]
-| | ✓
+| ✓
 
 | xref:optimization-algorithms/move-selector-reference.adoc#nearbySelection[Nearby selection]
-| | ✓
+| ✓
 
 | xref:running-timefold-solver/multithreaded-solving.adoc#multithreadedIncrementalSolving[Multithreaded solving]
-| | ✓
+| ✓
 
 | xref:running-timefold-solver/multithreaded-solving.adoc#partitionedSearch[Partitioned search]
-| | ✓
+| ✓
 
 | xref:constraints-and-score/performance.adoc#constraintProfiling[Constraint profiling]
-| | ✓
+| ✓
 
 | xref:commercial-editions/multistage-moves.adoc[Multistage moves]
-| | ✓
+| ✓
 
 | xref:running-timefold-solver/library/library-integration.adoc#throttlingBestSolutionEvents[Throttling best solution events]
-| | ✓
+| ✓
 
 |===

--- a/docs/src/modules/ROOT/pages/commercial-editions/installation.adoc
+++ b/docs/src/modules/ROOT/pages/commercial-editions/installation.adoc
@@ -1,6 +1,6 @@
-= Installing Timefold Solver Plus & Enterprise
+= Installing Timefold Solver Enterprise
 
-In order to work with the commercial editions of Timefold Solver, 2 actions need to be taken:
+In order to work with the commercial edition of Timefold Solver, 2 actions need to be taken:
 
 - <<solverLicenseKey,Configure a license key>>;
 - <<enterpriseArtifacts,Use the Enterprise artifacts>>;
@@ -38,8 +38,7 @@ These artifacts are available from Maven Central, so no additional repositories 
 
 [NOTE]
 ====
-To avoid operational complexity, both Plus and Enterprise editions of Timefold Solver use the `enterprise` artifacts.
-Features for your licensed version are enabled based on the provided license key.
+The Enterprise edition of Timefold Solver uses the `enterprise` artifacts.
 ====
 
 Replace references to open-source artifacts by their `enterprise` counterparts

--- a/docs/src/modules/ROOT/pages/constraints-and-score/score-calculation.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/score-calculation.adoc
@@ -2304,7 +2304,7 @@ add the `incrementalScoreCalculatorCustomProperties` element and use xref:runnin
 [#analyzableIncrementalScoreCalculator]
 ==== Incremental score calculator and score analysis
 
-include::../commercial-editions/_only-plus-and-enterprise.adoc[]
+include::../commercial-editions/_only-enterprise.adoc[]
 
 To add support for xref:constraints-and-score/understanding-the-score.adoc[score analysis],
 implement the `AnalyzableIncrementalScoreCalculator` interface instead of `IncrementalScoreCalculator`:

--- a/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
@@ -8,7 +8,7 @@ The score in its pure form is just a number, and does not help us understand the
 It doesn't say which constraints are broken, or what caused them to break.
 To understand the score, it needs to be broken down.
 
-include::../commercial-editions/_only-plus-and-enterprise.adoc[]
+include::../commercial-editions/_only-enterprise.adoc[]
 
 The easiest way to break down the score during development is to print the score summary:
 

--- a/docs/src/modules/ROOT/pages/frequently-asked-questions.adoc
+++ b/docs/src/modules/ROOT/pages/frequently-asked-questions.adoc
@@ -9,10 +9,10 @@ released under http://www.apache.org/licenses/LICENSE-2.0.html[the Apache Licens
 This license is very liberal and allows reuse for commercial purposes.
 Read http://www.apache.org/foundation/licence-FAQ.html#WhatDoesItMEAN[the layman's explanation].
 
-_Timefold Solver Plus and Enterprise editions_ are commercial products
-that offer xref:commercial-editions/commercial-editions.adoc[additional features]
+_Timefold Solver Enterprise Edition_ is a commercial product
+that offers xref:commercial-editions/commercial-editions.adoc[additional features]
 to scale out to very large datasets.
-To find out more, see xref:commercial-editions/commercial-editions.adoc[Plus / Enterprise Edition section] of this documentation.
+To find out more, see xref:commercial-editions/commercial-editions.adoc[Enterprise Edition section] of this documentation.
 
 == Does Timefold offer pre-built models?
 

--- a/docs/src/modules/ROOT/pages/responding-to-change/recommendation-api.adoc
+++ b/docs/src/modules/ROOT/pages/responding-to-change/recommendation-api.adoc
@@ -5,7 +5,7 @@
 :sectnums:
 :icons: font
 
-include::../commercial-editions/_only-plus-and-enterprise.adoc[]
+include::../commercial-editions/_only-enterprise.adoc[]
 
 With xref:responding-to-change/real-time-planning.adoc[real-time planning], we can respond to a continuous stream of external changes.
 However, it is often necessary to respond to ad hoc changes too,

--- a/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-from-v1.adoc
+++ b/docs/src/modules/ROOT/pages/upgrading-timefold-solver/upgrade-from-v1.adoc
@@ -301,7 +301,7 @@ We invite you to read the xref:upgrading-timefold-solver/migration-guides/variab
 [%collapsible%open]
 ====
 `ScoreExplanation` has been removed.
-Use `ScoreAnalysis` instead, which is now provided exclusively by _Timefold Solver Plus and Enterprise Editions_.
+Use `ScoreAnalysis` instead, which is now provided exclusively by _Timefold Solver Enterprise Edition_.
 
 `ScoreAnalysis` provides the following methods:
 
@@ -321,14 +321,14 @@ The following `ScoreExplanation` methods have no direct replacement and must be 
 
 `IncrementalScoreCalculator` has also seen changes in this area.
 `ConstraintMatchAwareIncrementalScoreCalculator` was removed.
-The replacement `AnalyzableIncrementalScoreCalculator` is provided by the Plus and Enterprise editions.
+The replacement `AnalyzableIncrementalScoreCalculator` is provided by the Enterprise edition.
 
 Instead of overriding methods to return constraint matches, implement the `enableConstraintMatch(ConstraintMatchRegistry<Score_>)` method.
 Use `ConstraintMatchRegistry.registerConstraintMatch(ConstraintRef, score, justification)` to register each match;
 it returns a `ConstraintMatchRegistration` whose `cancel()` method removes the match when the assignment changes.
 
 To use `ScoreAnalysis` or `AnalyzableIncrementalScoreCalculator`,
-xref:commercial-editions/installation.adoc[install either of the commercial editions].
+xref:commercial-editions/installation.adoc[install the commercial editions].
 There is no automated migration recipe for these changes; all changes must be made manually.
 ====
 


### PR DESCRIPTION
Plus version is getting discontinued, remove reference to it in docs.

closes https://github.com/TimefoldAI/timefold-solver-enterprise/issues/753