### PR TITLE
test: empty commit

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolver.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolver.java
@@ -53,6 +53,7 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
             BestSolutionRecaller<Solution_> bestSolutionRecaller, BasicPlumbingTermination<Solution_> basicPlumbingTermination,
             UniversalTermination<Solution_> termination, List<Phase<Solution_>> phaseList,
             SolverScope<Solution_> solverScope, String moveThreadCountDescription) {
+        // A random comment to trigger workflow
         super(bestSolutionRecaller, termination, phaseList);
         this.environmentMode = environmentMode;
         this.randomFactory = randomFactory;


### PR DESCRIPTION
Test to see if this fix the downstream; reruning jobs on existing PR's seems to still use the old GraalVM 6.3 version instead of 6.1.