### PR TITLE
chore: remove storage from REST

### DIFF
--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
@@ -1,0 +1,211 @@
+package ai.timefold.solver.service.definition.impl.solver;
+
+import java.util.List;
+import java.util.Set;
+
+import ai.timefold.solver.service.definition.api.ModelConfigOverrides;
+import ai.timefold.solver.service.definition.api.ModelInput;
+import ai.timefold.solver.service.definition.api.ModelOutput;
+import ai.timefold.solver.service.definition.api.domain.Configuration;
+import ai.timefold.solver.service.definition.api.domain.Metadata;
+import ai.timefold.solver.service.definition.api.domain.ModelInputPatchRequest;
+import ai.timefold.solver.service.definition.api.domain.ModelRequest;
+import ai.timefold.solver.service.definition.api.domain.ModelResponse;
+import ai.timefold.solver.service.definition.api.log.LogInfo;
+import ai.timefold.solver.service.definition.api.metrics.ModelInputMetrics;
+import ai.timefold.solver.service.definition.api.metrics.ModelOutputMetrics;
+import ai.timefold.solver.service.definition.api.rest.DatasetSelector;
+
+/**
+ * Facade used by the REST layer to interact with dataset storage and the solver worker,
+ * without depending on storage or messaging internals directly.
+ */
+public interface SolverWorkerFacade {
+
+    /***
+     * Starts solving an existing dataset identified by the given id.
+     * 
+     * @param id the dataset identifier
+     * @return the {@link Metadata} associated with the dataset that will be solved
+     * @throws ai.timefold.solver.service.definition.internal.error.ItemNotFoundException
+     *         if no dataset exists for the given id
+     */
+    <Score_> Metadata<Score_> solveDataset(String id);
+
+    /**
+     * Creates a new dataset derived from an existing one (identified by {@code id}), * without starting the solving process.
+     * The resulting dataset is validated and * computed asynchronously.
+     * 
+     * @param id the identifier of the source (parent)dataset.
+     * @param select whether to derive from the unsolved input or the solved output of the parent
+     * @param runName a human-readable name for the new run * @param tags the set of tags to attach to the new dataset
+     * @param configuration the configuration to apply; if {@code null}, the parent's configuration is reused
+     * @return the {@link Metadata} of the newly created dataset
+     */
+    <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> createDataset(String id,
+            DatasetSelector select, String runName, Set<String> tags,
+            Configuration<ModelConfigurationOverrides_> configuration);
+
+    /**
+     * Creates a new dataset derived from an existing one (identified by {@code id}) and immediately schedules it to be
+     * solved after validation/compute completes.
+     * 
+     * @param id the identifier of the source (parent) dataset
+     * @param select whether to derive from the unsolved input or the solved output of the parent
+     * @param runName a human-readable name for the new run
+     * @param tags the set of tags to attach to the new dataset
+     * @param configuration the configuration to apply; if {@code null}, the parent's configuration is reused
+     * @return the {@link Metadata} of the newly created dataset
+     */
+    <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> createAndSolveDataset(String id,
+            DatasetSelector select, String runName, Set<String> tags,
+            Configuration<ModelConfigurationOverrides_> configuration);
+
+    /**
+     * Creates a new dataset from the provided {@link ModelInput} without starting the solving process. The resulting
+     * dataset is validated and computed asynchronously.
+     * 
+     * @param runName a human-readable name for the new run
+     * @param tags the set of tags to attach to the new dataset
+     * @param modelInput the model input to store as the dataset problem
+     * @param configuration the configuration to apply to the dataset
+     * @return the {@link Metadata} of the newly created dataset
+     */
+    <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> createDataset(String runName,
+            Set<String> tags, ModelInput modelInput, Configuration<ModelConfigurationOverrides_> configuration);
+
+    /**
+     * Creates a new dataset from the provided {@link ModelInput} and immediately schedules it to be solved after
+     * validation/compute completes.
+     * 
+     * @param runName a human-readable name for the new run
+     * @param tags the set of tags to attach to the new dataset
+     * @param modelInput the model input to store as the dataset problem
+     * @param configuration the configuration to apply to the dataset
+     * @return the {@link Metadata} of the newly created dataset
+     */
+    <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> createAndSolveDataset(String runName,
+            Set<String> tags, ModelInput modelInput,
+            Configuration<ModelConfigurationOverrides_> configuration);
+
+    /**
+     * Creates a new dataset by applying a JSON patch to an existing dataset's {@link ModelInput}, without starting
+     * the solving process. The resulting dataset is validated and computed asynchronously.
+     *
+     * @param id the identifier of the source (parent) dataset
+     * @param select whether to derive from the unsolved input or the solved output of the parent
+     * @param runName a human-readable name for the new run
+     * @param modelInputPatchRequest the patch request containing the JSON patch operations and an optional
+     *        {@link Configuration} override
+     * @return the {@link Metadata} of the newly created dataset
+     * @throws ai.timefold.solver.service.definition.internal.error.ItemNotFoundException
+     *         if no dataset exists for the given id
+     */
+    <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> patchDataset(String id,
+            DatasetSelector select, String runName,
+            ModelInputPatchRequest<ModelConfigurationOverrides_> modelInputPatchRequest);
+
+    /**
+     * Creates a new dataset by applying a JSON patch to an existing dataset's {@link ModelInput} and immediately
+     * schedules it to be solved after validation/compute completes.
+     *
+     * @param id the identifier of the source (parent) dataset
+     * @param select whether to derive from the unsolved input or the solved output of the parent
+     * @param runName a human-readable name for the new run
+     * @param modelInputPatchRequest the patch request containing the JSON patch operations and an optional
+     *        {@link Configuration} override
+     * @return the {@link Metadata} of the newly created dataset
+     * @throws ai.timefold.solver.service.definition.internal.error.ItemNotFoundException
+     *         if no dataset exists for the given id
+     */
+    <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> patchAndSolveDataset(String id,
+            DatasetSelector select, String runName,
+            ModelInputPatchRequest<ModelConfigurationOverrides_> modelInputPatchRequest);
+
+    /**
+     * Terminates the ongoing solve for the given dataset (if any) and returns the current model response
+     * 
+     * @param id the dataset identifier * @return the {@link ModelResponse} for the dataset after termination
+     */
+    <Score_, ModelOutput_ extends ModelOutput, InputMetrics_ extends ModelInputMetrics, OutputMetrics_ extends ModelOutputMetrics>
+            ModelResponse<Score_, ModelOutput_, InputMetrics_, OutputMetrics_> terminate(String id);
+
+    /**
+     * Returns the {@link Metadata} for the given dataset, or {@code null} if none exists.
+     * 
+     * @param id the dataset identifier
+     * @return the dataset metadata, or {@code null} if not found
+     */
+    <Score_> Metadata<Score_> getMetadata(String id);
+
+    /**
+     * Returns the effective (processed) {@link Configuration} of the given dataset.
+     * 
+     * @param id the dataset identifier
+     * @return the effective configuration, or {@code null} if not found
+     */
+    <ModelConfigurationOverrides_ extends ModelConfigOverrides> Configuration<ModelConfigurationOverrides_>
+            getConfiguration(String id);
+
+    /**
+     * Returns the original (unprocessed) {@link Configuration} of the given dataset, as it was supplied by the caller
+     * before any post-processing.
+     * 
+     * @param id the dataset identifier
+     * @return the unprocessed configuration, or {@code null}if not found
+     */
+    <ModelConfigurationOverrides_ extends ModelConfigOverrides> Configuration<ModelConfigurationOverrides_>
+            getUnprocessedConfiguration(String id);
+
+    /**
+     * * Returns the {@link ModelInput} originally submitted for the given dataset. * * @param id the dataset identifier
+     * * @return the model input, or {@code null} if not found
+     */
+    ModelInput getModelInput(String id);
+
+    /**
+     * Returns the {@link ModelInput} representing the solved state of the given dataset (i.e. planning entities updated
+     * with the best solution).
+     * 
+     * @param id the dataset identifier
+     * @return the solved model input, or {@code null} if notavailable
+     */
+    ModelInput getSolvedModelInput(String id);
+
+    /**
+     * Returns a paginated list of dataset runs.
+     * 
+     * @param pageNumber the zero-based page index
+     * @param pageSize the number of runs per page
+     * @return the list of {@link Metadata} entries for the requested page
+     */
+    <Score_> List<Metadata<Score_>> listRuns(int pageNumber, int pageSize);
+
+    /**
+     * Returns the {@link ModelResponse} for the given dataset.
+     * 
+     * @param id the dataset identifier
+     * @return the model response, or {@code null} if not available
+     */
+    <Score_, ModelOutput_ extends ModelOutput, InputMetrics_ extends ModelInputMetrics, OutputMetrics_ extends ModelOutputMetrics>
+            ModelResponse<Score_, ModelOutput_, InputMetrics_, OutputMetrics_> getModelResponse(String id);
+
+    /**
+     * Returns the original {@link ModelRequest} for the given dataset.
+     * 
+     * @param id the dataset identifier
+     * @return the model request, or {@code null} if not found
+     */
+    <ModelInput_ extends ModelInput, ModelConfigurationOverrides_ extends ModelConfigOverrides>
+            ModelRequest<ModelInput_, ModelConfigurationOverrides_> getModelRequest(String id);
+
+    /**
+     * Returns the solver logs associated with the given dataset.
+     * The result combines the currently running pod's log file (if present) with any previously persisted log content
+     * 
+     * @param id the dataset identifier
+     * @return the aggregated {@link LogInfo}, or {@code null} if no logs are available
+     */
+    LogInfo getLogs(String id);
+
+}

--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
@@ -33,11 +33,12 @@ public interface SolverWorkerFacade {
     <Score_> Metadata<Score_> solveDataset(String id);
 
     /**
-     * Creates a new dataset derived from an existing one (identified by {@code id}), * without starting the solving process.
-     * The resulting dataset is validated and * computed asynchronously.
-     * 
-     * @param id the identifier of the source (parent)dataset.
-     * @param select whether to derive from the unsolved input or the solved output of the parent
+     /**
+      * Creates a new dataset derived from an existing one (identified by {@code id}) without starting the solving process.
+      * The resulting dataset is validated and computed asynchronously.
+      * 
+      * @param id the identifier of the source (parent) dataset.
+      * @param select whether to derive from the unsolved input or the solved output of the parent
      * @param runName a human-readable name for the new run
      * @param tags the set of tags to attach to the new dataset
      * @param configuration the configuration to apply; if {@code null}, the parent's configuration is reused
@@ -170,9 +171,13 @@ public interface SolverWorkerFacade {
      * Returns the {@link ModelInput} representing the solved state of the given dataset (i.e. planning entities updated
      * with the best solution).
      * 
-     * @param id the dataset identifier
-     * @return the solved model input, or {@code null} if notavailable
-     */
+     /**
+      * Returns the {@link ModelInput} representing the solved state of the given dataset (i.e. planning entities updated
+      * with the best solution).
+      * 
+      * @param id the dataset identifier
+      * @return the solved model input, or {@code null} if not available
+      */
     ModelInput getSolvedModelInput(String id);
 
     /**

--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
@@ -33,7 +33,6 @@ public interface SolverWorkerFacade {
     <Score_> Metadata<Score_> solveDataset(String id);
 
     /**
-     * /**
      * Creates a new dataset derived from an existing one (identified by {@code id}) without starting the solving process.
      * The resulting dataset is validated and computed asynchronously.
      * 
@@ -169,10 +168,6 @@ public interface SolverWorkerFacade {
     ModelInput getModelInput(String id);
 
     /**
-     * Returns the {@link ModelInput} representing the solved state of the given dataset (i.e. planning entities updated
-     * with the best solution).
-     * 
-     * /**
      * Returns the {@link ModelInput} representing the solved state of the given dataset (i.e. planning entities updated
      * with the best solution).
      * 

--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
@@ -38,7 +38,8 @@ public interface SolverWorkerFacade {
      * 
      * @param id the identifier of the source (parent)dataset.
      * @param select whether to derive from the unsolved input or the solved output of the parent
-     * @param runName a human-readable name for the new run * @param tags the set of tags to attach to the new dataset
+     * @param runName a human-readable name for the new run
+     * @param tags the set of tags to attach to the new dataset
      * @param configuration the configuration to apply; if {@code null}, the parent's configuration is reused
      * @return the {@link Metadata} of the newly created dataset
      */
@@ -125,7 +126,8 @@ public interface SolverWorkerFacade {
     /**
      * Terminates the ongoing solve for the given dataset (if any) and returns the current model response
      * 
-     * @param id the dataset identifier * @return the {@link ModelResponse} for the dataset after termination
+     * @param id the dataset identifier
+     * @return the {@link ModelResponse} for the dataset after termination
      */
     <Score_, ModelOutput_ extends ModelOutput, InputMetrics_ extends ModelInputMetrics, OutputMetrics_ extends ModelOutputMetrics>
             ModelResponse<Score_, ModelOutput_, InputMetrics_, OutputMetrics_> terminate(String id);
@@ -158,8 +160,9 @@ public interface SolverWorkerFacade {
             getUnprocessedConfiguration(String id);
 
     /**
-     * * Returns the {@link ModelInput} originally submitted for the given dataset. * * @param id the dataset identifier
-     * * @return the model input, or {@code null} if not found
+     * Returns the {@link ModelInput} originally submitted for the given dataset.
+     * @param id the dataset identifier
+     * @return the model input, or {@code null} if not found
      */
     ModelInput getModelInput(String id);
 

--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/impl/solver/SolverWorkerFacade.java
@@ -33,12 +33,12 @@ public interface SolverWorkerFacade {
     <Score_> Metadata<Score_> solveDataset(String id);
 
     /**
-     /**
-      * Creates a new dataset derived from an existing one (identified by {@code id}) without starting the solving process.
-      * The resulting dataset is validated and computed asynchronously.
-      * 
-      * @param id the identifier of the source (parent) dataset.
-      * @param select whether to derive from the unsolved input or the solved output of the parent
+     * /**
+     * Creates a new dataset derived from an existing one (identified by {@code id}) without starting the solving process.
+     * The resulting dataset is validated and computed asynchronously.
+     * 
+     * @param id the identifier of the source (parent) dataset.
+     * @param select whether to derive from the unsolved input or the solved output of the parent
      * @param runName a human-readable name for the new run
      * @param tags the set of tags to attach to the new dataset
      * @param configuration the configuration to apply; if {@code null}, the parent's configuration is reused
@@ -162,6 +162,7 @@ public interface SolverWorkerFacade {
 
     /**
      * Returns the {@link ModelInput} originally submitted for the given dataset.
+     * 
      * @param id the dataset identifier
      * @return the model input, or {@code null} if not found
      */
@@ -171,13 +172,13 @@ public interface SolverWorkerFacade {
      * Returns the {@link ModelInput} representing the solved state of the given dataset (i.e. planning entities updated
      * with the best solution).
      * 
-     /**
-      * Returns the {@link ModelInput} representing the solved state of the given dataset (i.e. planning entities updated
-      * with the best solution).
-      * 
-      * @param id the dataset identifier
-      * @return the solved model input, or {@code null} if not available
-      */
+     * /**
+     * Returns the {@link ModelInput} representing the solved state of the given dataset (i.e. planning entities updated
+     * with the best solution).
+     * 
+     * @param id the dataset identifier
+     * @return the solved model input, or {@code null} if not available
+     */
     ModelInput getSolvedModelInput(String id);
 
     /**

--- a/service/json/src/main/java/ai/timefold/solver/service/json/internal/patch/JsonPatch.java
+++ b/service/json/src/main/java/ai/timefold/solver/service/json/internal/patch/JsonPatch.java
@@ -31,7 +31,7 @@ public class JsonPatch {
                     + "an object or array is required");
         }
 
-        if (patch.size() == 0) {
+        if (patch.isEmpty()) {
             return source;
         }
 
@@ -61,7 +61,7 @@ public class JsonPatch {
             throw new IllegalArgumentException("Invalid \"path\" property: " + pathNode);
         }
         String path = pathNode.asText();
-        if (path.length() != 0 && path.charAt(0) != '/') {
+        if (!path.isEmpty() && path.charAt(0) != '/') {
             throw new IllegalArgumentException("Invalid \"path\" property: " + path);
         }
 
@@ -166,7 +166,7 @@ public class JsonPatch {
      * @return the patched JSON document
      */
     protected static JsonNode remove(JsonNode doc, String path) {
-        if (path.equals("")) {
+        if (path.isEmpty()) {
             if (doc.isObject()) {
                 ObjectNode docObject = (ObjectNode) doc;
                 docObject.removeAll();

--- a/service/maps/service-rest/src/main/java/ai/timefold/solver/service/maps/service/rest/impl/AbstractMapsModelAPIResource.java
+++ b/service/maps/service-rest/src/main/java/ai/timefold/solver/service/maps/service/rest/impl/AbstractMapsModelAPIResource.java
@@ -20,12 +20,8 @@ import ai.timefold.solver.service.definition.api.metrics.ModelInputMetrics;
 import ai.timefold.solver.service.definition.api.metrics.ModelOutputMetrics;
 import ai.timefold.solver.service.definition.api.validation.Issue;
 import ai.timefold.solver.service.definition.api.validation.ModelValidator;
+import ai.timefold.solver.service.definition.impl.solver.SolverWorkerFacade;
 import ai.timefold.solver.service.definition.impl.validation.ValidationIssueTypeCatalog;
-import ai.timefold.solver.service.definition.internal.events.DatasetCreatedEvent;
-import ai.timefold.solver.service.definition.internal.events.DatasetValidateComputeCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveStartCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveTerminateCommand;
-import ai.timefold.solver.service.definition.internal.storage.AbstractStorageService;
 import ai.timefold.solver.service.maps.api.model.Waypoints;
 import ai.timefold.solver.service.maps.service.integration.impl.WaypointsService;
 import ai.timefold.solver.service.rest.impl.AbstractModelAPIResource;
@@ -36,15 +32,10 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
-import io.smallrye.reactive.messaging.MutinyEmitter;
 
 @RegisterForReflection
-@SuppressWarnings({ "rawtypes", "unchecked" })
 public class AbstractMapsModelAPIResource<ModelInput_ extends ModelInput, ModelOutput_ extends ModelOutput, ModelConfigurationOverrides_ extends ModelConfigOverrides, Score_ extends Score<?>, InputMetrics_ extends ModelInputMetrics, OutputMetrics_ extends ModelOutputMetrics, Justification_ extends ModelConstraintJustification, ValidationIssue_ extends Issue>
         extends
         AbstractModelAPIResource<ModelInput_, ModelOutput_, ModelConfigurationOverrides_, Score_, InputMetrics_, OutputMetrics_, Justification_, ValidationIssue_> {
@@ -56,17 +47,10 @@ public class AbstractMapsModelAPIResource<ModelInput_ extends ModelInput, ModelO
     }
 
     public AbstractMapsModelAPIResource(ModelValidator<ModelInput_, ModelConfigurationOverrides_> modelValidator,
-            AbstractStorageService storageService,
-            Emitter<DatasetCreatedEvent> datasetPostedEventEmitter,
-            Emitter<DatasetValidateComputeCommand> datasetValidateComputeCommandEmitter,
-            Emitter<SolveStartCommand> scheduleStartEmitter,
-            MutinyEmitter<SolveTerminateCommand> scheduleTerminateEmitter,
-            ObjectMapper mapper,
+            SolverWorkerFacade solverWorkerFacade,
             ValidationIssueTypeCatalog validationIssueTypeCatalog,
             WaypointsService waypointsService) {
-        super(modelValidator, storageService, datasetPostedEventEmitter,
-                datasetValidateComputeCommandEmitter, scheduleStartEmitter, scheduleTerminateEmitter, mapper,
-                validationIssueTypeCatalog);
+        super(modelValidator, solverWorkerFacade, validationIssueTypeCatalog);
         this.waypointsService = waypointsService;
     }
 

--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/DefaultModelResourceTypeInfo.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/DefaultModelResourceTypeInfo.java
@@ -1,20 +1,11 @@
 package ai.timefold.solver.service.quarkus.deployment.rest;
 
-import java.util.Map;
-
 import ai.timefold.solver.service.definition.api.validation.ModelValidator;
+import ai.timefold.solver.service.definition.impl.solver.SolverWorkerFacade;
 import ai.timefold.solver.service.definition.impl.validation.ValidationIssueTypeCatalog;
-import ai.timefold.solver.service.definition.internal.events.DatasetCreatedEvent;
-import ai.timefold.solver.service.definition.internal.events.DatasetValidateComputeCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveStartCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveTerminateCommand;
-import ai.timefold.solver.service.definition.internal.events.SolverChannels;
-import ai.timefold.solver.service.definition.internal.storage.AbstractStorageService;
 import ai.timefold.solver.service.quarkus.deployment.builditem.ModelComponentsBuildItem;
 
 import org.jboss.jandex.DotName;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.gizmo.SignatureBuilder;
 import io.quarkus.gizmo.Type;
@@ -46,27 +37,7 @@ public class DefaultModelResourceTypeInfo implements ModelResourceTypeInfo {
                 .addParameterType(Type.parameterizedType(Type.classType(ModelValidator.class),
                         Type.classType(modelComponents.getModelInput().name()),
                         Type.classType(modelComponents.getModelConfigOverrides().name())))
-                .addParameterType(Type.parameterizedType(Type.classType(AbstractStorageService.class),
-                        Type.classType(modelComponents.getModelInput().name()),
-                        Type.classType(modelComponents.getModelConfigOverrides().name()),
-                        Type.classType(modelComponents.getModelInputMetrics().name()),
-                        Type.classType(modelComponents.getModelOutputMetrics().name()),
-                        Type.classType(modelComponents.getModelOutput().name()),
-                        Type.classType(modelComponents.getModelScoreClass().name()),
-                        Type.classType(modelComponents.getModelConstraintJustification().name())))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(DatasetCreatedEvent.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(DatasetValidateComputeCommand.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(SolveStartCommand.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(MUTINY_EMITTER_CLASS_NAME),
-                                Type.classType(SolveTerminateCommand.class)))
-                .addParameterType(Type.classType(ObjectMapper.class))
+                .addParameterType(Type.classType(SolverWorkerFacade.class))
                 .addParameterType(Type.classType(ValidationIssueTypeCatalog.class))
                 .build();
     }
@@ -74,22 +45,8 @@ public class DefaultModelResourceTypeInfo implements ModelResourceTypeInfo {
     @Override
     public String[] constructorParameterTypes(ModelComponentsBuildItem modelComponents) {
         return new String[] { ModelValidator.class.getCanonicalName(),
-                AbstractStorageService.class.getCanonicalName(),
-                EMITTER_CLASS_NAME,
-                EMITTER_CLASS_NAME,
-                EMITTER_CLASS_NAME,
-                MUTINY_EMITTER_CLASS_NAME,
-                ObjectMapper.class.getCanonicalName(),
+                SolverWorkerFacade.class.getCanonicalName(),
                 ValidationIssueTypeCatalog.class.getCanonicalName(),
         };
-    }
-
-    @Override
-    public Map<String, Integer> channelConstructorParameterIndices() {
-        return Map.of(
-                SolverChannels.DATASET_CREATED, 2,
-                SolverChannels.DATASET_VALIDATE_COMPUTE, 3,
-                SolverChannels.START, 4,
-                SolverChannels.TERMINATE, 5);
     }
 }

--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/EnterpriseModelResourceTypeInfo.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/EnterpriseModelResourceTypeInfo.java
@@ -1,20 +1,11 @@
 package ai.timefold.solver.service.quarkus.deployment.rest;
 
-import java.util.Map;
-
 import ai.timefold.solver.service.definition.api.validation.ModelValidator;
+import ai.timefold.solver.service.definition.impl.solver.SolverWorkerFacade;
 import ai.timefold.solver.service.definition.impl.validation.ValidationIssueTypeCatalog;
-import ai.timefold.solver.service.definition.internal.events.DatasetCreatedEvent;
-import ai.timefold.solver.service.definition.internal.events.DatasetValidateComputeCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveStartCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveTerminateCommand;
-import ai.timefold.solver.service.definition.internal.events.SolverChannels;
-import ai.timefold.solver.service.definition.internal.storage.AbstractStorageService;
 import ai.timefold.solver.service.quarkus.deployment.builditem.ModelComponentsBuildItem;
 
 import org.jboss.jandex.DotName;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.gizmo.SignatureBuilder;
 import io.quarkus.gizmo.Type;
@@ -47,27 +38,7 @@ public class EnterpriseModelResourceTypeInfo implements ModelResourceTypeInfo {
                 .addParameterType(Type.parameterizedType(Type.classType(ModelValidator.class),
                         Type.classType(modelComponents.getModelInput().name()),
                         Type.classType(modelComponents.getModelConfigOverrides().name())))
-                .addParameterType(Type.parameterizedType(Type.classType(AbstractStorageService.class),
-                        Type.classType(modelComponents.getModelInput().name()),
-                        Type.classType(modelComponents.getModelConfigOverrides().name()),
-                        Type.classType(modelComponents.getModelInputMetrics().name()),
-                        Type.classType(modelComponents.getModelOutputMetrics().name()),
-                        Type.classType(modelComponents.getModelOutput().name()),
-                        Type.classType(modelComponents.getModelScoreClass().name()),
-                        Type.classType(modelComponents.getModelConstraintJustification().name())))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(DatasetCreatedEvent.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(DatasetValidateComputeCommand.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(SolveStartCommand.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(MUTINY_EMITTER_CLASS_NAME),
-                                Type.classType(SolveTerminateCommand.class)))
-                .addParameterType(Type.classType(ObjectMapper.class))
+                .addParameterType(Type.classType(SolverWorkerFacade.class))
                 .addParameterType(Type.classType(ValidationIssueTypeCatalog.class))
                 .build();
     }
@@ -77,22 +48,8 @@ public class EnterpriseModelResourceTypeInfo implements ModelResourceTypeInfo {
         return new String[] {
                 SCORE_ANALYSIS_FACADE_BASE.toString(),
                 ModelValidator.class.getCanonicalName(),
-                AbstractStorageService.class.getCanonicalName(),
-                EMITTER_CLASS_NAME,
-                EMITTER_CLASS_NAME,
-                EMITTER_CLASS_NAME,
-                MUTINY_EMITTER_CLASS_NAME,
-                ObjectMapper.class.getCanonicalName(),
+                SolverWorkerFacade.class.getCanonicalName(),
                 ValidationIssueTypeCatalog.class.getCanonicalName(),
         };
-    }
-
-    @Override
-    public Map<String, Integer> channelConstructorParameterIndices() {
-        return Map.of(
-                SolverChannels.DATASET_CREATED, 3,
-                SolverChannels.DATASET_VALIDATE_COMPUTE, 4,
-                SolverChannels.START, 5,
-                SolverChannels.TERMINATE, 6);
     }
 }

--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/EnterpriseModelResourceWithMapsTypeInfo.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/EnterpriseModelResourceWithMapsTypeInfo.java
@@ -1,20 +1,11 @@
 package ai.timefold.solver.service.quarkus.deployment.rest;
 
-import java.util.Map;
-
 import ai.timefold.solver.service.definition.api.validation.ModelValidator;
+import ai.timefold.solver.service.definition.impl.solver.SolverWorkerFacade;
 import ai.timefold.solver.service.definition.impl.validation.ValidationIssueTypeCatalog;
-import ai.timefold.solver.service.definition.internal.events.DatasetCreatedEvent;
-import ai.timefold.solver.service.definition.internal.events.DatasetValidateComputeCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveStartCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveTerminateCommand;
-import ai.timefold.solver.service.definition.internal.events.SolverChannels;
-import ai.timefold.solver.service.definition.internal.storage.AbstractStorageService;
 import ai.timefold.solver.service.quarkus.deployment.builditem.ModelComponentsBuildItem;
 
 import org.jboss.jandex.DotName;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.gizmo.SignatureBuilder;
 import io.quarkus.gizmo.Type;
@@ -48,27 +39,7 @@ public class EnterpriseModelResourceWithMapsTypeInfo implements ModelResourceTyp
                 .addParameterType(Type.parameterizedType(Type.classType(ModelValidator.class),
                         Type.classType(modelComponents.getModelInput().name()),
                         Type.classType(modelComponents.getModelConfigOverrides().name())))
-                .addParameterType(Type.parameterizedType(Type.classType(AbstractStorageService.class),
-                        Type.classType(modelComponents.getModelInput().name()),
-                        Type.classType(modelComponents.getModelConfigOverrides().name()),
-                        Type.classType(modelComponents.getModelInputMetrics().name()),
-                        Type.classType(modelComponents.getModelOutputMetrics().name()),
-                        Type.classType(modelComponents.getModelOutput().name()),
-                        Type.classType(modelComponents.getModelScoreClass().name()),
-                        Type.classType(modelComponents.getModelConstraintJustification().name())))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(DatasetCreatedEvent.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(DatasetValidateComputeCommand.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(SolveStartCommand.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(MUTINY_EMITTER_CLASS_NAME),
-                                Type.classType(SolveTerminateCommand.class)))
-                .addParameterType(Type.classType(ObjectMapper.class))
+                .addParameterType(Type.classType(SolverWorkerFacade.class))
                 .addParameterType(Type.classType(ValidationIssueTypeCatalog.class))
                 .addParameterType(Type.classType(WAYPOINT_SERVICE.toString()))
                 .build();
@@ -79,23 +50,9 @@ public class EnterpriseModelResourceWithMapsTypeInfo implements ModelResourceTyp
         return new String[] {
                 SCORE_ANALYSIS_FACADE_BASE.toString(),
                 ModelValidator.class.getCanonicalName(),
-                AbstractStorageService.class.getCanonicalName(),
-                EMITTER_CLASS_NAME,
-                EMITTER_CLASS_NAME,
-                EMITTER_CLASS_NAME,
-                MUTINY_EMITTER_CLASS_NAME,
-                ObjectMapper.class.getCanonicalName(),
+                SolverWorkerFacade.class.getCanonicalName(),
                 ValidationIssueTypeCatalog.class.getCanonicalName(),
                 WAYPOINT_SERVICE.toString()
         };
-    }
-
-    @Override
-    public Map<String, Integer> channelConstructorParameterIndices() {
-        return Map.of(
-                SolverChannels.DATASET_CREATED, 3,
-                SolverChannels.DATASET_VALIDATE_COMPUTE, 4,
-                SolverChannels.START, 5,
-                SolverChannels.TERMINATE, 6);
     }
 }

--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/ModelResourceBeanGenerator.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/ModelResourceBeanGenerator.java
@@ -18,7 +18,6 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
 
-import io.quarkus.gizmo.AnnotatedElement;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.DescriptorUtils;
 import io.quarkus.gizmo.FieldCreator;
@@ -43,16 +42,9 @@ import io.quarkus.gizmo.Type;
  *
  *         public SolverModelName_EndpointName(ModelValidator<...> modelValidator,
  *                 ScoreAnalysisFacadeBase scoreAnalysisFacade,
- *                 AbstractStorageService<...> storageService,
- *                 &#64;Channel(SolverChannels.DATASET_POSTED)
- *                 &#64;Broadcast
- *                 Emitter<DatasetPostedEvent> datasetPostedEmitter,
- *                 &#64;Channel(SolverChannels.START)
- *                 Emitter<ItemStartCommand> scheduleStartEmitter,
- *                 &#64;Channel(SolverChannels.TERMINATE)
- *                 MutinyEmitter<ItemTerminateCommand> scheduleTerminateEmitter) {
- *             super(modelValidator, scoreAnalysisFacade, storageService, datasetPostedEmitter, scheduleStartEmitter,
- *                     scheduleTerminateEmitter);
+ *                 SolverWorkerFacade solverWorkerFacade,
+ *                 ValidationIssueTypeCatalog validationIssueTypeCatalog) {
+ *             super(scoreAnalysisFacade, modelValidator, solverWorkerFacade, mapper, validationIssueTypeCatalog);
  *         }
  *     }
  *     }
@@ -126,14 +118,6 @@ public final class ModelResourceBeanGenerator {
 
         constructorParams.addAnnotation(Inject.class);
         ResultHandle thisObj = constructorParams.getThis();
-
-        // add channel annotation to arguments that are used for sending events
-        resourceBeanTypeInfo.channelConstructorParameterIndices()
-                .forEach((channelName, parameterIndex) -> {
-                    AnnotatedElement parameter = constructorParams.getParameterAnnotations(parameterIndex);
-                    var parameterAnnotator = resourceBeanTypeInfo.channelConstructorParameterAnnotators().get(channelName);
-                    parameterAnnotator.accept(parameter);
-                });
 
         ResultHandle[] params = new ResultHandle[constructorParameterTypes.length];
         for (int i = 0; i < params.length; i++) {

--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/ModelResourceBeanGenerator.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/ModelResourceBeanGenerator.java
@@ -44,7 +44,7 @@ import io.quarkus.gizmo.Type;
  *                 ScoreAnalysisFacadeBase scoreAnalysisFacade,
  *                 SolverWorkerFacade solverWorkerFacade,
  *                 ValidationIssueTypeCatalog validationIssueTypeCatalog) {
- *             super(scoreAnalysisFacade, modelValidator, solverWorkerFacade, mapper, validationIssueTypeCatalog);
+ *             super(scoreAnalysisFacade, modelValidator, solverWorkerFacade, validationIssueTypeCatalog);
  *         }
  *     }
  *     }

--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/ModelResourceTypeInfo.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/ModelResourceTypeInfo.java
@@ -1,32 +1,18 @@
 package ai.timefold.solver.service.quarkus.deployment.rest;
 
-import java.util.Map;
-import java.util.function.Consumer;
-
-import ai.timefold.solver.service.definition.internal.events.SolverChannels;
 import ai.timefold.solver.service.quarkus.deployment.builditem.ModelComponentsBuildItem;
 
 import org.jboss.jandex.DotName;
 
-import io.quarkus.gizmo.AnnotatedElement;
-import io.quarkus.gizmo.AnnotationCreator;
 import io.quarkus.gizmo.Type.ParameterizedType;
 
 public interface ModelResourceTypeInfo {
-
-    String EMITTER_CLASS_NAME = "org.eclipse.microprofile.reactive.messaging.Emitter";
-
-    String MUTINY_EMITTER_CLASS_NAME = "io.smallrye.reactive.messaging.MutinyEmitter";
 
     DotName WAYPOINT_SERVICE =
             DotName.createSimple("ai.timefold.solver.service.maps.service.integration.impl.WaypointsService");
 
     DotName SCORE_ANALYSIS_FACADE_BASE =
             DotName.createSimple("ai.timefold.solver.enterprise.service.definition.api.analysis.ScoreAnalysisFacadeBase");
-
-    String CHANNEL_CLASS_NAME = "org.eclipse.microprofile.reactive.messaging.Channel";
-
-    String BROADCAST_ANNOTATION_CLASS_NAME = "io.smallrye.reactive.messaging.annotations.Broadcast";
 
     DotName modelResourceSuperClassName();
 
@@ -35,29 +21,5 @@ public interface ModelResourceTypeInfo {
     String constructorSignature(ModelComponentsBuildItem modelComponents);
 
     String[] constructorParameterTypes(ModelComponentsBuildItem modelComponents);
-
-    Map<String, Integer> channelConstructorParameterIndices();
-
-    default Map<String, Consumer<AnnotatedElement>> channelConstructorParameterAnnotators() {
-        return Map.of(
-                SolverChannels.DATASET_CREATED, (AnnotatedElement parameter) -> {
-                    AnnotationCreator channelAnnotation = parameter.addAnnotation(CHANNEL_CLASS_NAME);
-                    channelAnnotation.add("value", SolverChannels.DATASET_CREATED);
-                    parameter.addAnnotation(BROADCAST_ANNOTATION_CLASS_NAME);
-                },
-                SolverChannels.DATASET_VALIDATE_COMPUTE, (AnnotatedElement parameter) -> {
-                    AnnotationCreator channelAnnotation = parameter.addAnnotation(CHANNEL_CLASS_NAME);
-                    channelAnnotation.add("value", SolverChannels.DATASET_VALIDATE_COMPUTE);
-                    parameter.addAnnotation(BROADCAST_ANNOTATION_CLASS_NAME);
-                },
-                SolverChannels.START, (AnnotatedElement parameter) -> {
-                    AnnotationCreator channelAnnotation = parameter.addAnnotation(CHANNEL_CLASS_NAME);
-                    channelAnnotation.add("value", SolverChannels.START);
-                },
-                SolverChannels.TERMINATE, (AnnotatedElement parameter) -> {
-                    AnnotationCreator channelAnnotation = parameter.addAnnotation(CHANNEL_CLASS_NAME);
-                    channelAnnotation.add("value", SolverChannels.TERMINATE);
-                });
-    }
 
 }

--- a/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/ModelResourceWithMapsTypeInfo.java
+++ b/service/quarkus/deployment/src/main/java/ai/timefold/solver/service/quarkus/deployment/rest/ModelResourceWithMapsTypeInfo.java
@@ -1,20 +1,11 @@
 package ai.timefold.solver.service.quarkus.deployment.rest;
 
-import java.util.Map;
-
 import ai.timefold.solver.service.definition.api.validation.ModelValidator;
+import ai.timefold.solver.service.definition.impl.solver.SolverWorkerFacade;
 import ai.timefold.solver.service.definition.impl.validation.ValidationIssueTypeCatalog;
-import ai.timefold.solver.service.definition.internal.events.DatasetCreatedEvent;
-import ai.timefold.solver.service.definition.internal.events.DatasetValidateComputeCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveStartCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveTerminateCommand;
-import ai.timefold.solver.service.definition.internal.events.SolverChannels;
-import ai.timefold.solver.service.definition.internal.storage.AbstractStorageService;
 import ai.timefold.solver.service.quarkus.deployment.builditem.ModelComponentsBuildItem;
 
 import org.jboss.jandex.DotName;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.gizmo.SignatureBuilder;
 import io.quarkus.gizmo.Type;
@@ -45,27 +36,7 @@ public class ModelResourceWithMapsTypeInfo implements ModelResourceTypeInfo {
                 .addParameterType(Type.parameterizedType(Type.classType(ModelValidator.class),
                         Type.classType(modelComponents.getModelInput().name()),
                         Type.classType(modelComponents.getModelConfigOverrides().name())))
-                .addParameterType(Type.parameterizedType(Type.classType(AbstractStorageService.class),
-                        Type.classType(modelComponents.getModelInput().name()),
-                        Type.classType(modelComponents.getModelConfigOverrides().name()),
-                        Type.classType(modelComponents.getModelInputMetrics().name()),
-                        Type.classType(modelComponents.getModelOutputMetrics().name()),
-                        Type.classType(modelComponents.getModelOutput().name()),
-                        Type.classType(modelComponents.getModelScoreClass().name()),
-                        Type.classType(modelComponents.getModelConstraintJustification().name())))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(DatasetCreatedEvent.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(DatasetValidateComputeCommand.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(EMITTER_CLASS_NAME),
-                                Type.classType(SolveStartCommand.class)))
-                .addParameterType(
-                        Type.parameterizedType(Type.classType(MUTINY_EMITTER_CLASS_NAME),
-                                Type.classType(SolveTerminateCommand.class)))
-                .addParameterType(Type.classType(ObjectMapper.class))
+                .addParameterType(Type.classType(SolverWorkerFacade.class))
                 .addParameterType(Type.classType(ValidationIssueTypeCatalog.class))
                 .addParameterType(Type.classType(WAYPOINT_SERVICE.toString()))
                 .build();
@@ -74,23 +45,9 @@ public class ModelResourceWithMapsTypeInfo implements ModelResourceTypeInfo {
     @Override
     public String[] constructorParameterTypes(ModelComponentsBuildItem modelComponents) {
         return new String[] { ModelValidator.class.getCanonicalName(),
-                AbstractStorageService.class.getCanonicalName(),
-                EMITTER_CLASS_NAME,
-                EMITTER_CLASS_NAME,
-                EMITTER_CLASS_NAME,
-                MUTINY_EMITTER_CLASS_NAME,
-                ObjectMapper.class.getCanonicalName(),
+                SolverWorkerFacade.class.getCanonicalName(),
                 ValidationIssueTypeCatalog.class.getCanonicalName(),
                 WAYPOINT_SERVICE.toString()
         };
-    }
-
-    @Override
-    public Map<String, Integer> channelConstructorParameterIndices() {
-        return Map.of(
-                SolverChannels.DATASET_CREATED, 2,
-                SolverChannels.DATASET_VALIDATE_COMPUTE, 3,
-                SolverChannels.START, 4,
-                SolverChannels.TERMINATE, 5);
     }
 }

--- a/service/rest/src/main/java/ai/timefold/solver/service/rest/api/ModelRest.java
+++ b/service/rest/src/main/java/ai/timefold/solver/service/rest/api/ModelRest.java
@@ -1,22 +1,13 @@
 package ai.timefold.solver.service.rest.api;
 
-import ai.timefold.solver.service.definition.internal.storage.AbstractStorageService;
-
 /**
  * Interface used by models to indicate that REST API should be generated for given model.
- *
+ * <p>
  * This interface will drive a complete REST API of the model and can also be used to extend the REST API with
  * additional endpoints by adding default interface methods.
- *
+ * <p>
  * Models should only create interface extending this interface and not implement it as a class.
  */
 public interface ModelRest {
 
-    /**
-     * Provides access to storage in case of extra endpoint methods needs to get hold of stored data like model input, output
-     * etc
-     *
-     * @return configured storage service instance
-     */
-    AbstractStorageService storageService();
 }

--- a/service/rest/src/main/java/ai/timefold/solver/service/rest/api/ModelRest.java
+++ b/service/rest/src/main/java/ai/timefold/solver/service/rest/api/ModelRest.java
@@ -2,10 +2,8 @@ package ai.timefold.solver.service.rest.api;
 
 /**
  * Interface used by models to indicate that REST API should be generated for given model.
- * <p>
  * This interface will drive a complete REST API of the model and can also be used to extend the REST API with
  * additional endpoints by adding default interface methods.
- * <p>
  * Models should only create interface extending this interface and not implement it as a class.
  */
 public interface ModelRest {

--- a/service/rest/src/main/java/ai/timefold/solver/service/rest/impl/AbstractModelAPIResource.java
+++ b/service/rest/src/main/java/ai/timefold/solver/service/rest/impl/AbstractModelAPIResource.java
@@ -1,13 +1,8 @@
 package ai.timefold.solver.service.rest.impl;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.Max;
@@ -34,6 +29,7 @@ import ai.timefold.solver.service.definition.api.ModelOutput;
 import ai.timefold.solver.service.definition.api.SolvingStatus;
 import ai.timefold.solver.service.definition.api.domain.Configuration;
 import ai.timefold.solver.service.definition.api.domain.Metadata;
+import ai.timefold.solver.service.definition.api.domain.ModelConfig;
 import ai.timefold.solver.service.definition.api.domain.ModelInputPatchRequest;
 import ai.timefold.solver.service.definition.api.domain.ModelRequest;
 import ai.timefold.solver.service.definition.api.domain.ModelResponse;
@@ -53,18 +49,11 @@ import ai.timefold.solver.service.definition.api.validation.Validated;
 import ai.timefold.solver.service.definition.api.validation.ValidationBuilder;
 import ai.timefold.solver.service.definition.api.validation.dto.ValidationIssueTypes;
 import ai.timefold.solver.service.definition.api.validation.dto.ValidationResult;
-import ai.timefold.solver.service.definition.impl.log.LoggingConstants;
+import ai.timefold.solver.service.definition.impl.solver.SolverWorkerFacade;
 import ai.timefold.solver.service.definition.impl.validation.ValidationIssueTypeCatalog;
 import ai.timefold.solver.service.definition.internal.error.ErrorCodes;
 import ai.timefold.solver.service.definition.internal.error.ItemNotFoundException;
-import ai.timefold.solver.service.definition.internal.error.TimefoldRuntimeException;
-import ai.timefold.solver.service.definition.internal.events.DatasetCreatedEvent;
-import ai.timefold.solver.service.definition.internal.events.DatasetValidateComputeCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveStartCommand;
-import ai.timefold.solver.service.definition.internal.events.SolveTerminateCommand;
 import ai.timefold.solver.service.definition.internal.events.SolverChannels;
-import ai.timefold.solver.service.definition.internal.storage.AbstractStorageService;
-import ai.timefold.solver.service.json.internal.patch.JsonPatch;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -76,19 +65,13 @@ import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.jboss.resteasy.reactive.ResponseStatus;
 import org.jboss.resteasy.reactive.RestStreamElementType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.reactive.messaging.MutinyEmitter;
 
 @RegisterForReflection
 @SuppressWarnings("unchecked")
@@ -100,17 +83,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
 
     protected final ModelValidator<ModelInput_, ModelConfigurationOverrides_> modelValidator;
 
-    protected AbstractStorageService<ModelInput_, ModelConfigurationOverrides_, InputMetrics_, OutputMetrics_, ModelOutput_, Score_, Justification_> storageService;
-
-    private Emitter<DatasetCreatedEvent> datasetCreatedEventEmitter;
-
-    private Emitter<DatasetValidateComputeCommand> datasetValidateComputeCommandEmitter;
-
-    private Emitter<SolveStartCommand> solveStartCommandEmitter;
-
-    private MutinyEmitter<SolveTerminateCommand> solveTerminateCommandEmitter;
-
-    private ObjectMapper mapper;
+    protected SolverWorkerFacade solverWorkerFacade;
 
     private ValidationIssueTypeCatalog validationIssueTypeCatalog;
 
@@ -123,22 +96,13 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
         modelValidator = null;
     }
 
+    // required for CDI injection
     public AbstractModelAPIResource(
             ModelValidator<ModelInput_, ModelConfigurationOverrides_> modelValidator,
-            AbstractStorageService storageService,
-            Emitter<DatasetCreatedEvent> datasetCreatedEventEmitter,
-            Emitter<DatasetValidateComputeCommand> datasetValidateComputeCommandEmitter,
-            Emitter<SolveStartCommand> solveStartCommandEmitter,
-            MutinyEmitter<SolveTerminateCommand> solveTerminateCommandEmitter,
-            ObjectMapper mapper,
+            SolverWorkerFacade solverWorkerFacade,
             ValidationIssueTypeCatalog validationIssueTypeCatalog) {
         this.modelValidator = modelValidator;
-        this.storageService = storageService;
-        this.datasetCreatedEventEmitter = datasetCreatedEventEmitter;
-        this.datasetValidateComputeCommandEmitter = datasetValidateComputeCommandEmitter;
-        this.solveStartCommandEmitter = solveStartCommandEmitter;
-        this.solveTerminateCommandEmitter = solveTerminateCommandEmitter;
-        this.mapper = mapper;
+        this.solverWorkerFacade = solverWorkerFacade;
         this.validationIssueTypeCatalog = validationIssueTypeCatalog;
     }
 
@@ -178,14 +142,12 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
 
         // if not provided in the request payload, use the query parameter
         runName = runName != null ? runName : name;
-        Metadata<Score_> metadata = new Metadata<>(runName);
-        metadata.setTags(tags);
-        metadata.datasetCreated();
-        storageService.storeProblem(metadata.getId(), request.modelInput(), metadata, request.configuration(),
-                request.configuration());
-        datasetCreatedEventEmitter.send(new DatasetCreatedEvent(metadata));
-        datasetValidateComputeCommandEmitter
-                .send(new DatasetValidateComputeCommand(metadata.getId(), operation == OperationOnPost.SOLVE));
+        var metadata = switch (operation) {
+            case OperationOnPost.NONE ->
+                solverWorkerFacade.createDataset(runName, tags, request.modelInput(), request.configuration());
+            case OperationOnPost.SOLVE ->
+                solverWorkerFacade.createAndSolveDataset(runName, tags, request.modelInput(), request.configuration());
+        };
 
         // The dataset is accepted, even if the validation fails, as on the platform, the validation is an asynchronous process.
         return Response.accepted(metadata).build();
@@ -207,14 +169,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @ResponseStatus(202)
     public Metadata<Score_> solve(
             @Parameter(description = "Unique identifier of the dataset", required = true) @PathParam("id") String id) {
-        Metadata<Score_> metadata = storageService().getMetadata(id); // ensure the dataset exists
-        if (metadata == null) {
-            throw new ItemNotFoundException(ErrorCodes.STORAGE_NO_JOB_FOUND, "Dataset with id " + id + " was not found");
-        }
-
-        solveStartCommandEmitter.send(new SolveStartCommand(id));
-
-        return metadata;
+        return solverWorkerFacade.solveDataset(id);
     }
 
     @APIResponses(value = {
@@ -279,40 +234,18 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
 
         Set<String> tags = null;
         String runName = null;
-        Configuration<ModelConfigurationOverrides_> initialConfiguration = null;
 
         if (configuration != null && configuration.run() != null) {
             RunConfiguration runConfiguration = configuration.run();
             runName = runConfiguration.name();
             tags = runConfiguration.tags();
-            initialConfiguration = configuration;
-        } else if (configuration == null) {
-            configuration = storageService.getConfiguration(id);
-            initialConfiguration = storageService.getUnprocessedConfiguration(id);
         }
+        runName = name == null ? runName : name;
 
-        ModelInput_ input =
-                select == DatasetSelector.UNSOLVED ? storageService.getModelInput(id) : storageService.getSolvedModelInput(id);
-        if (input == null) {
-            throw new ItemNotFoundException(ErrorCodes.STORAGE_NO_JOB_FOUND, id);
-        }
-        ModelRequest<ModelInput_, ModelConfigurationOverrides_> request =
-                new ModelRequest<>(configuration, input);
-        Metadata<Score_> metadata = new Metadata<>(name == null ? runName : name);
-        metadata.setTags(tags);
-        // set parent id to the id this data set is created from
-
-        metadata.setParentId(id);
-        // set origin id based on the origin id of the parent data set
-        Metadata<Score_> parentRun = storageService.getMetadata(id);
-        metadata.setOriginId(parentRun.getOriginId());
-        metadata.datasetCreated();
-        storageService.storeProblem(metadata.getId(), request.modelInput(), metadata, initialConfiguration,
-                request.configuration());
-        datasetCreatedEventEmitter.send(new DatasetCreatedEvent(metadata));
-        datasetValidateComputeCommandEmitter
-                .send(new DatasetValidateComputeCommand(metadata.getId(), operation == OperationOnPost.SOLVE));
-        return metadata;
+        return switch (operation) {
+            case OperationOnPost.NONE -> solverWorkerFacade.createDataset(id, select, runName, tags, configuration);
+            case OperationOnPost.SOLVE -> solverWorkerFacade.createAndSolveDataset(id, select, runName, tags, configuration);
+        };
     }
 
     @APIResponses(value = {
@@ -346,50 +279,15 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
                     description = "Operation to execute on the POST request.") @DefaultValue(OperationOnPost.DEFAULT_OPERATION) @QueryParam("operation") OperationOnPost operation,
             @Validated(nullable = true,
                     operationId = OperationId.FROM_PATCH) ModelInputPatchRequest<ModelConfigurationOverrides_> patchRequest) {
-
-        ModelInput_ input =
-                select == DatasetSelector.UNSOLVED ? storageService.getModelInput(id) : storageService.getSolvedModelInput(id);
-        if (input == null) {
-            throw new ItemNotFoundException(ErrorCodes.STORAGE_NO_JOB_FOUND, id);
-        }
         try {
-            Configuration<ModelConfigurationOverrides_> configuration =
-                    patchRequest.config() != null ? patchRequest.config() : storageService.getConfiguration(id);
-            Configuration<ModelConfigurationOverrides_> initialConfiguration = storageService.getUnprocessedConfiguration(id);
-            if (configuration == null) {
-                configuration = Configuration.empty();
-                initialConfiguration = Configuration.empty();
-            }
-            JsonNode inputTree = mapper.valueToTree(input);
-            ArrayNode patchTree = mapper.valueToTree(patchRequest.patch());
-
-            JsonNode patchedInput = JsonPatch.apply(patchTree, inputTree);
-
-            ModelInput_ patchedModelInput = (ModelInput_) mapper.treeToValue(patchedInput, input.getClass());
-
-            ModelRequest<ModelInput_, ModelConfigurationOverrides_> request =
-                    new ModelRequest<>(configuration, patchedModelInput);
-            Metadata<Score_> metadata = new Metadata<>(name);
-            // set parent id to the id this data set is created from
-            metadata.setParentId(id);
-            // set origin id based on the origin id of the parent data set
-            Metadata<Score_> parentRun = storageService.getMetadata(id);
-            metadata.setOriginId(parentRun.getOriginId());
-            metadata.datasetCreated();
-            storageService.storeProblem(metadata.getId(), request.modelInput(), metadata, initialConfiguration,
-                    request.configuration());
-            datasetCreatedEventEmitter.send(new DatasetCreatedEvent(metadata));
-            datasetValidateComputeCommandEmitter
-                    .send(new DatasetValidateComputeCommand(metadata.getId(), operation == OperationOnPost.SOLVE));
-            return metadata;
-
-        } catch (IllegalStateException e) {
+            return switch (operation) {
+                case OperationOnPost.NONE -> solverWorkerFacade.patchDataset(id, select, name, patchRequest);
+                case OperationOnPost.SOLVE -> solverWorkerFacade.patchAndSolveDataset(id, select, name, patchRequest);
+            };
+        } catch (IllegalArgumentException e) {
             throw new BadRequestException(Response.status(Response.Status.BAD_REQUEST)
                     .entity(new ValidationErrorInfo(List.of(e.getMessage()))).build());
-        } catch (Exception e) {
-            throw new TimefoldRuntimeException(ErrorCodes.UNKNOWN, UUID.randomUUID().toString(), e);
         }
-
     }
 
     @APIResponses(value = {
@@ -410,8 +308,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @Deprecated
     public List<Metadata<Score_>> getSchedules(@QueryParam("page") @DefaultValue("0") @PositiveOrZero int pageNumber,
             @QueryParam("size") @DefaultValue("100") @PositiveOrZero @Max(1000) int pageSize) {
-        // TODO: temporarily use a meta data in the modelOutput
-        return storageService.listRuns(pageNumber, pageSize);
+        return solverWorkerFacade.listRuns(pageNumber, pageSize);
     }
 
     @APIResponses(value = {
@@ -429,7 +326,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @Produces(MediaType.APPLICATION_JSON)
     public ModelResponse<Score_, ModelOutput_, InputMetrics_, OutputMetrics_> getSchedule(
             @Parameter(description = "Unique identifier of the schedule", required = true) @PathParam("id") String id) {
-        return storageService.getModelResponse(id);
+        return solverWorkerFacade.getModelResponse(id);
     }
 
     @APIResponses(value = {
@@ -447,7 +344,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @Produces(MediaType.APPLICATION_JSON)
     public ModelRequest<ModelInput_, ModelConfigurationOverrides_> getModelRequest(
             @Parameter(description = "Unique identifier of the schedule", required = true) @PathParam("id") String id) {
-        return storageService.getModelRequest(id);
+        return solverWorkerFacade.getModelRequest(id);
     }
 
     @APIResponses(value = {
@@ -465,7 +362,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @Produces(MediaType.APPLICATION_JSON)
     public ModelInput_ getScheduleInput(
             @Parameter(description = "Unique identifier of the schedule", required = true) @PathParam("id") String id) {
-        return storageService.getModelInput(id);
+        return (ModelInput_) solverWorkerFacade.getModelInput(id);
     }
 
     @APIResponses(value = {
@@ -506,7 +403,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @Produces(MediaType.APPLICATION_JSON)
     public Metadata<Score_> getMetadata(
             @Parameter(description = "Unique identifier of the schedule", required = true) @PathParam("id") String id) {
-        return storageService.getMetadata(id);
+        return solverWorkerFacade.getMetadata(id);
     }
 
     @APIResponses(value = {
@@ -525,7 +422,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @Produces(MediaType.APPLICATION_JSON)
     public Configuration<ModelConfigurationOverrides_> getScheduleConfiguration(
             @Parameter(description = "Unique identifier of the schedule", required = true) @PathParam("id") String id) {
-        return storageService.getConfiguration(id);
+        return solverWorkerFacade.getConfiguration(id);
     }
 
     @APIResponses(value = {
@@ -542,8 +439,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @Produces(MediaType.APPLICATION_JSON)
     public ModelResponse<Score_, ModelOutput_, InputMetrics_, OutputMetrics_> terminateSchedule(
             @Parameter(description = "Unique identifier of the schedule", required = true) @PathParam("id") String id) {
-        solveTerminateCommandEmitter.sendAndAwait(new SolveTerminateCommand(id));
-        return storageService.getModelResponse(id);
+        return solverWorkerFacade.terminate(id);
     }
 
     @APIResponses(value = {
@@ -562,27 +458,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @Produces(MediaType.APPLICATION_JSON)
     public LogInfo getScheduleLogs(
             @Parameter(description = "Unique identifier of the schedule", required = true) @PathParam("id") String id) {
-
-        LogInfo podLogInfo = null;
-        LogInfo logs = storageService.getLogs(id);
-        java.nio.file.Path solverLogPath = Paths.get(LoggingConstants.SOLVER_LOG_PATH);
-        if (Files.exists(solverLogPath)) {
-            try {
-                podLogInfo = new LogInfo(
-                        Files.readAllLines(solverLogPath).stream().collect(Collectors.joining(System.lineSeparator())));
-            } catch (IOException e) {
-                LOGGER.warn("Unable to read solver log file at {}: {}", solverLogPath, e.getMessage());
-            }
-        }
-
-        if (podLogInfo != null && logs != null) {
-            podLogInfo.appendPreviousLog(logs.getDetails());
-            return podLogInfo;
-        } else if (podLogInfo != null) {
-            return podLogInfo;
-        } else {
-            return logs;
-        }
+        return solverWorkerFacade.getLogs(id);
     }
 
     @APIResponses(value = {
@@ -608,7 +484,7 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
             @PathParam("id") String id,
             @QueryParam("status") List<SolvingStatus> statusFilter) {
 
-        Metadata<Score_> metadata = storageService.getMetadata(id);
+        Metadata<Score_> metadata = solverWorkerFacade.getMetadata(id);
         if (metadata == null) {
             throw new ItemNotFoundException(ErrorCodes.NOT_FOUND, "Dataset " + id + " was not found");
         }
@@ -656,13 +532,13 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
     @Produces(MediaType.APPLICATION_JSON)
     public ValidationResult<ValidationIssue_> getValidationResult(
             @Parameter(description = "Unique identifier of the schedule", required = true) @PathParam("id") String id) {
-        ModelInput_ modelInput = storageService.getModelInput(id);
+        ModelInput_ modelInput = (ModelInput_) solverWorkerFacade.getModelInput(id);
         if (modelInput == null) {
             throw new ItemNotFoundException(ErrorCodes.STORAGE_NO_JOB_FOUND, id);
         }
-        var modelConfig = Configuration.getSafeModelConfig(storageService.getConfiguration(id));
+        var modelConfig = Configuration.getSafeModelConfig(solverWorkerFacade.getConfiguration(id));
         ValidationBuilder validationBuilder = new ValidationBuilder();
-        modelValidator.validate(validationBuilder, modelInput, modelConfig);
+        modelValidator.validate(validationBuilder, modelInput, (ModelConfig<ModelConfigurationOverrides_>) modelConfig);
         return validationBuilder.build();
     }
 
@@ -705,9 +581,5 @@ public abstract class AbstractModelAPIResource<ModelInput_ extends ModelInput, M
             }
         }
         return Response.status(Response.Status.NOT_FOUND).build();
-    }
-
-    public AbstractStorageService storageService() {
-        return storageService;
     }
 }

--- a/service/test-model/src/test/java/ai/timefold/solver/model/testmodel/EmployeeScheduleResourceTest.java
+++ b/service/test-model/src/test/java/ai/timefold/solver/model/testmodel/EmployeeScheduleResourceTest.java
@@ -33,6 +33,7 @@ import ai.timefold.solver.service.definition.api.SolvingStatus;
 import ai.timefold.solver.service.definition.api.domain.Metadata;
 import ai.timefold.solver.service.definition.api.domain.ModelRequest;
 import ai.timefold.solver.service.definition.api.domain.ModelResponse;
+import ai.timefold.solver.service.definition.api.rest.OperationOnPost;
 import ai.timefold.solver.service.definition.api.validation.IssueCode;
 import ai.timefold.solver.service.definition.api.validation.IssueSeverity;
 import ai.timefold.solver.service.definition.api.validation.IssueType;
@@ -44,7 +45,6 @@ import ai.timefold.solver.service.definition.internal.events.FinalBestSolutionEv
 import ai.timefold.solver.service.definition.internal.events.InitSolutionEvent;
 import ai.timefold.solver.service.definition.internal.events.SolverChannels;
 import ai.timefold.solver.service.quarkus.deployment.defaults.EmptyModelConfigOverrides;
-import ai.timefold.solver.service.definition.api.rest.OperationOnPost;
 import ai.timefold.solver.service.testmodel.domain.Employee;
 import ai.timefold.solver.service.testmodel.domain.EmployeeSchedule;
 import ai.timefold.solver.service.testmodel.domain.Shift;

--- a/service/worker/pom.xml
+++ b/service/worker/pom.xml
@@ -21,11 +21,11 @@
     </dependency>
     <dependency>
       <groupId>ai.timefold.solver</groupId>
-      <artifactId>timefold-solver-quarkus</artifactId>
+      <artifactId>timefold-solver-quarkus-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>ai.timefold.solver</groupId>
-      <artifactId>timefold-solver-quarkus-jackson</artifactId>
+      <artifactId>timefold-solver-service-json</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/DefaultSolverWorkerFacade.java
+++ b/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/DefaultSolverWorkerFacade.java
@@ -1,0 +1,306 @@
+package ai.timefold.solver.service.worker.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import ai.timefold.solver.service.definition.api.ModelConfigOverrides;
+import ai.timefold.solver.service.definition.api.ModelInput;
+import ai.timefold.solver.service.definition.api.ModelOutput;
+import ai.timefold.solver.service.definition.api.domain.Configuration;
+import ai.timefold.solver.service.definition.api.domain.Metadata;
+import ai.timefold.solver.service.definition.api.domain.ModelInputPatchRequest;
+import ai.timefold.solver.service.definition.api.domain.ModelRequest;
+import ai.timefold.solver.service.definition.api.domain.ModelResponse;
+import ai.timefold.solver.service.definition.api.log.LogInfo;
+import ai.timefold.solver.service.definition.api.metrics.ModelInputMetrics;
+import ai.timefold.solver.service.definition.api.metrics.ModelOutputMetrics;
+import ai.timefold.solver.service.definition.api.rest.DatasetSelector;
+import ai.timefold.solver.service.definition.impl.log.LoggingConstants;
+import ai.timefold.solver.service.definition.impl.solver.SolverWorkerFacade;
+import ai.timefold.solver.service.definition.internal.error.ErrorCodes;
+import ai.timefold.solver.service.definition.internal.error.ItemNotFoundException;
+import ai.timefold.solver.service.definition.internal.error.TimefoldRuntimeException;
+import ai.timefold.solver.service.definition.internal.events.DatasetCreatedEvent;
+import ai.timefold.solver.service.definition.internal.events.DatasetValidateComputeCommand;
+import ai.timefold.solver.service.definition.internal.events.SolveStartCommand;
+import ai.timefold.solver.service.definition.internal.events.SolveTerminateCommand;
+import ai.timefold.solver.service.definition.internal.events.SolverChannels;
+import ai.timefold.solver.service.definition.internal.storage.AbstractStorageService;
+import ai.timefold.solver.service.json.internal.patch.JsonPatch;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+
+/**
+ * Single implementation of {@link SolverWorkerFacade}, orchestrating {@link AbstractStorageService} reads/writes
+ * together with the dataset lifecycle commands/events the solver worker reacts to.
+ */
+@SuppressWarnings({ "unchecked", "rawtypes" })
+@ApplicationScoped
+public class DefaultSolverWorkerFacade implements SolverWorkerFacade {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSolverWorkerFacade.class);
+
+    private final AbstractStorageService storageService;
+
+    private final Emitter<DatasetCreatedEvent> datasetCreatedEventEmitter;
+
+    private final Emitter<DatasetValidateComputeCommand> datasetValidateComputeCommandEmitter;
+
+    private final Emitter<SolveStartCommand> solveStartCommandEmitter;
+
+    private final MutinyEmitter<SolveTerminateCommand> solveTerminateCommandEmitter;
+
+    private final ObjectMapper mapper;
+
+    @Inject
+    public DefaultSolverWorkerFacade(
+            @SuppressWarnings("CdiInjectionPointsInspection") AbstractStorageService<?, ?, ?, ?, ?, ?, ?> storageService,
+            @Broadcast @Channel(SolverChannels.DATASET_CREATED) Emitter<DatasetCreatedEvent> datasetCreatedEventEmitter,
+            @Broadcast @Channel(SolverChannels.DATASET_VALIDATE_COMPUTE) Emitter<DatasetValidateComputeCommand> datasetValidateComputeCommandEmitter,
+            @Channel(SolverChannels.START) Emitter<SolveStartCommand> solveStartCommandEmitter,
+            @Channel(SolverChannels.TERMINATE) MutinyEmitter<SolveTerminateCommand> solveTerminateCommandEmitter,
+            ObjectMapper mapper) {
+        this.storageService = storageService;
+        this.datasetCreatedEventEmitter = datasetCreatedEventEmitter;
+        this.datasetValidateComputeCommandEmitter = datasetValidateComputeCommandEmitter;
+        this.solveStartCommandEmitter = solveStartCommandEmitter;
+        this.solveTerminateCommandEmitter = solveTerminateCommandEmitter;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public <Score_> Metadata<Score_> solveDataset(String id) {
+        Metadata metadata = storageService.getMetadata(id);
+        if (metadata == null) {
+            throw new ItemNotFoundException(ErrorCodes.STORAGE_NO_JOB_FOUND, "Dataset with id " + id + " was not found");
+        }
+        solveStartCommandEmitter.send(new SolveStartCommand(id));
+        return metadata;
+    }
+
+    @Override
+    public <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> createDataset(String id,
+            DatasetSelector select, String runName, Set<String> tags,
+            Configuration<ModelConfigurationOverrides_> configuration) {
+        var metadata = createDatasetInternal(id, select, runName, tags, configuration);
+        datasetValidateComputeCommandEmitter
+                .send(new DatasetValidateComputeCommand(metadata.getId(), false));
+        return metadata;
+
+    }
+
+    @Override
+    public <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> createAndSolveDataset(String id,
+            DatasetSelector select, String runName, Set<String> tags,
+            Configuration<ModelConfigurationOverrides_> configuration) {
+        var metadata = createDatasetInternal(id, select, runName, tags, configuration);
+        datasetValidateComputeCommandEmitter
+                .send(new DatasetValidateComputeCommand(metadata.getId(), true));
+        return metadata;
+    }
+
+    @Override
+    public <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> createDataset(String runName,
+            Set<String> tags, ModelInput modelInput, Configuration<ModelConfigurationOverrides_> configuration) {
+        var metadata = createDatasetInternal(runName, tags, modelInput, configuration);
+        datasetValidateComputeCommandEmitter.send(new DatasetValidateComputeCommand(metadata.getId(), false));
+        return metadata;
+    }
+
+    @Override
+    public <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> createAndSolveDataset(
+            String runName, Set<String> tags, ModelInput modelInput,
+            Configuration<ModelConfigurationOverrides_> configuration) {
+        var metadata = createDatasetInternal(runName, tags, modelInput, configuration);
+        datasetValidateComputeCommandEmitter.send(new DatasetValidateComputeCommand(metadata.getId(), true));
+        return metadata;
+    }
+
+    @Override
+    public <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> patchDataset(String id,
+            DatasetSelector select, String runName,
+            ModelInputPatchRequest<ModelConfigurationOverrides_> modelInputPatchRequest) {
+        var metadata = createPatchedDataset(id, select, runName, modelInputPatchRequest);
+        datasetValidateComputeCommandEmitter.send(new DatasetValidateComputeCommand(metadata.getId(), false));
+        return metadata;
+    }
+
+    @Override
+    public <Score_, ModelConfigurationOverrides_ extends ModelConfigOverrides> Metadata<Score_> patchAndSolveDataset(String id,
+            DatasetSelector select, String runName,
+            ModelInputPatchRequest<ModelConfigurationOverrides_> modelInputPatchRequest) {
+        var metadata = createPatchedDataset(id, select, runName, modelInputPatchRequest);
+        datasetValidateComputeCommandEmitter.send(new DatasetValidateComputeCommand(metadata.getId(), true));
+        return metadata;
+    }
+
+    @Override
+    public <Score_, ModelOutput_ extends ModelOutput, InputMetrics_ extends ModelInputMetrics, OutputMetrics_ extends ModelOutputMetrics>
+            ModelResponse<Score_, ModelOutput_, InputMetrics_, OutputMetrics_> terminate(String id) {
+        solveTerminateCommandEmitter.sendAndAwait(new SolveTerminateCommand(id));
+        return storageService.getModelResponse(id);
+    }
+
+    @Override
+    public <Score_> Metadata<Score_> getMetadata(String id) {
+        return storageService.getMetadata(id);
+    }
+
+    @Override
+    public Configuration getConfiguration(String id) {
+        return storageService.getConfiguration(id);
+    }
+
+    @Override
+    public Configuration getUnprocessedConfiguration(String id) {
+        return storageService.getUnprocessedConfiguration(id);
+    }
+
+    @Override
+    public ModelInput getModelInput(String id) {
+        return storageService.getModelInput(id);
+    }
+
+    @Override
+    public ModelInput getSolvedModelInput(String id) {
+        return storageService.getSolvedModelInput(id);
+    }
+
+    @Override
+    public <Score_> List<Metadata<Score_>> listRuns(int pageNumber, int pageSize) {
+        return storageService.listRuns(pageNumber, pageSize);
+    }
+
+    @Override
+    public <Score_, ModelOutput_ extends ModelOutput, InputMetrics_ extends ModelInputMetrics, OutputMetrics_ extends ModelOutputMetrics>
+            ModelResponse<Score_, ModelOutput_, InputMetrics_, OutputMetrics_> getModelResponse(String id) {
+        return storageService.getModelResponse(id);
+    }
+
+    @Override
+    public <ModelInput_ extends ModelInput, ModelConfigurationOverrides_ extends ModelConfigOverrides>
+            ModelRequest<ModelInput_, ModelConfigurationOverrides_> getModelRequest(String id) {
+        return storageService.getModelRequest(id);
+    }
+
+    @Override
+    public LogInfo getLogs(String id) {
+        LogInfo podLogInfo = null;
+        LogInfo logs = storageService.getLogs(id);
+        java.nio.file.Path solverLogPath = Paths.get(LoggingConstants.SOLVER_LOG_PATH);
+        if (Files.exists(solverLogPath)) {
+            try {
+                podLogInfo = new LogInfo(
+                        Files.readAllLines(solverLogPath).stream().collect(Collectors.joining(System.lineSeparator())));
+            } catch (IOException e) {
+                LOGGER.warn("Unable to read solver log file at {}: {}", solverLogPath, e.getMessage());
+            }
+        }
+
+        if (podLogInfo != null && logs != null) {
+            podLogInfo.appendPreviousLog(logs.getDetails());
+            return podLogInfo;
+        } else if (podLogInfo != null) {
+            return podLogInfo;
+        } else {
+            return logs;
+        }
+    }
+
+    private Metadata createDatasetInternal(String runName, Set<String> tags, ModelInput modelInput,
+            Configuration configuration) {
+        var metadata = new Metadata<>(runName);
+        metadata.setTags(tags);
+        metadata.datasetCreated();
+        storageService.storeProblem(metadata.getId(), modelInput, metadata, configuration, configuration);
+        datasetCreatedEventEmitter.send(new DatasetCreatedEvent(metadata));
+        return metadata;
+    }
+
+    private Metadata createDatasetInternal(String id, DatasetSelector select, String runName, Set<String> tags,
+            Configuration configuration) {
+        var modelInput =
+                select == DatasetSelector.UNSOLVED ? getModelInput(id) : getSolvedModelInput(id);
+        if (modelInput == null) {
+            throw new ItemNotFoundException(ErrorCodes.STORAGE_NO_JOB_FOUND, id);
+        }
+
+        Configuration initialConfiguration = null;
+        if (configuration != null && configuration.run() != null) {
+            initialConfiguration = configuration;
+        } else if (configuration == null) {
+            configuration = getConfiguration(id);
+            initialConfiguration = getUnprocessedConfiguration(id);
+        }
+
+        var metadata = new Metadata<>(runName);
+        metadata.setTags(tags);
+        metadata.datasetCreated();
+        // set parent id to the id this data set is created from
+        metadata.setParentId(id);
+        // set origin id based on the origin id of the parent data set
+        Metadata parentRun = getMetadata(id);
+        metadata.setOriginId(parentRun.getOriginId());
+
+        storageService.storeProblem(metadata.getId(), modelInput, metadata, initialConfiguration, configuration);
+        datasetCreatedEventEmitter.send(new DatasetCreatedEvent(metadata));
+        return metadata;
+    }
+
+    private Metadata createPatchedDataset(String id, DatasetSelector select, String runName,
+            ModelInputPatchRequest patchRequest) {
+        var input =
+                select == DatasetSelector.UNSOLVED ? getModelInput(id) : getSolvedModelInput(id);
+        if (input == null) {
+            throw new ItemNotFoundException(ErrorCodes.STORAGE_NO_JOB_FOUND, id);
+        }
+        try {
+            Configuration configuration =
+                    patchRequest.config() != null ? patchRequest.config() : getConfiguration(id);
+            Configuration initialConfiguration = getUnprocessedConfiguration(id);
+            if (configuration == null) {
+                configuration = Configuration.empty();
+                initialConfiguration = Configuration.empty();
+            }
+            JsonNode inputTree = mapper.valueToTree(input);
+            ArrayNode patchTree = mapper.valueToTree(patchRequest.patch());
+
+            JsonNode patchedInput = JsonPatch.apply(patchTree, inputTree);
+
+            ModelInput patchedModelInput = mapper.treeToValue(patchedInput, input.getClass());
+
+            Metadata metadata = new Metadata<>(runName);
+            // set parent id to the id this data set is created from
+            metadata.setParentId(id);
+            // set origin id based on the origin id of the parent data set
+            Metadata parentRun = getMetadata(id);
+            metadata.setOriginId(parentRun.getOriginId());
+            metadata.datasetCreated();
+            storageService.storeProblem(metadata.getId(), patchedModelInput, metadata, initialConfiguration, configuration);
+            datasetCreatedEventEmitter.send(new DatasetCreatedEvent(metadata));
+            return metadata;
+        } catch (IllegalArgumentException e) { // thrown by the JsonPatch
+            throw e;
+        } catch (Exception e) {
+            throw new TimefoldRuntimeException(ErrorCodes.UNKNOWN, UUID.randomUUID().toString(), e);
+        }
+    }
+}

--- a/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/DefaultSolverWorkerFacade.java
+++ b/service/worker/src/main/java/ai/timefold/solver/service/worker/impl/DefaultSolverWorkerFacade.java
@@ -243,12 +243,18 @@ public class DefaultSolverWorkerFacade implements SolverWorkerFacade {
             throw new ItemNotFoundException(ErrorCodes.STORAGE_NO_JOB_FOUND, id);
         }
 
-        Configuration initialConfiguration = null;
-        if (configuration != null && configuration.run() != null) {
-            initialConfiguration = configuration;
-        } else if (configuration == null) {
+        Configuration initialConfiguration = configuration;
+        if (configuration == null) {
             configuration = getConfiguration(id);
             initialConfiguration = getUnprocessedConfiguration(id);
+        }
+
+        if (configuration == null) {
+            configuration = Configuration.empty();
+        }
+
+        if (initialConfiguration == null) {
+            initialConfiguration = Configuration.empty();
         }
 
         var metadata = new Metadata<>(runName);

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/DefaultSolverWorkerFacadeTest.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/DefaultSolverWorkerFacadeTest.java
@@ -1,0 +1,251 @@
+package ai.timefold.solver.service.worker.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import ai.timefold.solver.service.definition.api.SolvingStatus;
+import ai.timefold.solver.service.definition.api.domain.Configuration;
+import ai.timefold.solver.service.definition.api.domain.Metadata;
+import ai.timefold.solver.service.definition.api.domain.ModelInputPatchRequest;
+import ai.timefold.solver.service.definition.api.rest.DatasetSelector;
+import ai.timefold.solver.service.definition.internal.error.ItemNotFoundException;
+import ai.timefold.solver.service.definition.internal.events.DatasetCreatedEvent;
+import ai.timefold.solver.service.definition.internal.events.DatasetValidateComputeCommand;
+import ai.timefold.solver.service.definition.internal.events.SolveStartCommand;
+import ai.timefold.solver.service.definition.internal.events.SolveTerminateCommand;
+import ai.timefold.solver.service.worker.impl.testdata.TestdataModelInput;
+import ai.timefold.solver.service.worker.impl.testdata.TestdataStorage;
+import ai.timefold.solver.service.worker.impl.testdata.TestdataStorageService;
+import ai.timefold.solver.service.worker.impl.testutil.RecordingEmitter;
+import ai.timefold.solver.service.worker.impl.testutil.RecordingMutinyEmitter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class DefaultSolverWorkerFacadeTest {
+
+    private RecordingEmitter<DatasetCreatedEvent> datasetCreatedEmitter;
+    private RecordingEmitter<DatasetValidateComputeCommand> validateComputeEmitter;
+    private RecordingEmitter<SolveStartCommand> solveStartEmitter;
+    private RecordingMutinyEmitter<SolveTerminateCommand> terminateEmitter;
+    private TestdataStorageService storageService;
+
+    private DefaultSolverWorkerFacade facade;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper mapper = new ObjectMapper();
+        storageService = new TestdataStorageService(new TestdataStorage(mapper));
+
+        datasetCreatedEmitter = new RecordingEmitter<>();
+        validateComputeEmitter = new RecordingEmitter<>();
+        solveStartEmitter = new RecordingEmitter<>();
+        terminateEmitter = new RecordingMutinyEmitter<>();
+
+        facade = new DefaultSolverWorkerFacade(
+                storageService,
+                datasetCreatedEmitter,
+                validateComputeEmitter,
+                solveStartEmitter,
+                terminateEmitter,
+                mapper);
+    }
+
+    @Test
+    void createDataset_persistsAndEmitsValidateComputeWithoutSolve() {
+        TestdataModelInput input = new TestdataModelInput("hello");
+        String runName = uniqueRunName();
+
+        Metadata<?> metadata = facade.createDataset(runName, Set.of("test-tag"), input, Configuration.empty());
+
+        assertThat(metadata.getId()).isNotBlank();
+        // dataset-created event emitted
+        assertThat(datasetCreatedEmitter.size()).isEqualTo(1);
+        assertThat(datasetCreatedEmitter.getLastMessage().getId()).isEqualTo(metadata.getId());
+        // validate-compute with solve=false
+        assertThat(validateComputeEmitter.size()).isEqualTo(1);
+        DatasetValidateComputeCommand cmd = validateComputeEmitter.getLastMessage();
+        assertThat(cmd.getId()).isEqualTo(metadata.getId());
+        assertThat(cmd.solve()).isFalse();
+
+        assertThat(metadata.getId()).isNotBlank();
+        assertThat(metadata.getName()).isEqualTo(runName);
+        assertThat(metadata.getSolverStatus()).isEqualTo(SolvingStatus.DATASET_CREATED);
+        assertThat(metadata.getSubmitDateTime()).isNotNull();
+        assertThat(metadata.getTags()).containsExactly("test-tag");
+        assertThat(storageService.getModelInput(metadata.getId())).isEqualTo(input);
+        assertThat(storageService.getMetadata(metadata.getId())).isNotNull()
+                .extracting(Metadata::getId, Metadata::getName)
+                .containsExactly(metadata.getId(), runName);
+    }
+
+    @Test
+    void createAndSolveDataset_emitsValidateComputeWithSolveTrue() {
+        String runName = uniqueRunName();
+        Metadata<?> metadata =
+                facade.createAndSolveDataset(runName, Set.of("test-tag"), new TestdataModelInput("x"),
+                        Configuration.empty());
+
+        assertThat(validateComputeEmitter.size()).isEqualTo(1);
+        DatasetValidateComputeCommand cmd = validateComputeEmitter.getLastMessage();
+        assertThat(cmd.solve()).isTrue();
+        assertThat(cmd.getId()).isEqualTo(metadata.getId());
+
+        assertThat(metadata.getTags()).containsExactly("test-tag");
+        assertThat(storageService.getModelInput(metadata.getId()))
+                .isEqualTo(new TestdataModelInput("x"));
+        assertThat(storageService.getMetadata(metadata.getId()).getName()).isEqualTo(runName);
+    }
+
+    @Test
+    void solveDataset_sendsStartCommand() {
+        Metadata<?> parent = facade.createDataset(
+                uniqueRunName(), Set.of("test-tag"), new TestdataModelInput("x"), Configuration.empty());
+
+        facade.solveDataset(parent.getId());
+
+        assertThat(solveStartEmitter.size()).isEqualTo(1);
+        assertThat(solveStartEmitter.getLastMessage().getId()).isEqualTo(parent.getId());
+
+        var metadata = facade.getMetadata(parent.getId());
+        assertThat(metadata.getId()).isEqualTo(parent.getId());
+        assertThat(metadata.getName()).isEqualTo(parent.getName());
+        assertThat(metadata.getTags()).containsExactly("test-tag");
+    }
+
+    @Test
+    void solveDataset_unknownId_throwsItemNotFound() {
+        assertThatThrownBy(() -> facade.solveDataset("does-not-exist"))
+                .isInstanceOf(ItemNotFoundException.class);
+        assertThat(solveStartEmitter.size()).isEqualTo(0);
+    }
+
+    @Test
+    void createDataset_fromExistingDataset_missingParent_throwsItemNotFound() {
+        assertThatThrownBy(() -> facade.createDataset("missing", DatasetSelector.UNSOLVED, uniqueRunName(), Set.of(),
+                Configuration.empty()))
+                .isInstanceOf(ItemNotFoundException.class);
+        assertThat(validateComputeEmitter.size()).isEqualTo(0);
+    }
+
+    @Test
+    void createDataset_fromExistingDataset_emitsValidateComputeWithoutSolve() {
+        Metadata<?> parent = facade.createDataset(
+                uniqueRunName(), Set.of(), new TestdataModelInput("orig"), Configuration.empty());
+        datasetCreatedEmitter.clear();
+        validateComputeEmitter.clear();
+        String childRunName = uniqueRunName();
+
+        Metadata<?> child = facade.createDataset(parent.getId(), DatasetSelector.UNSOLVED, childRunName, Set.of("t2"),
+                Configuration.empty());
+
+        // emitter assertions
+        assertThat(datasetCreatedEmitter.size()).isEqualTo(1);
+        assertThat(datasetCreatedEmitter.getLastMessage().getId()).isEqualTo(child.getId());
+        assertThat(validateComputeEmitter.size()).isEqualTo(1);
+        assertThat(validateComputeEmitter.getLastMessage().solve()).isFalse();
+
+        // metadata assertions — status was set exactly once, not reset to null nor thrown on double-set
+        assertThat(child.getSolverStatus()).isEqualTo(SolvingStatus.DATASET_CREATED);
+        assertThat(child.getName()).isEqualTo(childRunName);
+        assertThat(child.getTags()).containsExactly("t2");
+        assertThat(child.getParentId()).isEqualTo(parent.getId());
+        assertThat(child.getOriginId()).isEqualTo(parent.getOriginId());
+
+        // storage assertions — child dataset is stored independently with parent linkage
+        assertThat(storageService.getMetadata(child.getId())).isNotNull()
+                .extracting(Metadata::getParentId, Metadata::getOriginId)
+                .containsExactly(parent.getId(), parent.getOriginId());
+        assertThat(storageService.getModelInput(child.getId()))
+                .isEqualTo(new TestdataModelInput("orig"));
+        // parent input must not be affected
+        assertThat(storageService.getModelInput(parent.getId()))
+                .isEqualTo(new TestdataModelInput("orig"));
+    }
+
+    @Test
+    void createAndSolveDataset_fromExistingDataset_emitsValidateComputeWithSolveTrue() {
+        Metadata<?> parent = facade.createDataset(
+                uniqueRunName(), Set.of(), new TestdataModelInput("orig"), Configuration.empty());
+        validateComputeEmitter.clear();
+
+        Metadata<?> child = facade.createAndSolveDataset(parent.getId(), DatasetSelector.UNSOLVED, uniqueRunName(),
+                Set.of("test-child-tag"), Configuration.empty());
+
+        assertThat(validateComputeEmitter.size()).isEqualTo(1);
+        assertThat(validateComputeEmitter.getLastMessage().solve()).isTrue();
+        assertThat(child.getSolverStatus()).isEqualTo(SolvingStatus.DATASET_CREATED);
+        assertThat(child.getTags()).containsExactly("test-child-tag");
+        assertThat(child.getParentId()).isEqualTo(parent.getId());
+        assertThat(child.getOriginId()).isEqualTo(parent.getOriginId());
+    }
+
+    @Test
+    void patchDataset_missingParent_throwsItemNotFound() {
+        ModelInputPatchRequest<?> patch = new ModelInputPatchRequest<>(null, List.of());
+
+        assertThatThrownBy(() -> facade.patchDataset("missing", DatasetSelector.UNSOLVED, uniqueRunName(), patch))
+                .isInstanceOf(ItemNotFoundException.class);
+        assertThat(validateComputeEmitter.size()).isEqualTo(0);
+    }
+
+    @Test
+    void patchDataset_emitsValidateComputeWithoutSolve() {
+        Metadata<?> parent = facade.createDataset(
+                uniqueRunName(), Set.of(), new TestdataModelInput("orig"), Configuration.empty());
+        validateComputeEmitter.clear();
+        String childRunName = uniqueRunName();
+
+        ModelInputPatchRequest<?> patch = new ModelInputPatchRequest<>(null, List.of());
+        Metadata<?> child = facade.patchDataset(parent.getId(), DatasetSelector.UNSOLVED, childRunName, patch);
+
+        // emitter assertions
+        assertThat(validateComputeEmitter.size()).isEqualTo(1);
+        assertThat(validateComputeEmitter.getLastMessage().solve()).isFalse();
+
+        // storage assertions — child dataset is stored independently with parent linkage
+        assertThat(child.getParentId()).isEqualTo(parent.getId());
+        assertThat(child.getOriginId()).isEqualTo(parent.getOriginId());
+        assertThat(storageService.getMetadata(child.getId())).isNotNull()
+                .extracting(Metadata::getParentId, Metadata::getOriginId)
+                .containsExactly(parent.getId(), parent.getOriginId());
+        // the empty patch leaves the input unchanged
+        assertThat(storageService.getModelInput(child.getId()))
+                .isEqualTo(new TestdataModelInput("orig"));
+        // parent input must not be affected
+        assertThat(storageService.getModelInput(parent.getId()))
+                .isEqualTo(new TestdataModelInput("orig"));
+    }
+
+    @Test
+    void patchAndSolveDataset_emitsValidateComputeWithSolveTrue() {
+        Metadata<?> parent = facade.createDataset(
+                uniqueRunName(), Set.of(), new TestdataModelInput("orig"), Configuration.empty());
+        validateComputeEmitter.clear();
+
+        ModelInputPatchRequest<?> patch = new ModelInputPatchRequest<>(null, List.of());
+        Metadata<?> child = facade.patchAndSolveDataset(
+                parent.getId(), DatasetSelector.UNSOLVED, uniqueRunName(), patch);
+
+        // emitter assertions
+        assertThat(validateComputeEmitter.size()).isEqualTo(1);
+        assertThat(validateComputeEmitter.getLastMessage().solve()).isTrue();
+
+        // storage assertions
+        assertThat(child.getParentId()).isEqualTo(parent.getId());
+        assertThat(child.getOriginId()).isEqualTo(parent.getOriginId());
+        assertThat(storageService.getMetadata(child.getId())).isNotNull();
+        assertThat(storageService.getModelInput(child.getId()))
+                .isEqualTo(new TestdataModelInput("orig"));
+    }
+
+    private static String uniqueRunName() {
+        return "run-" + UUID.randomUUID();
+    }
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/DefaultSolverWorkerFacadeTest.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/DefaultSolverWorkerFacadeTest.java
@@ -40,7 +40,7 @@ class DefaultSolverWorkerFacadeTest {
 
     @BeforeEach
     void setUp() {
-        ObjectMapper mapper = new ObjectMapper();
+        var mapper = new ObjectMapper();
         storageService = new TestdataStorageService(new TestdataStorage(mapper));
 
         datasetCreatedEmitter = new RecordingEmitter<>();
@@ -59,8 +59,8 @@ class DefaultSolverWorkerFacadeTest {
 
     @Test
     void createDataset_persistsAndEmitsValidateComputeWithoutSolve() {
-        TestdataModelInput input = new TestdataModelInput("hello");
-        String runName = uniqueRunName();
+        var input = new TestdataModelInput("hello");
+        var runName = uniqueRunName();
 
         Metadata<?> metadata = facade.createDataset(runName, Set.of("test-tag"), input, Configuration.empty());
 
@@ -70,7 +70,7 @@ class DefaultSolverWorkerFacadeTest {
         assertThat(datasetCreatedEmitter.getLastMessage().getId()).isEqualTo(metadata.getId());
         // validate-compute with solve=false
         assertThat(validateComputeEmitter.size()).isEqualTo(1);
-        DatasetValidateComputeCommand cmd = validateComputeEmitter.getLastMessage();
+        var cmd = validateComputeEmitter.getLastMessage();
         assertThat(cmd.getId()).isEqualTo(metadata.getId());
         assertThat(cmd.solve()).isFalse();
 
@@ -87,13 +87,13 @@ class DefaultSolverWorkerFacadeTest {
 
     @Test
     void createAndSolveDataset_emitsValidateComputeWithSolveTrue() {
-        String runName = uniqueRunName();
-        Metadata<?> metadata =
+        var runName = uniqueRunName();
+        var metadata =
                 facade.createAndSolveDataset(runName, Set.of("test-tag"), new TestdataModelInput("x"),
                         Configuration.empty());
 
         assertThat(validateComputeEmitter.size()).isEqualTo(1);
-        DatasetValidateComputeCommand cmd = validateComputeEmitter.getLastMessage();
+        var cmd = validateComputeEmitter.getLastMessage();
         assertThat(cmd.solve()).isTrue();
         assertThat(cmd.getId()).isEqualTo(metadata.getId());
 
@@ -140,7 +140,7 @@ class DefaultSolverWorkerFacadeTest {
                 uniqueRunName(), Set.of(), new TestdataModelInput("orig"), Configuration.empty());
         datasetCreatedEmitter.clear();
         validateComputeEmitter.clear();
-        String childRunName = uniqueRunName();
+        var childRunName = uniqueRunName();
 
         Metadata<?> child = facade.createDataset(parent.getId(), DatasetSelector.UNSOLVED, childRunName, Set.of("t2"),
                 Configuration.empty());
@@ -197,10 +197,10 @@ class DefaultSolverWorkerFacadeTest {
 
     @Test
     void patchDataset_emitsValidateComputeWithoutSolve() {
-        Metadata<?> parent = facade.createDataset(
+        var parent = facade.createDataset(
                 uniqueRunName(), Set.of(), new TestdataModelInput("orig"), Configuration.empty());
         validateComputeEmitter.clear();
-        String childRunName = uniqueRunName();
+        var childRunName = uniqueRunName();
 
         ModelInputPatchRequest<?> patch = new ModelInputPatchRequest<>(null, List.of());
         Metadata<?> child = facade.patchDataset(parent.getId(), DatasetSelector.UNSOLVED, childRunName, patch);

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelConfigOverrides.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelConfigOverrides.java
@@ -1,0 +1,10 @@
+package ai.timefold.solver.service.worker.impl.testdata;
+
+import ai.timefold.solver.service.definition.api.ModelConfigOverrides;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class TestdataModelConfigOverrides implements ModelConfigOverrides {
+
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelConstraintJustification.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelConstraintJustification.java
@@ -1,0 +1,7 @@
+package ai.timefold.solver.service.worker.impl.testdata;
+
+import ai.timefold.solver.service.definition.api.ModelConstraintJustification;
+
+public class TestdataModelConstraintJustification implements ModelConstraintJustification {
+
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelInput.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelInput.java
@@ -1,0 +1,35 @@
+package ai.timefold.solver.service.worker.impl.testdata;
+
+import java.util.Objects;
+
+import ai.timefold.solver.service.definition.api.ModelInput;
+
+public class TestdataModelInput implements ModelInput {
+
+    private String value;
+
+    public TestdataModelInput() {
+    }
+
+    public TestdataModelInput(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof TestdataModelInput other && Objects.equals(value, other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelInputMetrics.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelInputMetrics.java
@@ -1,0 +1,7 @@
+package ai.timefold.solver.service.worker.impl.testdata;
+
+import ai.timefold.solver.service.definition.api.metrics.ModelInputMetrics;
+
+public class TestdataModelInputMetrics implements ModelInputMetrics {
+
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelOutput.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelOutput.java
@@ -1,0 +1,7 @@
+package ai.timefold.solver.service.worker.impl.testdata;
+
+import ai.timefold.solver.service.definition.api.ModelOutput;
+
+public class TestdataModelOutput implements ModelOutput {
+
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelOutputMetrics.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataModelOutputMetrics.java
@@ -1,0 +1,7 @@
+package ai.timefold.solver.service.worker.impl.testdata;
+
+import ai.timefold.solver.service.definition.api.metrics.ModelOutputMetrics;
+
+public class TestdataModelOutputMetrics implements ModelOutputMetrics {
+
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataStorage.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataStorage.java
@@ -1,0 +1,21 @@
+package ai.timefold.solver.service.worker.impl.testdata;
+
+import ai.timefold.solver.service.definition.impl.storage.inmemory.InMemoryStorage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Real, in-memory-backed {@code Storage} used by tests instead of a mock, so that reads reflect what was
+ * actually written rather than a stubbed expectation.
+ */
+public class TestdataStorage extends InMemoryStorage<TestdataModelOutput> {
+
+    public TestdataStorage(ObjectMapper mapper) {
+        super(mapper);
+    }
+
+    @Override
+    public Class<TestdataModelOutput> clazz() {
+        return TestdataModelOutput.class;
+    }
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataStorageService.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testdata/TestdataStorageService.java
@@ -1,0 +1,40 @@
+package ai.timefold.solver.service.worker.impl.testdata;
+
+import ai.timefold.solver.core.api.score.HardSoftScore;
+import ai.timefold.solver.service.definition.api.domain.Configuration;
+import ai.timefold.solver.service.definition.internal.storage.AbstractStorageService;
+import ai.timefold.solver.service.definition.internal.storage.Storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+/**
+ * Real (non-mocked) {@code AbstractStorageService} implementation for tests, backed by {@link TestdataStorage}.
+ */
+public class TestdataStorageService extends
+        AbstractStorageService<TestdataModelInput, TestdataModelConfigOverrides, TestdataModelInputMetrics, TestdataModelOutputMetrics, TestdataModelOutput, HardSoftScore, TestdataModelConstraintJustification> {
+
+    public TestdataStorageService(Storage<TestdataModelOutput> storage) {
+        super(storage);
+    }
+
+    @Override
+    protected Class<?> getModelInputClass() {
+        return TestdataModelInput.class;
+    }
+
+    @Override
+    protected Class<?> getInputMetricsClass() {
+        return TestdataModelInputMetrics.class;
+    }
+
+    @Override
+    protected Class<?> getOutputMetricsClass() {
+        return TestdataModelOutputMetrics.class;
+    }
+
+    @Override
+    protected TypeReference<Configuration<TestdataModelConfigOverrides>> getConfigurationClass() {
+        return new TypeReference<>() {
+        };
+    }
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testutil/RecordingEmitter.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testutil/RecordingEmitter.java
@@ -1,0 +1,63 @@
+package ai.timefold.solver.service.worker.impl.testutil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+
+/**
+ * Test utility emitter that records payloads sent through {@link #send(Object)}.
+ */
+public final class RecordingEmitter<T> implements Emitter<T> {
+
+    private final List<T> messages = new ArrayList<>();
+
+    @Override
+    public CompletionStage<Void> send(T msg) {
+        messages.add(msg);
+        return java.util.concurrent.CompletableFuture.completedFuture(null);
+    }
+
+    public List<T> getMessages() {
+        return Collections.unmodifiableList(messages);
+    }
+
+    public T getLastMessage() {
+        return messages.isEmpty() ? null : messages.get(messages.size() - 1);
+    }
+
+    public int size() {
+        return messages.size();
+    }
+
+    public void clear() {
+        messages.clear();
+    }
+
+    @Override
+    public <M extends org.eclipse.microprofile.reactive.messaging.Message<? extends T>> void send(M msg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void complete() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void error(Exception e) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasRequests() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testutil/RecordingEmitter.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testutil/RecordingEmitter.java
@@ -3,9 +3,11 @@ package ai.timefold.solver.service.worker.impl.testutil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
 
 /**
  * Test utility emitter that records payloads sent through {@link #send(Object)}.
@@ -17,7 +19,7 @@ public final class RecordingEmitter<T> implements Emitter<T> {
     @Override
     public CompletionStage<Void> send(T msg) {
         messages.add(msg);
-        return java.util.concurrent.CompletableFuture.completedFuture(null);
+        return CompletableFuture.completedFuture(null);
     }
 
     public List<T> getMessages() {
@@ -37,7 +39,7 @@ public final class RecordingEmitter<T> implements Emitter<T> {
     }
 
     @Override
-    public <M extends org.eclipse.microprofile.reactive.messaging.Message<? extends T>> void send(M msg) {
+    public <M extends Message<? extends T>> void send(M msg) {
         throw new UnsupportedOperationException();
     }
 

--- a/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testutil/RecordingMutinyEmitter.java
+++ b/service/worker/src/test/java/ai/timefold/solver/service/worker/impl/testutil/RecordingMutinyEmitter.java
@@ -1,0 +1,92 @@
+package ai.timefold.solver.service.worker.impl.testutil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+
+/**
+ * Test utility mutiny emitter that records payloads sent through {@link #send(Object)}
+ * and {@link #sendAndAwait(Object)}.
+ */
+public final class RecordingMutinyEmitter<T> implements MutinyEmitter<T> {
+
+    private final List<T> messages = new ArrayList<>();
+
+    @Override
+    public Uni<Void> send(T payload) {
+        messages.add(payload);
+        return Uni.createFrom().voidItem();
+    }
+
+    @Override
+    public void sendAndAwait(T payload) {
+        messages.add(payload);
+    }
+
+    @Override
+    public Cancellable sendAndForget(T payload) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <M extends Message<? extends T>> void send(M msg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <M extends Message<? extends T>> Uni<Void> sendMessage(M msg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <M extends Message<? extends T>> void sendMessageAndAwait(M msg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <M extends Message<? extends T>> Cancellable sendMessageAndForget(M msg) {
+        throw new UnsupportedOperationException();
+    }
+
+    public List<T> getMessages() {
+        return Collections.unmodifiableList(messages);
+    }
+
+    public T getLastMessage() {
+        return messages.isEmpty() ? null : messages.get(messages.size() - 1);
+    }
+
+    public int size() {
+        return messages.size();
+    }
+
+    public void clear() {
+        messages.clear();
+    }
+
+    @Override
+    public void complete() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void error(Exception e) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasRequests() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/TimefoldAI/timefold-solver-enterprise/issues/591.

- REST no longer directly uses storage
- the logic coordinating storage and events moved to a separate service, `SolverWorkerFacade`
- `SolverWorkerFacade` is now unit-tested
- one fix along the way: `from-patch` used to catch `IllegalStateException`, but the patching utils throw `IllegalArgumentException`