### PR TITLE
Revert "ci: do not publish Javadocs outside of public API (#2551)"

### DIFF
--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -70,6 +70,7 @@
     <version.jacoco.plugin>0.8.15</version.jacoco.plugin>
     <version.jandex.plugin>3.6.0</version.jandex.plugin>
     <version.jar.plugin>3.5.1</version.jar.plugin>
+    <version.javadoc.plugin>3.12.0</version.javadoc.plugin>
     <version.jaxb2.plugin>4.1.0</version.jaxb2.plugin>
     <version.maven-plugin.plugin>3.15.2</version.maven-plugin.plugin>
     <version.maven-plugin.plugin-testing>3.5.1</version.maven-plugin.plugin-testing>

--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -70,7 +70,6 @@
     <version.jacoco.plugin>0.8.15</version.jacoco.plugin>
     <version.jandex.plugin>3.6.0</version.jandex.plugin>
     <version.jar.plugin>3.5.1</version.jar.plugin>
-    <version.javadoc.plugin>3.12.0</version.javadoc.plugin>
     <version.jaxb2.plugin>4.1.0</version.jaxb2.plugin>
     <version.maven-plugin.plugin>3.15.2</version.maven-plugin.plugin>
     <version.maven-plugin.plugin-testing>3.5.1</version.maven-plugin.plugin-testing>

--- a/pom.xml
+++ b/pom.xml
@@ -171,35 +171,12 @@
           <plugin> <!-- Make sure the build fails-fast on Javadoc issues. -->
             <artifactId>maven-javadoc-plugin</artifactId>
             <executions>
-              <execution> <!-- Lints Javadoc of all classes, including implementation classes. -->
-                <id>lint-javadoc</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>javadoc-no-fork</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>${project.build.directory}/javadoc-lint</outputDirectory>
-                  <!-- module-info.java has no documentable declarations of its own; without this,
-                       modules whose only source file is module-info.java fail with
-                       "No public or protected classes found to document" instead of skipping. -->
-                  <sourceFileExcludes>
-                    <sourceFileExclude>module-info.java</sourceFileExclude>
-                  </sourceFileExcludes>
-                </configuration>
-              </execution>
-              <execution> <!-- Only publishes the backwards-compatible surface: api and config packages. -->
+              <execution>
                 <id>build-javadoc-jar</id>
                 <phase>package</phase>
                 <goals>
                   <goal>jar</goal>
                 </goals>
-                <configuration>
-                  <sourceFileIncludes>
-                    <sourceFileInclude>**/api/**/*.java</sourceFileInclude>
-                    <sourceFileInclude>ai/timefold/solver/core/config/**/*.java</sourceFileInclude>
-                    <sourceFileInclude>ai/timefold/solver/benchmark/config/**/*.java</sourceFileInclude>
-                  </sourceFileIncludes>
-                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
This reverts commit 9f8d3f71806e14ed03201694201f1939e7d74c09.

Instead, we empty all enterprise javadoc JARs.