### PR TITLE
fix: change graalvm version to latest tag with a corresponding release

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: graalvm/setup-graalvm@0def53c0fd8534bc13416c9469f5be45265824fd # v1.6.3
+      - uses: graalvm/setup-graalvm@8c5543b71f44568342e106336639979e94a8f6de # v1.6.1
         with:
           java-version: ${{matrix.java-version}}
           distribution: 'graalvm-community'

--- a/.github/workflows/pull_request_secure.yml
+++ b/.github/workflows/pull_request_secure.yml
@@ -178,7 +178,7 @@ jobs:
           path: ./timefold-solver-enterprise
           fetch-depth: 0 # Otherwise merge will fail on account of not having history.
 
-      - uses: graalvm/setup-graalvm@0def53c0fd8534bc13416c9469f5be45265824fd # v1.6.3
+      - uses: graalvm/setup-graalvm@8c5543b71f44568342e106336639979e94a8f6de # v1.6.1
         with:
           java-version: ${{matrix.java-version}}
           distribution: 'graalvm-community'


### PR DESCRIPTION
This is techically a downgrade. This seems to be the only relevant commit that changed in the past week (GraalVM was bumped from `1.6.2` (which also does not have a release) to `1.6.3` here: https://github.com/TimefoldAI/timefold-solver/pull/2521.