### PR TITLE
fix: replay RecordedUndoMove actions in reverse recording order

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/move/RecordedUndoMove.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/move/RecordedUndoMove.java
@@ -21,8 +21,12 @@ record RecordedUndoMove<Solution_>(List<ChangeAction<Solution_>> variableChangeA
     @Override
     public void execute(MutableSolutionView<Solution_> solutionView) {
         var scoreDirector = ((InnerMutableSolutionView<Solution_>) solutionView).getScoreDirector();
-        for (var changeAction : variableChangeActionList) {
-            changeAction.undo(scoreDirector);
+        // Undo actions must be replayed in reverse recording order,
+        // otherwise repeated changes to the same variable restore a stale value
+        // and multi-action list windows replay out of order.
+        var listIterator = variableChangeActionList.listIterator(variableChangeActionList.size());
+        while (listIterator.hasPrevious()) {
+            listIterator.previous().undo(scoreDirector);
         }
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/move/RecordedUndoMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/move/RecordedUndoMoveTest.java
@@ -1,0 +1,42 @@
+package ai.timefold.solver.core.impl.move;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
+import ai.timefold.solver.core.impl.score.director.VariableDescriptorAwareScoreDirector;
+
+import org.junit.jupiter.api.Test;
+
+class RecordedUndoMoveTest {
+
+    @Test
+    void executeReplaysActionsInReverseRecordingOrder() {
+        var callOrder = new ArrayList<String>();
+        var action1 = variableChangeAction("action1", callOrder);
+        var action2 = variableChangeAction("action2", callOrder);
+        var action3 = variableChangeAction("action3", callOrder);
+        var move = new RecordedUndoMove<>(List.of(action1, action2, action3));
+
+        var scoreDirector = mock(VariableDescriptorAwareScoreDirector.class);
+        var solutionView = mock(InnerMutableSolutionView.class);
+        doAnswer(invocation -> scoreDirector).when(solutionView).getScoreDirector();
+
+        move.execute(solutionView);
+
+        assertThat(callOrder).containsExactly("action3", "action2", "action1");
+    }
+
+    @SuppressWarnings("unchecked")
+    private ChangeAction<Object> variableChangeAction(String label, List<String> callOrder) {
+        var variableDescriptor = mock(VariableDescriptor.class);
+        doAnswer(invocation -> callOrder.add(label)).when(variableDescriptor).setValue(any(), any());
+        return new VariableChangeAction<>(new Object(), new Object(), variableDescriptor);
+    }
+
+}


### PR DESCRIPTION
execute() undid variable changes in forward order, while the equivalent VariableChangeRecordingScoreDirector.undoChanges() path correctly undoes in reverse. Forward order is a no-op or leaves stale values whenever a move records more than one action touching the same variable or list window, silently corrupting Exhaustive Search's backtracking undo for such moves.