### PR TITLE
feat: Maven plugin progress upload for model descriptor

### DIFF
--- a/docs/src/modules/ROOT/pages/deploying-to-platform/guide.adoc
+++ b/docs/src/modules/ROOT/pages/deploying-to-platform/guide.adoc
@@ -121,6 +121,9 @@ That is most commonly the same model already being registered under a _different
 Registering a model does not automatically subscribe your tenant to it; with `handleSubscription` set to `true`, the plugin also subscribes your tenant when it registers the model.
 Without it, your tenant won't see the model on the platform after you deploy it.
 
+The archive is normally only a few tens of kilobytes, so the upload itself is quick.
+If the archive is large or the connection is slow, the plugin logs a progress line every few seconds while the upload is in flight, and once the upload finishes it reports that it is waiting for the platform to process the model rather than going silent.
+
 [#_verify_on_the_platform]
 == Verify on the platform
 

--- a/service/tools/maven-plugin/README.adoc
+++ b/service/tools/maven-plugin/README.adoc
@@ -34,6 +34,7 @@ The plugin uses a goal prefix of `timefold` (see the plugin configuration in the
 - If the platform responds with 409 (conflict) and `timefold.model.overwrite=true`, the plugin will PATCH `/api/platform/v1/models/{registrationKey}` to update the existing model
 - The plugin reads the model descriptor to obtain name/id by extracting `timefold-model-descriptor.json` from the archive (or reading `target/timefold/timefold-model-descriptor.json` when present)
 - The platform validates the model version (`timefold.application.version`) on registration. It must be a release version `vN` (e.g. `v1`), a git commit hash (1–40 lowercase hex characters), or the literal `SNAPSHOT`; any other value is rejected with HTTP 400.
+- While the request is in flight the plugin reports progress. Archives of at least 1 MiB are announced up front, then at most one throttled line every 5 seconds reports the percentage uploaded, then a heartbeat reports that the upload is done and the platform is still processing, and finally a single line reports the total transferred and elapsed time. A normal deploy of an archive of a few tens of kilobytes completes before the first heartbeat and produces none of these lines. Note that `mvn -q` suppresses `[INFO]`, so it hides all progress output.
 
 === Undeploy goal (timefold:undeploy)
 
@@ -148,6 +149,12 @@ Goals are implemented as Mojos in `src/main/java/ai/timefold/solver/tools/maven`
 - `ConfigureMojo` — writes build properties
 - `DeployModelMojo` — handles upload/register/patch flow
 - `UndeployModelMojo` — handles deletion
-- `AbstractPlatformModelMojo` — common behavior, HTTP client, descriptor reading
+- `AbstractPlatformModelMojo` — common behavior, HTTP client, descriptor reading, and `sendWithProgress`
+
+Upload progress reporting lives in `src/main/java/ai/timefold/solver/tools/maven/http`:
+
+- `CountingBodyPublisher` — a `BodyPublisher` wrapper that counts bytes handed to the client. Its `contentLength()` must stay delegated: returning `-1` switches the request to chunked transfer encoding and drops the `Content-Length` header.
+- `UploadProgressReporter` — turns those byte counts into throttled log lines. Deliberately not thread safe, because it is only ever called from the mojo thread; see `Progress feedback and timeouts` above.
+- `UploadProgressSettings` — the throttling parameters, with tighter values injected by tests via `DeployModelMojo.setProgressSettings`.
 
 The plugin relies on the environment variable `TIMEFOLD_PAT` for authentication; tests provide a test helper to mock token retrieval.

--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/AbstractPlatformModelMojo.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/AbstractPlatformModelMojo.java
@@ -5,7 +5,10 @@ import java.io.InputStream;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -14,8 +17,14 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
+import ai.timefold.solver.tools.maven.http.UploadProgressReporter;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -89,6 +98,49 @@ public abstract class AbstractPlatformModelMojo extends AbstractMojo {
         if (tenants != null && !tenants.isEmpty()) {
             builder.header("X-TF-TENANT-ID", tenants.getFirst());
             getLog().debug("Tenant " + tenants.getFirst() + " is used as context of the request");
+        }
+    }
+
+    /**
+     * Sends the request and, while waiting for the response, lets the reporter log progress from this thread.
+     * <p>
+     * {@link HttpClient#sendAsync(HttpRequest, BodyHandler)} is used rather than
+     * {@link HttpClient#send(HttpRequest, BodyHandler)} so that this thread stays free to log while the request body is
+     * written by the client's own threads. The exception unwrapping below restores the exception types that the
+     * blocking send would have thrown, so callers and their error messages do not have to change.
+     */
+    protected <T> HttpResponse<T> sendWithProgress(HttpRequest request, BodyHandler<T> responseBodyHandler,
+            UploadProgressReporter reporter) throws IOException, InterruptedException {
+        CompletableFuture<HttpResponse<T>> future = httpClient.sendAsync(request, responseBodyHandler);
+        long heartbeatMillis = Math.max(1L, reporter.getHeartbeatInterval().toMillis());
+        try {
+            while (true) {
+                try {
+                    HttpResponse<T> response = future.get(heartbeatMillis, TimeUnit.MILLISECONDS);
+                    reporter.finished();
+                    return response;
+                } catch (TimeoutException timeoutException) {
+                    // not an error, the request is simply still in flight
+                    reporter.heartbeat();
+                }
+            }
+        } catch (ExecutionException executionException) {
+            reporter.finished();
+            Throwable cause = executionException.getCause();
+            // HttpTimeoutException, ConnectException, SSLException, ... are all IOException subtypes and are rethrown
+            // as is, exactly as httpClient.send() would have thrown them
+            if (cause instanceof IOException ioException) {
+                throw ioException;
+            } else if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            } else if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new IOException(cause == null ? executionException.getMessage() : cause.getMessage(),
+                    cause == null ? executionException : cause);
+        } catch (InterruptedException interruptedException) {
+            future.cancel(true);
+            throw interruptedException;
         }
     }
 

--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/ConfigureMojo.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/ConfigureMojo.java
@@ -227,6 +227,7 @@ public class ConfigureMojo extends AbstractPlatformModelMojo {
         requestBuilder.uri(URI.create(platformUrl + "/api/platform/v1/aboutme?includeConfig=true"));
 
         HttpRequest httpRequest = requestBuilder.build();
+        getLog().info("Fetching configuration from the Timefold Platform at " + platformUrl);
         try {
             HttpResponse<String> authResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
             if (authResponse.statusCode() == 200) {

--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/DeployModelMojo.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/DeployModelMojo.java
@@ -1,5 +1,6 @@
 package ai.timefold.solver.tools.maven;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -11,6 +12,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
+
+import ai.timefold.solver.tools.maven.http.CountingBodyPublisher;
+import ai.timefold.solver.tools.maven.http.UploadProgressReporter;
+import ai.timefold.solver.tools.maven.http.UploadProgressSettings;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -78,6 +83,15 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
     @Parameter(property = PROP_DRY_RUN, required = false, defaultValue = "false")
     private boolean dryRun;
 
+    private UploadProgressSettings progressSettings = UploadProgressSettings.defaults();
+
+    /**
+     * Visible for testing, so that progress reporting can be exercised without a slow upload.
+     */
+    protected void setProgressSettings(UploadProgressSettings progressSettings) {
+        this.progressSettings = Objects.requireNonNull(progressSettings, "progressSettings");
+    }
+
     public void execute() throws MojoExecutionException {
         if (getPropertyOrParameter(PROP_MODEL_SKIP_DEPLOY, skip)) {
             getLog().info("Model deployment skipped by configuration");
@@ -130,12 +144,8 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
                 getLog().info("DRY_RUN: Would perform POST on " + requestURI);
             } else {
 
-                Builder builder =
-                        HttpRequest.newBuilder().uri(requestURI).POST(BodyPublishers.ofFile(modelDescriptorArchivePath));
-
-                configureHttpRequest(builder);
-
-                HttpResponse<String> response = httpClient.send(builder.build(), BodyHandlers.ofString());
+                HttpResponse<String> response =
+                        uploadModelDescriptor("POST", requestURI, modelDescriptorArchivePath);
                 if (response.statusCode() >= 200 && response.statusCode() < 400) {
                     getLog().info(
                             String.format(
@@ -157,10 +167,7 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
 
                         requestURI =
                                 URI.create(platformUrl + "/api/platform/v1/models/" + key + "?" + queryString.toString());
-                        builder = HttpRequest.newBuilder().uri(requestURI).method("PATCH",
-                                BodyPublishers.ofFile(modelDescriptorArchivePath));
-                        configureHttpRequest(builder);
-                        response = httpClient.send(builder.build(), BodyHandlers.ofString());
+                        response = uploadModelDescriptor("PATCH", requestURI, modelDescriptorArchivePath);
                         if (response.statusCode() >= 200 && response.statusCode() < 400) {
                             getLog().info(String.format(
                                     "Model %s (%s) has been successfully updated on platform %s with registration key %s",
@@ -200,6 +207,29 @@ public class DeployModelMojo extends AbstractPlatformModelMojo {
     private String readErrorCode(String responseBody) {
         String code = readErrorField(responseBody, "code");
         return code == null ? ERROR_CODE_UNKNOWN : code;
+    }
+
+    /**
+     * Uploads the model descriptor archive, reporting progress while the request is in flight. A fresh
+     * {@link CountingBodyPublisher} per call is required: the overwrite PATCH is a genuinely new request, and sharing
+     * the counter across both verbs would report more than 100%.
+     */
+    private HttpResponse<String> uploadModelDescriptor(String method, URI requestURI, Path archivePath)
+            throws IOException, InterruptedException {
+        CountingBodyPublisher bodyPublisher = new CountingBodyPublisher(BodyPublishers.ofFile(archivePath));
+        Builder builder = HttpRequest.newBuilder().uri(requestURI).method(method, bodyPublisher);
+        configureHttpRequest(builder);
+
+        long contentLength = bodyPublisher.contentLength();
+        getLog().debug(String.format("%s %s (%s)", method, requestURI,
+                UploadProgressReporter.formatBytes(contentLength)));
+        if (contentLength >= progressSettings.minimumSizeToAnnounceBytes()) {
+            getLog().info(String.format("Uploading model descriptor archive (%s), this can take a while on a slow "
+                    + "connection", UploadProgressReporter.formatBytes(contentLength)));
+        }
+        UploadProgressReporter reporter = new UploadProgressReporter(getLog(), progressSettings, contentLength,
+                bodyPublisher::getTransferredBytes);
+        return sendWithProgress(builder.build(), BodyHandlers.ofString(), reporter);
     }
 
     protected void validate(String type) {

--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/http/CountingBodyPublisher.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/http/CountingBodyPublisher.java
@@ -1,0 +1,90 @@
+package ai.timefold.solver.tools.maven.http;
+
+import java.net.http.HttpRequest.BodyPublisher;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Wraps another {@link BodyPublisher} and counts the bytes handed over to the HTTP client's write pipeline, so that
+ * the thread waiting for the response can tell whether the request body is still moving.
+ * <p>
+ * The count is <em>not</em> the number of bytes acknowledged by the peer, it is the number of bytes the client has
+ * accepted for writing. The overshoot is bounded by the socket send buffer plus, for HTTP/2, the peer's flow control
+ * window, because the client only requests more buffers from this publisher once the previous ones have been written
+ * and the window allows more. On a slow connection that overshoot is a few hundred kilobytes at most and roughly
+ * constant, which makes the count a usable approximation of upload progress - and a slow connection is the only
+ * situation in which the count is ever reported.
+ */
+public final class CountingBodyPublisher implements BodyPublisher {
+
+    private final BodyPublisher delegate;
+    private final AtomicLong transferredBytes = new AtomicLong();
+
+    public CountingBodyPublisher(BodyPublisher delegate) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+    }
+
+    /**
+     * Delegated unchanged on purpose. Returning anything else (for example -1) makes the client fall back to chunked
+     * transfer encoding instead of sending a Content-Length header, which changes the request on the wire.
+     */
+    @Override
+    public long contentLength() {
+        return delegate.contentLength();
+    }
+
+    /**
+     * Safe to call from any thread, in particular from the thread waiting for the response.
+     */
+    public long getTransferredBytes() {
+        return transferredBytes.get();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+        Objects.requireNonNull(subscriber, "subscriber");
+        // The client may subscribe more than once for a single logical request, for example when it resends the
+        // request after a redirect. Every subscription restarts the body from the beginning, so the counter has to
+        // restart too, otherwise it runs past contentLength() and progress exceeds 100%.
+        transferredBytes.set(0);
+        delegate.subscribe(new CountingSubscriber(subscriber));
+    }
+
+    private final class CountingSubscriber implements Subscriber<ByteBuffer> {
+
+        private final Subscriber<? super ByteBuffer> downstream;
+
+        private CountingSubscriber(Subscriber<? super ByteBuffer> downstream) {
+            this.downstream = downstream;
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            downstream.onSubscribe(subscription);
+        }
+
+        @Override
+        public void onNext(ByteBuffer item) {
+            // remaining() has to be read before forwarding: the downstream subscriber consumes the buffer, which
+            // advances its position, so remaining() is 0 by the time onNext returns. The counter is only updated
+            // after the forward, so a buffer rejected by a throwing subscriber is not counted.
+            int count = item.remaining();
+            downstream.onNext(item);
+            transferredBytes.addAndGet(count);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            downstream.onError(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            downstream.onComplete();
+        }
+    }
+
+}

--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/http/UploadProgressReporter.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/http/UploadProgressReporter.java
@@ -1,0 +1,124 @@
+package ai.timefold.solver.tools.maven.http;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.LongSupplier;
+
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * Turns the byte counter of a {@link CountingBodyPublisher} into a small number of throttled {@code [INFO]} lines.
+ * Maven's {@link Log} prefixes every line with {@code [INFO]} and cannot do in-place carriage return updates (and a
+ * bare carriage return is garbage in CI logs), so progress is reported as discrete, deliberately rare lines rather
+ * than as a progress bar.
+ * <p>
+ * Not thread safe by design: {@link #heartbeat()} and {@link #finished()} are only ever called from the Maven thread
+ * executing the mojo, so the throttling state needs no synchronization and nothing is ever logged from an HTTP client
+ * thread. Only the byte counter itself crosses threads, and that is an
+ * {@link java.util.concurrent.atomic.AtomicLong AtomicLong} inside {@link CountingBodyPublisher}.
+ */
+public final class UploadProgressReporter {
+
+    private final Log log;
+    private final UploadProgressSettings settings;
+    private final long contentLength;
+    private final LongSupplier transferredBytesSupplier;
+    private final LongSupplier nanoTimeSupplier;
+
+    private final long startNanos;
+    private long lastReportNanos;
+    private int lastReportedPercentage;
+    private boolean reportedAnything;
+
+    public UploadProgressReporter(Log log, UploadProgressSettings settings, long contentLength,
+            LongSupplier transferredBytesSupplier) {
+        this(log, settings, contentLength, transferredBytesSupplier, System::nanoTime);
+    }
+
+    /**
+     * Visible for testing: an injected clock makes the throttling rules verifiable without sleeping.
+     */
+    UploadProgressReporter(Log log, UploadProgressSettings settings, long contentLength,
+            LongSupplier transferredBytesSupplier, LongSupplier nanoTimeSupplier) {
+        this.log = Objects.requireNonNull(log, "log");
+        this.settings = Objects.requireNonNull(settings, "settings");
+        this.contentLength = contentLength;
+        this.transferredBytesSupplier = Objects.requireNonNull(transferredBytesSupplier, "transferredBytesSupplier");
+        this.nanoTimeSupplier = Objects.requireNonNull(nanoTimeSupplier, "nanoTimeSupplier");
+        this.startNanos = this.nanoTimeSupplier.getAsLong();
+        this.lastReportNanos = this.startNanos;
+    }
+
+    public Duration getHeartbeatInterval() {
+        return settings.heartbeatInterval();
+    }
+
+    /**
+     * Called from the mojo thread whenever the in-flight request did not complete within the heartbeat interval.
+     * Emits at most one line per call, and only when the throttling rules allow it.
+     */
+    public void heartbeat() {
+        long now = nanoTimeSupplier.getAsLong();
+        long transferred = transferredBytesSupplier.getAsLong();
+        if (contentLength > 0 && transferred < contentLength) {
+            int percentage = (int) (transferred * 100 / contentLength);
+            if (percentage - lastReportedPercentage < settings.minimumPercentageDelta() && !isSilentForTooLong(now)) {
+                return;
+            }
+            lastReportedPercentage = percentage;
+            report(now, String.format("Uploading model descriptor archive: %d%% (%s of %s, %s elapsed)", percentage,
+                    formatBytes(transferred), formatBytes(contentLength), formatElapsed(now)));
+        } else if (isSilentForTooLong(now)) {
+            report(now, String.format("Uploaded %s, waiting for the Timefold Platform to process it (%s elapsed)",
+                    formatBytes(transferred), formatElapsed(now)));
+        }
+    }
+
+    /**
+     * Called from the mojo thread once the request completed, successfully or not.
+     */
+    public void finished() {
+        if (!reportedAnything) {
+            // the common case: the request was faster than a single heartbeat, so stay completely quiet
+            return;
+        }
+        long now = nanoTimeSupplier.getAsLong();
+        log.info(String.format("Model descriptor archive transfer finished: %s in %s",
+                formatBytes(transferredBytesSupplier.getAsLong()), formatElapsed(now)));
+    }
+
+    private boolean isSilentForTooLong(long now) {
+        // the very first heartbeat always reports, so that feedback starts after a single interval
+        return !reportedAnything || now - lastReportNanos >= settings.maximumSilence().toNanos();
+    }
+
+    private void report(long now, String message) {
+        lastReportNanos = now;
+        reportedAnything = true;
+        log.info(message);
+    }
+
+    private String formatElapsed(long now) {
+        return formatDuration(Duration.ofNanos(now - startNanos));
+    }
+
+    public static String formatBytes(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        } else if (bytes < 1024 * 1024) {
+            // Locale.ROOT: a comma decimal separator would break log assertions on a non-English build agent
+            return String.format(Locale.ROOT, "%.1f KiB", bytes / 1024.0);
+        }
+        return String.format(Locale.ROOT, "%.1f MiB", bytes / (1024.0 * 1024.0));
+    }
+
+    public static String formatDuration(Duration duration) {
+        long seconds = Math.max(0, duration.toSeconds());
+        if (seconds < 60) {
+            return seconds + " s";
+        }
+        return (seconds / 60) + " m " + (seconds % 60) + " s";
+    }
+
+}

--- a/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/http/UploadProgressSettings.java
+++ b/service/tools/maven-plugin/src/main/java/ai/timefold/solver/tools/maven/http/UploadProgressSettings.java
@@ -1,0 +1,48 @@
+package ai.timefold.solver.tools.maven.http;
+
+import java.time.Duration;
+
+/**
+ * Tuning of the progress feedback of an upload. {@link #defaults()} is what the deploy goal uses, tests use tighter
+ * values to make the throttling observable without waiting.
+ *
+ * @param heartbeatInterval how often the mojo thread checks the in-flight request, which is also the hard floor
+ *        between two log lines
+ * @param maximumSilence after this long without a log line, the next heartbeat logs regardless of how little progress
+ *        was made, so that a very slow connection never looks hung
+ * @param minimumPercentageDelta how much of the upload has to have completed since the previous log line
+ * @param minimumSizeToAnnounceBytes archives smaller than this are not announced up front
+ */
+public record UploadProgressSettings(Duration heartbeatInterval, Duration maximumSilence, int minimumPercentageDelta,
+        long minimumSizeToAnnounceBytes) {
+
+    public UploadProgressSettings {
+        if (heartbeatInterval == null || heartbeatInterval.isNegative() || heartbeatInterval.isZero()) {
+            // a zero timeout on Future.get() would busy loop
+            throw new IllegalArgumentException(
+                    "heartbeatInterval must be a positive duration but was (" + heartbeatInterval + ").");
+        }
+        if (maximumSilence == null || maximumSilence.isNegative()) {
+            throw new IllegalArgumentException("maximumSilence must not be negative but was (" + maximumSilence + ").");
+        }
+        if (minimumPercentageDelta < 0 || minimumPercentageDelta > 100) {
+            throw new IllegalArgumentException(
+                    "minimumPercentageDelta must be between 0 and 100 but was (" + minimumPercentageDelta + ").");
+        }
+        if (minimumSizeToAnnounceBytes < 0) {
+            throw new IllegalArgumentException(
+                    "minimumSizeToAnnounceBytes must not be negative but was (" + minimumSizeToAnnounceBytes + ").");
+        }
+    }
+
+    /**
+     * 5 seconds is short enough that nobody concludes the build hung, and long enough that a normal deploy of a small
+     * archive completes before the first heartbeat and stays entirely silent. The 15 second maximum silence caps a ten
+     * minute upload at roughly 40 lines, and the 5% delta caps a fast large upload at roughly 20 lines. The 1 MiB
+     * announcement threshold keeps the typical model descriptor archive of a few tens of kilobytes unannounced.
+     */
+    public static UploadProgressSettings defaults() {
+        return new UploadProgressSettings(Duration.ofSeconds(5), Duration.ofSeconds(15), 5, 1024L * 1024L);
+    }
+
+}

--- a/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/DeployModelMojoTest.java
+++ b/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/DeployModelMojoTest.java
@@ -14,11 +14,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.ConnectException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.Enumeration;
+import java.util.Random;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
 
+import ai.timefold.solver.tools.maven.http.UploadProgressSettings;
 import ai.timefold.solver.tools.maven.utils.InMemoryMojoLog;
 import ai.timefold.solver.tools.maven.utils.InMemoryMojoLog.Level;
 
@@ -33,6 +42,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 
 @MojoTest
 public class DeployModelMojoTest {
+
+    private static final long MIB = 1024L * 1024L;
 
     @RegisterExtension
     static WireMockExtension wm1 = WireMockExtension.newInstance()
@@ -366,5 +377,112 @@ public class DeployModelMojoTest {
                 .hasMessage(
                         "'package' goal was not requested, deploy of timefold model might not be complete, make sure to use 'clean package timefold:deploy' or set '-Dtimefold.model.deploy.descriptorOnly=true'");
 
+    }
+
+    @Test
+    @MojoParameter(name = "key", value = "slowplatform")
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testHeartbeatWhilePlatformIsProcessing(DeployModelMojo mojo) throws Exception {
+        // atPriority(1) because setUp already registers a catch-all POST stub at priority 15
+        wm1.stubFor(post(urlPathEqualTo("/api/platform/v1/models"))
+                .atPriority(1)
+                .withQueryParam("registrationKey", equalTo("slowplatform"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withFixedDelay(1_000)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
+
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+        // a heartbeat and silence budget of 100 ms against a 1 s server delay leaves roughly ten chances to log
+        mojo.setProgressSettings(new UploadProgressSettings(Duration.ofMillis(100), Duration.ofMillis(100), 5, MIB));
+        mojo.execute();
+
+        wm1.verify(1, postRequestedFor(urlPathEqualTo("/api/platform/v1/models")));
+
+        // only presence is asserted, never elapsed times or line counts, so this cannot become time sensitive
+        log.assertContains("waiting for the Timefold Platform to process it", Level.INFO);
+        log.assertContains("transfer finished", Level.INFO);
+        log.assertContains("Model .* has been successfully deployed into platform.*", Level.INFO);
+    }
+
+    @Test
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testAnnouncesArchiveSizeForLargeArchives(DeployModelMojo mojo) throws Exception {
+        createLargeModelDescriptorArchive(2 * (int) MIB);
+
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+        // a heartbeat longer than the test can possibly take, so only the up-front announcement can appear
+        mojo.setProgressSettings(new UploadProgressSettings(Duration.ofMinutes(5), Duration.ofMinutes(5), 5, MIB));
+        mojo.execute();
+
+        wm1.verify(1, postRequestedFor(urlPathEqualTo("/api/platform/v1/models")));
+        log.assertContains("Uploading model descriptor archive \\(2\\.\\d MiB", Level.INFO);
+    }
+
+    @Test
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testNoProgressOutputForTheTypicalSmallArchive(DeployModelMojo mojo) throws Exception {
+        mojo.setLog(log);
+        mojo.platformUrl = wm1.getRuntimeInfo().getHttpBaseUrl();
+        // explicitly longer than the default, rather than relying on 5 s outrunning a loaded CI agent's loopback
+        mojo.setProgressSettings(new UploadProgressSettings(Duration.ofMinutes(5), Duration.ofMinutes(5), 5, MIB));
+        mojo.execute();
+
+        assertThat(log.contains("Uploading model descriptor archive", Level.INFO)).isFalse();
+        assertThat(log.contains("waiting for the Timefold Platform", Level.INFO)).isFalse();
+        assertThat(log.contains("transfer finished", Level.INFO)).isFalse();
+        log.assertContains("Model .* has been successfully deployed into platform.*", Level.INFO);
+    }
+
+    @Test
+    @MojoParameter(name = "descriptorOnly", value = "true")
+    @InjectMojo(goal = "deploy", pom = "src/test/resources/project-to-test/pom.xml")
+    public void testFailureCauseIsUnwrapped(DeployModelMojo mojo) {
+        mojo.setLog(log);
+        // nothing listens on port 1, so the connection is refused immediately; a request timeout would also exercise
+        // this branch but would make the test wait for it
+        mojo.platformUrl = "http://localhost:1";
+
+        // sendAsync reports failures as an ExecutionException; sendWithProgress unwraps it so that the cause stays
+        // exactly what the previously blocking send() would have thrown
+        assertThatThrownBy(mojo::execute)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Unexpected error while deploying model")
+                .hasCauseInstanceOf(ConnectException.class);
+    }
+
+    /**
+     * Copies every entry of the test fixture, so that {@code readModelDescriptor} still finds
+     * {@code timefold-model-descriptor.json} in the archive, then appends incompressible filler to grow it past the
+     * announcement threshold. Only writes under {@code target/}, which {@code setUp} overwrites for every other test.
+     */
+    private static void createLargeModelDescriptorArchive(int fillerBytes) throws IOException {
+        byte[] filler = new byte[fillerBytes];
+        new Random(42).nextBytes(filler); // random data does not deflate, so the archive really is this big
+        Path source = Paths.get("src", "test", "resources", "model-descriptor.zip");
+        Path target = Paths.get("target", "model-descriptor.zip");
+        try (ZipFile sourceZip = new ZipFile(source.toFile());
+                ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(target))) {
+            Enumeration<? extends ZipEntry> entries = sourceZip.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                out.putNextEntry(new ZipEntry(entry.getName()));
+                if (!entry.isDirectory()) {
+                    try (InputStream in = sourceZip.getInputStream(entry)) {
+                        in.transferTo(out);
+                    }
+                }
+                out.closeEntry();
+            }
+            out.putNextEntry(new ZipEntry("filler.bin"));
+            out.write(filler);
+            out.closeEntry();
+        }
     }
 }

--- a/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/http/CountingBodyPublisherTest.java
+++ b/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/http/CountingBodyPublisherTest.java
@@ -1,0 +1,110 @@
+package ai.timefold.solver.tools.maven.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpRequest.BodyPublishers;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+class CountingBodyPublisherTest {
+
+    private static final Duration COMPLETION_TIMEOUT = Duration.ofSeconds(10);
+
+    @Test
+    void delegatesContentLengthAndStartsAtZero() {
+        CountingBodyPublisher publisher = new CountingBodyPublisher(BodyPublishers.ofByteArray(new byte[123]));
+
+        // must be delegated: returning -1 would switch the request to chunked transfer encoding
+        assertThat(publisher.contentLength()).isEqualTo(123);
+        assertThat(publisher.getTransferredBytes()).isZero();
+    }
+
+    @Test
+    void countsBytesEvenWhenTheSubscriberDrainsTheBuffer() throws Exception {
+        // more than one 16 KiB chunk, so that onNext is called repeatedly
+        byte[] payload = new byte[100_000];
+        CountingBodyPublisher publisher = new CountingBodyPublisher(BodyPublishers.ofByteArray(payload));
+        DrainingSubscriber subscriber = new DrainingSubscriber();
+
+        publisher.subscribe(subscriber);
+
+        assertThat(subscriber.awaitCompletion(COMPLETION_TIMEOUT)).isTrue();
+        assertThat(subscriber.getDrainedBytes()).isEqualTo(payload.length);
+        assertThat(publisher.getTransferredBytes()).isEqualTo(payload.length);
+    }
+
+    @Test
+    void resubscribingRestartsTheCounter() throws Exception {
+        Path archive = Paths.get("src", "test", "resources", "model-descriptor.zip");
+        long size = Files.size(archive);
+        CountingBodyPublisher publisher = new CountingBodyPublisher(BodyPublishers.ofFile(archive));
+
+        DrainingSubscriber first = new DrainingSubscriber();
+        publisher.subscribe(first);
+        assertThat(first.awaitCompletion(COMPLETION_TIMEOUT)).isTrue();
+        assertThat(publisher.getTransferredBytes()).isEqualTo(size);
+
+        // the client resubscribes when it resends the request, for example after a redirect
+        DrainingSubscriber second = new DrainingSubscriber();
+        publisher.subscribe(second);
+        assertThat(second.awaitCompletion(COMPLETION_TIMEOUT)).isTrue();
+        assertThat(publisher.getTransferredBytes()).isEqualTo(size); // not twice the size
+    }
+
+    /**
+     * Deliberately consumes every buffer it is given, exactly like the real downstream subscriber does when it writes
+     * to the socket. That is what makes {@link CountingBodyPublisher}'s rule of reading {@code remaining()} before
+     * forwarding load-bearing: counting after the forward instead would report 0 bytes here.
+     */
+    private static final class DrainingSubscriber implements Subscriber<ByteBuffer> {
+
+        private final CountDownLatch completionLatch = new CountDownLatch(1);
+        private long drainedBytes;
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(ByteBuffer item) {
+            while (item.hasRemaining()) {
+                item.get();
+                drainedBytes++;
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            completionLatch.countDown();
+        }
+
+        @Override
+        public void onComplete() {
+            completionLatch.countDown();
+        }
+
+        /**
+         * Awaiting a latch rather than assuming the current JDK's synchronous delivery keeps this test correct either
+         * way. The assertion is "completed", not "completed within N", so it is not time sensitive.
+         */
+        public boolean awaitCompletion(Duration timeout) throws InterruptedException {
+            return completionLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        public long getDrainedBytes() {
+            return drainedBytes;
+        }
+
+    }
+
+}

--- a/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/http/UploadProgressReporterTest.java
+++ b/service/tools/maven-plugin/src/test/java/ai/timefold/solver/tools/maven/http/UploadProgressReporterTest.java
@@ -1,0 +1,145 @@
+package ai.timefold.solver.tools.maven.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import ai.timefold.solver.tools.maven.utils.InMemoryMojoLog;
+import ai.timefold.solver.tools.maven.utils.InMemoryMojoLog.Level;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * The clock and the byte counter are both injected, so every throttling rule is asserted without sleeping and none of
+ * these tests depend on wall clock time.
+ */
+class UploadProgressReporterTest {
+
+    private static final long ONE_KIB = 1024L;
+    private static final long ONE_MIB = 1024L * 1024L;
+
+    private final InMemoryMojoLog log = new InMemoryMojoLog();
+    private final AtomicLong nanos = new AtomicLong();
+    private final AtomicLong transferred = new AtomicLong();
+
+    private UploadProgressReporter createReporter(long contentLength) {
+        UploadProgressSettings settings =
+                new UploadProgressSettings(Duration.ofSeconds(5), Duration.ofSeconds(15), 5, ONE_MIB);
+        return new UploadProgressReporter(log, settings, contentLength, transferred::get, nanos::get);
+    }
+
+    private void advance(Duration duration) {
+        nanos.addAndGet(duration.toNanos());
+    }
+
+    @Test
+    void reportsUploadPercentageThrottledByPercentageDelta() {
+        UploadProgressReporter reporter = createReporter(10 * ONE_MIB);
+
+        advance(Duration.ofSeconds(5));
+        transferred.set(ONE_MIB);
+        reporter.heartbeat();
+        assertThat(log.messages())
+                .containsExactly("Uploading model descriptor archive: 10% (1.0 MiB of 10.0 MiB, 5 s elapsed)");
+
+        // 12% is only 2 percentage points on from the last line, and maximumSilence has not elapsed either
+        advance(Duration.ofSeconds(5));
+        transferred.set(ONE_MIB + 200 * ONE_KIB);
+        reporter.heartbeat();
+        assertThat(log.messages()).hasSize(1);
+
+        advance(Duration.ofSeconds(5));
+        transferred.set(2 * ONE_MIB);
+        reporter.heartbeat();
+        assertThat(log.messages()).hasSize(2)
+                .last().isEqualTo("Uploading model descriptor archive: 20% (2.0 MiB of 10.0 MiB, 15 s elapsed)");
+    }
+
+    @Test
+    void breaksTheSilenceWhenTheUploadBarelyMoves() {
+        UploadProgressReporter reporter = createReporter(10 * ONE_MIB);
+        transferred.set(1);
+
+        // the first heartbeat always reports, so that feedback starts after a single interval
+        advance(Duration.ofSeconds(5));
+        reporter.heartbeat();
+        assertThat(log.messages())
+                .containsExactly("Uploading model descriptor archive: 0% (1 B of 10.0 MiB, 5 s elapsed)");
+
+        // still 0%, and only 5 s then 10 s since the last line, so both are suppressed
+        advance(Duration.ofSeconds(5));
+        reporter.heartbeat();
+        advance(Duration.ofSeconds(5));
+        reporter.heartbeat();
+        assertThat(log.messages()).hasSize(1);
+
+        // 15 s since the last line: report anyway, so a dying connection never looks hung
+        advance(Duration.ofSeconds(5));
+        reporter.heartbeat();
+        assertThat(log.messages()).hasSize(2)
+                .last().isEqualTo("Uploading model descriptor archive: 0% (1 B of 10.0 MiB, 20 s elapsed)");
+    }
+
+    @Test
+    void reportsWaitingOncePlatformHasEverythingItNeeds() {
+        UploadProgressReporter reporter = createReporter(25_000);
+        transferred.set(25_000);
+
+        advance(Duration.ofSeconds(5));
+        reporter.heartbeat();
+        assertThat(log.messages()).containsExactly(
+                "Uploaded 24.4 KiB, waiting for the Timefold Platform to process it (5 s elapsed)");
+
+        advance(Duration.ofSeconds(5));
+        reporter.heartbeat();
+        assertThat(log.messages()).hasSize(1);
+
+        advance(Duration.ofSeconds(10));
+        reporter.heartbeat();
+        assertThat(log.messages()).hasSize(2).last().isEqualTo(
+                "Uploaded 24.4 KiB, waiting for the Timefold Platform to process it (20 s elapsed)");
+    }
+
+    @Test
+    void staysCompletelyQuietWhenNothingWasReported() {
+        UploadProgressReporter reporter = createReporter(25_000);
+        transferred.set(25_000);
+
+        // the common case: the request completed before the first heartbeat ever fired
+        reporter.finished();
+
+        assertThat(log.messages()).isEmpty();
+    }
+
+    @Test
+    void logsAClosingLineAfterReporting() {
+        UploadProgressReporter reporter = createReporter(6 * ONE_MIB);
+        transferred.set(6 * ONE_MIB);
+
+        advance(Duration.ofSeconds(5));
+        reporter.heartbeat();
+        reporter.finished();
+
+        assertThat(log.messages()).hasSize(2)
+                .last().isEqualTo("Model descriptor archive transfer finished: 6.0 MiB in 5 s");
+        assertThat(log.contains("transfer finished", Level.INFO)).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "0, 0 B", "1023, 1023 B", "1024, 1.0 KiB", "25000, 24.4 KiB", "1048576, 1.0 MiB",
+            "6291456, 6.0 MiB" })
+    void formatsBytes(long bytes, String expected) {
+        // Locale.ROOT is asserted implicitly: a comma decimal separator would fail here on a non-English agent
+        assertThat(UploadProgressReporter.formatBytes(bytes)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "0, 0 s", "59, 59 s", "60, 1 m 0 s", "130, 2 m 10 s" })
+    void formatsDuration(long seconds, String expected) {
+        assertThat(UploadProgressReporter.formatDuration(Duration.ofSeconds(seconds))).isEqualTo(expected);
+    }
+
+}


### PR DESCRIPTION
Related to https://github.com/TimefoldAI/timefold-solver-enterprise/issues/807

Sample output:
```
[INFO] Uploading model descriptor archive (24.2 KiB), this can take a while on a slow connection
[INFO] Uploaded 24.2 KiB, waiting for the Timefold Platform to process it (0 s elapsed)
[INFO] Model descriptor archive transfer finished: 24.2 KiB in 0 s
```