### PR TITLE
chore: Only redeploy model with same registration key

### DIFF
--- a/docs/src/modules/ROOT/pages/deploying-to-platform/guide.adoc
+++ b/docs/src/modules/ROOT/pages/deploying-to-platform/guide.adoc
@@ -111,6 +111,10 @@ The `timefold:deploy` goal uploads that archive and registers it against the pla
 If a model with the same `key` is already registered, the deploy fails with a conflict (HTTP 409) unless `overwrite` is enabled, in which case the existing registration is updated instead (`PATCH /api/platform/v1/models/<key>`).
 You can also set this from the command line with `-Dtimefold.model.overwrite=true`.
 
+The platform reports the kind of conflict as an error code in the response, and `overwrite` only applies to a conflict on the registration key itself (`TFP-14001`) or on the version already registered under that key (`TFP-14005`).
+Every other conflict fails the deploy regardless of `overwrite`, as there is no registration under your `key` to update.
+That is most commonly the same model already being registered under a _different_ registration key (`TFP-14002`, `TFP-14003` or `TFP-14004`); either unregister the existing registration, or deploy with the registration key it was registered under.
+
 Registering a model does not automatically subscribe your tenant to it; with `handleSubscription` set to `true`, the plugin also subscribes your tenant when it registers the model.
 Without it, your tenant won't see the model on the platform after you deploy it.
 

--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/AbstractPlatformModelMojo.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/AbstractPlatformModelMojo.java
@@ -21,6 +21,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -94,6 +95,38 @@ public abstract class AbstractPlatformModelMojo extends AbstractMojo {
     protected void validate() {
         Objects.requireNonNull(platformUrl, "Platform Url is mandatory");
         Objects.requireNonNull(key, "Registration key is mandatory");
+    }
+
+    protected void printErrorInfo(String responseBody) {
+        if (responseBody != null && !responseBody.isBlank()) {
+            getLog().error(responseBody);
+        }
+    }
+
+    /**
+     * Reads the platform error message from an error response body, so that the reason for the failure is part of the
+     * reported error and not only of the build log. Falls back to the response body itself, as the platform does not
+     * report every error as an {@code ErrorInfo}.
+     */
+    protected String readErrorMessage(String responseBody) {
+        String message = readErrorField(responseBody, "message");
+        if (message != null && !message.isBlank()) {
+            return message;
+        }
+        return responseBody == null || responseBody.isBlank() ? "no error message reported by the platform" : responseBody;
+    }
+
+    protected String readErrorField(String responseBody, String fieldName) {
+        if (responseBody == null || responseBody.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode field = mapper.readTree(responseBody).get(fieldName);
+            return field == null || field.isNull() ? null : field.asText();
+        } catch (IOException e) {
+            getLog().debug("Unable to read error " + fieldName + " from response body " + responseBody, e);
+            return null;
+        }
     }
 
     /**

--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/DeployModelMojo.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/DeployModelMojo.java
@@ -1,7 +1,5 @@
 package ai.timefold.solver.tools.maven;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -29,6 +27,18 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
 
     private static final String PRIVATE_MODEL_TYPE = "Private";
     private static final String SHARED_MODEL_TYPE = "Shared";
+
+    /**
+     * Error codes the platform reports on a conflict (HTTP 409). Only a conflict on the registration key itself or on
+     * the version registered under it can be resolved by updating that registration, any other conflict, including one
+     * the platform does not identify, fails the deployment as updating this registration key does not resolve it.
+     */
+    private static final String ERROR_CODE_REGISTRATION_KEY_ALREADY_EXISTS = "TFP-14001";
+    private static final String ERROR_CODE_MODEL_VERSION_ALREADY_EXISTS = "TFP-14005";
+    private static final String ERROR_CODE_UNKNOWN = "TFP-99999";
+
+    private static final List<String> OVERWRITABLE_CONFLICT_ERROR_CODES =
+            List.of(ERROR_CODE_REGISTRATION_KEY_ALREADY_EXISTS, ERROR_CODE_MODEL_VERSION_ALREADY_EXISTS);
 
     protected static final String PROP_MODEL_TYPE = "timefold.model.type";
 
@@ -125,14 +135,24 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
 
                 configureHttpRequest(builder);
 
-                HttpResponse<InputStream> response = httpClient.send(builder.build(), BodyHandlers.ofInputStream());
+                HttpResponse<String> response = httpClient.send(builder.build(), BodyHandlers.ofString());
                 if (response.statusCode() >= 200 && response.statusCode() < 400) {
                     getLog().info(
                             String.format(
                                     "Model %s (%s) has been successfully deployed into platform %s with registration key %s",
                                     modelDescriptor.get("name").asText(), modelDescriptor.get("id").asText(), platformUrl,
                                     key));
-                } else if (response.statusCode() >= 409) {
+                } else if (response.statusCode() == 409) {
+                    String conflictBody = response.body();
+                    String errorCode = readErrorCode(conflictBody);
+                    if (!OVERWRITABLE_CONFLICT_ERROR_CODES.contains(errorCode)) {
+                        // e.g. the model id is already registered under a different registration key, updating the
+                        // registration key used here would only fail with 404 as it was never registered
+                        printErrorInfo(conflictBody);
+                        throw new IllegalStateException(String.format(
+                                "Model deployment of %s failed due to conflict (%s) that cannot be resolved by updating the registration with key %s: %s",
+                                modelDescriptor.get("id").asText(), errorCode, key, readErrorMessage(conflictBody)));
+                    }
                     if (getPropertyOrParameter(PROP_MODEL_OVERWRITE, overwrite)) {
 
                         requestURI =
@@ -140,24 +160,28 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
                         builder = HttpRequest.newBuilder().uri(requestURI).method("PATCH",
                                 BodyPublishers.ofFile(modelDescriptorArchivePath));
                         configureHttpRequest(builder);
-                        response = httpClient.send(builder.build(), BodyHandlers.ofInputStream());
+                        response = httpClient.send(builder.build(), BodyHandlers.ofString());
                         if (response.statusCode() >= 200 && response.statusCode() < 400) {
                             getLog().info(String.format(
                                     "Model %s (%s) has been successfully updated on platform %s with registration key %s",
                                     modelDescriptor.get("name").asText(), modelDescriptor.get("id").asText(), platformUrl,
                                     key));
                         } else {
+                            printErrorInfo(response.body());
                             throw new IllegalStateException(
-                                    "Model deployment (override) failed with " + response.statusCode() + " status code");
+                                    "Model deployment (override) failed with " + response.statusCode() + " status code: "
+                                            + readErrorMessage(response.body()));
                         }
                     } else {
-                        throw new IllegalStateException(
-                                "Model deployment failed due to conflict, there is already model with that registration key "
-                                        + key + " use 'overwrite' parameter to update existing");
+                        printErrorInfo(conflictBody);
+                        throw new IllegalStateException(String.format(
+                                "Model deployment failed due to conflict (%s), there is already model with that registration key %s use 'overwrite' parameter to update existing: %s",
+                                errorCode, key, readErrorMessage(conflictBody)));
                     }
                 } else {
-                    printErrorInfo(response);
-                    throw new IllegalStateException("Model deployment failed with " + response.statusCode() + " status code");
+                    printErrorInfo(response.body());
+                    throw new IllegalStateException("Model deployment failed with " + response.statusCode() + " status code: "
+                            + readErrorMessage(response.body()));
                 }
             }
         } catch (Exception e) {
@@ -169,13 +193,13 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
 
     }
 
-    private void printErrorInfo(HttpResponse<InputStream> response) {
-        try (InputStream body = response.body()) {
-            String responseBody = new String(body.readAllBytes());
-            getLog().error(responseBody);
-        } catch (IOException e) {
-            getLog().error("Unable to read response body", e);
-        }
+    /**
+     * Reads the platform error code from an error response body, a response that does not report one is treated as an
+     * unknown error.
+     */
+    private String readErrorCode(String responseBody) {
+        String code = readErrorField(responseBody, "code");
+        return code == null ? ERROR_CODE_UNKNOWN : code;
     }
 
     protected void validate(String type) {

--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/UndeployModelMojo.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/UndeployModelMojo.java
@@ -75,9 +75,10 @@ public class UndeployModelMojo extends AbstractPlatformModelMojo {
                                     modelDescriptor.get("name").asText(), modelDescriptor.get("id").asText(), platformUrl,
                                     key));
                 } else {
-                    getLog().debug(response.body());
+                    printErrorInfo(response.body());
                     throw new IllegalStateException(
-                            "Model undeploy failed with " + response.statusCode() + " status code");
+                            "Model undeploy failed with " + response.statusCode() + " status code: "
+                                    + readErrorMessage(response.body()));
                 }
             }
         } catch (IllegalStateException e) {

--- a/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/DeployModelMojoTest.java
+++ b/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/DeployModelMojoTest.java
@@ -10,6 +10,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -45,19 +46,84 @@ public class DeployModelMojoTest {
         log.clear();
         wm1.resetAll();
 
-        // represents already existing model so patch would be required
+        // represents a model already registered under the same registration key so patch would be required
         wm1.stubFor(post(urlPathEqualTo("/api/platform/v1/models"))
                 .withQueryParam("registrationKey", equalTo("existing"))
                 .willReturn(aResponse()
                         .withStatus(409)
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{}")));
+                        .withBody(
+                                "{\"id\":\"1\",\"code\":\"TFP-14001\",\"message\":\"Registered model conflicts with existing model (model_v1), unique model registration key is required\"}")));
 
         wm1.stubFor(patch(urlPathEqualTo("/api/platform/v1/models/existing"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
                         .withBody("{}")));
+
+        // represents a conflict the platform did not identify
+        wm1.stubFor(post(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("unknown-conflict"))
+                .willReturn(aResponse()
+                        .withStatus(409)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"id\":\"1\",\"code\":\"TFP-99999\",\"message\":\"Registered model conflicts with existing model (model_v1)\"}")));
+
+        // represents a conflict on the registration key where the registration cannot be updated afterwards
+        wm1.stubFor(post(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("failing-update"))
+                .willReturn(aResponse()
+                        .withStatus(409)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"id\":\"1\",\"code\":\"TFP-14001\",\"message\":\"Registered model conflicts with existing model (model_v1), unique model registration key is required\"}")));
+
+        wm1.stubFor(patch(urlPathEqualTo("/api/platform/v1/models/failing-update"))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"id\":\"1\",\"code\":\"TFP-99999\",\"message\":\"Model with registration key 'failing-update' was not found\"}")));
+
+        // represents a conflict reported with a body that is not the expected JSON, e.g. produced by a proxy
+        wm1.stubFor(post(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("malformed-conflict"))
+                .willReturn(aResponse()
+                        .withStatus(409)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("<html>Conflict</html>")));
+
+        // represents a conflict reported without any body
+        wm1.stubFor(post(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("empty-conflict"))
+                .willReturn(aResponse()
+                        .withStatus(409)
+                        .withHeader("Content-Type", "application/json")));
+
+        // represents the same model version already being the latest release of that registration key
+        wm1.stubFor(post(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("existing-version"))
+                .willReturn(aResponse()
+                        .withStatus(409)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"id\":\"1\",\"code\":\"TFP-14005\",\"message\":\"Model build version '1.0.0' already matches the current latest release for registration key 'existing-version'; override the existing release instead of registering a duplicate.\"}")));
+
+        wm1.stubFor(patch(urlPathEqualTo("/api/platform/v1/models/existing-version"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
+
+        // represents the same model id already registered under a different registration key
+        wm1.stubFor(post(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("existing-model-id"))
+                .willReturn(aResponse()
+                        .withStatus(409)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"id\":\"1\",\"code\":\"TFP-14004\",\"message\":\"Existing private model (model_v1), already exists for tenants\"}")));
 
         // represents successful registration on first call - no other model with given id existed
         wm1.stubFor(post(urlPathEqualTo("/api/platform/v1/models"))
@@ -129,6 +195,134 @@ public class DeployModelMojoTest {
 
         // assert that plugin executed and produced expected logs
         log.assertContains("Model .* has been successfully updated on platform.*", Level.INFO);
+    }
+
+    @Test
+    @MojoParameter(name = "key", value = "existing-version")
+    @MojoParameter(name = "overwrite", value = "true")
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testRegisterModelWithPatchOnModelVersionConflict(DeployModelMojo mojo) throws Exception {
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+        mojo.execute();
+
+        // conflict on the model version of the same registration key is resolved by overriding that release
+        wm1.verify(1, postRequestedFor(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("existing-version")));
+
+        wm1.verify(1, patchRequestedFor(urlPathEqualTo("/api/platform/v1/models/existing-version")));
+
+        log.assertContains("Model .* has been successfully updated on platform.*", Level.INFO);
+    }
+
+    @Test
+    @MojoParameter(name = "key", value = "existing-model-id")
+    @MojoParameter(name = "overwrite", value = "true")
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testFailWithoutPatchOnModelIdConflict(DeployModelMojo mojo) {
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+
+        assertThatThrownBy(mojo::execute).rootCause().isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Model deployment of timefold-test-model_v2-beta failed due to conflict (TFP-14004) that cannot be resolved by updating the registration with key existing-model-id: Existing private model (model_v1), already exists for tenants");
+
+        // the registration key was never registered, so it must not be updated even with overwrite enabled
+        wm1.verify(1, postRequestedFor(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("existing-model-id")));
+
+        wm1.verify(0, patchRequestedFor(urlPathEqualTo("/api/platform/v1/models/existing-model-id")));
+
+        log.assertContains(".*Existing private model \\(model_v1\\), already exists for tenants.*", Level.ERROR);
+    }
+
+    @Test
+    @MojoParameter(name = "key", value = "unknown-conflict")
+    @MojoParameter(name = "overwrite", value = "true")
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testFailWithoutPatchOnUnidentifiedConflict(DeployModelMojo mojo) {
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+
+        assertThatThrownBy(mojo::execute).rootCause().isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Model deployment of timefold-test-model_v2-beta failed due to conflict (TFP-99999) that cannot be resolved by updating the registration with key unknown-conflict: Registered model conflicts with existing model (model_v1)");
+
+        // a conflict that the platform does not identify is not assumed to be on the registration key
+        wm1.verify(1, postRequestedFor(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("unknown-conflict")));
+
+        wm1.verify(0, patchRequestedFor(urlPathEqualTo("/api/platform/v1/models/unknown-conflict")));
+
+        log.assertContains(".*Registered model conflicts with existing model \\(model_v1\\).*", Level.ERROR);
+    }
+
+    @Test
+    @MojoParameter(name = "key", value = "failing-update")
+    @MojoParameter(name = "overwrite", value = "true")
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testFailOnUpdateReportsPlatformError(DeployModelMojo mojo) {
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+
+        // the reason reported by the platform is part of the failure and not only of the build log
+        assertThatThrownBy(mojo::execute).rootCause().isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Model deployment (override) failed with 404 status code: Model with registration key 'failing-update' was not found");
+
+        wm1.verify(1, patchRequestedFor(urlPathEqualTo("/api/platform/v1/models/failing-update")));
+
+        log.assertContains(".*Model with registration key 'failing-update' was not found.*", Level.ERROR);
+    }
+
+    @Test
+    @MojoParameter(name = "key", value = "malformed-conflict")
+    @MojoParameter(name = "overwrite", value = "true")
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testFailWithoutPatchOnMalformedConflictBody(DeployModelMojo mojo) {
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+
+        // a body that cannot be read as JSON reports no error code, so the conflict is not resolvable
+        assertThatThrownBy(mojo::execute).rootCause().isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Model deployment of timefold-test-model_v2-beta failed due to conflict (TFP-99999) that cannot be resolved by updating the registration with key malformed-conflict: <html>Conflict</html>");
+
+        wm1.verify(1, postRequestedFor(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("malformed-conflict")));
+
+        wm1.verify(0, patchRequestedFor(urlPathEqualTo("/api/platform/v1/models/malformed-conflict")));
+
+        log.assertContains("Unable to read error code from response body <html>Conflict</html>", Level.DEBUG);
+        log.assertContains("<html>Conflict</html>", Level.ERROR);
+    }
+
+    @Test
+    @MojoParameter(name = "key", value = "empty-conflict")
+    @MojoParameter(name = "overwrite", value = "true")
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testFailWithoutPatchOnEmptyConflictBody(DeployModelMojo mojo) {
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+
+        // a conflict without a body reports no error code, so the conflict is not resolvable
+        assertThatThrownBy(mojo::execute).rootCause().isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Model deployment of timefold-test-model_v2-beta failed due to conflict (TFP-99999) that cannot be resolved by updating the registration with key empty-conflict: no error message reported by the platform");
+
+        wm1.verify(1, postRequestedFor(urlPathEqualTo("/api/platform/v1/models"))
+                .withQueryParam("registrationKey", equalTo("empty-conflict")));
+
+        wm1.verify(0, patchRequestedFor(urlPathEqualTo("/api/platform/v1/models/empty-conflict")));
+
+        // there is nothing to report from an empty body
+        assertThat(log.getEvents()).noneMatch(event -> event.level == Level.ERROR);
     }
 
     @Test

--- a/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/UndeployModelMojoTest.java
+++ b/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/UndeployModelMojoTest.java
@@ -5,6 +5,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -50,7 +51,13 @@ public class UndeployModelMojoTest {
                 .willReturn(aResponse()
                         .withStatus(404)
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{}")));
+                        .withBody(
+                                "{\"id\":\"1\",\"code\":\"TFP-99999\",\"message\":\"Model with registration key 'notexisting' was not found\"}")));
+
+        wm1.stubFor(delete(urlPathEqualTo("/api/platform/v1/models/nodetails"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")));
 
         // copy sample model descriptor
         Path modelDescriptor = Paths.get("src", "test", "resources", "model-descriptor.zip");
@@ -89,15 +96,34 @@ public class UndeployModelMojoTest {
     @Test
     @MojoParameter(name = "key", value = "notexisting")
     @InjectMojo(goal = "undeploy", pom = "src/test/resources/project-to-test/pom.xml")
-    public void testUndeployNotExisting(UndeployModelMojo mojo) throws Exception {
+    public void testUndeployNotExisting(UndeployModelMojo mojo) {
 
         mojo.setLog(log);
         mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
-        assertThatThrownBy(() -> mojo.execute()).isInstanceOf(IllegalStateException.class)
-                .hasMessage("Model undeploy failed with 404 status code");
+        // the reason reported by the platform is part of the failure and not only of the build log
+        assertThatThrownBy(mojo::execute).isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Model undeploy failed with 404 status code: Model with registration key 'notexisting' was not found");
 
         // verify plugin performed expected HTTP call
         wm1.verify(1, deleteRequestedFor(urlPathEqualTo("/api/platform/v1/models/notexisting")));
 
+        log.assertContains(".*Model with registration key 'notexisting' was not found.*", Level.ERROR);
+    }
+
+    @Test
+    @MojoParameter(name = "key", value = "nodetails")
+    @InjectMojo(goal = "undeploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testUndeployFailureWithoutDetails(UndeployModelMojo mojo) {
+
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+        assertThatThrownBy(mojo::execute).isInstanceOf(IllegalStateException.class)
+                .hasMessage("Model undeploy failed with 500 status code: no error message reported by the platform");
+
+        wm1.verify(1, deleteRequestedFor(urlPathEqualTo("/api/platform/v1/models/nodetails")));
+
+        // there is nothing to report from an empty body
+        assertThat(log.getEvents()).noneMatch(event -> event.level == Level.ERROR);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/TimefoldAI/timefold-platform/issues/5261 and https://github.com/TimefoldAI/timefold-solver-enterprise/issues/809
Depends on: https://github.com/TimefoldAI/timefold-platform/pull/5289