### PR TITLE
fix: make sure test outputs for models are visible in the console

### DIFF
--- a/service/facade/service-parent/pom.xml
+++ b/service/facade/service-parent/pom.xml
@@ -239,7 +239,8 @@
           <configuration>
             <!-- Currently not running on the module path, despite including JPMS -->
             <useModulePath>false</useModulePath>
-            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <!-- Make sure test outputs are always visible -->
+            <redirectTestOutputToFile>false</redirectTestOutputToFile>
             <skipTests>${skipUTs}</skipTests>
             <!-- Avoid defining the argLine; it's configured in a profile for code coverage -->
           </configuration>
@@ -250,7 +251,8 @@
           <configuration>
             <!-- Currently not running on the module path, despite including JPMS -->
             <useModulePath>false</useModulePath>
-            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <!-- Make sure test outputs are always visible -->
+            <redirectTestOutputToFile>false</redirectTestOutputToFile>
             <skipTests>${skipTests}</skipTests>
             <skipITs>${skipITs}</skipITs>
           </configuration>


### PR DESCRIPTION
Test outputs were hidden for models; likely overlooked during merging build parents pom.xml