### PR TITLE
fix: normalize mvnw.cmd line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 
 *.sh eol=lf
 *.bat eol=crlf
+*.cmd eol=crlf
 
 # Binary files
 ##############


### PR DESCRIPTION
`.gitattributes` applies `* text eol=lf` to every file and adds an `*.bat eol=crlf` exception, but `mvnw.cmd` is a `.cmd` file and so was never covered by it. Git therefore treated mvnw.cmd as text requiring LF normalization, while the committed blob still held CRLF endings.

This left the file permanently marked as modified and impossible to revert: `eol=lf` applies no conversion on checkout, so the CRLF blob bytes landed in the working tree verbatim, the clean filter then normalized them to LF when diffing, and the resulting hash never matched the stored blob. `git checkout -- mvnw.cmd` restored the same CRLF bytes and reproduced the change immediately.

Add `*.cmd eol=crlf` alongside the existing `*.bat` rule and renormalize the blob to LF. mvnw.cmd is a Windows-only polyglot batch/PowerShell script, where LF endings are known to break label and `goto` handling, so CRLF remains the correct working-tree representation.

The working-tree file is byte-identical before and after; only the stored blob changes, which is why the diff touches all 189 lines.