### PR TITLE
chore: return null when the solution is invalid in calculate score

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/decider/ConstructionHeuristicDecider.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/decider/ConstructionHeuristicDecider.java
@@ -159,7 +159,8 @@ public class ConstructionHeuristicDecider<Solution_> {
         }
         if (isLoggingEnabled()) {
             logger.trace("{}        Move index ({}), score ({}), move ({}).",
-                    logIndentation, moveScope.getMoveIndex(), moveScope.getScore().raw(), moveScope.getMove());
+                    logIndentation, moveScope.getMoveIndex(),
+                    (score != null) ? moveScope.getScore().raw() : "invalid", moveScope.getMove());
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/decider/forager/DefaultConstructionHeuristicForager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/constructionheuristic/decider/forager/DefaultConstructionHeuristicForager.java
@@ -42,7 +42,8 @@ public class DefaultConstructionHeuristicForager<Solution_> extends AbstractCons
         moveScope.getStepScope().getPhaseScope()
                 .addMoveEvaluationCount(moveScope.getMove(), 1L);
         checkPickEarly(moveScope);
-        if (maxScoreMoveScope == null || moveScope.getScore().compareTo(maxScoreMoveScope.getScore()) > 0) {
+        if (maxScoreMoveScope == null || maxScoreMoveScope.getScore() == null ||
+                (moveScope.getScore() != null && moveScope.getScore().compareTo(maxScoreMoveScope.getScore()) > 0)) {
             maxScoreMoveScope = moveScope;
         }
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/LocalSearchDecider.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/LocalSearchDecider.java
@@ -123,9 +123,12 @@ public class LocalSearchDecider<Solution_> {
                     moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore(),
                     SolverLifecyclePoint.of(moveScope));
         }
-        logger.trace("{}        Move index ({}), score ({}), accepted ({}), move ({}).",
-                logIndentation, moveScope.getMoveIndex(), moveScope.getScore().raw(), moveScope.getAccepted(),
-                moveScope.getMove());
+        if (logger.isTraceEnabled()) {
+            logger.trace("{}        Move index ({}), score ({}), accepted ({}), move ({}).",
+                    logIndentation, moveScope.getMoveIndex(),
+                    (moveScope.getScore() != null) ? moveScope.getScore().raw() : "invalid",
+                    moveScope.getAccepted(), moveScope.getMove());
+        }
     }
 
     protected void pickMove(LocalSearchStepScope<Solution_> stepScope) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AbstractAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AbstractAcceptor.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.localsearch.decider.acceptor;
 
 import ai.timefold.solver.core.impl.localsearch.event.LocalSearchPhaseLifecycleListenerAdapter;
+import ai.timefold.solver.core.impl.localsearch.scope.LocalSearchMoveScope;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,5 +19,14 @@ public abstract class AbstractAcceptor<Solution_> extends LocalSearchPhaseLifecy
     // ************************************************************************
     // Worker methods
     // ************************************************************************
+
+    public final boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
+        if (moveScope.getScore() == null) {
+            return false;
+        }
+        return isConsistentSolutionAccepted(moveScope);
+    }
+
+    public abstract boolean isConsistentSolutionAccepted(LocalSearchMoveScope<Solution_> moveScope);
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/CompositeAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/CompositeAcceptor.java
@@ -51,10 +51,7 @@ public class CompositeAcceptor<Solution_> extends AbstractAcceptor<Solution_> {
     }
 
     @Override
-    public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
-        if (moveScope.getScore().isInvalid()) {
-            return false;
-        }
+    public boolean isConsistentSolutionAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         for (Acceptor<Solution_> acceptor : acceptorList) {
             boolean accepted = acceptor.isAccepted(moveScope);
             if (!accepted) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptor.java
@@ -62,10 +62,7 @@ public class GreatDelugeAcceptor<Solution_> extends AbstractAcceptor<Solution_> 
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public boolean isAccepted(LocalSearchMoveScope moveScope) {
-        if (moveScope.getScore().isInvalid()) {
-            return false;
-        }
+    public boolean isConsistentSolutionAccepted(LocalSearchMoveScope moveScope) {
         var moveScore = moveScope.getScore().raw();
         if (moveScore.compareTo(currentWaterLevel) >= 0) {
             return true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptor.java
@@ -6,13 +6,10 @@ import ai.timefold.solver.core.impl.score.director.InnerScore;
 
 public class HillClimbingAcceptor<Solution_> extends AbstractAcceptor<Solution_> {
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public boolean isConsistentSolutionAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         InnerScore moveScore = moveScope.getScore();
-        if (moveScore.isInvalid()) {
-            return false;
-        }
         InnerScore lastStepScore = moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore();
         return moveScore.compareTo(lastStepScore) >= 0;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/DiversifiedLateAcceptanceAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/DiversifiedLateAcceptanceAcceptor.java
@@ -49,13 +49,10 @@ public class DiversifiedLateAcceptanceAcceptor<Solution_> extends AbstractAccept
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
+    public boolean isConsistentSolutionAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         // The acceptance and replacement strategies are based on the work:
         // Diversified Late Acceptance Search by M. Namazi, C. Sanderson, M. A. H. Newton, M. M. A. Polash, and A. Sattar
         var moveScore = moveScope.getScore();
-        if (moveScore.isInvalid()) {
-            return false;
-        }
         var current = (InnerScore) moveScope.getStepScope().getPhaseScope()
                 .getLastCompletedStepScope().getScore();
         var previous = current;

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptor.java
@@ -47,11 +47,8 @@ public class LateAcceptanceAcceptor<Solution_> extends AbstractAcceptor<Solution
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
+    public boolean isConsistentSolutionAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         var moveScore = (InnerScore) moveScope.getScore();
-        if (moveScore.isInvalid()) {
-            return false;
-        }
         var lateScore = scoreBuffer.getCurrent();
         if (moveScore.compareTo(lateScore) >= 0) {
             return true;

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptor.java
@@ -52,15 +52,11 @@ public class SimulatedAnnealingAcceptor<Solution_> extends AbstractAcceptor<Solu
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
+    public boolean isConsistentSolutionAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         var phaseScope = moveScope.getStepScope().getPhaseScope();
         // Guaranteed local search; no need for InnerScore.
         Score lastStepScore = phaseScope.getLastCompletedStepScope().getScore().raw();
         Score moveScore = moveScope.getScore().raw();
-        var thisStepInvalid = moveScope.getScore().isInvalid();
-        if (thisStepInvalid) {
-            return false;
-        }
         if (moveScore.compareTo(lastStepScore) >= 0) {
             return true;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptor.java
@@ -42,12 +42,9 @@ public class StepCountingHillClimbingAcceptor<Solution_> extends AbstractAccepto
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
+    public boolean isConsistentSolutionAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         InnerScore lastStepScore = moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore();
         InnerScore moveScore = moveScope.getScore();
-        if (moveScore.isInvalid()) {
-            return false;
-        }
         if (moveScore.compareTo(lastStepScore) >= 0) {
             return true;
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/tabu/AbstractTabuAcceptor.java
@@ -123,11 +123,7 @@ public abstract sealed class AbstractTabuAcceptor<Solution_>
     }
 
     @Override
-    public boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
-        var thisStepInvalid = moveScope.getScore().isInvalid();
-        if (thisStepInvalid) {
-            return false;
-        }
+    public boolean isConsistentSolutionAccepted(LocalSearchMoveScope<Solution_> moveScope) {
         var maximumTabuStepIndex = locateMaximumTabuStepIndex(moveScope);
         if (maximumTabuStepIndex < 0) {
             // The move isn't tabu at all

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/forager/finalist/HighestScoreFinalistPodium.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/forager/finalist/HighestScoreFinalistPodium.java
@@ -23,7 +23,7 @@ public final class HighestScoreFinalistPodium<Solution_> extends AbstractFinalis
     @Override
     public void addMove(LocalSearchMoveScope<Solution_> moveScope) {
         var accepted = moveScope.getAccepted() != null && moveScope.getAccepted();
-        if (finalistIsAccepted && !accepted) {
+        if ((finalistIsAccepted && !accepted) || moveScope.getScore() == null) {
             return;
         }
         if (accepted && !finalistIsAccepted) {

--- a/core/src/main/java/ai/timefold/solver/core/impl/move/MoveDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/move/MoveDirector.java
@@ -417,7 +417,7 @@ public sealed class MoveDirector<Solution_, Score_ extends Score<Score_>>
         }
     }
 
-    public final InnerScore<Score_> executeTemporary(Move<Solution_> move) {
+    public @Nullable final InnerScore<Score_> executeTemporary(Move<Solution_> move) {
         var ephemeralMoveDirector = ephemeral();
         ephemeralMoveDirector.execute(move);
         var score = backingScoreDirector.calculateScore();
@@ -426,7 +426,7 @@ public sealed class MoveDirector<Solution_, Score_ extends Score<Score_>>
     }
 
     public @Nullable <Result_> Result_ executeTemporary(Move<Solution_> move,
-            TemporaryMovePostprocessor<Solution_, Score_, @Nullable Result_> postprocessor) {
+            TemporaryMovePostprocessor<Solution_, @Nullable Score_, @Nullable Result_> postprocessor) {
         try (var ephemeralMoveDirector = ephemeral()) {
             ephemeralMoveDirector.execute(move);
             var score = backingScoreDirector.calculateScore();

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
@@ -88,7 +88,7 @@ public final class DefaultCustomPhase<Solution_>
                 () -> phaseTermination.isPhaseTerminated(stepScope.getPhaseScope()));
         customPhaseCommand.changeWorkingSolution(commandContext);
         calculateWorkingStepScore(stepScope, customPhaseCommand);
-        if (stepScope.getScore().isInvalid()) {
+        if (stepScope.getScore() == null) {
             throw new IllegalStateException("The custom phase command (%s) resulted in an inconsistent solution."
                     .formatted(customPhaseCommand));
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -246,13 +246,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     public abstract InnerScore<Score_> innerCalculateScore();
 
     @Override
+    @Nullable
     public final InnerScore<Score_> calculateScore() {
         if (lastVariableUpdateSuccessful) {
             return innerCalculateScore();
         } else {
-            var invalidScore = InnerScore.invalid(getScoreDefinition().getZeroScore());
-            getSolutionDescriptor().setScore(workingSolution, invalidScore.raw());
-            return invalidScore;
+            return null;
         }
     }
 
@@ -432,12 +431,13 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     }
 
     @Override
+    @Nullable
     public InnerScore<Score_> executeTemporaryMove(Move<Solution_> move, @Nullable Consumer<SolutionView<Solution_>> consumer,
             boolean assertMoveScoreFromScratch) {
         if (solutionTracker != null) {
             solutionTracker.setBeforeMoveSolution(workingSolution);
         }
-        var result = moveDirector.executeTemporary(move, (score, undoMove) -> {
+        return moveDirector.executeTemporary(move, (score, undoMove) -> {
             if (solutionTracker != null) {
                 solutionTracker.setAfterMoveSolution(workingSolution);
             }
@@ -449,7 +449,6 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             }
             return score;
         });
-        return Objects.requireNonNull(result);
     }
 
     @Override
@@ -809,7 +808,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
                 .buildDerived()) {
             uncorruptedScoreDirector.setWorkingSolution(workingSolution);
             var uncorruptedInnerScore = uncorruptedScoreDirector.calculateScore();
-            if (!innerScore.equals(uncorruptedInnerScore)) {
+            if (!Objects.equals(innerScore, uncorruptedInnerScore)) {
                 var corruptionAnalyzer = new CorruptionAnalyzer<>(this);
                 var scoreCorruptionAnalysis = corruptionAnalyzer.analyzeScore(uncorruptedScoreDirector, predicted);
                 var shadowVariableAnalysis = corruptionAnalyzer.analyzeShadowVariables(predicted);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScore.java
@@ -34,10 +34,6 @@ public record InnerScore<Score_ extends Score<Score_>>(Score_ raw, int unassigne
         return new InnerScore<>(score, unassignedCount);
     }
 
-    public static <Score_ extends Score<Score_>> InnerScore<Score_> invalid(Score_ zeroScore) {
-        return new InnerScore<>(zeroScore, Integer.MAX_VALUE);
-    }
-
     public InnerScore {
         Objects.requireNonNull(raw);
         if (unassignedCount < 0) {
@@ -48,10 +44,6 @@ public record InnerScore<Score_ extends Score<Score_>>(Score_ raw, int unassigne
 
     public boolean isFullyAssigned() {
         return unassignedCount == 0;
-    }
-
-    public boolean isInvalid() {
-        return unassignedCount == Integer.MAX_VALUE;
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -76,8 +76,10 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
     /**
      * Calculates the {@link Score} and updates the {@link PlanningSolution working solution} accordingly.
      *
-     * @return never null, the {@link Score} of the {@link PlanningSolution working solution}
+     * @return the {@link Score} of the {@link PlanningSolution working solution}, null if the working solution is
+     *         inconsistent
      */
+    @Nullable
     InnerScore<Score_> calculateScore();
 
     /**
@@ -125,12 +127,14 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
      * @param assertMoveScoreFromScratch true will hurt performance
      * @return never null
      */
+    @Nullable
     InnerScore<Score_> executeTemporaryMove(Move<Solution_> move, @Nullable Consumer<SolutionView<Solution_>> consumer,
             boolean assertMoveScoreFromScratch);
 
     /**
      * As defined by {@link #executeTemporaryMove(Move, Consumer, boolean)}, but with no consumer.
      */
+    @Nullable
     default InnerScore<Score_> executeTemporaryMove(Move<Solution_> move, boolean assertMoveScoreFromScratch) {
         return executeTemporaryMove(move, null, assertMoveScoreFromScratch);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -85,7 +85,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
             }
             if (solutionUpdatePolicy.isScoreUpdateEnabled()) {
                 var score = scoreDirector.calculateScore();
-                if (score.isInvalid()) {
+                if (score == null) {
                     var inconsistentEntities = scoreDirector.computeInconsistentEntities();
                     throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
                 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -55,11 +55,11 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
         var scoreDirector = solverScope.getScoreDirector();
         @SuppressWarnings("rawtypes")
         InnerScore innerScore = scoreDirector.calculateScore();
-        if (innerScore.isInvalid()) {
+        if (innerScore == null) {
             LOGGER.warn("The initial solution passed to the solver is inconsistent. Unassigning involved entities.");
             scoreDirector.unassignInconsistentEntities();
             innerScore = scoreDirector.calculateScore();
-            if (innerScore.isInvalid()) {
+            if (innerScore == null) {
                 // If there were a fixed dependency loop, the shadow variable session would fail fast before here
                 throw new IllegalStateException(
                         "Impossible state: The initial solution passed to the solver is inconsistent even after unassigning involved entities.");


### PR DESCRIPTION
Note: `DefaultPhaseCommandContext.executeTemporary` throws if the score is null/invalid (via `Objects.requireNonNull(score, () -> "The move (%s) failed to calculate a score.".formatted(move));`). Should that be change (i.e. what should happen when a user executes a temporary move that results in an inconsistent solution in a PhaseCommand).