### PR TITLE
fix: race condition in SolverWorker job registration

### DIFF
--- a/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/SolverWorker.java
+++ b/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/SolverWorker.java
@@ -100,8 +100,6 @@ public class SolverWorker {
     private static final Logger LOGGER = LoggerFactory.getLogger(SolverWorker.class);
     private static final long COMPLETION_TIMEOUT = 60_000;
     private static final long EMITTER_TIMEOUT = 5;
-    // run() only submits to the solver thread pool and returns - it never waits on solving - so resolving the
-    // job future should take microseconds; this bounds the wait defensively in case that assumption is ever wrong.
     private static final long JOB_REGISTRATION_TIMEOUT_MS = 5_000;
 
     private Optional<String> modelName;

--- a/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/SolverWorker.java
+++ b/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/SolverWorker.java
@@ -8,7 +8,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
@@ -101,6 +100,9 @@ public class SolverWorker {
     private static final Logger LOGGER = LoggerFactory.getLogger(SolverWorker.class);
     private static final long COMPLETION_TIMEOUT = 60_000;
     private static final long EMITTER_TIMEOUT = 5;
+    // run() only submits to the solver thread pool and returns - it never waits on solving - so resolving the
+    // job future should take microseconds; this bounds the wait defensively in case that assumption is ever wrong.
+    private static final long JOB_REGISTRATION_TIMEOUT_MS = 5_000;
 
     private Optional<String> modelName;
     private Optional<String> modelVersion;
@@ -431,25 +433,30 @@ public class SolverWorker {
 
             var jobFuture = new CompletableFuture<SolverJob<SolverModel>>();
             solverJobs.put(id, jobFuture);
-            try {
-                var job = solverManager.solveBuilder()
-                        .withProblemFinder(id_ -> notifyOnStart((String) id_, modelInput, previousModelOutput, modelConfig))
-                        .withConfigOverride(solverConfigOverride)
-                        .withProblemId(id)
-                        .withBestSolutionEventConsumer(
-                                decorateIfPossible(event -> notifyOnSave(id, event.solution(), event.producerId())))
-                        .withFinalBestSolutionEventConsumer(event -> notifyOnComplete(id, event.solution()))
-                        .withFirstInitializedSolutionEventConsumer(
-                                event -> notifyOnInit(id, event.solution(), event.isTerminatedEarly(), event.producerId()))
-                        .withExceptionHandler(this::notifyOnFailure)
-                        .run();
-                jobFuture.complete(job);
-            } catch (Throwable e) {
-                jobFuture.completeExceptionally(e);
-                throw e;
-            }
+            startJob(modelInput, previousModelOutput, modelConfig, solverConfigOverride, id, jobFuture);
         } catch (Throwable e) {
             notifyOnFailure(id, e);
+        }
+    }
+
+    private void startJob(ModelInput modelInput, ModelOutput previousModelOutput, ModelConfig modelConfig,
+            SolverConfigOverride solverConfigOverride, String id, CompletableFuture<SolverJob<SolverModel>> jobFuture) {
+        try {
+            var job = solverManager.solveBuilder()
+                    .withProblemFinder(id_ -> notifyOnStart((String) id_, modelInput, previousModelOutput, modelConfig))
+                    .withConfigOverride(solverConfigOverride)
+                    .withProblemId(id)
+                    .withBestSolutionEventConsumer(
+                            decorateIfPossible(event -> notifyOnSave(id, event.solution(), event.producerId())))
+                    .withFinalBestSolutionEventConsumer(event -> notifyOnComplete(id, event.solution()))
+                    .withFirstInitializedSolutionEventConsumer(
+                            event -> notifyOnInit(id, event.solution(), event.isTerminatedEarly(), event.producerId()))
+                    .withExceptionHandler(this::notifyOnFailure)
+                    .run();
+            jobFuture.complete(job);
+        } catch (Throwable e) {
+            jobFuture.completeExceptionally(e);
+            throw e;
         }
     }
 
@@ -847,13 +854,21 @@ public class SolverWorker {
         return consumer;
     }
 
-    private SolverJob<SolverModel> resolveJob(CompletableFuture<SolverJob<SolverModel>> jobFuture) {
+    private static SolverJob<SolverModel> resolveJob(CompletableFuture<SolverJob<SolverModel>> jobFuture) {
         if (jobFuture == null) {
             return null;
         }
         try {
-            return jobFuture.join();
-        } catch (CompletionException e) {
+            return jobFuture.get(JOB_REGISTRATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            LOGGER.warn("Solver job registration failed before a job could be created", e);
+            return null;
+        } catch (TimeoutException e) {
+            LOGGER.warn("Timed out after {} ms waiting for the solver job to be registered", JOB_REGISTRATION_TIMEOUT_MS, e);
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warn("Interrupted while waiting for the solver job to be registered", e);
             return null;
         }
     }

--- a/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/SolverWorker.java
+++ b/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/SolverWorker.java
@@ -7,6 +7,8 @@ import static ai.timefold.solver.service.definition.internal.platform.Environmen
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
@@ -151,7 +153,7 @@ public class SolverWorker {
 
     private final CompletionStatus completionStatus;
 
-    private final ConcurrentMap<Object, SolverJob<SolverModel>> solverJobs = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Object, CompletableFuture<SolverJob<SolverModel>>> solverJobs = new ConcurrentHashMap<>();
 
     private final String planName;
 
@@ -426,18 +428,26 @@ public class SolverWorker {
             var modelConfig = Configuration.getSafeModelConfig(configuration);
 
             var previousModelOutput = loadModelOutput(id);
-            var job = solverManager.solveBuilder()
-                    .withProblemFinder(id_ -> notifyOnStart((String) id_, modelInput, previousModelOutput, modelConfig))
-                    .withConfigOverride(solverConfigOverride)
-                    .withProblemId(id)
-                    .withBestSolutionEventConsumer(
-                            decorateIfPossible(event -> notifyOnSave(id, event.solution(), event.producerId())))
-                    .withFinalBestSolutionEventConsumer(event -> notifyOnComplete(id, event.solution()))
-                    .withFirstInitializedSolutionEventConsumer(
-                            event -> notifyOnInit(id, event.solution(), event.isTerminatedEarly(), event.producerId()))
-                    .withExceptionHandler(this::notifyOnFailure)
-                    .run();
-            solverJobs.put(job.getProblemId(), job);
+
+            var jobFuture = new CompletableFuture<SolverJob<SolverModel>>();
+            solverJobs.put(id, jobFuture);
+            try {
+                var job = solverManager.solveBuilder()
+                        .withProblemFinder(id_ -> notifyOnStart((String) id_, modelInput, previousModelOutput, modelConfig))
+                        .withConfigOverride(solverConfigOverride)
+                        .withProblemId(id)
+                        .withBestSolutionEventConsumer(
+                                decorateIfPossible(event -> notifyOnSave(id, event.solution(), event.producerId())))
+                        .withFinalBestSolutionEventConsumer(event -> notifyOnComplete(id, event.solution()))
+                        .withFirstInitializedSolutionEventConsumer(
+                                event -> notifyOnInit(id, event.solution(), event.isTerminatedEarly(), event.producerId()))
+                        .withExceptionHandler(this::notifyOnFailure)
+                        .run();
+                jobFuture.complete(job);
+            } catch (Throwable e) {
+                jobFuture.completeExceptionally(e);
+                throw e;
+            }
         } catch (Throwable e) {
             notifyOnFailure(id, e);
         }
@@ -635,7 +645,7 @@ public class SolverWorker {
         }
 
         var metadata = storageService.getMetadata(id);
-        var solverJob = solverJobs.get(id);
+        var solverJob = resolveJob(solverJobs.get(id));
         if (metadata != null && SolvingStatus.SOLVING_ACTIVE == metadata.getSolverStatus() && solverJob != null) {
             var modelOutput = convertToModelOutput(id, solverModel);
 
@@ -651,7 +661,7 @@ public class SolverWorker {
     protected void notifyOnSave(String id, SolverModel solverModel, EventProducerId eventProducerId) {
         LOGGER.debug("Notify run save for id {}", id);
         var metadata = storageService.getMetadata(id);
-        var solverJob = solverJobs.get(id);
+        var solverJob = resolveJob(solverJobs.get(id));
         if (metadata != null && SolvingStatus.SOLVING_ACTIVE == metadata.getSolverStatus() && solverJob != null) {
             processor.onNext(metadata);
             var modelOutput = convertToModelOutput(id, solverModel);
@@ -676,7 +686,7 @@ public class SolverWorker {
         LOGGER.debug("Notify run complete for id {}", id);
         try {
             // remove it as the first thing so in case any best solution events will arrive while this method is executed they will be discarded
-            var solverJob = solverJobs.remove(id);
+            var solverJob = resolveJob(solverJobs.remove(id));
 
             if (solverJob == null) {
                 return;
@@ -751,7 +761,7 @@ public class SolverWorker {
         Metadata metadata = null;
         try {
             // remove it as the first thing so in case any best solution events will arrive while this method is executed they will be discarded
-            var solverJob = solverJobs.remove(id);
+            var solverJob = resolveJob(solverJobs.remove(id));
 
             // update run status only as failed
             metadata = storageService.getMetadata(problemId);
@@ -835,6 +845,17 @@ public class SolverWorker {
         }
 
         return consumer;
+    }
+
+    private SolverJob<SolverModel> resolveJob(CompletableFuture<SolverJob<SolverModel>> jobFuture) {
+        if (jobFuture == null) {
+            return null;
+        }
+        try {
+            return jobFuture.join();
+        } catch (CompletionException e) {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
This PR aims to fix a very rare race condition in the SolverWorker. If the dataset fails right after it has started (eg. when creating a solver model), it may be the case that the job was not stored yet in the jobs map. That will make the sending of the failed event failed, because we have no way of fetching the job's metadata.

This PR makes sure that if we need to access the job metadata, we will wait for the job to be there to fetch all the metadata needed.

Fixes: github.com/TimefoldAI/timefold-platform/issues/5172