### PR TITLE
chore: Backport changes from version `2.x`

### DIFF
--- a/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
+++ b/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
@@ -494,27 +494,29 @@ public class BenchmarkAggregatorFrame extends JFrame {
     }
 
     private MixedCheckBox createPlannerBenchmarkCheckBox(PlannerBenchmarkResult plannerBenchmarkResult) {
-        String plannerBenchmarkDetail = String.format(
-                "Average score: %s%n"
-                        + "Average problem scale: %d",
-                plannerBenchmarkResult.getAverageScore(),
-                plannerBenchmarkResult.getAverageProblemScale());
+        var plannerBenchmarkDetail =
+                """
+                        Average score: %s
+                        Average problem scale: %s""".formatted(
+                        plannerBenchmarkResult.getAverageScore(),
+                        plannerBenchmarkResult.getAverageProblemScale());
         return new MixedCheckBox(plannerBenchmarkResult.getName(), plannerBenchmarkDetail, plannerBenchmarkResult);
     }
 
     private MixedCheckBox createSolverBenchmarkCheckBox(SolverBenchmarkResult solverBenchmarkResult) {
-        String solverCheckBoxName = solverBenchmarkResult.getName() + " (" + solverBenchmarkResult.getRanking() + ")";
-        String solverBenchmarkDetail = String.format(
-                "Total score: %s%n"
-                        + "Average score: %s%n"
-                        + "Total winning score difference: %s"
-                        + "Average time spent: %s%n",
-                solverBenchmarkResult.getTotalScore(),
-                solverBenchmarkResult.getAverageScore(),
-                solverBenchmarkResult.getTotalWinningScoreDifference(),
-                solverBenchmarkResult.getAverageTimeMillisSpent() == null
-                        ? ""
-                        : millisecondsSpentNumberFormat.format(solverBenchmarkResult.getAverageTimeMillisSpent()));
+        var solverCheckBoxName = "%s (%d)".formatted(solverBenchmarkResult.getName(), solverBenchmarkResult.getRanking());
+        var solverBenchmarkDetail =
+                """
+                        Total score: %s
+                        Average score: %s
+                        Total winning score difference: %s
+                        Average time spent: %s""".formatted(
+                        solverBenchmarkResult.getTotalScore(),
+                        solverBenchmarkResult.getAverageScore(),
+                        solverBenchmarkResult.getTotalWinningScoreDifference(),
+                        solverBenchmarkResult.getAverageTimeMillisSpent() == null
+                                ? ""
+                                : millisecondsSpentNumberFormat.format(solverBenchmarkResult.getAverageTimeMillisSpent()));
         solverBenchmarkResultNameMapping.put(solverBenchmarkResult, solverBenchmarkResult.getName());
         return new MixedCheckBox(solverCheckBoxName, solverBenchmarkDetail, solverBenchmarkResult);
     }
@@ -531,14 +533,15 @@ public class BenchmarkAggregatorFrame extends JFrame {
     }
 
     private MixedCheckBox createSingleBenchmarkCheckBox(SingleBenchmarkResult singleBenchmarkResult) {
-        String singleCheckBoxName = singleBenchmarkResult.getName() + " (" + singleBenchmarkResult.getRanking() + ")";
-        String singleBenchmarkDetail = String.format(
-                "Score: %s%n"
-                        + "Used memory: %s%n"
-                        + "Time spent: %s",
-                singleBenchmarkResult.getAverageScore(),
-                toEmptyStringIfNull(singleBenchmarkResult.getUsedMemoryAfterInputSolution()),
-                millisecondsSpentNumberFormat.format(singleBenchmarkResult.getTimeMillisSpent()));
+        var singleCheckBoxName = "%s (%d)".formatted(singleBenchmarkResult.getName(), singleBenchmarkResult.getRanking());
+        var singleBenchmarkDetail =
+                """
+                        Score: %s
+                        Used memory: %s
+                        Time spent: %s""".formatted(
+                        singleBenchmarkResult.getAverageScore(),
+                        toEmptyStringIfNull(singleBenchmarkResult.getUsedMemoryAfterInputSolution()),
+                        millisecondsSpentNumberFormat.format(singleBenchmarkResult.getTimeMillisSpent()));
         return new MixedCheckBox(singleCheckBoxName, singleBenchmarkDetail, singleBenchmarkResult);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
+++ b/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
@@ -49,6 +49,11 @@ public interface TimefoldSolverEnterpriseService {
     String ENTERPRISE_COORDINATES = "ai.timefold.solver.enterprise:timefold-solver-enterprise-core";
     String DEVELOPMENT_SNAPSHOT = "Development Snapshot";
 
+    /**
+     *
+     * @return A string in the format of
+     *         "Timefold Solver (Community|Enterprise) Edition v(999-SNAPSHOT|Development Snapshot|x.y.z)".
+     */
     static String identifySolverVersion() {
         var packaging = COMMUNITY_NAME;
         try {

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/RecordAndReplayPropagator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/RecordAndReplayPropagator.java
@@ -41,6 +41,14 @@ public final class RecordAndReplayPropagator<Tuple_ extends Tuple> implements Pr
     private final Supplier<BavetPrecomputeBuildHelper<Tuple_>> precomputeBuildHelperSupplier;
     private final UnaryOperator<Tuple_> internalTupleToOutputTupleMapper;
     private final Map<Object, List<Tuple_>> objectToOutputTuplesMap;
+    /**
+     * Output tuples which depend only on problem facts.
+     * Unlike entity-derived output, these are not stored per-source
+     * (facts never update, so they need no replay),
+     * but they must still be delivered downstream exactly once.
+     * Retained between recalculations so they can be retracted on cache invalidation.
+     */
+    private final List<Tuple_> factOutputTupleList = new ArrayList<>();
     private final Set<Object> alreadyUpdatingSet = Collections.newSetFromMap(new IdentityHashMap<>());
     private final Map<Class<?>, Boolean> objectClassToIsEntitySourceClassMap;
 
@@ -189,13 +197,19 @@ public final class RecordAndReplayPropagator<Tuple_ extends Tuple> implements Pr
     }
 
     private void invalidateCache() {
-        objectToOutputTuplesMap.values().stream().flatMap(List::stream).forEach(this::retractIfPresent);
+        objectToOutputTuplesMap.values()
+                .stream()
+                .flatMap(List::stream)
+                .forEach(this::retractIfPresent);
         objectToOutputTuplesMap.clear();
+        factOutputTupleList.forEach(this::retractIfPresent);
+        factOutputTupleList.clear();
     }
 
     private void recalculateTuples(NodeNetwork internalNodeNetwork, Map<Class<?>, List<BavetRootNode<?>>> classToRootNodeList,
             RecordingTupleLifecycle<Tuple_> recordingTupleLifecycle) {
-        var internalTupleToOutputTupleMap = new IdentityHashMap<Tuple_, Tuple_>(seenEntitySet.size());
+        var internalTupleToOutputTupleMap =
+                new IdentityHashMap<Tuple_, Tuple_>(seenEntitySet.size() + seenFactSet.size());
         for (var invalidated : seenEntitySet) {
             var mappedTuples = new ArrayList<Tuple_>();
             try (var unusedActiveRecordingLifecycle = recordingTupleLifecycle.recordInto(
@@ -212,7 +226,28 @@ public final class RecordAndReplayPropagator<Tuple_ extends Tuple> implements Pr
                 objectToOutputTuplesMap.put(invalidated, mappedTuples);
             }
         }
-        objectToOutputTuplesMap.values().stream().flatMap(List::stream).forEach(this::insertIfAbsent);
+        objectToOutputTuplesMap.values()
+                .stream()
+                .flatMap(List::stream)
+                .forEach(this::insertIfAbsent);
+        // Output tuples derived purely from facts are not re-emitted by any entity update above,
+        // so they would never be delivered.
+        // Facts never update during solving,
+        // so a single recording pass over all facts is enough to capture every fact-dependent output tuple exactly once.
+        // Tuples also derived from an entity were already delivered above;
+        // insertIfAbsent skips them via tuple-state deduplication.
+        if (!seenFactSet.isEmpty()) {
+            try (var unusedActiveRecordingLifecycle =
+                    recordingTupleLifecycle.recordInto(new TupleRecorder<>(factOutputTupleList,
+                            internalTupleToOutputTupleMapper, internalTupleToOutputTupleMap))) {
+                for (var fact : seenFactSet) {
+                    classToRootNodeList.get(fact.getClass())
+                            .forEach(node -> ((BavetRootNode<Object>) node).update(fact));
+                }
+                internalNodeNetwork.settle();
+            }
+            factOutputTupleList.forEach(this::insertIfAbsent);
+        }
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/AbstractFromPropertyValueRangeDescriptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/valuerange/descriptor/AbstractFromPropertyValueRangeDescriptor.java
@@ -143,7 +143,8 @@ public abstract non-sealed class AbstractFromPropertyValueRangeDescriptor<Soluti
                             Use SortedSet or LinkedHashSet to ensure solver reproducibility.
                             """
                             .formatted(ValueRangeProvider.class.getSimpleName(), memberAccessor, bean, set.getClass()));
-                } else if (set.contains(null)) {
+                } else if (containsNull(set)) {
+
                     throw new IllegalStateException("""
                             The @%s-annotated member (%s) called on bean (%s) returns a Set (%s) with a null element.
                             Maybe remove that null element from the dataset \
@@ -160,6 +161,18 @@ public abstract non-sealed class AbstractFromPropertyValueRangeDescriptor<Soluti
         } else {
             var valueRange = (CountableValueRange<Value_>) valueRangeObject;
             return valueRange.isEmpty() ? EmptyValueRange.instance() : valueRange;
+        }
+    }
+
+    private <Value_> boolean containsNull(Set<Value_> set) {
+        try {
+            return set.contains(null);
+        } catch (NullPointerException e) {
+            // The Set contract states that implementations that do not allow null values must fail when null is read in some operations,
+            // such as add and contains.
+            // We ignore the NPE in such situations,
+            // as implementations like TreeSet with natural ordering will fail when reading null values.
+            return false;
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/BiasedRandomUnionMoveIterator.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/composite/BiasedRandomUnionMoveIterator.java
@@ -41,17 +41,13 @@ final class BiasedRandomUnionMoveIterator<Solution_> extends SelectionIterator<M
 
     @Override
     public boolean hasNext() {
-        if (stale) {
-            refreshMoveIteratorMap();
-        }
+        refreshMoveIteratorMap();
         return !moveIteratorMap.isEmpty();
     }
 
     @Override
     public Move<Solution_> next() {
-        if (stale) {
-            refreshMoveIteratorMap();
-        }
+        refreshMoveIteratorMap();
         double randomOffset = RandomUtils.nextDouble(workingRandom, probabilityWeightTotal);
         Map.Entry<Double, Iterator<Move<Solution_>>> entry = moveIteratorMap.floorEntry(randomOffset);
         // The entry is never null because randomOffset < probabilityWeightTotal
@@ -64,6 +60,9 @@ final class BiasedRandomUnionMoveIterator<Solution_> extends SelectionIterator<M
     }
 
     private void refreshMoveIteratorMap() {
+        if (!stale) {
+            return;
+        }
         moveIteratorMap.clear();
         double probabilityWeightOffset = 0.0;
         for (ProbabilityItem<Solution_> probabilityItem : probabilityItemMap.values()) {
@@ -74,6 +73,7 @@ final class BiasedRandomUnionMoveIterator<Solution_> extends SelectionIterator<M
             }
         }
         probabilityWeightTotal = probabilityWeightOffset;
+        stale = false;
     }
 
     private static final class ProbabilityItem<Solution_> {

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateConstructionHeuristicPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateConstructionHeuristicPhase.java
@@ -48,7 +48,12 @@ public final class RuinRecreateConstructionHeuristicPhase<Solution_>
 
     @Override
     protected void doStep(ConstructionHeuristicStepScope<Solution_> stepScope) {
-        if (!elementsToRuinSet.isEmpty()) {
+        var checkMissingElements = !elementsToRuinSet.isEmpty()
+                // The generated step may include a no-change move
+                // when it's better to keep a planning value unassigned
+                // or when there are no unpinned entities
+                && !stepScope.getStep().getPlanningEntities().isEmpty();
+        if (checkMissingElements) {
             var listVariableDescriptor = stepScope.getPhaseScope().getSolverScope().getSolutionDescriptor()
                     .getListVariableDescriptor();
             var entity = stepScope.getStep().getPlanningEntities().iterator().next();

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/ListRuinRecreateMove.java
@@ -19,6 +19,7 @@ import ai.timefold.solver.core.impl.move.VariableChangeRecordingScoreDirector;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.impl.util.CollectionUtils;
+import ai.timefold.solver.core.preview.api.domain.metamodel.PositionInList;
 
 public final class ListRuinRecreateMove<Solution_> extends AbstractMove<Solution_> {
 
@@ -99,8 +100,10 @@ public final class ListRuinRecreateMove<Solution_> extends AbstractMove<Solution
             }
 
             for (var ruinedValue : ruinedValueList) {
-                var position = listVariableStateSupply.getElementPosition(ruinedValue)
-                        .ensureAssigned();
+                // Some ruined values may be left unassigned
+                if (!(listVariableStateSupply.getElementPosition(ruinedValue) instanceof PositionInList position)) {
+                    continue;
+                }
                 entityToNewPositionMap.computeIfAbsent(position.entity(), ignored -> new TreeSet<>())
                         .add(new RuinedPosition(ruinedValue, position.index()));
                 entityToInsertedValuesMap.computeIfAbsent(position.entity(), ignored -> new ArrayList<>()).add(ruinedValue);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/RuinRecreateMoveSelectorTest.java
@@ -5,6 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.List;
 
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
 import ai.timefold.solver.core.api.solver.SolverFactory;
 import ai.timefold.solver.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
 import ai.timefold.solver.core.config.heuristic.selector.move.generic.RuinRecreateMoveSelectorConfig;
@@ -21,6 +25,7 @@ import ai.timefold.solver.core.testdomain.unassignedvar.TestdataAllowsUnassigned
 import ai.timefold.solver.core.testdomain.unassignedvar.TestdataAllowsUnassignedSolution;
 import ai.timefold.solver.core.testutil.AbstractMeterTest;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.Metrics;
@@ -92,6 +97,46 @@ class RuinRecreateMoveSelectorTest extends AbstractMeterTest {
         var problem = TestdataAllowsUnassignedSolution.generateSolution(5, 30);
         var solver = SolverFactory.create(solverConfig).buildSolver();
         assertDoesNotThrow(() -> solver.solve(problem));
+    }
+
+    @Test
+    void testRuiningNoAssignedValues() {
+        var solverConfig = new SolverConfig()
+                .withEnvironmentMode(EnvironmentMode.TRACKED_FULL_ASSERT)
+                .withSolutionClass(TestdataAllowsUnassignedSolution.class)
+                .withEntityClasses(TestdataAllowsUnassignedEntity.class)
+                .withConstraintProviderClass(TestdataNoAssignedValuesListMixedConstraintProvider.class)
+                .withPhaseList(List.of(
+                        new LocalSearchPhaseConfig()
+                                // Since the problem has 3 planning entities, the R&R will select all of them
+                                .withMoveSelectorConfig(new RuinRecreateMoveSelectorConfig().withMinimumRuinedCount(3))
+                                .withTerminationConfig(new TerminationConfig()
+                                        .withStepCountLimit(1))));
+        // The problem involves three entities and three planning values,
+        // with the initial solution assigning a value to each entity
+        var problem = TestdataAllowsUnassignedSolution.generateSolution(3, 3);
+        for (var i = 0; i < 3; i++) {
+            problem.getEntityList().get(i).setValue(problem.getValueList().get(i));
+        }
+        var solver = SolverFactory.create(solverConfig).buildSolver();
+        // All values must remain unassigned
+        var solution = (TestdataAllowsUnassignedSolution) assertDoesNotThrow(() -> solver.solve(problem));
+        assertThat(solution.getEntityList().get(0).getValue()).isNull();
+        assertThat(solution.getEntityList().get(1).getValue()).isNull();
+        assertThat(solution.getEntityList().get(2).getValue()).isNull();
+    }
+
+    public static final class TestdataNoAssignedValuesListMixedConstraintProvider
+            implements ConstraintProvider {
+
+        @Override
+        public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory constraintFactory) {
+            return new Constraint[] {
+                    constraintFactory.forEach(TestdataAllowsUnassignedEntity.class)
+                            .penalize(SimpleScore.ONE)
+                            .asConstraint("No Assigned")
+            };
+        }
     }
 
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ListRuinRecreateMoveSelectorTest.java
@@ -154,4 +154,42 @@ class ListRuinRecreateMoveSelectorTest extends AbstractMeterTest {
         assertDoesNotThrow(() -> solver.solve(problem));
     }
 
+    @Test
+    void testRuiningOnlyOneAssignedValues() {
+        var solverConfig = new SolverConfig()
+                .withEnvironmentMode(EnvironmentMode.TRACKED_FULL_ASSERT)
+                .withSolutionClass(TestdataAllowsUnassignedValuesListSolution.class)
+                .withEntityClasses(TestdataAllowsUnassignedValuesListEntity.class,
+                        TestdataAllowsUnassignedValuesListValue.class)
+                .withConstraintProviderClass(TestdataOnlyOneAssignedValuesListMixedConstraintProvider.class)
+                .withPhaseList(List.of(
+                        new LocalSearchPhaseConfig()
+                                // Since the problem has 3 planning values, the R&R will select all of them
+                                .withMoveSelectorConfig(new ListRuinRecreateMoveSelectorConfig().withMinimumRuinedCount(3))
+                                .withTerminationConfig(new TerminationConfig()
+                                        .withStepCountLimit(1))));
+        var problem = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(3, 1);
+        // The problem involves one entity and three planning values,
+        // with the initial solution assigning all values to that single entity
+        problem.getEntityList().get(0).getValueList().addAll(problem.getValueList());
+        var solver = SolverFactory.create(solverConfig).buildSolver();
+        var solution = (TestdataAllowsUnassignedValuesListSolution) assertDoesNotThrow(() -> solver.solve(problem));
+        // Two values must remain unassigned
+        assertThat(solution.getEntityList().get(0).getValueList()).hasSize(1);
+    }
+
+    public static final class TestdataOnlyOneAssignedValuesListMixedConstraintProvider
+            implements ConstraintProvider {
+
+        @Override
+        public Constraint @NonNull [] defineConstraints(@NonNull ConstraintFactory constraintFactory) {
+            return new Constraint[] {
+                    constraintFactory.forEach(TestdataAllowsUnassignedValuesListEntity.class)
+                            .filter(entity -> entity.getValueList().size() != 1)
+                            .penalize(SimpleScore.ONE)
+                            .asConstraint("Only One Assigned")
+            };
+        }
+    }
+
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/uni/AbstractUniConstraintStreamPrecomputeTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/common/uni/AbstractUniConstraintStreamPrecomputeTest.java
@@ -33,6 +33,40 @@ public abstract class AbstractUniConstraintStreamPrecomputeTest extends Abstract
         super(implSupport);
     }
 
+    /**
+     * A precompute that simply enumerates a problem-fact class must emit one tuple per fact.
+     * Removing a problem fact must re-derive the fact-only output
+     * and retract the removed fact's tuple.
+     * Exercises the cache-invalidation path for fact-derived output.
+     */
+    @TestTemplate
+    void forEachUnfiltered_fact() {
+        var solution = TestdataLavishSolution.generateEmptySolution();
+        var value1 = new TestdataLavishValue();
+        var value2 = new TestdataLavishValue();
+        var value3 = new TestdataLavishValue();
+        solution.getValueList().addAll(List.of(value1, value2, value3));
+
+        var scoreDirector = buildScoreDirector(
+                factory -> factory.precompute(pf -> pf.forEachUnfiltered(TestdataLavishValue.class))
+                        .penalize(SimpleScore.ONE)
+                        .asConstraint(TEST_CONSTRAINT_NAME));
+
+        scoreDirector.setWorkingSolution(solution);
+        assertScore(scoreDirector,
+                assertMatch(value1),
+                assertMatch(value2),
+                assertMatch(value3));
+
+        scoreDirector.beforeProblemFactRemoved(value3);
+        solution.getValueList().remove(value3);
+        scoreDirector.afterProblemFactRemoved(value3);
+
+        assertScore(scoreDirector,
+                assertMatch(value1),
+                assertMatch(value2));
+    }
+
     @Override
     @TestTemplate
     public void filter_0_changed() {

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -110,6 +110,8 @@ import ai.timefold.solver.core.testdomain.list.valuerange.TestdataListEntityProv
 import ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.TestdataListUnassignedEntityProvidingEntity;
 import ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.TestdataListUnassignedEntityProvidingScoreCalculator;
 import ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.TestdataListUnassignedEntityProvidingSolution;
+import ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.sortedset.TestdataListUnassignedEntityProvidingSortedSetEntity;
+import ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.sortedset.TestdataListUnassignedEntityProvidingSortedSetSolution;
 import ai.timefold.solver.core.testdomain.mixed.multientity.TestdataMixedEntityEasyScoreCalculator;
 import ai.timefold.solver.core.testdomain.mixed.multientity.TestdataMixedMultiEntityFirstEntity;
 import ai.timefold.solver.core.testdomain.mixed.multientity.TestdataMixedMultiEntityFirstValue;
@@ -1934,6 +1936,20 @@ class DefaultSolverTest {
         var bestEntity3 = bestSolution.getEntityList().get(2);
         assertThat(bestEntity3.getValueList()).hasSizeGreaterThan(0);
         assertThat(bestEntity3.getValueList()).doesNotContain(value1, value2, value3);
+    }
+
+    @Test
+    void solveListVarEntityRangeModelWithTreeSet() {
+        var solverConfig = new SolverConfig()
+                .withSolutionClass(TestdataListUnassignedEntityProvidingSortedSetSolution.class)
+                .withEntityClasses(TestdataListUnassignedEntityProvidingSortedSetEntity.class)
+                .withEasyScoreCalculatorClass(DummySimpleScoreEasyScoreCalculator.class)
+                .withTerminationConfig(new TerminationConfig().withMoveCountLimit(10L));
+
+        var problem = TestdataListUnassignedEntityProvidingSortedSetSolution.generateSolution();
+
+        problem = PlannerTestUtils.solve(solverConfig, problem, true);
+        assertThat(problem).isNotNull();
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/unassignedvar/sortedset/TestdataListUnassignedEntityProvidingSortedSetEntity.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/unassignedvar/sortedset/TestdataListUnassignedEntityProvidingSortedSetEntity.java
@@ -1,0 +1,60 @@
+package ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.sortedset;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
+import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
+import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import ai.timefold.solver.core.testdomain.TestdataObject;
+import ai.timefold.solver.core.testdomain.TestdataValue;
+
+@PlanningEntity
+public class TestdataListUnassignedEntityProvidingSortedSetEntity extends TestdataObject {
+
+    public static EntityDescriptor<TestdataListUnassignedEntityProvidingSortedSetSolution> buildEntityDescriptor() {
+        return TestdataListUnassignedEntityProvidingSortedSetSolution.buildSolutionDescriptor()
+                .findEntityDescriptorOrFail(TestdataListUnassignedEntityProvidingSortedSetEntity.class);
+    }
+
+    public static ListVariableDescriptor<TestdataListUnassignedEntityProvidingSortedSetSolution>
+            buildVariableDescriptorForValueList() {
+        return (ListVariableDescriptor<TestdataListUnassignedEntityProvidingSortedSetSolution>) buildEntityDescriptor()
+                .getGenuineVariableDescriptor("valueList");
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    private final SortedSet<TestdataValue> valueRange;
+    @PlanningListVariable(valueRangeProviderRefs = "valueRange", allowsUnassignedValues = true)
+    private List<TestdataValue> valueList;
+
+    public TestdataListUnassignedEntityProvidingSortedSetEntity() {
+        valueRange = new TreeSet<>(Comparator.comparing(TestdataValue::getCode));
+        valueList = new ArrayList<>();
+    }
+
+    public TestdataListUnassignedEntityProvidingSortedSetEntity(String code, List<TestdataValue> valueRange) {
+        super(code);
+        this.valueRange = new TreeSet<>(Comparator.comparing(TestdataValue::getCode));
+        this.valueRange.addAll(valueRange);
+        this.valueList = new ArrayList<>();
+    }
+
+    public SortedSet<TestdataValue> getValueRange() {
+        return valueRange;
+    }
+
+    public List<TestdataValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataValue> valueList) {
+        this.valueList = valueList;
+    }
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/unassignedvar/sortedset/TestdataListUnassignedEntityProvidingSortedSetSolution.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/list/valuerange/unassignedvar/sortedset/TestdataListUnassignedEntityProvidingSortedSetSolution.java
@@ -1,0 +1,67 @@
+package ai.timefold.solver.core.testdomain.list.valuerange.unassignedvar.sortedset;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
+import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
+import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.preview.api.domain.metamodel.PlanningSolutionMetaModel;
+import ai.timefold.solver.core.testdomain.TestdataValue;
+
+@PlanningSolution
+public class TestdataListUnassignedEntityProvidingSortedSetSolution {
+
+    public static SolutionDescriptor<TestdataListUnassignedEntityProvidingSortedSetSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataListUnassignedEntityProvidingSortedSetSolution.class,
+                TestdataListUnassignedEntityProvidingSortedSetEntity.class);
+    }
+
+    public static PlanningSolutionMetaModel<TestdataListUnassignedEntityProvidingSortedSetSolution> buildMetaModel() {
+        return buildSolutionDescriptor().getMetaModel();
+    }
+
+    public static TestdataListUnassignedEntityProvidingSortedSetSolution generateSolution() {
+        var solution = new TestdataListUnassignedEntityProvidingSortedSetSolution();
+        var value1 = new TestdataValue("v1");
+        var value2 = new TestdataValue("v2");
+        var value3 = new TestdataValue("v3");
+        var entity1 = new TestdataListUnassignedEntityProvidingSortedSetEntity("e1", List.of(value1, value2));
+        var entity2 = new TestdataListUnassignedEntityProvidingSortedSetEntity("e2", List.of(value1, value3));
+        solution.setEntityList(List.of(entity1, entity2));
+        return solution;
+    }
+
+    private List<TestdataListUnassignedEntityProvidingSortedSetEntity> entityList;
+
+    private SimpleScore score;
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataListUnassignedEntityProvidingSortedSetEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataListUnassignedEntityProvidingSortedSetEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> getValueList() {
+        return entityList.stream()
+                .flatMap(entity -> entity.getValueRange().stream())
+                .distinct()
+                .toList();
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}

--- a/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/bean/TimefoldSolverBannerBean.java
+++ b/quarkus-integration/quarkus/runtime/src/main/java/ai/timefold/solver/quarkus/bean/TimefoldSolverBannerBean.java
@@ -15,7 +15,7 @@ public class TimefoldSolverBannerBean {
     private static final Logger LOGGER = Logger.getLogger(TimefoldSolverBannerBean.class);
 
     void onStart(@Observes StartupEvent ev) {
-        LOGGER.info("Using Timefold Solver " + TimefoldSolverEnterpriseService.identifySolverVersion() + ".");
+        LOGGER.info("Using %s.".formatted(TimefoldSolverEnterpriseService.identifySolverVersion()));
     }
 
 }

--- a/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverBannerBean.java
+++ b/spring-integration/spring-boot-autoconfigure/src/main/java/ai/timefold/solver/spring/boot/autoconfigure/TimefoldSolverBannerBean.java
@@ -14,6 +14,6 @@ public class TimefoldSolverBannerBean implements InitializingBean {
 
     @Override
     public void afterPropertiesSet() {
-        LOG.info("Using Timefold Solver " + TimefoldSolverEnterpriseService.identifySolverVersion() + ".");
+        LOG.info("Using %s.".formatted(TimefoldSolverEnterpriseService.identifySolverVersion()));
     }
 }


### PR DESCRIPTION
This PR backports commits from the `main` branch made in the last three months. Only commits not impacted by the `2.x` version updates are included. Please review this PR commit-by-commit, as all commits were cherry-picked from the main branch. 

The [Quarkus dependency](https://quarkus.io/releases/) has already been updated to the latest LTS `3.33` release, `3.33.2.1`.
