### PR TITLE
deps: upgrade Quarkus to 3.37.2

### DIFF
--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -34,7 +34,7 @@
     <version.ch.qos.logback>1.5.38</version.ch.qos.logback>
     <version.com.networknt.json-schem-validator>1.5.9</version.com.networknt.json-schem-validator>
     <version.jakarta.enterprise.cdi-api>4.1.0</version.jakarta.enterprise.cdi-api>
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.logging.log4j>2.26.1</version.org.apache.logging.log4j>
     <version.org.assertj>3.27.7</version.org.assertj>

--- a/quarkus-integration/quarkus-jackson/integration-test/src/main/resources/application.properties
+++ b/quarkus-integration/quarkus-jackson/integration-test/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 # The solver runs only for few milliseconds to avoid a HTTP timeout in this simple implementation.
 quarkus.timefold.solver.termination.best-score-limit=0
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/service/facade/service-parent/pom.xml
+++ b/service/facade/service-parent/pom.xml
@@ -89,7 +89,7 @@
     <!-- Keep in sync with the build-parent -->
     <!-- ************************************************************************ -->
     <version.ai.timefold.solver>${revision}</version.ai.timefold.solver>
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.org.assertj>3.27.7</version.org.assertj>
     <version.org.awaitility>4.3.0</version.org.awaitility>
 

--- a/service/service-defaults/src/main/resources/application.properties
+++ b/service/service-defaults/src/main/resources/application.properties
@@ -86,6 +86,9 @@ quarkus.log.console.darken=1
 ########################
 quarkus.rest.path=${model.api.version}
 
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false
+
 ########################
 # OpenAPI and swagger ui configuration
 ########################


### PR DESCRIPTION
The bytecode-generated (de)serializers made available by default in Quarkus 3.37 are not fully compatible. Deactivating them until known issues are resolved.