### PR TITLE
fix(bavet): close stale-activity race across all nodes

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/AbstractGroupBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/AbstractGroupBiNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollectorAccumulator;
@@ -21,19 +22,19 @@ abstract class AbstractGroupBiNode<OldA, OldB, OutTuple_ extends Tuple, GroupKey
     private final int groupAccumulatorIndex;
     private final @Nullable BiConstraintCollectorAccumulator<ResultContainer_, OldA, OldB> incrementalAccumulator;
 
-    protected AbstractGroupBiNode(int groupStoreIndex, int groupAccumulatorIndex,
+    protected AbstractGroupBiNode(IntSupplier storeIndexReserver,
             Function<BiTuple<OldA, OldB>, GroupKey_> groupKeyFunction,
             @NonNull BiConstraintCollector<OldA, OldB, ResultContainer_, Result_> collector,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, groupKeyFunction, collector.supplier(), collector.finisher(), nextNodesTupleLifecycle,
+        super(storeIndexReserver, groupKeyFunction, collector.supplier(), collector.finisher(), nextNodesTupleLifecycle,
                 environmentMode);
-        this.groupAccumulatorIndex = groupAccumulatorIndex;
+        this.groupAccumulatorIndex = storeIndexReserver.getAsInt();
         this.incrementalAccumulator = BiCollectorUtils.toIncremental(collector.accumulator());
     }
 
-    protected AbstractGroupBiNode(int groupStoreIndex, Function<BiTuple<OldA, OldB>, GroupKey_> groupKeyFunction,
+    protected AbstractGroupBiNode(IntSupplier storeIndexReserver, Function<BiTuple<OldA, OldB>, GroupKey_> groupKeyFunction,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, groupKeyFunction, nextNodesTupleLifecycle, environmentMode);
+        super(storeIndexReserver, groupKeyFunction, nextNodesTupleLifecycle, environmentMode);
         this.groupAccumulatorIndex = -1;
         this.incrementalAccumulator = null;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group0Mapping1CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group0Mapping1CollectorBiNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
@@ -10,10 +12,10 @@ public final class Group0Mapping1CollectorBiNode<OldA, OldB, A, ResultContainer_
 
     private final int outputStoreSize;
 
-    public Group0Mapping1CollectorBiNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping1CollectorBiNode(IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainer_, A> collector,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, collector, nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group0Mapping2CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group0Mapping2CollectorBiNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -12,11 +14,11 @@ public final class Group0Mapping2CollectorBiNode<OldA, OldB, A, B, ResultContain
 
     private final int outputStoreSize;
 
-    public Group0Mapping2CollectorBiNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping2CollectorBiNode(IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainerA_, A> collectorA,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group0Mapping3CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group0Mapping3CollectorBiNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -12,12 +14,12 @@ public final class Group0Mapping3CollectorBiNode<OldA, OldB, A, B, C, ResultCont
 
     private final int outputStoreSize;
 
-    public Group0Mapping3CollectorBiNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping3CollectorBiNode(IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainerA_, A> collectorA,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB, collectorC),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group0Mapping4CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group0Mapping4CollectorBiNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -13,14 +15,14 @@ public final class Group0Mapping4CollectorBiNode<OldA, OldB, A, B, C, D, ResultC
 
     private final int outputStoreSize;
 
-    public Group0Mapping4CollectorBiNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping4CollectorBiNode(IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainerA_, A> collectorA,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             BiConstraintCollector<OldA, OldB, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB, collectorC, collectorD),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group1Mapping0CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group1Mapping0CollectorBiNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.BiTuple;
@@ -13,9 +14,9 @@ public final class Group1Mapping0CollectorBiNode<OldA, OldB, A>
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMapping, tuple), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group1Mapping1CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group1Mapping1CollectorBiNode.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.bavet.bi;
 import static ai.timefold.solver.core.impl.bavet.bi.Group1Mapping0CollectorBiNode.createGroupKey;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -15,10 +16,10 @@ public final class Group1Mapping1CollectorBiNode<OldA, OldB, A, B, ResultContain
     private final int outputStoreSize;
 
     public Group1Mapping1CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainer_, B> collector,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMapping, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group1Mapping2CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group1Mapping2CollectorBiNode.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.bavet.bi;
 import static ai.timefold.solver.core.impl.bavet.bi.Group1Mapping0CollectorBiNode.createGroupKey;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -16,11 +17,11 @@ public final class Group1Mapping2CollectorBiNode<OldA, OldB, A, B, C, ResultCont
     private final int outputStoreSize;
 
     public Group1Mapping2CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMapping, tuple),
                 Group0Mapping2CollectorBiNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group1Mapping3CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group1Mapping3CollectorBiNode.java
@@ -4,6 +4,7 @@ import static ai.timefold.solver.core.impl.bavet.bi.Group0Mapping3CollectorBiNod
 import static ai.timefold.solver.core.impl.bavet.bi.Group1Mapping0CollectorBiNode.createGroupKey;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -17,13 +18,13 @@ public final class Group1Mapping3CollectorBiNode<OldA, OldB, A, B, C, D, ResultC
     private final int outputStoreSize;
 
     public Group1Mapping3CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             BiConstraintCollector<OldA, OldB, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMapping, tuple),
                 mergeCollectors(collectorB, collectorC, collectorD), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group2Mapping0CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group2Mapping0CollectorBiNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.BiTuple;
@@ -13,10 +14,10 @@ public final class Group2Mapping0CollectorBiNode<OldA, OldB, A, B>
     private final int outputStoreSize;
 
     public Group2Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
-            int groupStoreIndex, TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle,
+            IntSupplier storeIndexReserver, TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle,
             int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group2Mapping1CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group2Mapping1CollectorBiNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -14,10 +15,10 @@ public final class Group2Mapping1CollectorBiNode<OldA, OldB, A, B, C, ResultCont
     private final int outputStoreSize;
 
     public Group2Mapping1CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainer_, C> collector,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group2Mapping0CollectorBiNode.createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group2Mapping2CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group2Mapping2CollectorBiNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -15,12 +16,12 @@ public final class Group2Mapping2CollectorBiNode<OldA, OldB, A, B, C, D, ResultC
     private final int outputStoreSize;
 
     public Group2Mapping2CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             BiConstraintCollector<OldA, OldB, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group2Mapping0CollectorBiNode.createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
                 Group0Mapping2CollectorBiNode.mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group3Mapping0CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group3Mapping0CollectorBiNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.BiTuple;
@@ -14,9 +15,9 @@ public final class Group3Mapping0CollectorBiNode<OldA, OldB, A, B, C>
     private final int outputStoreSize;
 
     public Group3Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
-            BiFunction<OldA, OldB, C> groupKeyMappingC, int groupStoreIndex,
+            BiFunction<OldA, OldB, C> groupKeyMappingC, IntSupplier storeIndexReserver,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group3Mapping1CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group3Mapping1CollectorBiNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.bi.BiConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -16,11 +17,11 @@ public final class Group3Mapping1CollectorBiNode<OldA, OldB, A, B, C, D, ResultC
 
     public Group3Mapping1CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA,
             BiFunction<OldA, OldB, B> groupKeyMappingB, BiFunction<OldA, OldB, C> groupKeyMappingC,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             BiConstraintCollector<OldA, OldB, ResultContainer_, D> collector,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group3Mapping0CollectorBiNode.createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC,
                         tuple),
                 collector,

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group4Mapping0CollectorBiNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/bi/Group4Mapping0CollectorBiNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.bi;
 
 import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.BiTuple;
@@ -16,10 +17,10 @@ public final class Group4Mapping0CollectorBiNode<OldA, OldB, A, B, C, D>
 
     public Group4Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
             BiFunction<OldA, OldB, C> groupKeyMappingC, BiFunction<OldA, OldB, D> groupKeyMappingD,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, groupKeyMappingD, tuple),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractFlattenNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractFlattenNode.java
@@ -73,6 +73,7 @@ public abstract class AbstractFlattenNode<InTuple_ extends Tuple, OutTuple_ exte
         var reuse = bag.reuseOrAdvance();
         if (reuse == null) {
             var created = createTuple(originalTuple, bag.value);
+            created.setActivityParent(originalTuple);
             bag.append(created);
             propagationQueue.insert(created);
         } else {

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractGroupNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractGroupNode.java
@@ -4,17 +4,25 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
+import ai.timefold.solver.core.impl.bavet.common.tuple.TupleList;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleState;
 
 public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extends Tuple, GroupKey_, ResultContainer_, Result_>
         extends AbstractSingleInputNode<InTuple_> {
 
     private final int groupStoreIndex;
+    /**
+     * Builds a fresh, empty contributor list for each new group; one per {@link Group}, backed by 2
+     * store indices reserved once, node-wide, from the same {@code storeIndexReserver} the constructor
+     * received.
+     */
+    private final Supplier<TupleList<InTuple_>> contributorListBuilder;
     /**
      * Unused when {@link #hasGroupKeyFunction} is false.
      */
@@ -40,23 +48,26 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
     /**
      * Used when {@link #hasGroupKeyFunction} is true, otherwise {@link #singletonGroup} is used.
      */
-    private final Map<Object, Group<OutTuple_, ResultContainer_>> groupMap;
+    private final Map<Object, Group<InTuple_, OutTuple_, ResultContainer_>> groupMap;
     /**
      * Used when {@link #hasGroupKeyFunction} is false, otherwise {@link #groupMap} is used.
      *
      * @implNote The field is lazy initialized in order to maintain the same semantics as with the groupMap above.
      *           When all tuples are removed, the field will be set to null, as if the group never existed.
      */
-    private Group<OutTuple_, ResultContainer_> singletonGroup;
-    private final DynamicPropagationQueue<OutTuple_, Group<OutTuple_, ResultContainer_>> propagationQueue;
+    private Group<InTuple_, OutTuple_, ResultContainer_> singletonGroup;
+    private final DynamicPropagationQueue<OutTuple_, Group<InTuple_, OutTuple_, ResultContainer_>> propagationQueue;
     private final boolean useAssertingGroupKey;
 
-    protected AbstractGroupNode(int groupStoreIndex, Function<InTuple_, GroupKey_> groupKeyFunction,
+    protected AbstractGroupNode(IntSupplier storeIndexReserver, Function<InTuple_, GroupKey_> groupKeyFunction,
             Supplier<ResultContainer_> supplier,
             Function<ResultContainer_, Result_> finisher,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, EnvironmentMode environmentMode) {
         super(nextNodesTupleLifecycle);
-        this.groupStoreIndex = groupStoreIndex;
+        this.groupStoreIndex = storeIndexReserver.getAsInt();
+        var contributorPrevIndex = storeIndexReserver.getAsInt();
+        var contributorNextIndex = storeIndexReserver.getAsInt();
+        this.contributorListBuilder = () -> new TupleList<>(contributorPrevIndex, contributorNextIndex);
         this.groupKeyFunction = groupKeyFunction;
         this.supplier = supplier;
         this.finisher = finisher;
@@ -79,10 +90,10 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
         this.useAssertingGroupKey = environmentMode.isStepAssertOrMore();
     }
 
-    protected AbstractGroupNode(int groupStoreIndex,
+    protected AbstractGroupNode(IntSupplier storeIndexReserver,
             Function<InTuple_, GroupKey_> groupKeyFunction, TupleLifecycle<OutTuple_> nextNodesTupleLifecycle,
             EnvironmentMode environmentMode) {
-        this(groupStoreIndex,
+        this(storeIndexReserver,
                 groupKeyFunction, null, null, nextNodesTupleLifecycle,
                 environmentMode);
     }
@@ -104,7 +115,7 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
     }
 
     private void createTuple(InTuple_ tuple, GroupKey_ userSuppliedKey) {
-        var group = getOrCreateGroup(userSuppliedKey);
+        var group = getOrCreateGroup(tuple, userSuppliedKey);
         if (hasCollector) {
             groupInsert(group.getResultContainer(), tuple);
         }
@@ -122,7 +133,7 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
         }
     }
 
-    private Group<OutTuple_, ResultContainer_> getOrCreateGroup(GroupKey_ userSuppliedKey) {
+    private Group<InTuple_, OutTuple_, ResultContainer_> getOrCreateGroup(InTuple_ tuple, GroupKey_ userSuppliedKey) {
         var groupMapKey = useAssertingGroupKey ? new AssertingGroupKey<>(userSuppliedKey) : userSuppliedKey;
         if (hasGroupKeyFunction) {
             // Avoids computeIfAbsent in order to not create lambdas on the hot path.
@@ -130,37 +141,39 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
             if (group == null) {
                 group = createGroupWithGroupKey(groupMapKey);
                 groupMap.put(groupMapKey, group);
-            } else {
-                group.parentCount++;
             }
+            group.addContributor(tuple);
             return group;
         } else {
             if (singletonGroup == null) {
                 singletonGroup = createGroupWithoutGroupKey();
-            } else {
-                singletonGroup.parentCount++;
             }
+            singletonGroup.addContributor(tuple);
             return singletonGroup;
         }
     }
 
-    private Group<OutTuple_, ResultContainer_> createGroupWithGroupKey(Object groupMapKey) {
+    private Group<InTuple_, OutTuple_, ResultContainer_> createGroupWithGroupKey(Object groupMapKey) {
         var userSuppliedKey = extractUserSuppliedKey(groupMapKey);
         var outTuple = createOutTuple(userSuppliedKey);
-        var group = hasCollector ? Group.create(groupMapKey, supplier.get(), outTuple)
-                : Group.<OutTuple_, ResultContainer_> createWithoutAccumulate(groupMapKey, outTuple);
+        var contributors = contributorListBuilder.get();
+        var group = hasCollector ? Group.create(groupMapKey, supplier.get(), outTuple, contributors)
+                : Group.<InTuple_, OutTuple_, ResultContainer_> createWithoutAccumulate(groupMapKey, outTuple, contributors);
+        outTuple.setActivitySource(group);
         propagationQueue.insert(group);
         return group;
     }
 
-    private Group<OutTuple_, ResultContainer_> createGroupWithoutGroupKey() {
+    private Group<InTuple_, OutTuple_, ResultContainer_> createGroupWithoutGroupKey() {
         var outTuple = createOutTuple(null);
         if (!hasCollector) {
             throw new IllegalStateException(
                     "Impossible state: The node (%s) has no collector, but it is still trying to create a group without a group key."
                             .formatted(this));
         }
-        var group = Group.createWithoutGroupKey(supplier.get(), outTuple);
+        var contributors = contributorListBuilder.get();
+        var group = Group.createWithoutGroupKey(supplier.get(), outTuple, contributors);
+        outTuple.setActivitySource(group);
         propagationQueue.insert(group);
         return group;
     }
@@ -172,7 +185,7 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
 
     @Override
     public final void update(InTuple_ tuple) {
-        Group<OutTuple_, ResultContainer_> oldGroup = tuple.getStore(groupStoreIndex);
+        Group<InTuple_, OutTuple_, ResultContainer_> oldGroup = tuple.getStore(groupStoreIndex);
         if (oldGroup == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             insert(tuple);
@@ -193,14 +206,14 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
             if (hasCollector) {
                 groupRetract(tuple);
             }
-            var newParentCount = --oldGroup.parentCount;
-            killOutTuple(oldGroup, newParentCount == 0);
+            oldGroup.removeContributor(tuple);
+            killOutTuple(oldGroup);
             createTuple(tuple, newUserSuppliedGroupKey);
         }
     }
 
-    private void updateGroup(InTuple_ tuple, Group<OutTuple_, ResultContainer_> oldGroup) {
-        // No need to change parentCount because it is the same group.
+    private void updateGroup(InTuple_ tuple, Group<InTuple_, OutTuple_, ResultContainer_> oldGroup) {
+        // No need to change contributors because it is the same group.
         if (hasCollector) {
             groupUpdate(oldGroup.getResultContainer(), tuple);
         }
@@ -219,9 +232,9 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
     /**
      *
      * @param group the group which created the outTuple
-     * @param killGroup true if the group should be removed from downstream nodes
      */
-    private void killOutTuple(Group<OutTuple_, ResultContainer_> group, boolean killGroup) {
+    private void killOutTuple(Group<InTuple_, OutTuple_, ResultContainer_> group) {
+        var killGroup = group.isEmpty();
         if (killGroup) {
             var groupKey = hasGroupKeyFunction ? group.getGroupKey() : null;
             var oldGroup = removeGroup(groupKey);
@@ -257,7 +270,7 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
         }
     }
 
-    private Group<OutTuple_, ResultContainer_> removeGroup(Object groupKey) {
+    private Group<InTuple_, OutTuple_, ResultContainer_> removeGroup(Object groupKey) {
         if (hasGroupKeyFunction) {
             return groupMap.remove(groupKey);
         } else {
@@ -269,7 +282,7 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
 
     @Override
     public final void retract(InTuple_ tuple) {
-        Group<OutTuple_, ResultContainer_> group = tuple.removeStore(groupStoreIndex);
+        Group<InTuple_, OutTuple_, ResultContainer_> group = tuple.removeStore(groupStoreIndex);
         if (group == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
@@ -277,8 +290,8 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
         if (hasCollector) {
             groupRetract(tuple);
         }
-        var newParentCount = --group.parentCount;
-        killOutTuple(group, newParentCount == 0);
+        group.removeContributor(tuple);
+        killOutTuple(group);
     }
 
     protected abstract void groupInsert(ResultContainer_ resultContainer, InTuple_ tuple);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIfExistsNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIfExistsNode.java
@@ -191,10 +191,8 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
     }
 
     protected void updateCounterLeft(ExistsCounter<LeftTuple_> counter, UniTuple<Right_> rightTuple) {
-        if (!rightTuple.getState().isActive()) {
-            // The mirror image of updateCounterRight(...): here the right tuple is the retracting one,
-            // which happens when the right input's node sits in a higher layer than the left input's,
-            // so the left's inserts and updates are delivered before the right's retracts are.
+        if (!rightTuple.isActiveTransitively()) {
+            // See Tuple#isActiveTransitively for why the immediate state alone isn't enough here.
             // Skipping is safe, as the pending retract will not have a tracker to clear for this pair.
             return;
         }
@@ -232,21 +230,8 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
 
     protected void updateCounterRight(ExistsCounter<LeftTuple_> counter, UniTuple<Right_> rightTuple) {
         var leftTuple = counter.leftTuple;
-        if (!leftTuple.getState().isActive()) {
-            // Assume the following scenario:
-            // - The operation is of two entities of the same type, both filtering out unassigned.
-            // - One entity became unassigned, so the outTuple is getting retracted.
-            // - The entity whose existence is being asserted is still assigned and is being updated.
-            //
-            // This means the filter would be called with (unassignedEntity, assignedEntity),
-            // which breaks the expectation that the filter is only called on two assigned entities
-            // and requires adding null checks to the filter for something that should intuitively be impossible.
-            // We avoid this situation as it is clear that the outTuple must be retracted anyway,
-            // and therefore any further updates to it are pointless.
-            //
-            // The left tuple can be inactive here because its node sits in a higher layer than the right's:
-            // the right's inserts and updates are delivered before the left's retracts are.
-            // The mirror case is possible too, see updateCounterLeft(...).
+        if (!leftTuple.isActiveTransitively()) {
+            // See Tuple#isActiveTransitively for why the immediate state alone isn't enough here.
             return;
         }
         if (testFiltering(leftTuple, rightTuple)) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIndexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractIndexedJoinNode.java
@@ -142,19 +142,8 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
         } else {
             leftTuple.setStore(inputStoreIndexLeftEntry, indexerLeft.put(compositeKey, leftTuple));
         }
-        if (!leftTuple.getState().isActive()) {
-            // Assume the following scenario:
-            // - The join is of two entities of the same type, both filtering out unassigned.
-            // - One entity became unassigned, so the outTuple is getting retracted.
-            // - The other entity became assigned, and is therefore getting inserted.
-            //
-            // This means the filter would be called with (unassignedEntity, assignedEntity),
-            // which breaks the expectation that the filter is only called on two assigned entities
-            // and requires adding null checks to the filter for something that should intuitively be impossible.
-            // We avoid this situation as it is clear that it is pointless to insert this tuple.
-            //
-            // The left tuple can be inactive here because its node sits in a higher layer than the right's:
-            // the right's inserts are delivered before the left's retracts are.
+        if (!leftTuple.isActiveTransitively()) {
+            // See Tuple#isActiveTransitively for why the immediate state alone isn't enough here.
             return;
         }
         // The right tuples come out of the index and can be retracting for the mirror-image reason,

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractJoinNode.java
@@ -70,20 +70,8 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     protected abstract boolean testFiltering(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple);
 
     protected final void insertOutTupleFilteredLeft(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple) {
-        if (!leftTuple.getState().isActive()) {
-            // Assume the following scenario:
-            // - The join is of two entities of the same type, both filtering out unassigned.
-            // - One entity became unassigned, so the outTuple is getting retracted.
-            // - The other entity became assigned, and is therefore getting inserted.
-            //
-            // This means the filter would be called with (unassignedEntity, assignedEntity),
-            // which breaks the expectation that the filter is only called on two assigned entities
-            // and requires adding null checks to the filter for something that should intuitively be impossible.
-            // We avoid this situation as it is clear that it is pointless to insert this tuple.
-            //
-            // The left tuple can be inactive here because its node sits in a higher layer than the right's:
-            // the right's inserts are delivered before the left's retracts are.
-            // The mirror case is possible too, see insertOutTupleFilteredRight(...).
+        if (!leftTuple.isActiveTransitively()) {
+            // See Tuple#isActiveTransitively for why the immediate state alone isn't enough here.
             return;
         }
         insertOutTupleIfActiveFiltered(leftTuple, rightTuple);
@@ -92,11 +80,10 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     /**
      * The mirror image of {@link #insertOutTupleFilteredLeft}:
      * the right tuple is the one read out of storage, and can therefore be the retracting one.
-     * Reachable when the right input's node sits in a higher layer than the left input's,
-     * which delivers the left's inserts before the right's retracts.
+     * See {@link Tuple#isActiveTransitively} for why the immediate state alone isn't enough here.
      */
     protected final void insertOutTupleFilteredRight(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple) {
-        if (!rightTuple.getState().isActive()) {
+        if (!rightTuple.isActiveTransitively()) {
             return;
         }
         insertOutTupleIfActiveFiltered(leftTuple, rightTuple);
@@ -110,6 +97,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     private void insertOutTuple(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple) {
         var outTuple = createOutTuple(leftTuple, rightTuple);
+        outTuple.setActivityParents(leftTuple, rightTuple);
         TupleList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
         outTupleListLeft.add(outTuple);
         outTuple.setStore(outputStoreIndexLeftOutTupleList, outTupleListLeft);
@@ -128,21 +116,8 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
                 updateOutTupleLeft(outTuple, leftTuple);
             }
         } else {
-            if (!leftTuple.getState().isActive()) {
-                // Assume the following scenario:
-                // - The join is of two entities of the same type, both filtering out unassigned.
-                // - One entity became unassigned, so the outTuple is getting retracted.
-                // - The other entity is still assigned and is being updated.
-                //
-                // This means the filter would be called with (unassignedEntity, assignedEntity),
-                // which breaks the expectation that the filter is only called on two assigned entities
-                // and requires adding null checks to the filter for something that should intuitively be impossible.
-                // We avoid this situation as it is clear that the outTuple must be retracted anyway,
-                // and therefore any further updates to it are pointless.
-                //
-                // The left tuple can be inactive here because its node sits in a higher layer than the right's:
-                // the right's updates are delivered before the left's retracts are.
-                // The mirror case is possible too, see processOutTupleUpdateRight(...).
+            if (!leftTuple.isActiveTransitively()) {
+                // See Tuple#isActiveTransitively for why the immediate state alone isn't enough here.
                 return;
             }
             // Every out-tuple's partner is guaranteed to be swept below,
@@ -174,7 +149,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     }
 
     private void processOutTupleUpdateRight(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple, long version) {
-        if (!rightTuple.getState().isActive()) {
+        if (!rightTuple.isActiveTransitively()) {
             // The mirror image of processOutTupleUpdateLeft(...): here the right tuple is the retracting one.
             // Leaving its mark set is harmless, as getMark() only ever returns a mark of the matching version.
             return;
@@ -246,21 +221,8 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     }
 
     private void processOutTupleUpdateLeft(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple, long version) {
-        if (!leftTuple.getState().isActive()) {
-            // Assume the following scenario:
-            // - The join is of two entities of the same type, both filtering out unassigned.
-            // - One entity became unassigned, so the outTuple is getting retracted.
-            // - The other entity is still assigned and is being updated.
-            //
-            // This means the filter would be called with (unassignedEntity, assignedEntity),
-            // which breaks the expectation that the filter is only called on two assigned entities
-            // and requires adding null checks to the filter for something that should intuitively be impossible.
-            // We avoid this situation as it is clear that the outTuple must be retracted anyway,
-            // and therefore any further updates to it are pointless.
-            //
-            // The left tuple can be inactive here because its node sits in a higher layer than the right's:
-            // the right's updates are delivered before the left's retracts are.
-            // The mirror case is possible too, see processOutTupleUpdateRight(...).
+        if (!leftTuple.isActiveTransitively()) {
+            // See Tuple#isActiveTransitively for why the immediate state alone isn't enough here.
             return;
         }
         TupleList<OutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractMapNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractMapNode.java
@@ -30,6 +30,7 @@ public abstract class AbstractMapNode<InTuple_ extends Tuple, OutTuple_ extends 
                     + ") was already added in the tupleStore.");
         }
         var outTuple = map(tuple);
+        outTuple.setActivityParent(tuple);
         tuple.setStore(inputStoreIndex, outTuple);
         propagationQueue.insert(outTuple);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/AbstractUnindexedJoinNode.java
@@ -40,19 +40,8 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
         }
         leftTupleList.add(leftTuple);
         leftTuple.setStore(inputStoreIndexLeftOutTupleList, leftOutTupleListBuilder.get());
-        if (!leftTuple.getState().isActive()) {
-            // Assume the following scenario:
-            // - The join is of two entities of the same type, both filtering out unassigned.
-            // - One entity became unassigned, so the outTuple is getting retracted.
-            // - The other entity became assigned, and is therefore getting inserted.
-            //
-            // This means the filter would be called with (unassignedEntity, assignedEntity),
-            // which breaks the expectation that the filter is only called on two assigned entities
-            // and requires adding null checks to the filter for something that should intuitively be impossible.
-            // We avoid this situation as it is clear that it is pointless to insert this tuple.
-            //
-            // The left tuple can be inactive here because its node sits in a higher layer than the right's:
-            // the right's inserts are delivered before the left's retracts are.
+        if (!leftTuple.isActiveTransitively()) {
+            // See Tuple#isActiveTransitively for why the immediate state alone isn't enough here.
             return;
         }
         // The right tuples come out of the list and can be retracting for the mirror-image reason,

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/Group.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/Group.java
@@ -1,35 +1,64 @@
 package ai.timefold.solver.core.impl.bavet.common;
 
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
+import ai.timefold.solver.core.impl.bavet.common.tuple.TupleActivitySource;
+import ai.timefold.solver.core.impl.bavet.common.tuple.TupleList;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleState;
 
-final class Group<OutTuple_ extends Tuple, ResultContainer_>
-        extends AbstractPropagationMetadataCarrier<OutTuple_> {
+final class Group<InTuple_ extends Tuple, OutTuple_ extends Tuple, ResultContainer_>
+        extends AbstractPropagationMetadataCarrier<OutTuple_> implements TupleActivitySource {
 
-    public static <OutTuple_ extends Tuple, ResultContainer_> Group<OutTuple_, ResultContainer_>
-            createWithoutAccumulate(Object groupKey, OutTuple_ outTuple) {
-        return new Group<>(groupKey, null, outTuple);
+    public static <InTuple_ extends Tuple, OutTuple_ extends Tuple, ResultContainer_>
+            Group<InTuple_, OutTuple_, ResultContainer_> createWithoutAccumulate(Object groupKey, OutTuple_ outTuple,
+                    TupleList<InTuple_> contributors) {
+        return new Group<>(groupKey, null, outTuple, contributors);
     }
 
-    public static <OutTuple_ extends Tuple, ResultContainer_> Group<OutTuple_, ResultContainer_>
-            createWithoutGroupKey(ResultContainer_ resultContainer, OutTuple_ outTuple) {
-        return new Group<>(null, resultContainer, outTuple);
+    public static <InTuple_ extends Tuple, OutTuple_ extends Tuple, ResultContainer_>
+            Group<InTuple_, OutTuple_, ResultContainer_> createWithoutGroupKey(ResultContainer_ resultContainer,
+                    OutTuple_ outTuple, TupleList<InTuple_> contributors) {
+        return new Group<>(null, resultContainer, outTuple, contributors);
     }
 
-    public static <OutTuple_ extends Tuple, ResultContainer_> Group<OutTuple_, ResultContainer_> create(Object groupKey,
-            ResultContainer_ resultContainer, OutTuple_ outTuple) {
-        return new Group<>(groupKey, resultContainer, outTuple);
+    public static <InTuple_ extends Tuple, OutTuple_ extends Tuple, ResultContainer_>
+            Group<InTuple_, OutTuple_, ResultContainer_> create(Object groupKey, ResultContainer_ resultContainer,
+                    OutTuple_ outTuple, TupleList<InTuple_> contributors) {
+        return new Group<>(groupKey, resultContainer, outTuple, contributors);
     }
 
     private final Object groupKey;
     private final ResultContainer_ resultContainer;
     private final OutTuple_ outTuple;
-    public int parentCount = 1;
+    /**
+     * The input tuples currently mapped into this group. Backs both membership tracking (what used to be
+     * a bare {@code parentCount}) and this group's own {@link TupleActivitySource} answer, at zero
+     * per-element allocation cost regardless of how many contributors the group has.
+     * <p>
+     * This cost (2 reserved store slots per input tuple, plus list bookkeeping on every insert/retract) is
+     * paid unconditionally today, even when nothing downstream ever reads it — {@link #isActiveTransitively()}
+     * is only ever consulted by a join or {@code ifExists} node, so a groupBy feeding straight into a
+     * scorer (e.g. {@code groupBy(...).penalize(...)} with no further join) never needs it at all.
+     * <p>
+     * A build-time "is a join/ifExists reachable anywhere downstream of this group" check — the full
+     * stream graph is known before any node is built, and {@code ActivitySupport}/{@code canProduceTuples()}
+     * already do a comparable whole-network reachability fold — could gate this {@link TupleList} behind
+     * that check, falling back to a bare count when nothing downstream needs it. Considered and judged not
+     * worth it for now: {@code getChildStreamList()} alone doesn't capture the full downstream graph (join/
+     * {@code ifExists}/concat streams are consumed via {@code leftParent}/{@code rightParent}, not forward
+     * child-list edges, so a naive walk dead-ends at fore-bridges — reconstructing the true forward graph
+     * needs an O(N) fixup pass first), and {@code AbstractConcatNode} already doesn't propagate
+     * {@code activityParent} at all (a separate, pre-existing gap that such a traversal would need to treat
+     * conservatively). A static analysis that's ever wrong in the unsafe direction would silently
+     * reintroduce the exact staleness crash this mechanism exists to fix — revisit only if profiling shows
+     * this specific cost matters in practice.
+     */
+    private final TupleList<InTuple_> contributors;
 
-    private Group(Object groupKey, ResultContainer_ resultContainer, OutTuple_ outTuple) {
+    private Group(Object groupKey, ResultContainer_ resultContainer, OutTuple_ outTuple, TupleList<InTuple_> contributors) {
         this.groupKey = groupKey;
         this.resultContainer = resultContainer;
         this.outTuple = outTuple;
+        this.contributors = contributors;
     }
 
     public Object getGroupKey() {
@@ -53,6 +82,33 @@ final class Group<OutTuple_ extends Tuple, ResultContainer_>
     @Override
     public void setState(TupleState state) {
         outTuple.setState(state);
+    }
+
+    public void addContributor(InTuple_ tuple) {
+        contributors.add(tuple);
+    }
+
+    public void removeContributor(InTuple_ tuple) {
+        contributors.remove(tuple);
+    }
+
+    public boolean isEmpty() {
+        return contributors.size() == 0;
+    }
+
+    /**
+     * A group survives as long as at least one of its current contributors does; unlike a join's
+     * out-tuple (which needs all of a fixed 1-2 parents to survive), this is an OR across however many
+     * contributors currently exist. Short-circuits on the first live one, which is the common case.
+     */
+    @Override
+    public boolean isActiveTransitively() {
+        for (var tuple = contributors.first(); tuple != null; tuple = contributors.next(tuple)) {
+            if (tuple.isActiveTransitively()) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/GroupNodeConstructor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/GroupNodeConstructor.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.common;
 
 import java.util.List;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
@@ -19,13 +20,18 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
     // GroupNodeConstructorWithoutAccumulate's constructor.
 
     // Each Group...Node with at least one collector have a constructor with the following signature:
-    // Group...Node(<keyMappings>, int groupStoreIndex, int undoStoreIndex, <collectors>,
+    // Group...Node(<keyMappings>, IntSupplier storeIndexReserver, <collectors>,
     // TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize,
     // Environment environmentMode)
     //
     // The Group...Nodes with no collectors have a constructor with the following signature:
-    // Group...Node(<keyMappings>, int groupStoreIndex, TupleLifecycle<Tuple_> nextNodesTupleLifecycle,
+    // Group...Node(<keyMappings>, IntSupplier storeIndexReserver, TupleLifecycle<Tuple_> nextNodesTupleLifecycle,
     // int outputStoreSize, Environment environmentMode)
+    //
+    // storeIndexReserver replaces what used to be pre-resolved groupStoreIndex/undoStoreIndex ints:
+    // the node reserves everything it needs itself, from a shared, order-independent, monotonic
+    // per-stream counter (see AbstractNodeBuildHelper#reserveTupleStoreIndex), the same way
+    // AbstractJoinNode reserves its own store indices from the tracker it receives.
     //
     // TupleLifecycle<Tuple_> in the constructor is the reason why having Tuple_ in the
     // generic signature of this interface is useful.
@@ -38,8 +44,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
     static <CollectorA_, Tuple_ extends Tuple> GroupNodeConstructor<Tuple_>
             zeroKeysGroupBy(CollectorA_ collector, GroupBy0Mapping1CollectorNodeBuilder<CollectorA_, Tuple_> builder) {
         return new GroupNodeConstructorWithAccumulate<>(collector,
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        groupStoreIndex, undoStoreIndex, collector, nextNodesTupleLifecycle, outputStoreSize,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        storeIndexReserver, collector, nextNodesTupleLifecycle, outputStoreSize,
                         environmentMode));
     }
 
@@ -47,8 +53,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
             zeroKeysGroupBy(CollectorA_ collectorA, CollectorB_ collectorB,
                     GroupBy0Mapping2CollectorNodeBuilder<CollectorA_, CollectorB_, Tuple_> builder) {
         return new GroupNodeConstructorWithAccumulate<>(new Pair<>(collectorA, collectorB),
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        groupStoreIndex, undoStoreIndex, collectorA, collectorB, nextNodesTupleLifecycle,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        storeIndexReserver, collectorA, collectorB, nextNodesTupleLifecycle,
                         outputStoreSize, environmentMode));
     }
 
@@ -57,8 +63,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
                     GroupBy0Mapping3CollectorNodeBuilder<CollectorA_, CollectorB_, CollectorC_, Tuple_> builder) {
         return new GroupNodeConstructorWithAccumulate<>(
                 new Triple<>(collectorA, collectorB, collectorC),
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        groupStoreIndex, undoStoreIndex, collectorA, collectorB, collectorC,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        storeIndexReserver, collectorA, collectorB, collectorC,
                         nextNodesTupleLifecycle, outputStoreSize, environmentMode));
     }
 
@@ -68,24 +74,24 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
         return new GroupNodeConstructorWithAccumulate<>(
                 new Quadruple<>(collectorA, collectorB, collectorC,
                         collectorD),
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        groupStoreIndex, undoStoreIndex, collectorA, collectorB, collectorC, collectorD,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        storeIndexReserver, collectorA, collectorB, collectorC, collectorD,
                         nextNodesTupleLifecycle, outputStoreSize, environmentMode));
     }
 
     static <KeyA_, Tuple_ extends Tuple> GroupNodeConstructor<Tuple_>
             oneKeyGroupBy(KeyA_ keyMapping, GroupBy1Mapping0CollectorNodeBuilder<KeyA_, Tuple_> builder) {
         return new GroupNodeConstructorWithoutAccumulate<>(keyMapping,
-                (groupStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(keyMapping,
-                        groupStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode));
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(keyMapping,
+                        storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode));
     }
 
     static <KeyA_, CollectorB_, Tuple_ extends Tuple> GroupNodeConstructor<Tuple_>
             oneKeyGroupBy(KeyA_ keyMappingA, CollectorB_ collectorB,
                     GroupBy1Mapping1CollectorNodeBuilder<KeyA_, CollectorB_, Tuple_> builder) {
         return new GroupNodeConstructorWithAccumulate<>(new Pair<>(keyMappingA, collectorB),
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        keyMappingA, groupStoreIndex, undoStoreIndex, collectorB, nextNodesTupleLifecycle,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        keyMappingA, storeIndexReserver, collectorB, nextNodesTupleLifecycle,
                         outputStoreSize, environmentMode));
     }
 
@@ -94,8 +100,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
                     GroupBy1Mapping2CollectorNodeBuilder<KeyA_, CollectorB_, CollectorC_, Tuple_> builder) {
         return new GroupNodeConstructorWithAccumulate<>(
                 new Triple<>(keyMappingA, collectorB, collectorC),
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        keyMappingA, groupStoreIndex, undoStoreIndex, collectorB, collectorC,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        keyMappingA, storeIndexReserver, collectorB, collectorC,
                         nextNodesTupleLifecycle,
                         outputStoreSize, environmentMode));
     }
@@ -105,8 +111,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
                     GroupBy1Mapping3CollectorNodeBuilder<KeyA_, CollectorB_, CollectorC_, CollectorD_, Tuple_> builder) {
         return new GroupNodeConstructorWithAccumulate<>(
                 new Quadruple<>(keyMappingA, collectorB, collectorC, collectorD),
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        keyMappingA, groupStoreIndex, undoStoreIndex, collectorB, collectorC, collectorD,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        keyMappingA, storeIndexReserver, collectorB, collectorC, collectorD,
                         nextNodesTupleLifecycle,
                         outputStoreSize, environmentMode));
     }
@@ -115,8 +121,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
             twoKeysGroupBy(KeyA_ keyMappingA, KeyB_ keyMappingB,
                     GroupBy2Mapping0CollectorNodeBuilder<KeyA_, KeyB_, Tuple_> builder) {
         return new GroupNodeConstructorWithoutAccumulate<>(new Pair<>(keyMappingA, keyMappingB),
-                (groupStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(keyMappingA,
-                        keyMappingB, groupStoreIndex, nextNodesTupleLifecycle, outputStoreSize,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(keyMappingA,
+                        keyMappingB, storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize,
                         environmentMode));
     }
 
@@ -125,8 +131,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
                     GroupBy2Mapping1CollectorNodeBuilder<KeyA_, KeyB_, CollectorC_, Tuple_> builder) {
         return new GroupNodeConstructorWithAccumulate<>(
                 new Triple<>(keyMappingA, keyMappingB, collectorC),
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        keyMappingA, keyMappingB, groupStoreIndex, undoStoreIndex, collectorC,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        keyMappingA, keyMappingB, storeIndexReserver, collectorC,
                         nextNodesTupleLifecycle,
                         outputStoreSize, environmentMode));
     }
@@ -136,8 +142,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
                     GroupBy2Mapping2CollectorNodeBuilder<KeyA_, KeyB_, CollectorC_, CollectorD_, Tuple_> builder) {
         return new GroupNodeConstructorWithAccumulate<>(
                 new Quadruple<>(keyMappingA, keyMappingB, collectorC, collectorD),
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        keyMappingA, keyMappingB, groupStoreIndex, undoStoreIndex, collectorC, collectorD,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        keyMappingA, keyMappingB, storeIndexReserver, collectorC, collectorD,
                         nextNodesTupleLifecycle,
                         outputStoreSize, environmentMode));
     }
@@ -147,8 +153,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
                     GroupBy3Mapping0CollectorNodeBuilder<KeyA_, KeyB_, KeyC_, Tuple_> builder) {
         return new GroupNodeConstructorWithoutAccumulate<>(
                 new Triple<>(keyMappingA, keyMappingB, keyMappingC),
-                (groupStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(keyMappingA,
-                        keyMappingB, keyMappingC, groupStoreIndex, nextNodesTupleLifecycle,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(keyMappingA,
+                        keyMappingB, keyMappingC, storeIndexReserver, nextNodesTupleLifecycle,
                         outputStoreSize, environmentMode));
     }
 
@@ -157,8 +163,8 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
                     GroupBy3Mapping1CollectorNodeBuilder<KeyA_, KeyB_, KeyC_, CollectorD_, Tuple_> builder) {
         return new GroupNodeConstructorWithAccumulate<>(
                 new Quadruple<>(keyMappingA, keyMappingB, keyMappingC, collectorD),
-                (groupStoreIndex, undoStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
-                        keyMappingA, keyMappingB, keyMappingC, groupStoreIndex, undoStoreIndex, collectorD,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(
+                        keyMappingA, keyMappingB, keyMappingC, storeIndexReserver, collectorD,
                         nextNodesTupleLifecycle,
                         outputStoreSize, environmentMode));
     }
@@ -168,15 +174,15 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
                     GroupBy4Mapping0CollectorNodeBuilder<KeyA_, KeyB_, KeyC_, KeyD_, Tuple_> builder) {
         return new GroupNodeConstructorWithoutAccumulate<>(
                 new Quadruple<>(keyMappingA, keyMappingB, keyMappingC, keyMappingD),
-                (groupStoreIndex, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(keyMappingA,
-                        keyMappingB, keyMappingC, keyMappingD, groupStoreIndex,
+                (storeIndexReserver, nextNodesTupleLifecycle, outputStoreSize, environmentMode) -> builder.build(keyMappingA,
+                        keyMappingB, keyMappingC, keyMappingD, storeIndexReserver,
                         nextNodesTupleLifecycle, outputStoreSize, environmentMode));
     }
 
     @FunctionalInterface
     interface NodeConstructorWithAccumulate<Tuple_ extends Tuple> {
 
-        AbstractNode apply(int groupStoreIndex, int undoStoreIndex, TupleLifecycle<Tuple_> nextNodesTupleLifecycle,
+        AbstractNode apply(IntSupplier storeIndexReserver, TupleLifecycle<Tuple_> nextNodesTupleLifecycle,
                 int outputStoreSize, EnvironmentMode environmentMode);
 
     }
@@ -184,21 +190,21 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
     @FunctionalInterface
     interface NodeConstructorWithoutAccumulate<Tuple_ extends Tuple> {
 
-        AbstractNode apply(int groupStoreIndex, TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize,
-                EnvironmentMode environmentMode);
+        AbstractNode apply(IntSupplier storeIndexReserver, TupleLifecycle<Tuple_> nextNodesTupleLifecycle,
+                int outputStoreSize, EnvironmentMode environmentMode);
 
     }
 
     @FunctionalInterface
     interface GroupBy0Mapping1CollectorNodeBuilder<CollectorA_, Tuple_ extends Tuple> {
-        AbstractNode build(int groupStoreIndex, int undoStoreIndex,
+        AbstractNode build(IntSupplier storeIndexReserver,
                 CollectorA_ collector,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
     }
 
     @FunctionalInterface
     interface GroupBy0Mapping2CollectorNodeBuilder<CollectorA_, CollectorB_, Tuple_ extends Tuple> {
-        AbstractNode build(int groupStoreIndex, int undoStoreIndex,
+        AbstractNode build(IntSupplier storeIndexReserver,
                 CollectorA_ collectorA,
                 CollectorB_ collectorB,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
@@ -206,7 +212,7 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
 
     @FunctionalInterface
     interface GroupBy0Mapping3CollectorNodeBuilder<CollectorA_, CollectorB_, CollectorC_, Tuple_ extends Tuple> {
-        AbstractNode build(int groupStoreIndex, int undoStoreIndex,
+        AbstractNode build(IntSupplier storeIndexReserver,
                 CollectorA_ collectorA,
                 CollectorB_ collectorB,
                 CollectorC_ collectorC,
@@ -215,7 +221,7 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
 
     @FunctionalInterface
     interface GroupBy0Mapping4CollectorNodeBuilder<CollectorA_, CollectorB_, CollectorC_, CollectorD_, Tuple_ extends Tuple> {
-        AbstractNode build(int groupStoreIndex, int undoStoreIndex,
+        AbstractNode build(IntSupplier storeIndexReserver,
                 CollectorA_ collectorA,
                 CollectorB_ collectorB,
                 CollectorC_ collectorC,
@@ -226,14 +232,14 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
     @FunctionalInterface
     interface GroupBy1Mapping0CollectorNodeBuilder<KeyA_, Tuple_ extends Tuple> {
         AbstractNode build(KeyA_ keyMapping,
-                int groupStoreIndex,
+                IntSupplier storeIndexReserver,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
     }
 
     @FunctionalInterface
     interface GroupBy2Mapping0CollectorNodeBuilder<KeyA_, KeyB_, Tuple_ extends Tuple> {
         AbstractNode build(KeyA_ keyMappingA,
-                KeyB_ keyMappingB, int groupStoreIndex,
+                KeyB_ keyMappingB, IntSupplier storeIndexReserver,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
     }
 
@@ -242,7 +248,7 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
         AbstractNode build(KeyA_ keyMappingA,
                 KeyB_ keyMappingB,
                 KeyC_ keyMappingC,
-                int groupStoreIndex,
+                IntSupplier storeIndexReserver,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
     }
 
@@ -252,14 +258,14 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
                 KeyB_ keyMappingB,
                 KeyC_ keyMappingC,
                 KeyD_ keyMappingD,
-                int groupStoreIndex,
+                IntSupplier storeIndexReserver,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
     }
 
     @FunctionalInterface
     interface GroupBy1Mapping1CollectorNodeBuilder<KeyA_, CollectorB_, Tuple_ extends Tuple> {
         AbstractNode build(KeyA_ keyMapping,
-                int groupStoreIndex, int undoStoreIndex,
+                IntSupplier storeIndexReserver,
                 CollectorB_ collector,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
     }
@@ -267,7 +273,7 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
     @FunctionalInterface
     interface GroupBy1Mapping2CollectorNodeBuilder<KeyA_, CollectorB_, CollectorC_, Tuple_ extends Tuple> {
         AbstractNode build(KeyA_ keyMapping,
-                int groupStoreIndex, int undoStoreIndex,
+                IntSupplier storeIndexReserver,
                 CollectorB_ collectorA,
                 CollectorC_ collectorB,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
@@ -276,7 +282,7 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
     @FunctionalInterface
     interface GroupBy1Mapping3CollectorNodeBuilder<KeyA_, CollectorB_, CollectorC_, CollectorD_, Tuple_ extends Tuple> {
         AbstractNode build(KeyA_ keyMapping,
-                int groupStoreIndex, int undoStoreIndex,
+                IntSupplier storeIndexReserver,
                 CollectorB_ collectorA,
                 CollectorC_ collectorB,
                 CollectorD_ collectorC,
@@ -286,7 +292,7 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
     @FunctionalInterface
     interface GroupBy2Mapping1CollectorNodeBuilder<KeyA_, KeyB_, CollectorC_, Tuple_ extends Tuple> {
         AbstractNode build(KeyA_ keyMappingA,
-                KeyB_ keyMappingB, int groupStoreIndex, int undoStoreIndex,
+                KeyB_ keyMappingB, IntSupplier storeIndexReserver,
                 CollectorC_ collectorC,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
     }
@@ -295,7 +301,7 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
     interface GroupBy2Mapping2CollectorNodeBuilder<KeyA_, KeyB_, CollectorC_, CollectorD_, Tuple_ extends Tuple> {
         AbstractNode build(KeyA_ keyMappingA,
                 KeyB_ keyMappingB,
-                int groupStoreIndex, int undoStoreIndex,
+                IntSupplier storeIndexReserver,
                 CollectorC_ collectorC,
                 CollectorD_ collectorD,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
@@ -306,7 +312,7 @@ public sealed interface GroupNodeConstructor<Tuple_ extends Tuple>
         AbstractNode build(KeyA_ keyMappingA,
                 KeyB_ keyMappingB,
                 KeyC_ keyMappingC,
-                int groupStoreIndex, int undoStoreIndex,
+                IntSupplier storeIndexReserver,
                 CollectorD_ collectorC,
                 TupleLifecycle<Tuple_> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/GroupNodeConstructorWithAccumulate.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/GroupNodeConstructorWithAccumulate.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.common;
 
 import java.util.List;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
@@ -19,11 +20,10 @@ final class GroupNodeConstructorWithAccumulate<Tuple_ extends Tuple> extends Abs
     @Override
     public <Stream_ extends BavetStream> void build(AbstractNodeBuildHelper<Stream_> buildHelper, Stream_ parentTupleSource,
             Stream_ aftStream, List<Stream_> aftStreamChildList, Stream_ bridgeStream, EnvironmentMode environmentMode) {
-        var groupStoreIndex = buildHelper.reserveTupleStoreIndex(parentTupleSource);
-        var undoStoreIndex = buildHelper.reserveTupleStoreIndex(parentTupleSource);
+        IntSupplier storeIndexReserver = () -> buildHelper.reserveTupleStoreIndex(parentTupleSource);
         TupleLifecycle<Tuple_> tupleLifecycle = buildHelper.getAggregatedTupleLifecycle(aftStreamChildList);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
-        var node = nodeConstructorFunction.apply(groupStoreIndex, undoStoreIndex, tupleLifecycle, outputStoreSize,
+        var node = nodeConstructorFunction.apply(storeIndexReserver, tupleLifecycle, outputStoreSize,
                 environmentMode);
         buildHelper.addNode(node, bridgeStream);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/GroupNodeConstructorWithoutAccumulate.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/GroupNodeConstructorWithoutAccumulate.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.common;
 
 import java.util.List;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.Tuple;
@@ -19,10 +20,10 @@ final class GroupNodeConstructorWithoutAccumulate<Tuple_ extends Tuple> extends 
     @Override
     public <Stream_ extends BavetStream> void build(AbstractNodeBuildHelper<Stream_> buildHelper, Stream_ parentTupleSource,
             Stream_ aftStream, List<Stream_> aftStreamChildList, Stream_ bridgeStream, EnvironmentMode environmentMode) {
-        var groupStoreIndex = buildHelper.reserveTupleStoreIndex(parentTupleSource);
+        IntSupplier storeIndexReserver = () -> buildHelper.reserveTupleStoreIndex(parentTupleSource);
         TupleLifecycle<Tuple_> tupleLifecycle = buildHelper.getAggregatedTupleLifecycle(aftStreamChildList);
         var outputStoreSize = buildHelper.extractTupleStoreSize(aftStream);
-        var node = nodeConstructorFunction.apply(groupStoreIndex, tupleLifecycle, outputStoreSize, environmentMode);
+        var node = nodeConstructorFunction.apply(storeIndexReserver, tupleLifecycle, outputStoreSize, environmentMode);
         buildHelper.addNode(node, bridgeStream);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/Tuple.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/Tuple.java
@@ -33,4 +33,55 @@ public sealed interface Tuple permits BiTuple, QuadTuple, TriTuple, UniTuple {
 
     <Value_> @Nullable Value_ removeStore(int index);
 
+    /**
+     * Records the one or two other tuples, if any, whose own activity this tuple's activity is entangled
+     * with (see {@link #isActiveTransitively}). Not readable from here: only {@link #isActiveTransitively}
+     * ever needs to walk this link, and it does so via direct field access on the sealed hierarchy's sole
+     * implementation, without a getter pair.
+     * <p>
+     * {@code map}/{@code flatten} call the single-argument overload, pointing at their one input.
+     * Join nodes call the two-argument overload, pointing at their left and right input. {@code
+     * ifExists}/{@code ifNotExists} need no equivalent: they re-propagate the original left tuple unchanged,
+     * so they inherit whatever chain that tuple already carries. {@code groupBy}/{@code distinct} must never
+     * call this: a group tuple's validity isn't reducible to any single contributing tuple (it's an N:1
+     * aggregate), so there is no correct parent to link.
+     */
+    void setActivityParent(Tuple activityParent);
+
+    /**
+     * @see #setActivityParent(Tuple)
+     */
+    void setActivityParents(Tuple leftParent, Tuple rightParent);
+
+    /**
+     * Whether {@code tuple}, and everything it was derived from, is still live — closes a race that
+     * plain {@code tuple.getState().isActive()} cannot see on its own.
+     * <p>
+     * A join, {@code ifExists}/{@code ifNotExists}, {@code map}, or {@code flatten} node retracts its
+     * own out-tuple the moment its retracting parent's flush <i>reaches</i> it — but that flush only runs
+     * during the parent's own network layer, which can come <i>after</i> a shallow sibling has already
+     * re-tested this out-tuple against some unrelated update. During that window, {@code tuple.getState()}
+     * alone still reports {@code OK} or {@code UPDATING} (both "active"), even though the tuple is only one
+     * flush away from being retracted. Concretely: a 3-hop self-join's last join can be poked by its own
+     * right-hand {@code .map()} bridge (a shallow, low-layer node) before an earlier join in the chain has
+     * had its turn to retract the tuple that poke is about to read — the read happens on stale-but-"active"
+     * data, and a user filtering predicate that dereferences a now-null shadow variable crashes.
+     * <p>
+     * {@link #setActivityParent(Tuple)} closes that window: it points at a tuple this one was built from,
+     * and that tuple's own {@code getState()} is always synchronously correct, because retraction eagerly
+     * sets a tuple's state the instant its own producing node's {@code retract()} runs — regardless of when
+     * that producing node's own downstream notification is flushed. Walking the chain therefore always
+     * terminates on state that's trustworthy, even when the tuple in hand is not (yet).
+     * <p>
+     * A join's out-tuple has <i>two</i> such ancestors (left and right), because either side retracting
+     * makes it stale — not just the left one; both are checked (the right one recursively, since it can
+     * itself be a deeper map/flatten chain).
+     * <p>
+     * Ceiling: {@code groupBy}/{@code distinct} never call {@link #setActivityParent(Tuple)} on their
+     * output, because a group tuple has no single input tuple whose activity implies the group's own — it's
+     * an N:1 aggregate that can outlive any one contributor's retraction, or die because a <i>different</i>
+     * contributor left. The walk correctly stops there; it just can't see past it.
+     */
+    boolean isActiveTransitively();
+
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/Tuple.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/Tuple.java
@@ -21,7 +21,9 @@ import org.jspecify.annotations.Nullable;
  * However, only the origin node of a tuple (the node where the tuple is the out tuple) may modify it.
  */
 @NullMarked
-public sealed interface Tuple permits BiTuple, QuadTuple, TriTuple, UniTuple {
+public sealed interface Tuple
+        extends TupleActivitySource
+        permits BiTuple, QuadTuple, TriTuple, UniTuple {
 
     TupleState getState();
 
@@ -54,6 +56,15 @@ public sealed interface Tuple permits BiTuple, QuadTuple, TriTuple, UniTuple {
     void setActivityParents(Tuple leftParent, Tuple rightParent);
 
     /**
+     * Overrides this tuple's default {@link #isActiveTransitively()} answer (the
+     * {@link #setActivityParent(Tuple)}/{@link #setActivityParents(Tuple, Tuple)} chain) with a custom
+     * {@link TupleActivitySource}. Only groupBy's {@code Group} calls this: a group tuple's validity is
+     * "at least one of however many contributors currently exist is still active," which isn't
+     * expressible as a chain of 1 or 2 fixed tuples.
+     */
+    void setActivitySource(TupleActivitySource activitySource);
+
+    /**
      * Whether {@code tuple}, and everything it was derived from, is still live — closes a race that
      * plain {@code tuple.getState().isActive()} cannot see on its own.
      * <p>
@@ -77,11 +88,12 @@ public sealed interface Tuple permits BiTuple, QuadTuple, TriTuple, UniTuple {
      * makes it stale — not just the left one; both are checked (the right one recursively, since it can
      * itself be a deeper map/flatten chain).
      * <p>
-     * Ceiling: {@code groupBy}/{@code distinct} never call {@link #setActivityParent(Tuple)} on their
-     * output, because a group tuple has no single input tuple whose activity implies the group's own — it's
-     * an N:1 aggregate that can outlive any one contributor's retraction, or die because a <i>different</i>
-     * contributor left. The walk correctly stops there; it just can't see past it.
+     * {@code groupBy}/{@code distinct} can't use this chain at all: a group tuple has no single input
+     * tuple whose activity implies the group's own — it's an N:1 aggregate that can outlive any one
+     * contributor's retraction, or die because a <i>different</i> contributor left. They instead call
+     * {@link #setActivitySource(TupleActivitySource)} to override this method's answer entirely.
      */
+    @Override
     boolean isActiveTransitively();
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/TupleActivitySource.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/TupleActivitySource.java
@@ -1,0 +1,15 @@
+package ai.timefold.solver.core.impl.bavet.common.tuple;
+
+/**
+ * Supplies a tuple's "is this, transitively, still live" answer. {@link Tuple} extends this — every
+ * tuple already answers this about itself via its own activityParent1/activityParent2 chain — so
+ * {@link #isActiveTransitively()} is one method regardless of producer. Only a producer whose
+ * out-tuple's validity can't be expressed as that chain overrides the default explicitly; currently
+ * only groupBy's {@code Group} (an OR across however many contributors currently exist, not a fixed
+ * 1-or-2-tuple chain).
+ */
+public interface TupleActivitySource {
+
+    boolean isActiveTransitively();
+
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/UniversalTuple.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/UniversalTuple.java
@@ -21,6 +21,8 @@ final class UniversalTuple<A, B, C, D>
     private @Nullable C c;
     private @Nullable D d;
     private TupleState state = TupleState.DEAD; // It's the node's job to mark a new tuple as CREATING.
+    private @Nullable Tuple activityParent1;
+    private @Nullable Tuple activityParent2;
 
     UniversalTuple(int storeSize, int cardinality) {
         this.cardinality = cardinality;
@@ -93,6 +95,36 @@ final class UniversalTuple<A, B, C, D>
         Value_ value = getStore(index);
         setStore(index, null);
         return value;
+    }
+
+    @Override
+    public void setActivityParent(Tuple activityParent) {
+        this.activityParent1 = activityParent;
+    }
+
+    @Override
+    public void setActivityParents(Tuple leftParent, Tuple rightParent) {
+        this.activityParent1 = leftParent;
+        this.activityParent2 = rightParent;
+    }
+
+    @Override
+    public boolean isActiveTransitively() {
+        var self = this;
+        while (true) {
+            if (!self.state.isActive()) {
+                return false;
+            }
+            var otherParent = self.activityParent2;
+            if (otherParent != null && !otherParent.isActiveTransitively()) {
+                return false;
+            }
+            var parent = self.activityParent1;
+            if (parent == null) {
+                return true;
+            }
+            self = (UniversalTuple<A, B, C, D>) parent;
+        }
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/UniversalTuple.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/common/tuple/UniversalTuple.java
@@ -23,6 +23,7 @@ final class UniversalTuple<A, B, C, D>
     private TupleState state = TupleState.DEAD; // It's the node's job to mark a new tuple as CREATING.
     private @Nullable Tuple activityParent1;
     private @Nullable Tuple activityParent2;
+    private @Nullable TupleActivitySource activitySource;
 
     UniversalTuple(int storeSize, int cardinality) {
         this.cardinality = cardinality;
@@ -109,7 +110,15 @@ final class UniversalTuple<A, B, C, D>
     }
 
     @Override
+    public void setActivitySource(TupleActivitySource activitySource) {
+        this.activitySource = activitySource;
+    }
+
+    @Override
     public boolean isActiveTransitively() {
+        if (activitySource != null) {
+            return state.isActive() && activitySource.isActiveTransitively();
+        }
         var self = this;
         while (true) {
             if (!self.state.isActive()) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/AbstractGroupQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/AbstractGroupQuadNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollectorAccumulator;
@@ -21,20 +22,20 @@ abstract class AbstractGroupQuadNode<OldA, OldB, OldC, OldD, OutTuple_ extends T
     private final int groupAccumulatorIndex;
     private final @Nullable QuadConstraintCollectorAccumulator<ResultContainer_, OldA, OldB, OldC, OldD> incrementalAccumulator;
 
-    protected AbstractGroupQuadNode(int groupStoreIndex, int groupAccumulatorIndex,
+    protected AbstractGroupQuadNode(IntSupplier storeIndexReserver,
             Function<QuadTuple<OldA, OldB, OldC, OldD>, GroupKey_> groupKeyFunction,
             @NonNull QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, Result_> collector,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, groupKeyFunction, collector.supplier(), collector.finisher(), nextNodesTupleLifecycle,
+        super(storeIndexReserver, groupKeyFunction, collector.supplier(), collector.finisher(), nextNodesTupleLifecycle,
                 environmentMode);
-        this.groupAccumulatorIndex = groupAccumulatorIndex;
+        this.groupAccumulatorIndex = storeIndexReserver.getAsInt();
         this.incrementalAccumulator = QuadCollectorUtils.toIncremental(collector.accumulator());
     }
 
-    protected AbstractGroupQuadNode(int groupStoreIndex,
+    protected AbstractGroupQuadNode(IntSupplier storeIndexReserver,
             Function<QuadTuple<OldA, OldB, OldC, OldD>, GroupKey_> groupKeyFunction,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, groupKeyFunction, nextNodesTupleLifecycle, environmentMode);
+        super(storeIndexReserver, groupKeyFunction, nextNodesTupleLifecycle, environmentMode);
         this.groupAccumulatorIndex = -1;
         this.incrementalAccumulator = null;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group0Mapping1CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group0Mapping1CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
@@ -10,10 +12,10 @@ public final class Group0Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, Re
 
     private final int outputStoreSize;
 
-    public Group0Mapping1CollectorQuadNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping1CollectorQuadNode(IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, A> collector,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, collector, nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group0Mapping2CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group0Mapping2CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -12,11 +14,11 @@ public final class Group0Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
 
     private final int outputStoreSize;
 
-    public Group0Mapping2CollectorQuadNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping2CollectorQuadNode(IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerA_, A> collectorA,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle,
                 environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group0Mapping3CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group0Mapping3CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -13,12 +15,12 @@ public final class Group0Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
 
     private final int outputStoreSize;
 
-    public Group0Mapping3CollectorQuadNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping3CollectorQuadNode(IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerA_, A> collectorA,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB, collectorC),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group0Mapping4CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group0Mapping4CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -13,14 +15,14 @@ public final class Group0Mapping4CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
 
     private final int outputStoreSize;
 
-    public Group0Mapping4CollectorQuadNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping4CollectorQuadNode(IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerA_, A> collectorA,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB, collectorC, collectorD),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group1Mapping0CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group1Mapping0CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.QuadTuple;
@@ -12,9 +14,9 @@ public final class Group1Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A>
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMapping, tuple), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group1Mapping1CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group1Mapping1CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -12,10 +14,10 @@ public final class Group1Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
     private final int outputStoreSize;
 
     public Group1Mapping1CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, B> collector,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group1Mapping0CollectorQuadNode.createGroupKey(groupKeyMapping, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group1Mapping2CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group1Mapping2CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -13,11 +15,11 @@ public final class Group1Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
     private final int outputStoreSize;
 
     public Group1Mapping2CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group1Mapping0CollectorQuadNode.createGroupKey(groupKeyMapping, tuple),
                 Group0Mapping2CollectorQuadNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group1Mapping3CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group1Mapping3CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -14,13 +16,13 @@ public final class Group1Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
     private final int outputStoreSize;
 
     public Group1Mapping3CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex, tuple -> Group1Mapping0CollectorQuadNode.createGroupKey(groupKeyMapping, tuple),
+        super(storeIndexReserver, tuple -> Group1Mapping0CollectorQuadNode.createGroupKey(groupKeyMapping, tuple),
                 Group0Mapping3CollectorQuadNode.mergeCollectors(collectorB, collectorC, collectorD), nextNodesTupleLifecycle,
                 environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group2Mapping0CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group2Mapping0CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.BiTuple;
@@ -14,9 +16,9 @@ public final class Group2Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B>
 
     public Group2Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), nextNodesTupleLifecycle,
                 environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group2Mapping1CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group2Mapping1CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -15,10 +17,10 @@ public final class Group2Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
 
     public Group2Mapping1CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, C> collector,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group2Mapping0CollectorQuadNode.createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group2Mapping2CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group2Mapping2CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -15,12 +17,12 @@ public final class Group2Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
 
     public Group2Mapping2CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group2Mapping0CollectorQuadNode.createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
                 Group0Mapping2CollectorQuadNode.mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group3Mapping0CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group3Mapping0CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.QuadTuple;
@@ -15,9 +17,9 @@ public final class Group3Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
 
     public Group3Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group3Mapping1CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group3Mapping1CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.api.score.stream.quad.QuadConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -15,11 +17,11 @@ public final class Group3Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
 
     public Group3Mapping1CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, D> collector,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group3Mapping0CollectorQuadNode.createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC,
                         tuple),
                 collector,

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group4Mapping0CollectorQuadNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/quad/Group4Mapping0CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.quad;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.QuadFunction;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.QuadTuple;
@@ -15,10 +17,10 @@ public final class Group4Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B,
     public Group4Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
             QuadFunction<OldA, OldB, OldC, OldD, D> groupKeyMappingD,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, groupKeyMappingD, tuple),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/AbstractGroupTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/AbstractGroupTriNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollectorAccumulator;
@@ -21,19 +22,20 @@ abstract class AbstractGroupTriNode<OldA, OldB, OldC, OutTuple_ extends Tuple, G
     private final int groupAccumulatorIndex;
     private final @Nullable TriConstraintCollectorAccumulator<ResultContainer_, OldA, OldB, OldC> incrementalAccumulator;
 
-    protected AbstractGroupTriNode(int groupStoreIndex, int groupAccumulatorIndex,
+    protected AbstractGroupTriNode(IntSupplier storeIndexReserver,
             Function<TriTuple<OldA, OldB, OldC>, GroupKey_> groupKeyFunction,
             @NonNull TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, Result_> collector,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, groupKeyFunction, collector.supplier(), collector.finisher(), nextNodesTupleLifecycle,
+        super(storeIndexReserver, groupKeyFunction, collector.supplier(), collector.finisher(), nextNodesTupleLifecycle,
                 environmentMode);
-        this.groupAccumulatorIndex = groupAccumulatorIndex;
+        this.groupAccumulatorIndex = storeIndexReserver.getAsInt();
         this.incrementalAccumulator = TriCollectorUtils.toIncremental(collector.accumulator());
     }
 
-    protected AbstractGroupTriNode(int groupStoreIndex, Function<TriTuple<OldA, OldB, OldC>, GroupKey_> groupKeyFunction,
+    protected AbstractGroupTriNode(IntSupplier storeIndexReserver,
+            Function<TriTuple<OldA, OldB, OldC>, GroupKey_> groupKeyFunction,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, groupKeyFunction, nextNodesTupleLifecycle, environmentMode);
+        super(storeIndexReserver, groupKeyFunction, nextNodesTupleLifecycle, environmentMode);
         this.groupAccumulatorIndex = -1;
         this.incrementalAccumulator = null;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group0Mapping1CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group0Mapping1CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
@@ -10,10 +12,10 @@ public final class Group0Mapping1CollectorTriNode<OldA, OldB, OldC, A, ResultCon
 
     private final int outputStoreSize;
 
-    public Group0Mapping1CollectorTriNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping1CollectorTriNode(IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, A> collector,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, collector, nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group0Mapping2CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group0Mapping2CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -12,11 +14,11 @@ public final class Group0Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, Result
 
     private final int outputStoreSize;
 
-    public Group0Mapping2CollectorTriNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping2CollectorTriNode(IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerA_, A> collectorA,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle,
                 environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group0Mapping3CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group0Mapping3CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -13,12 +15,12 @@ public final class Group0Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, Res
 
     private final int outputStoreSize;
 
-    public Group0Mapping3CollectorTriNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping3CollectorTriNode(IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerA_, A> collectorA,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB, collectorC),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group0Mapping4CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group0Mapping4CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -13,14 +15,14 @@ public final class Group0Mapping4CollectorTriNode<OldA, OldB, OldC, A, B, C, D, 
 
     private final int outputStoreSize;
 
-    public Group0Mapping4CollectorTriNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping4CollectorTriNode(IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerA_, A> collectorA,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB, collectorC, collectorD),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group1Mapping0CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group1Mapping0CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TriTuple;
@@ -12,9 +14,9 @@ public final class Group1Mapping0CollectorTriNode<OldA, OldB, OldC, A>
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMapping, tuple), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group1Mapping1CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group1Mapping1CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -12,10 +14,10 @@ public final class Group1Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, Result
     private final int outputStoreSize;
 
     public Group1Mapping1CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, B> collector,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group1Mapping0CollectorTriNode.createGroupKey(groupKeyMapping, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group1Mapping2CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group1Mapping2CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -13,11 +15,11 @@ public final class Group1Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, C, Res
     private final int outputStoreSize;
 
     public Group1Mapping2CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group1Mapping0CollectorTriNode.createGroupKey(groupKeyMapping, tuple),
                 Group0Mapping2CollectorTriNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group1Mapping3CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group1Mapping3CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -14,13 +16,13 @@ public final class Group1Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, D, 
     private final int outputStoreSize;
 
     public Group1Mapping3CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group1Mapping0CollectorTriNode.createGroupKey(groupKeyMapping, tuple),
                 Group0Mapping3CollectorTriNode.mergeCollectors(collectorB, collectorC, collectorD), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group2Mapping0CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group2Mapping0CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.BiTuple;
@@ -13,9 +15,9 @@ public final class Group2Mapping0CollectorTriNode<OldA, OldB, OldC, A, B>
     private final int outputStoreSize;
 
     public Group2Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
-            TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, int groupStoreIndex,
+            TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, IntSupplier storeIndexReserver,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group2Mapping1CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group2Mapping1CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -15,10 +17,10 @@ public final class Group2Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, C, Res
 
     public Group2Mapping1CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, C> collector,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group2Mapping0CollectorTriNode.createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group2Mapping2CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group2Mapping2CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -15,12 +17,12 @@ public final class Group2Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, C, D, 
 
     public Group2Mapping2CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group2Mapping0CollectorTriNode.createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
                 Group0Mapping2CollectorTriNode.mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group3Mapping0CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group3Mapping0CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TriTuple;
@@ -13,9 +15,9 @@ public final class Group3Mapping0CollectorTriNode<OldA, OldB, OldC, A, B, C>
 
     public Group3Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group3Mapping1CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group3Mapping1CollectorTriNode.java
@@ -2,6 +2,8 @@ package ai.timefold.solver.core.impl.bavet.tri;
 
 import static ai.timefold.solver.core.impl.bavet.tri.Group3Mapping0CollectorTriNode.createGroupKey;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.api.score.stream.tri.TriConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -17,11 +19,11 @@ public final class Group3Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, C, D, 
 
     public Group3Mapping1CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, D> collector,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group4Mapping0CollectorTriNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/tri/Group4Mapping0CollectorTriNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.tri;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.function.TriFunction;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.QuadTuple;
@@ -16,10 +18,10 @@ public final class Group4Mapping0CollectorTriNode<OldA, OldB, OldC, A, B, C, D>
     public Group4Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
             TriFunction<OldA, OldB, OldC, D> groupKeyMappingD,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, groupKeyMappingD, tuple),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/AbstractGroupUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/AbstractGroupUniNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollectorAccumulator;
@@ -21,19 +22,19 @@ abstract class AbstractGroupUniNode<OldA, OutTuple_ extends Tuple, GroupKey_, Re
     private final int groupAccumulatorIndex;
     private final @Nullable UniConstraintCollectorAccumulator<ResultContainer_, OldA> incrementalAccumulator;
 
-    protected AbstractGroupUniNode(int groupStoreIndex, int groupAccumulatorIndex,
+    protected AbstractGroupUniNode(IntSupplier storeIndexReserver,
             Function<UniTuple<OldA>, GroupKey_> groupKeyFunction,
             @NonNull UniConstraintCollector<OldA, ResultContainer_, Result_> collector,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, groupKeyFunction, collector.supplier(), collector.finisher(), nextNodesTupleLifecycle,
+        super(storeIndexReserver, groupKeyFunction, collector.supplier(), collector.finisher(), nextNodesTupleLifecycle,
                 environmentMode);
-        this.groupAccumulatorIndex = groupAccumulatorIndex;
+        this.groupAccumulatorIndex = storeIndexReserver.getAsInt();
         this.incrementalAccumulator = UniCollectorUtils.toIncremental(collector.accumulator());
     }
 
-    protected AbstractGroupUniNode(int groupStoreIndex, Function<UniTuple<OldA>, GroupKey_> groupKeyFunction,
+    protected AbstractGroupUniNode(IntSupplier storeIndexReserver, Function<UniTuple<OldA>, GroupKey_> groupKeyFunction,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, groupKeyFunction, nextNodesTupleLifecycle, environmentMode);
+        super(storeIndexReserver, groupKeyFunction, nextNodesTupleLifecycle, environmentMode);
         this.groupAccumulatorIndex = -1;
         this.incrementalAccumulator = null;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group0Mapping1CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group0Mapping1CollectorUniNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
@@ -10,10 +12,10 @@ public final class Group0Mapping1CollectorUniNode<OldA, A, ResultContainer_>
 
     private final int outputStoreSize;
 
-    public Group0Mapping1CollectorUniNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping1CollectorUniNode(IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainer_, A> collector,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, collector, nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group0Mapping2CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group0Mapping2CollectorUniNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -12,11 +14,11 @@ public final class Group0Mapping2CollectorUniNode<OldA, A, B, ResultContainerA_,
 
     private final int outputStoreSize;
 
-    public Group0Mapping2CollectorUniNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping2CollectorUniNode(IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainerA_, A> collectorA,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group0Mapping3CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group0Mapping3CollectorUniNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -12,12 +14,12 @@ public final class Group0Mapping3CollectorUniNode<OldA, A, B, C, ResultContainer
 
     private final int outputStoreSize;
 
-    public Group0Mapping3CollectorUniNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping3CollectorUniNode(IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainerA_, A> collectorA,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB, collectorC),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group0Mapping4CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group0Mapping4CollectorUniNode.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
+import java.util.function.IntSupplier;
+
 import ai.timefold.solver.core.api.score.stream.ConstraintCollectors;
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -13,14 +15,14 @@ public final class Group0Mapping4CollectorUniNode<OldA, A, B, C, D, ResultContai
 
     private final int outputStoreSize;
 
-    public Group0Mapping4CollectorUniNode(int groupStoreIndex, int undoStoreIndex,
+    public Group0Mapping4CollectorUniNode(IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainerA_, A> collectorA,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             UniConstraintCollector<OldA, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 null, mergeCollectors(collectorA, collectorB, collectorC, collectorD),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group1Mapping0CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group1Mapping0CollectorUniNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TupleLifecycle;
@@ -12,9 +13,9 @@ public final class Group1Mapping0CollectorUniNode<OldA, A>
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorUniNode(Function<OldA, A> groupKeyMapping,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMapping, tuple), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group1Mapping1CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group1Mapping1CollectorUniNode.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.bavet.uni;
 import static ai.timefold.solver.core.impl.bavet.uni.Group1Mapping0CollectorUniNode.createGroupKey;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -15,10 +16,10 @@ public final class Group1Mapping1CollectorUniNode<OldA, A, B, ResultContainer_>
     private final int outputStoreSize;
 
     public Group1Mapping1CollectorUniNode(Function<OldA, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainer_, B> collector,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMapping, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group1Mapping2CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group1Mapping2CollectorUniNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -14,11 +15,11 @@ public final class Group1Mapping2CollectorUniNode<OldA, A, B, C, ResultContainer
     private final int outputStoreSize;
 
     public Group1Mapping2CollectorUniNode(Function<OldA, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> Group1Mapping0CollectorUniNode.createGroupKey(groupKeyMapping, tuple),
                 Group0Mapping2CollectorUniNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group1Mapping3CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group1Mapping3CollectorUniNode.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.bavet.uni;
 import static ai.timefold.solver.core.impl.bavet.uni.Group1Mapping0CollectorUniNode.createGroupKey;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -16,13 +17,13 @@ public final class Group1Mapping3CollectorUniNode<OldA, A, B, C, D, ResultContai
     private final int outputStoreSize;
 
     public Group1Mapping3CollectorUniNode(Function<OldA, A> groupKeyMapping,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             UniConstraintCollector<OldA, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMapping, tuple),
                 Group0Mapping3CollectorUniNode.mergeCollectors(collectorB, collectorC, collectorD), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group2Mapping0CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group2Mapping0CollectorUniNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.BiTuple;
@@ -14,9 +15,9 @@ public final class Group2Mapping0CollectorUniNode<OldA, A, B>
     private final int outputStoreSize;
 
     public Group2Mapping0CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group2Mapping1CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group2Mapping1CollectorUniNode.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.bavet.uni;
 import static ai.timefold.solver.core.impl.bavet.uni.Group2Mapping0CollectorUniNode.createGroupKey;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -16,10 +17,10 @@ public final class Group2Mapping1CollectorUniNode<OldA, A, B, C, ResultContainer
     private final int outputStoreSize;
 
     public Group2Mapping1CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainer_, C> collector,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group2Mapping2CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group2Mapping2CollectorUniNode.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.bavet.uni;
 import static ai.timefold.solver.core.impl.bavet.uni.Group2Mapping0CollectorUniNode.createGroupKey;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -16,12 +17,12 @@ public final class Group2Mapping2CollectorUniNode<OldA, A, B, C, D, ResultContai
     private final int outputStoreSize;
 
     public Group2Mapping2CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             UniConstraintCollector<OldA, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
                 Group0Mapping2CollectorUniNode.mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle,
                 environmentMode);

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group3Mapping0CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group3Mapping0CollectorUniNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.TriTuple;
@@ -14,9 +15,9 @@ public final class Group3Mapping0CollectorUniNode<OldA, A, B, C>
     private final int outputStoreSize;
 
     public Group3Mapping0CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
-            Function<OldA, C> groupKeyMappingC, int groupStoreIndex,
+            Function<OldA, C> groupKeyMappingC, IntSupplier storeIndexReserver,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize, EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group3Mapping1CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group3Mapping1CollectorUniNode.java
@@ -3,6 +3,7 @@ package ai.timefold.solver.core.impl.bavet.uni;
 import static ai.timefold.solver.core.impl.bavet.uni.Group3Mapping0CollectorUniNode.createGroupKey;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.api.score.stream.uni.UniConstraintCollector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -18,11 +19,11 @@ public final class Group3Mapping1CollectorUniNode<OldA, A, B, C, D, ResultContai
 
     public Group3Mapping1CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             Function<OldA, C> groupKeyMappingC,
-            int groupStoreIndex, int undoStoreIndex,
+            IntSupplier storeIndexReserver,
             UniConstraintCollector<OldA, ResultContainer_, D> collector,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex, undoStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple), collector,
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group4Mapping0CollectorUniNode.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/bavet/uni/Group4Mapping0CollectorUniNode.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.bavet.uni;
 
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.impl.bavet.common.tuple.QuadTuple;
@@ -16,10 +17,10 @@ public final class Group4Mapping0CollectorUniNode<OldA, A, B, C, D>
 
     public Group4Mapping0CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             Function<OldA, C> groupKeyMappingC, Function<OldA, D> groupKeyMappingD,
-            int groupStoreIndex,
+            IntSupplier storeIndexReserver,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
             EnvironmentMode environmentMode) {
-        super(groupStoreIndex,
+        super(storeIndexReserver,
                 tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, groupKeyMappingD, tuple),
                 nextNodesTupleLifecycle, environmentMode);
         this.outputStoreSize = outputStoreSize;

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetRegressionTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetRegressionTest.java
@@ -23,7 +23,6 @@ import ai.timefold.solver.core.testdomain.list.unassignedvar.TestdataAllowsUnass
 import ai.timefold.solver.core.testdomain.shadow.multiplelistener.TestdataListMultipleShadowVariableSolution;
 import ai.timefold.solver.core.testdomain.shadow.multiplelistener.TestdataListMultipleShadowVariableValue;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 
 final class BavetRegressionTest extends AbstractConstraintStreamTest {
@@ -1223,13 +1222,11 @@ final class BavetRegressionTest extends AbstractConstraintStreamTest {
 
     /**
      * Like {@link #filteringJoinNullConflictThroughMapUnassignOne()}, but with {@code .groupBy()} instead
-     * of {@code .map()} in the middle of the chain. Unlike map/flatten, a group tuple is an N:1 aggregate
-     * with no single input tuple whose activity implies the group's own, so this one is expected to remain
-     * broken even after the fix — see "groupBy stays unfixed".
+     * of {@code .map()} in the middle of the chain. groupBy's out-tuple has no single input tuple whose
+     * activity implies its own (it's an N:1 aggregate), so it uses {@code Group}'s
+     * {@code TupleActivitySource} instead of the {@code activityParent1}/{@code activityParent2} chain.
      */
     @TestTemplate
-    @Disabled("Known ceiling: groupBy's output is an N:1 aggregate with no single parent tuple to track "
-            + "(see Tuple#isActiveTransitively); this reproduces the still-open stale-activity race.")
     public void filteringJoinNullConflictThroughGroupByUnassignOne() {
         var solution = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(2, 1);
         var entity = solution.getEntityList().getFirst();
@@ -1284,6 +1281,139 @@ final class BavetRegressionTest extends AbstractConstraintStreamTest {
 
             assertScore(scoreDirector,
                     assertMatch(value2, value2));
+        }
+    }
+
+    /**
+     * Like {@link #filteringJoinNullConflictThroughGroupByUnassignOne()}, but with many contributors
+     * mapped into a single group instead of one. Confirms {@code Group}'s {@code TupleList}-backed
+     * contributor tracking correctly identifies that the group survives when only one of many
+     * contributors dies, with the dying contributor's value excluded downstream.
+     */
+    @TestTemplate
+    public void filteringJoinNullConflictThroughLargeGroupUnassignOne() {
+        var solution = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(10, 1);
+        var entity = solution.getEntityList().getFirst();
+        var values = solution.getValueList();
+
+        try (InnerScoreDirector<TestdataAllowsUnassignedValuesListSolution, SimpleScore> scoreDirector =
+                buildScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(Function.identity(), Function.identity()))
+                                        .groupBy((TestdataAllowsUnassignedValuesListValue a,
+                                                TestdataAllowsUnassignedValuesListValue b) -> a.getEntity())
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(Function.identity(),
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity),
+                                                filtering((groupEntity, value) -> {
+                                                    Objects.requireNonNull(groupEntity);
+                                                    Objects.requireNonNull(value.getEntity());
+                                                    return true;
+                                                }))
+                                        .penalize(SimpleScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_ID)
+                        })) {
+
+            scoreDirector.setWorkingSolution(solution);
+            for (var value : values) {
+                scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value);
+            }
+            scoreDirector.beforeListVariableChanged(entity, "valueList", 0, 0);
+            entity.getValueList().addAll(values);
+            scoreDirector.afterListVariableChanged(entity, "valueList", 0, values.size());
+            for (var i = values.size() - 1; i >= 0; i--) {
+                scoreDirector.afterListVariableElementAssigned(entity, "valueList", values.get(i));
+            }
+
+            assertScore(scoreDirector,
+                    values.stream().map(value -> assertMatch(entity, value)).toArray(AssertableMatch[]::new));
+
+            // Unassign one of the ten contributors; the group (keyed by the shared entity) still has nine
+            // and survives.
+            var valueToUnassign = values.getFirst();
+            var variableDescriptor = scoreDirector.getSolutionDescriptor()
+                    .getListVariableDescriptor();
+            scoreDirector.beforeListVariableElementUnassigned(variableDescriptor, valueToUnassign);
+            scoreDirector.beforeListVariableChanged(variableDescriptor, entity, 0, values.size());
+            entity.getValueList().remove(valueToUnassign);
+            scoreDirector.afterListVariableChanged(variableDescriptor, entity, 0, values.size() - 1);
+            scoreDirector.afterListVariableElementUnassigned(variableDescriptor, valueToUnassign);
+
+            assertScore(scoreDirector,
+                    values.stream()
+                            .filter(value -> value != valueToUnassign)
+                            .map(value -> assertMatch(entity, value))
+                            .toArray(AssertableMatch[]::new));
+        }
+    }
+
+    /**
+     * Like {@link #filteringJoinNullConflictThroughLargeGroupUnassignOne()}, but unassigning every
+     * contributor in the same transaction. Confirms the group itself is correctly, fully retracted
+     * downstream once its {@code TupleList} of contributors becomes empty — exercises
+     * {@code Group#isEmpty()}/{@code AbstractGroupNode#killOutTuple} for a many-contributor group, not
+     * just the single-contributor case the disabled-then-fixed test above already covers.
+     */
+    @TestTemplate
+    public void filteringJoinNullConflictThroughLargeGroupUnassignAll() {
+        var solution = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(10, 1);
+        var entity = solution.getEntityList().getFirst();
+        var values = solution.getValueList();
+
+        try (InnerScoreDirector<TestdataAllowsUnassignedValuesListSolution, SimpleScore> scoreDirector =
+                buildScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(Function.identity(), Function.identity()))
+                                        .groupBy((TestdataAllowsUnassignedValuesListValue a,
+                                                TestdataAllowsUnassignedValuesListValue b) -> a.getEntity())
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(Function.identity(),
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity),
+                                                filtering((groupEntity, value) -> {
+                                                    Objects.requireNonNull(groupEntity);
+                                                    Objects.requireNonNull(value.getEntity());
+                                                    return true;
+                                                }))
+                                        .penalize(SimpleScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_ID)
+                        })) {
+
+            scoreDirector.setWorkingSolution(solution);
+            for (var value : values) {
+                scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value);
+            }
+            scoreDirector.beforeListVariableChanged(entity, "valueList", 0, 0);
+            entity.getValueList().addAll(values);
+            scoreDirector.afterListVariableChanged(entity, "valueList", 0, values.size());
+            for (var i = values.size() - 1; i >= 0; i--) {
+                scoreDirector.afterListVariableElementAssigned(entity, "valueList", values.get(i));
+            }
+
+            assertScore(scoreDirector,
+                    values.stream().map(value -> assertMatch(entity, value)).toArray(AssertableMatch[]::new));
+
+            // Unassign every contributor at once; the group must fully retract, with nothing left downstream.
+            var variableDescriptor = scoreDirector.getSolutionDescriptor()
+                    .getListVariableDescriptor();
+            for (var value : values) {
+                scoreDirector.beforeListVariableElementUnassigned(variableDescriptor, value);
+            }
+            scoreDirector.beforeListVariableChanged(variableDescriptor, entity, 0, values.size());
+            entity.getValueList().clear();
+            scoreDirector.afterListVariableChanged(variableDescriptor, entity, 0, 0);
+            for (var i = values.size() - 1; i >= 0; i--) {
+                scoreDirector.afterListVariableElementUnassigned(variableDescriptor, values.get(i));
+            }
+
+            assertScore(scoreDirector);
         }
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetRegressionTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/stream/bavet/BavetRegressionTest.java
@@ -23,6 +23,7 @@ import ai.timefold.solver.core.testdomain.list.unassignedvar.TestdataAllowsUnass
 import ai.timefold.solver.core.testdomain.shadow.multiplelistener.TestdataListMultipleShadowVariableSolution;
 import ai.timefold.solver.core.testdomain.shadow.multiplelistener.TestdataListMultipleShadowVariableValue;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 
 final class BavetRegressionTest extends AbstractConstraintStreamTest {
@@ -334,6 +335,88 @@ final class BavetRegressionTest extends AbstractConstraintStreamTest {
 
     }
 
+    /**
+     * Like {@link #filteringJoinNullConflictRightUnassignOne()}, but the null-checking filter sits behind
+     * a 3-hop self-join instead of a single bi-join. A bi-join's left input is always the root tuple
+     * (whose retraction is applied eagerly), so the existing single-hop guard is enough there. Two hops
+     * deeper, the left input is itself a join product whose own retraction is deferred to a later
+     * network layer — exposing a stale, "still active" tuple to the filtering predicate.
+     */
+    @TestTemplate
+    public void filteringJoinNullConflictRightQuadJoinUnassignOne() {
+        var solution = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(2, 1);
+        var entity = solution.getEntityList().getFirst();
+        var value1 = solution.getValueList().get(0);
+        var value2 = solution.getValueList().get(1);
+
+        try (InnerScoreDirector<TestdataAllowsUnassignedValuesListSolution, SimpleScore> scoreDirector =
+                buildScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(TestdataAllowsUnassignedValuesListValue::getEntity,
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity))
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal((a, b) -> a.getEntity(),
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity))
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal((a, b, c) -> a.getEntity(),
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity),
+                                                filtering((a, b, c, d) -> {
+                                                    Objects.requireNonNull(a.getEntity());
+                                                    Objects.requireNonNull(b.getEntity());
+                                                    Objects.requireNonNull(c.getEntity());
+                                                    Objects.requireNonNull(d.getEntity());
+                                                    return true;
+                                                }))
+                                        .penalize(SimpleScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_ID)
+                        })) {
+
+            scoreDirector.setWorkingSolution(solution);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value1);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.beforeListVariableChanged(entity, "valueList", 0, 0);
+            entity.getValueList().addAll(List.of(value1, value2));
+            scoreDirector.afterListVariableChanged(entity, "valueList", 0, 2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value1, value1, value1, value1),
+                    assertMatch(value1, value1, value1, value2),
+                    assertMatch(value1, value1, value2, value1),
+                    assertMatch(value1, value1, value2, value2),
+                    assertMatch(value1, value2, value1, value1),
+                    assertMatch(value1, value2, value1, value2),
+                    assertMatch(value1, value2, value2, value1),
+                    assertMatch(value1, value2, value2, value2),
+                    assertMatch(value2, value1, value1, value1),
+                    assertMatch(value2, value1, value1, value2),
+                    assertMatch(value2, value1, value2, value1),
+                    assertMatch(value2, value1, value2, value2),
+                    assertMatch(value2, value2, value1, value1),
+                    assertMatch(value2, value2, value1, value2),
+                    assertMatch(value2, value2, value2, value1),
+                    assertMatch(value2, value2, value2, value2));
+
+            // Unassign and check result.
+            var variableDescriptor = scoreDirector.getSolutionDescriptor()
+                    .getListVariableDescriptor();
+            scoreDirector.beforeListVariableElementUnassigned(variableDescriptor, value1);
+            scoreDirector.beforeListVariableChanged(variableDescriptor, entity, 0, 2);
+            entity.getValueList().remove(value1);
+            scoreDirector.afterListVariableChanged(variableDescriptor, entity, 0, 1);
+            scoreDirector.afterListVariableElementUnassigned(variableDescriptor, value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value2, value2, value2, value2));
+        }
+    }
+
     @TestTemplate
     public void filteringIfExistsNullConflictRight() {
         var solution = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(2, 1);
@@ -456,6 +539,90 @@ final class BavetRegressionTest extends AbstractConstraintStreamTest {
                     assertMatch(value1));
         }
 
+    }
+
+    /**
+     * Like {@link #filteringIfExistsNullConflictRight()}, but the left input to ifExists is a
+     * 3-hop self-join product instead of the root tuple directly — the ifExists counterpart to
+     * {@link #filteringJoinNullConflictRightQuadJoinUnassignOne()}.
+     */
+    @TestTemplate
+    public void filteringIfExistsNullConflictDeepLeftUnassignOne() {
+        var solution = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(2, 1);
+        var entity = solution.getEntityList().getFirst();
+        var value1 = solution.getValueList().get(0);
+        var value2 = solution.getValueList().get(1);
+
+        try (InnerScoreDirector<TestdataAllowsUnassignedValuesListSolution, SimpleScore> scoreDirector =
+                buildScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(TestdataAllowsUnassignedValuesListValue::getEntity,
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity))
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal((a, b) -> a.getEntity(),
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity))
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal((a, b, c) -> a.getEntity(),
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity))
+                                        .ifExists(TestdataAllowsUnassignedValuesListValue.class,
+                                                equal((a, b, c, d) -> a.getEntity(),
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity),
+                                                filtering((a, b, c, d, e) -> {
+                                                    Objects.requireNonNull(a.getEntity());
+                                                    Objects.requireNonNull(b.getEntity());
+                                                    Objects.requireNonNull(c.getEntity());
+                                                    Objects.requireNonNull(d.getEntity());
+                                                    Objects.requireNonNull(e.getEntity());
+                                                    return true;
+                                                }))
+                                        .penalize(SimpleScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_ID)
+                        })) {
+
+            scoreDirector.setWorkingSolution(solution);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value1);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.beforeListVariableChanged(entity, "valueList", 0, 0);
+            entity.getValueList().addAll(List.of(value1, value2));
+            scoreDirector.afterListVariableChanged(entity, "valueList", 0, 2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value1, value1, value1, value1),
+                    assertMatch(value1, value1, value1, value2),
+                    assertMatch(value1, value1, value2, value1),
+                    assertMatch(value1, value1, value2, value2),
+                    assertMatch(value1, value2, value1, value1),
+                    assertMatch(value1, value2, value1, value2),
+                    assertMatch(value1, value2, value2, value1),
+                    assertMatch(value1, value2, value2, value2),
+                    assertMatch(value2, value1, value1, value1),
+                    assertMatch(value2, value1, value1, value2),
+                    assertMatch(value2, value1, value2, value1),
+                    assertMatch(value2, value1, value2, value2),
+                    assertMatch(value2, value2, value1, value1),
+                    assertMatch(value2, value2, value1, value2),
+                    assertMatch(value2, value2, value2, value1),
+                    assertMatch(value2, value2, value2, value2));
+
+            // Unassign and check result.
+            var variableDescriptor = scoreDirector.getSolutionDescriptor()
+                    .getListVariableDescriptor();
+            scoreDirector.beforeListVariableElementUnassigned(variableDescriptor, value1);
+            scoreDirector.beforeListVariableChanged(variableDescriptor, entity, 0, 2);
+            entity.getValueList().remove(value1);
+            scoreDirector.afterListVariableChanged(variableDescriptor, entity, 0, 1);
+            scoreDirector.afterListVariableElementUnassigned(variableDescriptor, value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value2, value2, value2, value2));
+        }
     }
 
     /**
@@ -923,6 +1090,201 @@ final class BavetRegressionTest extends AbstractConstraintStreamTest {
         scoreDirector.clearPendingShadowVariableUpdates();
         assertThat(solution.getValueList().stream().allMatch(v -> v.getCascadeValue() == 2))
                 .isTrue(); // two if it is null
+    }
+
+    /**
+     * Like {@link #filteringJoinNullConflictRightUnassignOne()}, but the left input to the filtering join
+     * is derived via a {@code .map()} from an earlier join's output, instead of being that earlier join's
+     * product directly. A map node's own retraction of its output is deferred to its parent join's flush
+     * the same way an intermediate join's own output is — same race, one more node type in the chain.
+     */
+    @TestTemplate
+    public void filteringJoinNullConflictThroughMapUnassignOne() {
+        var solution = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(2, 1);
+        var entity = solution.getEntityList().getFirst();
+        var value1 = solution.getValueList().get(0);
+        var value2 = solution.getValueList().get(1);
+
+        try (InnerScoreDirector<TestdataAllowsUnassignedValuesListSolution, SimpleScore> scoreDirector =
+                buildScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(Function.identity(), Function.identity()))
+                                        .map((TestdataAllowsUnassignedValuesListValue a,
+                                                TestdataAllowsUnassignedValuesListValue b) -> a)
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(TestdataAllowsUnassignedValuesListValue::getEntity,
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity),
+                                                filtering((a, b) -> {
+                                                    Objects.requireNonNull(a.getEntity());
+                                                    Objects.requireNonNull(b.getEntity());
+                                                    return true;
+                                                }))
+                                        .penalize(SimpleScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_ID)
+                        })) {
+
+            scoreDirector.setWorkingSolution(solution);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value1);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.beforeListVariableChanged(entity, "valueList", 0, 0);
+            entity.getValueList().addAll(List.of(value1, value2));
+            scoreDirector.afterListVariableChanged(entity, "valueList", 0, 2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value1, value1),
+                    assertMatch(value1, value2),
+                    assertMatch(value2, value1),
+                    assertMatch(value2, value2));
+
+            // Unassign and check result.
+            var variableDescriptor = scoreDirector.getSolutionDescriptor()
+                    .getListVariableDescriptor();
+            scoreDirector.beforeListVariableElementUnassigned(variableDescriptor, value1);
+            scoreDirector.beforeListVariableChanged(variableDescriptor, entity, 0, 2);
+            entity.getValueList().remove(value1);
+            scoreDirector.afterListVariableChanged(variableDescriptor, entity, 0, 1);
+            scoreDirector.afterListVariableElementUnassigned(variableDescriptor, value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value2, value2));
+        }
+    }
+
+    /**
+     * Like {@link #filteringJoinNullConflictThroughMapUnassignOne()}, but with {@code .flatten()} instead
+     * of {@code .map()} in the middle of the chain. {@link ai.timefold.solver.core.impl.bavet.common.AbstractFlattenNode}
+     * has the identical eager-state/deferred-notification pattern as map, so it should reproduce the same way.
+     */
+    @TestTemplate
+    public void filteringJoinNullConflictThroughFlattenUnassignOne() {
+        var solution = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(2, 1);
+        var entity = solution.getEntityList().getFirst();
+        var value1 = solution.getValueList().get(0);
+        var value2 = solution.getValueList().get(1);
+
+        try (InnerScoreDirector<TestdataAllowsUnassignedValuesListSolution, SimpleScore> scoreDirector =
+                buildScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(Function.identity(), Function.identity()))
+                                        .flatten((TestdataAllowsUnassignedValuesListValue a,
+                                                TestdataAllowsUnassignedValuesListValue b) -> List.of(a))
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal((x, y, z) -> z.getEntity(),
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity),
+                                                filtering((x, y, z, w) -> {
+                                                    Objects.requireNonNull(x.getEntity());
+                                                    Objects.requireNonNull(y.getEntity());
+                                                    Objects.requireNonNull(z.getEntity());
+                                                    Objects.requireNonNull(w.getEntity());
+                                                    return true;
+                                                }))
+                                        .penalize(SimpleScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_ID)
+                        })) {
+
+            scoreDirector.setWorkingSolution(solution);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value1);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.beforeListVariableChanged(entity, "valueList", 0, 0);
+            entity.getValueList().addAll(List.of(value1, value2));
+            scoreDirector.afterListVariableChanged(entity, "valueList", 0, 2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value1, value1, value1, value1),
+                    assertMatch(value1, value1, value1, value2),
+                    assertMatch(value2, value2, value2, value1),
+                    assertMatch(value2, value2, value2, value2));
+
+            // Unassign and check result.
+            var variableDescriptor = scoreDirector.getSolutionDescriptor()
+                    .getListVariableDescriptor();
+            scoreDirector.beforeListVariableElementUnassigned(variableDescriptor, value1);
+            scoreDirector.beforeListVariableChanged(variableDescriptor, entity, 0, 2);
+            entity.getValueList().remove(value1);
+            scoreDirector.afterListVariableChanged(variableDescriptor, entity, 0, 1);
+            scoreDirector.afterListVariableElementUnassigned(variableDescriptor, value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value2, value2, value2, value2));
+        }
+    }
+
+    /**
+     * Like {@link #filteringJoinNullConflictThroughMapUnassignOne()}, but with {@code .groupBy()} instead
+     * of {@code .map()} in the middle of the chain. Unlike map/flatten, a group tuple is an N:1 aggregate
+     * with no single input tuple whose activity implies the group's own, so this one is expected to remain
+     * broken even after the fix — see "groupBy stays unfixed".
+     */
+    @TestTemplate
+    @Disabled("Known ceiling: groupBy's output is an N:1 aggregate with no single parent tuple to track "
+            + "(see Tuple#isActiveTransitively); this reproduces the still-open stale-activity race.")
+    public void filteringJoinNullConflictThroughGroupByUnassignOne() {
+        var solution = TestdataAllowsUnassignedValuesListSolution.generateUninitializedSolution(2, 1);
+        var entity = solution.getEntityList().getFirst();
+        var value1 = solution.getValueList().get(0);
+        var value2 = solution.getValueList().get(1);
+
+        try (InnerScoreDirector<TestdataAllowsUnassignedValuesListSolution, SimpleScore> scoreDirector =
+                buildScoreDirector(TestdataAllowsUnassignedValuesListSolution.buildSolutionDescriptor(),
+                        factory -> new Constraint[] {
+                                factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(Function.identity(), Function.identity()))
+                                        .groupBy((TestdataAllowsUnassignedValuesListValue a,
+                                                TestdataAllowsUnassignedValuesListValue b) -> a)
+                                        .join(factory.forEach(TestdataAllowsUnassignedValuesListValue.class)
+                                                .map(v -> v),
+                                                equal(TestdataAllowsUnassignedValuesListValue::getEntity,
+                                                        TestdataAllowsUnassignedValuesListValue::getEntity),
+                                                filtering((a, b) -> {
+                                                    Objects.requireNonNull(a.getEntity());
+                                                    Objects.requireNonNull(b.getEntity());
+                                                    return true;
+                                                }))
+                                        .penalize(SimpleScore.ONE)
+                                        .asConstraint(TEST_CONSTRAINT_ID)
+                        })) {
+
+            scoreDirector.setWorkingSolution(solution);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value1);
+            scoreDirector.beforeListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.beforeListVariableChanged(entity, "valueList", 0, 0);
+            entity.getValueList().addAll(List.of(value1, value2));
+            scoreDirector.afterListVariableChanged(entity, "valueList", 0, 2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value2);
+            scoreDirector.afterListVariableElementAssigned(entity, "valueList", value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value1, value1),
+                    assertMatch(value1, value2),
+                    assertMatch(value2, value1),
+                    assertMatch(value2, value2));
+
+            // Unassign and check result.
+            var variableDescriptor = scoreDirector.getSolutionDescriptor()
+                    .getListVariableDescriptor();
+            scoreDirector.beforeListVariableElementUnassigned(variableDescriptor, value1);
+            scoreDirector.beforeListVariableChanged(variableDescriptor, entity, 0, 2);
+            entity.getValueList().remove(value1);
+            scoreDirector.afterListVariableChanged(variableDescriptor, entity, 0, 1);
+            scoreDirector.afterListVariableElementUnassigned(variableDescriptor, value1);
+
+            assertScore(scoreDirector,
+                    assertMatch(value2, value2));
+        }
     }
 
 }


### PR DESCRIPTION
A downstream filtering node could read an out-tuple whose
state still reported active even though it was one flush away from being
retracted, because Bavet processes its node network in strict layers and a
shallow sibling can re-test a tuple before the layer that would retract it
has run. A filtering predicate dereferencing a stale shadow variable then
could crash with an NPE.

Each producing node now records the input tuple(s) its out-tuple was
derived from and staleness guards walk that chain instead of trusting bare tuple state.