### PR TITLE
docs: missing software component in service/getting-started documentation

### DIFF
--- a/docs/src/modules/ROOT/pages/quickstart/service/getting-started.adoc
+++ b/docs/src/modules/ROOT/pages/quickstart/service/getting-started.adoc
@@ -28,7 +28,7 @@ include::../shared/_solutionsourcecode.adoc[]
 To complete this guide, you need:
 
 * **Tools**
-** {java-version} or higher
+** JDK {java-version} or higher
 ** Maven
 ** An IDE of your choice (IntelliJ IDEA, VSCode, ...)
 


### PR DESCRIPTION
closes https://github.com/TimefoldAI/timefold-solver-enterprise/issues/755