### PR TITLE
ci: only publish SBOM in JSON (#2468)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,7 @@
                   <goal>makeAggregateBom</goal>
                 </goals>
                 <configuration>
+                  <outputFormat>json</outputFormat>
                   <excludeTestProject>true</excludeTestProject>
                 </configuration>
               </execution>


### PR DESCRIPTION
Cherry-pick deployment size reduction.