### PR TITLE
fix: return the sdkVersion to ModelBuildInfo

### DIFF
--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
@@ -1,7 +1,13 @@
 package ai.timefold.solver.service.definition.internal.descriptor;
 
+import io.quarkus.runtime.annotations.RecordableConstructor;
+
 public record ModelBuildInfo(String solverVersion, @Deprecated(forRemoval = true) String sdkVersion, String version,
         String buildTime, String branch, String buildCommit) {
+
+    @RecordableConstructor
+    public ModelBuildInfo {
+    }
 
     public ModelBuildInfo(String solverVersion, String version, String buildTime, String branch, String buildCommit) {
         this(solverVersion, solverVersion, version, buildTime, branch, buildCommit);

--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
@@ -16,7 +16,7 @@ import io.quarkus.runtime.annotations.RecordableConstructor;
 public record ModelBuildInfo(String solverVersion, @Deprecated(forRemoval = true) String sdkVersion, String version,
         String buildTime, String branch, String buildCommit) {
 
-    private static final ModelBuildInfo EMPTY = new ModelBuildInfo(null,null, null, null, null);
+    private static final ModelBuildInfo EMPTY = new ModelBuildInfo(null, null, null, null, null);
 
     @RecordableConstructor
     public ModelBuildInfo {

--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
@@ -1,9 +1,13 @@
 package ai.timefold.solver.service.definition.internal.descriptor;
 
-public record ModelBuildInfo(String solverVersion, String version, String buildTime, String branch,
-        String buildCommit) {
+public record ModelBuildInfo(String solverVersion, @Deprecated(forRemoval = true) String sdkVersion, String version,
+        String buildTime, String branch, String buildCommit) {
+
+    public ModelBuildInfo(String solverVersion, String version, String buildTime, String branch, String buildCommit) {
+        this(solverVersion, solverVersion, version, buildTime, branch, buildCommit);
+    }
 
     public static ModelBuildInfo empty() {
-        return new ModelBuildInfo(null, null, null, null, null);
+        return new ModelBuildInfo(null, null, null, null, null, null);
     }
 }

--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
@@ -16,6 +16,8 @@ import io.quarkus.runtime.annotations.RecordableConstructor;
 public record ModelBuildInfo(String solverVersion, @Deprecated(forRemoval = true) String sdkVersion, String version,
         String buildTime, String branch, String buildCommit) {
 
+    private static final ModelBuildInfo EMPTY = new ModelBuildInfo(null,null, null, null, null);
+
     @RecordableConstructor
     public ModelBuildInfo {
     }
@@ -25,6 +27,6 @@ public record ModelBuildInfo(String solverVersion, @Deprecated(forRemoval = true
     }
 
     public static ModelBuildInfo empty() {
-        return new ModelBuildInfo(null, null, null, null, null, null);
+        return EMPTY;
     }
 }

--- a/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
+++ b/service/definition/src/main/java/ai/timefold/solver/service/definition/internal/descriptor/ModelBuildInfo.java
@@ -2,6 +2,17 @@ package ai.timefold.solver.service.definition.internal.descriptor;
 
 import io.quarkus.runtime.annotations.RecordableConstructor;
 
+/**
+ * Holds build-time metadata about the Timefold Solver model, including version information and source control details
+ * captured at build time.
+ * 
+ * @param solverVersion the version of the Timefold Solver used to build the model
+ * @param sdkVersion the version of the SDK; deprecated, use {@link #solverVersion()} instead
+ * @param version the version of the model
+ * @param buildTime the timestamp when the model was built
+ * @param branch the source control branch from which the model was built
+ * @param buildCommit the source control commit hash from which the model was built
+ */
 public record ModelBuildInfo(String solverVersion, @Deprecated(forRemoval = true) String sdkVersion, String version,
         String buildTime, String branch, String buildCommit) {
 


### PR DESCRIPTION
Putting back the SDK version since it breaks the platform. Removal needs to be properly planned.