### PR TITLE
chore: add docs, fail fast on execute for structural flawed solutions, make ScoreAnalysis not fail fact on structural flawed input

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/api/domain/variable/InconsistentSolutionException.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/variable/InconsistentSolutionException.java
@@ -2,19 +2,19 @@ package ai.timefold.solver.core.api.domain.variable;
 
 import java.util.List;
 
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public class InconsistentSolutionException extends RuntimeException {
     private final Object solution;
-    private final List<LoopedVariableInfo> inconsistentGroups;
+    private final List<VariableLoop> variableLoops;
 
-    public InconsistentSolutionException(String feature, Object solution, List<LoopedVariableInfo> inconsistentGroups) {
+    public InconsistentSolutionException(String feature, Object solution, List<VariableLoop> variableLoops) {
         super("The solution (%s) is inconsistent. %s requires a consistent solution.".formatted(solution, feature));
         this.solution = solution;
-        this.inconsistentGroups = inconsistentGroups;
+        this.variableLoops = variableLoops;
     }
 
     @SuppressWarnings("unchecked")
@@ -22,7 +22,7 @@ public class InconsistentSolutionException extends RuntimeException {
         return (T) solution;
     }
 
-    public List<LoopedVariableInfo> getInconsistentGroups() {
-        return inconsistentGroups;
+    public List<VariableLoop> getVariableLoops() {
+        return variableLoops;
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/domain/variable/InconsistentSolutionException.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/variable/InconsistentSolutionException.java
@@ -1,19 +1,20 @@
 package ai.timefold.solver.core.api.domain.variable;
 
-import java.util.Collection;
 import java.util.List;
+
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public class InconsistentSolutionException extends RuntimeException {
     private final Object solution;
-    private final Collection<Object> involvedEntityCollection;
+    private final List<LoopedVariableInfo> inconsistentGroups;
 
-    public InconsistentSolutionException(String feature, Object solution, Collection<Object> involvedEntityCollection) {
+    public InconsistentSolutionException(String feature, Object solution, List<LoopedVariableInfo> inconsistentGroups) {
         super("The solution (%s) is inconsistent. %s requires a consistent solution.".formatted(solution, feature));
         this.solution = solution;
-        this.involvedEntityCollection = involvedEntityCollection;
+        this.inconsistentGroups = inconsistentGroups;
     }
 
     @SuppressWarnings("unchecked")
@@ -21,8 +22,7 @@ public class InconsistentSolutionException extends RuntimeException {
         return (T) solution;
     }
 
-    @SuppressWarnings("unchecked")
-    public <T> List<T> getInvolvedEntityCollection() {
-        return (List<T>) involvedEntityCollection;
+    public List<LoopedVariableInfo> getInconsistentGroups() {
+        return inconsistentGroups;
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/domain/variable/InconsistentSolutionException.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/variable/InconsistentSolutionException.java
@@ -7,7 +7,7 @@ import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class InconsistentSolutionException extends RuntimeException {
+public final class InconsistentSolutionException extends RuntimeException {
     private final Object solution;
     private final List<VariableLoop> variableLoops;
 

--- a/core/src/main/java/ai/timefold/solver/core/api/domain/variable/ShadowVariablesInconsistent.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/variable/ShadowVariablesInconsistent.java
@@ -9,6 +9,7 @@ import java.lang.annotation.Target;
 
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 
 /**
@@ -129,8 +130,13 @@ import ai.timefold.solver.core.api.score.stream.Constraint;
  * Do not use a {@link ShadowVariablesInconsistent} property in a method annotated with {@link ShadowSources}.
  * {@link ShadowSources} marked methods do not need to check {@link ShadowVariablesInconsistent} properties,
  * since they are only called if all their dependencies are consistent.
+ *
+ * @deprecated The introduction of {@link Score#structuralScore()} removed the need for this annotation.
+ *             If you currently have this annotation on a property, you are encouraged to remove
+ *             it to have simpler constraints and faster solve speeds.
  */
 @Target({ METHOD, FIELD })
 @Retention(RUNTIME)
+@Deprecated(since = "2.6.0")
 public @interface ShadowVariablesInconsistent {
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/domain/variable/ShadowVariablesInconsistent.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/domain/variable/ShadowVariablesInconsistent.java
@@ -137,6 +137,6 @@ import ai.timefold.solver.core.api.score.stream.Constraint;
  */
 @Target({ METHOD, FIELD })
 @Retention(RUNTIME)
-@Deprecated(since = "2.6.0")
+@Deprecated(since = "2.7.0")
 public @interface ShadowVariablesInconsistent {
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/EntityVariablePair.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/EntityVariablePair.java
@@ -1,0 +1,17 @@
+package ai.timefold.solver.core.api.score.analysis;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A pair of an entity and a variable on it.
+ * 
+ * @param entity The entity.
+ * @param variableName The variable on the entity.
+ */
+@NullMarked
+public record EntityVariablePair(Object entity, String variableName) {
+    @Override
+    public String toString() {
+        return "%s.%s".formatted(entity, variableName);
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/LoopedVariableInfo.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/LoopedVariableInfo.java
@@ -1,0 +1,31 @@
+package ai.timefold.solver.core.api.score.analysis;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A set of entity-variable pairs that form a cycle.
+ * 
+ * @param involvedVariableSet
+ */
+@NullMarked
+public record LoopedVariableInfo(Set<EntityVariablePair> involvedVariableSet) {
+    /**
+     * Get the set of involved entities in the cycle
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Set<T> getEntitySet() {
+        return (Set<T>) involvedVariableSet.stream()
+                .map(EntityVariablePair::entity)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String toString() {
+        return involvedVariableSet.stream()
+                .map(EntityVariablePair::toString)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ScoreAnalysis.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/ScoreAnalysis.java
@@ -87,6 +87,21 @@ public interface ScoreAnalysis<Score_ extends Score<Score_>> {
     boolean isSolutionInitialized();
 
     /**
+     * Indicates whether the solution was structurally flawed at the time of analysis.
+     *
+     * @return isSolutionStructurallyFlawed true if the solution was structurally flawed at the time of analysis.
+     */
+    boolean isSolutionStructurallyFlawed();
+
+    /**
+     * Returns an analysis of the structural flaws of a structurally flawed solution.
+     * 
+     * @return null if the solution was not structurally flawed at the time of analysis.
+     */
+    @Nullable
+    StructuralFlawAnalysis getStructuralFlawAnalysis();
+
+    /**
      * Performs a lookup on {@link #constraintMap()}.
      * Equivalent to {@code constraintMap().get(constraintRef)}.
      *

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/StructuralFlawAnalysis.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/StructuralFlawAnalysis.java
@@ -1,0 +1,17 @@
+package ai.timefold.solver.core.api.score.analysis;
+
+import java.util.Collection;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Represents a breakdown of the structural flaws of a solution.
+ */
+@NullMarked
+public interface StructuralFlawAnalysis {
+    /**
+     * Return a collection of {@link ai.timefold.solver.core.api.domain.entity.PlanningEntity}
+     * that have inconsistent shadow variables.
+     */
+    Collection<Object> getInconsistentEntities();
+}

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/StructuralFlawAnalysis.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/StructuralFlawAnalysis.java
@@ -10,8 +10,8 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public interface StructuralFlawAnalysis {
     /**
-     * Return a list of independent {@link LoopedVariableInfo}
+     * Return a list of independent {@link VariableLoop}
      * that form cycles and thus cause inconsistencies in the solution.
      */
-    List<LoopedVariableInfo> getInconsistentGroups();
+    List<VariableLoop> getVariableLoops();
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/StructuralFlawAnalysis.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/StructuralFlawAnalysis.java
@@ -1,6 +1,6 @@
 package ai.timefold.solver.core.api.score.analysis;
 
-import java.util.Collection;
+import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -10,8 +10,8 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public interface StructuralFlawAnalysis {
     /**
-     * Return a collection of {@link ai.timefold.solver.core.api.domain.entity.PlanningEntity}
-     * that have inconsistent shadow variables.
+     * Return a list of independent {@link LoopedVariableInfo}
+     * that form cycles and thus cause inconsistencies in the solution.
      */
-    Collection<Object> getInconsistentEntities();
+    List<LoopedVariableInfo> getInconsistentGroups();
 }

--- a/core/src/main/java/ai/timefold/solver/core/api/score/analysis/VariableLoop.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/analysis/VariableLoop.java
@@ -11,7 +11,7 @@ import org.jspecify.annotations.NullMarked;
  * @param involvedVariableSet
  */
 @NullMarked
-public record LoopedVariableInfo(Set<EntityVariablePair> involvedVariableSet) {
+public record VariableLoop(Set<EntityVariablePair> involvedVariableSet) {
     /**
      * Get the set of involved entities in the cycle
      */

--- a/core/src/main/java/ai/timefold/solver/core/api/solver/phase/PhaseCommandContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/phase/PhaseCommandContext.java
@@ -53,7 +53,10 @@ public interface PhaseCommandContext<Solution_>
      * without recalculating the score for performance reasons.
      *
      * @param move the move to execute
-     * @throws IllegalArgumentException if the move causes the solution to have a negative {@link Score#structuralScore()}.
+     * @throws IllegalArgumentException if the move causes the solution to have a negative
+     *         {@link Score#structuralScore()}. If you are unsure if a move will result in a structural
+     *         solution, use {@link #executeTemporarily(Move)} to check
+     *         if a move results in a structural flawed solution before executing it.
      */
     void execute(Move<Solution_> move);
 
@@ -63,7 +66,10 @@ public interface PhaseCommandContext<Solution_>
      *
      * @param move the move to execute
      * @return the new score of the working solution after executing the move
-     * @throws IllegalArgumentException if the move causes the solution to have a negative {@link Score#structuralScore()}.
+     * @throws IllegalArgumentException if the move causes the solution to have a negative
+     *         {@link Score#structuralScore()}. If you are unsure if a move will result in a structural
+     *         solution, use {@link #executeTemporarily(Move)} to check
+     *         if a move results in a structural flawed solution before executing it.
      */
     <Score_ extends Score<Score_>> Score_ executeAndCalculateScore(Move<Solution_> move);
 
@@ -77,6 +83,8 @@ public interface PhaseCommandContext<Solution_>
      *        this solution must not be modified any further.
      * @return the result of the consumer
      * @throws IllegalArgumentException if the move causes the solution to have a negative {@link Score#structuralScore()}.
+     *         Use {@link #executeTemporarily(Move, Function, Function)} instead,
+     *         where structurally flawed solutions are handled by a separate consumer.
      */
     <Result_> @Nullable Result_ executeTemporarily(Move<Solution_> move,
             Function<Solution_, @Nullable Result_> temporarySolutionConsumer);
@@ -86,11 +94,13 @@ public interface PhaseCommandContext<Solution_>
      * except having a separate consumer to handle solutions with a negative {@link Score#structuralScore()}.
      *
      * @param move the move to execute temporarily
-     * @param temporarySolutionConsumer the consumer to execute with the temporarily modified solution;
+     * @param temporarySolutionConsumer the consumer to execute with the temporarily modified structurally valid solution;
      *        this solution must not be modified any further.
+     * @param structurallyFlawedSolutionConsumer the consumer that is called when a move results in a structurally flawed
+     *        solution. This solution must not be modified any further.
      * @return the result of the consumer
      */
-    <Result_> @Nullable Result_ executeTemporarilyHandlingStructurallyFlawedSolutions(Move<Solution_> move,
+    <Result_> @Nullable Result_ executeTemporarily(Move<Solution_> move,
             Function<Solution_, @Nullable Result_> temporarySolutionConsumer,
             Function<Solution_, @Nullable Result_> structurallyFlawedSolutionConsumer);
 
@@ -113,17 +123,26 @@ public interface PhaseCommandContext<Solution_>
     /**
      * As defined by {@link #executeTemporarily(Move, Function)},
      * with the guarantee of a fresh score at the end of the method's invocation.
-     * 
+     *
+     * @param move the move to execute temporarily
+     * @param temporarySolutionConsumer the consumer to execute with the temporarily modified solution;
+     *        this solution must not be modified any further.
      * @throws IllegalArgumentException if the move causes the solution to have a negative {@link Score#structuralScore()}.
      */
     <Result_> @Nullable Result_ executeTemporarilyAndCalculateScore(Move<Solution_> move,
             Function<Solution_, @Nullable Result_> temporarySolutionConsumer);
 
     /**
-     * As defined by {@link #executeTemporarilyHandlingStructurallyFlawedSolutions(Move, Function, Function)},
+     * As defined by {@link #executeTemporarily(Move, Function, Function)},
      * with the guarantee of a fresh score at the end of the method's invocation.
+     *
+     * @param move the move to execute temporarily
+     * @param temporarySolutionConsumer the consumer to execute with the temporarily modified structurally valid solution;
+     *        this solution must not be modified any further.
+     * @param structurallyFlawedSolutionConsumer the consumer that is called when a move results in a structurally flawed
+     *        solution. This solution must not be modified any further.
      */
-    <Result_> @Nullable Result_ executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions(Move<Solution_> move,
+    <Result_> @Nullable Result_ executeTemporarilyAndCalculateScore(Move<Solution_> move,
             Function<Solution_, @Nullable Result_> temporarySolutionConsumer,
             Function<Solution_, @Nullable Result_> structurallyFlawedSolutionConsumer);
 

--- a/core/src/main/java/ai/timefold/solver/core/api/solver/phase/PhaseCommandContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/phase/PhaseCommandContext.java
@@ -54,7 +54,7 @@ public interface PhaseCommandContext<Solution_>
      *
      * @param move the move to execute
      * @throws IllegalArgumentException if the move causes the solution to have a negative
-     *         {@link Score#structuralScore()}. If you are unsure if a move will result in a structural
+     *         {@link Score#structuralScore()}. If you are unsure if a move will result in a structurally valid
      *         solution, use {@link #executeTemporarily(Move)} to check
      *         if a move results in a structural flawed solution before executing it.
      */
@@ -67,7 +67,7 @@ public interface PhaseCommandContext<Solution_>
      * @param move the move to execute
      * @return the new score of the working solution after executing the move
      * @throws IllegalArgumentException if the move causes the solution to have a negative
-     *         {@link Score#structuralScore()}. If you are unsure if a move will result in a structural
+     *         {@link Score#structuralScore()}. If you are unsure if a move will result in a structurally valid
      *         solution, use {@link #executeTemporarily(Move)} to check
      *         if a move results in a structural flawed solution before executing it.
      */

--- a/core/src/main/java/ai/timefold/solver/core/api/solver/phase/PhaseCommandContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/solver/phase/PhaseCommandContext.java
@@ -53,6 +53,7 @@ public interface PhaseCommandContext<Solution_>
      * without recalculating the score for performance reasons.
      *
      * @param move the move to execute
+     * @throws IllegalArgumentException if the move causes the solution to have a negative {@link Score#structuralScore()}.
      */
     void execute(Move<Solution_> move);
 
@@ -62,6 +63,7 @@ public interface PhaseCommandContext<Solution_>
      *
      * @param move the move to execute
      * @return the new score of the working solution after executing the move
+     * @throws IllegalArgumentException if the move causes the solution to have a negative {@link Score#structuralScore()}.
      */
     <Score_ extends Score<Score_>> Score_ executeAndCalculateScore(Move<Solution_> move);
 
@@ -74,9 +76,23 @@ public interface PhaseCommandContext<Solution_>
      * @param temporarySolutionConsumer the consumer to execute with the temporarily modified solution;
      *        this solution must not be modified any further.
      * @return the result of the consumer
+     * @throws IllegalArgumentException if the move causes the solution to have a negative {@link Score#structuralScore()}.
      */
     <Result_> @Nullable Result_ executeTemporarily(Move<Solution_> move,
             Function<Solution_, @Nullable Result_> temporarySolutionConsumer);
+
+    /**
+     * As defined by {@link #executeTemporarily(Move, Function)},
+     * except having a separate consumer to handle solutions with a negative {@link Score#structuralScore()}.
+     *
+     * @param move the move to execute temporarily
+     * @param temporarySolutionConsumer the consumer to execute with the temporarily modified solution;
+     *        this solution must not be modified any further.
+     * @return the result of the consumer
+     */
+    <Result_> @Nullable Result_ executeTemporarilyHandlingStructurallyFlawedSolutions(Move<Solution_> move,
+            Function<Solution_, @Nullable Result_> temporarySolutionConsumer,
+            Function<Solution_, @Nullable Result_> structurallyFlawedSolutionConsumer);
 
     /**
      * Executes the given move temporarily and returns the score of the temporarily modified solution.
@@ -97,9 +113,19 @@ public interface PhaseCommandContext<Solution_>
     /**
      * As defined by {@link #executeTemporarily(Move, Function)},
      * with the guarantee of a fresh score at the end of the method's invocation.
+     * 
+     * @throws IllegalArgumentException if the move causes the solution to have a negative {@link Score#structuralScore()}.
      */
     <Result_> @Nullable Result_ executeTemporarilyAndCalculateScore(Move<Solution_> move,
             Function<Solution_, @Nullable Result_> temporarySolutionConsumer);
+
+    /**
+     * As defined by {@link #executeTemporarilyHandlingStructurallyFlawedSolutions(Move, Function, Function)},
+     * with the guarantee of a fresh score at the end of the method's invocation.
+     */
+    <Result_> @Nullable Result_ executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions(Move<Solution_> move,
+            Function<Solution_, @Nullable Result_> temporarySolutionConsumer,
+            Function<Solution_, @Nullable Result_> structurallyFlawedSolutionConsumer);
 
     @Override
     <T> @Nullable T lookUpWorkingObject(@Nullable T problemFactOrPlanningEntity);

--- a/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
+++ b/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
@@ -1,7 +1,6 @@
 package ai.timefold.solver.core.enterprise;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -9,6 +8,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.api.score.analysis.ScoreAnalysis;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
 import ai.timefold.solver.core.api.score.stream.ConstraintRef;
@@ -227,9 +227,13 @@ public interface TimefoldSolverEnterpriseService {
 
     InnerConstraintProfiler buildConstraintProfiler();
 
+    /**
+     * @param inconsistentEntities the entities that are inconsistent
+     * @param scoreDefinition can be null if inconsistentEntities is known to be empty
+     */
     <Score_ extends Score<Score_>> ScoreAnalysis<Score_> analyze(InnerScore<Score_> state,
             Map<ConstraintRef, ConstraintMatchTotal<Score_>> constraintMatchTotalMap,
-            Collection<Object> inconsistentEntities,
+            List<LoopedVariableInfo> inconsistentEntities,
             @Nullable ScoreDefinition<Score_> scoreDefinition,
             ScoreAnalysisFetchPolicy fetchPolicy);
 

--- a/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
+++ b/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
@@ -8,8 +8,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import ai.timefold.solver.core.api.score.Score;
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.api.score.analysis.ScoreAnalysis;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
 import ai.timefold.solver.core.api.score.stream.ConstraintRef;
 import ai.timefold.solver.core.api.solver.RecommendedAssignment;
@@ -228,12 +228,12 @@ public interface TimefoldSolverEnterpriseService {
     InnerConstraintProfiler buildConstraintProfiler();
 
     /**
-     * @param inconsistentEntities the entities that are inconsistent
-     * @param scoreDefinition can be null if inconsistentEntities is known to be empty
+     * @param variableLoops the variable loops in the solution
+     * @param scoreDefinition can be null if variableLoops is known to be empty
      */
     <Score_ extends Score<Score_>> ScoreAnalysis<Score_> analyze(InnerScore<Score_> state,
             Map<ConstraintRef, ConstraintMatchTotal<Score_>> constraintMatchTotalMap,
-            List<LoopedVariableInfo> inconsistentEntities,
+            List<VariableLoop> variableLoops,
             @Nullable ScoreDefinition<Score_> scoreDefinition,
             ScoreAnalysisFetchPolicy fetchPolicy);
 

--- a/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
+++ b/core/src/main/java/ai/timefold/solver/core/enterprise/TimefoldSolverEnterpriseService.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.enterprise;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -44,6 +45,7 @@ import ai.timefold.solver.core.impl.localsearch.decider.forager.LocalSearchForag
 import ai.timefold.solver.core.impl.neighborhood.MoveRepository;
 import ai.timefold.solver.core.impl.partitionedsearch.PartitionedSearchPhase;
 import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchTotal;
+import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
 import ai.timefold.solver.core.impl.score.director.InnerScore;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.solver.DefaultSolverFactory;
@@ -226,7 +228,10 @@ public interface TimefoldSolverEnterpriseService {
     InnerConstraintProfiler buildConstraintProfiler();
 
     <Score_ extends Score<Score_>> ScoreAnalysis<Score_> analyze(InnerScore<Score_> state,
-            Map<ConstraintRef, ConstraintMatchTotal<Score_>> constraintMatchTotalMap, ScoreAnalysisFetchPolicy fetchPolicy);
+            Map<ConstraintRef, ConstraintMatchTotal<Score_>> constraintMatchTotalMap,
+            Collection<Object> inconsistentEntities,
+            @Nullable ScoreDefinition<Score_> scoreDefinition,
+            ScoreAnalysisFetchPolicy fetchPolicy);
 
     <Solution_> PlanningSolutionDiff<Solution_> solutionDiff(PlanningSolutionMetaModel<Solution_> metaModel,
             Solution_ oldSolution, Solution_ newSolution);

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableSupport.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 import ai.timefold.solver.core.enterprise.TimefoldSolverEnterpriseService;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.cascade.CascadingUpdateShadowVariableDescriptor;
@@ -425,11 +425,11 @@ public final class ShadowVariableSupport<Solution_> implements SupplyManager {
         return true;
     }
 
-    public List<LoopedVariableInfo> getInconsistentGroups() {
+    public List<VariableLoop> getVariableLoops() {
         if (shadowVariableSession == null) {
             return Collections.emptyList();
         }
-        return shadowVariableSession.getInconsistentGroups();
+        return shadowVariableSession.getVariableLoops();
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableSupport.java
@@ -12,6 +12,7 @@ import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.enterprise.TimefoldSolverEnterpriseService;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.cascade.CascadingUpdateShadowVariableDescriptor;
@@ -424,11 +425,11 @@ public final class ShadowVariableSupport<Solution_> implements SupplyManager {
         return true;
     }
 
-    public Collection<Object> getInconsistentEntities() {
+    public List<LoopedVariableInfo> getInconsistentGroups() {
         if (shadowVariableSession == null) {
             return Collections.emptyList();
         }
-        return shadowVariableSession.getInconsistentEntities();
+        return shadowVariableSession.getInconsistentGroups();
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ShadowVariableSupport.java
@@ -306,7 +306,8 @@ public final class ShadowVariableSupport<Solution_> implements SupplyManager {
                     shadowVariableGraphCreator);
             shadowVariableSession =
                     shadowVariableSessionFactory.forSolution(consistencyTracker,
-                            scoreDirector.getWorkingSolution());
+                            scoreDirector.getWorkingSolution(),
+                            scoreDirector.ignoreInconsistentSolutions());
         }
     }
 
@@ -425,8 +426,7 @@ public final class ShadowVariableSupport<Solution_> implements SupplyManager {
 
     public Collection<Object> getInconsistentEntities() {
         if (shadowVariableSession == null) {
-            throw new IllegalStateException(
-                    "Impossible state: The shadowVariableSession is null. A solution without shadow variables cannot be inconsistent.");
+            return Collections.emptyList();
         }
         return shadowVariableSession.getInconsistentEntities();
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
@@ -1,7 +1,8 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
-import java.util.Collection;
+import java.util.List;
 
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.supply.Supply;
@@ -53,7 +54,7 @@ public final class DefaultShadowVariableSession<Solution_> implements Supply {
         return graph.updateChanged();
     }
 
-    public Collection<Object> getInconsistentEntities() {
-        return graph.getInconsistentEntities();
+    public List<LoopedVariableInfo> getInconsistentGroups() {
+        return graph.getInconsistentGroups();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSession.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.List;
 
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.supply.Supply;
@@ -54,7 +54,7 @@ public final class DefaultShadowVariableSession<Solution_> implements Supply {
         return graph.updateChanged();
     }
 
-    public List<LoopedVariableInfo> getInconsistentGroups() {
-        return graph.getInconsistentGroups();
+    public List<VariableLoop> getVariableLoops() {
+        return graph.getVariableLoops();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultShadowVariableSessionFactory.java
@@ -78,27 +78,34 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
 
     public record GraphDescriptor<Solution_>(ConsistencyTracker<Solution_> consistencyTracker,
             SolutionDescriptor<Solution_> solutionDescriptor,
+            boolean ignoreInconsistentSolutions,
             VariableReferenceGraphBuilder<Solution_> variableReferenceGraphBuilder,
             Object[] entities, IntFunction<TopologicalOrderGraph> graphCreator) {
 
         public boolean ignoreInconsistentSolutions() {
-            return !solutionDescriptor.hasAnyShadowVariablesInconsistentMember();
+            return ignoreInconsistentSolutions;
         }
 
         public GraphDescriptor(SolutionDescriptor<Solution_> solutionDescriptor,
                 ChangedVariableNotifier<Solution_> changedVariableNotifier,
                 Object... entities) {
-            this(new ConsistencyTracker<>(), solutionDescriptor, new VariableReferenceGraphBuilder<>(changedVariableNotifier),
+            this(new ConsistencyTracker<>(), solutionDescriptor, !solutionDescriptor.hasAnyShadowVariablesInconsistentMember(),
+                    new VariableReferenceGraphBuilder<>(changedVariableNotifier),
                     entities, DefaultTopologicalOrderGraph::new);
         }
 
         public GraphDescriptor<Solution_> withGraphCreator(IntFunction<TopologicalOrderGraph> graphCreator) {
-            return new GraphDescriptor<>(consistencyTracker, solutionDescriptor,
+            return new GraphDescriptor<>(consistencyTracker, solutionDescriptor, ignoreInconsistentSolutions,
                     variableReferenceGraphBuilder, entities, graphCreator);
         }
 
         public GraphDescriptor<Solution_> withConsistencyTracker(ConsistencyTracker<Solution_> consistencyTracker) {
-            return new GraphDescriptor<>(consistencyTracker, solutionDescriptor,
+            return new GraphDescriptor<>(consistencyTracker, solutionDescriptor, ignoreInconsistentSolutions,
+                    variableReferenceGraphBuilder, entities, graphCreator);
+        }
+
+        public GraphDescriptor<Solution_> withIgnoreInconsistentSolutions(boolean ignoreInconsistentSolutions) {
+            return new GraphDescriptor<>(consistencyTracker, solutionDescriptor, ignoreInconsistentSolutions,
                     variableReferenceGraphBuilder, entities, graphCreator);
         }
 
@@ -741,18 +748,21 @@ public class DefaultShadowVariableSessionFactory<Solution_> {
     }
 
     public DefaultShadowVariableSession<Solution_> forSolution(ConsistencyTracker<Solution_> consistencyTracker,
-            Solution_ solution) {
+            Solution_ solution,
+            boolean ignoreInconsistentSolutions) {
         var entities = new ArrayList<>();
         solutionDescriptor.visitAllEntities(solution, entities::add);
-        return forEntities(consistencyTracker, entities.toArray());
+        return forEntities(consistencyTracker, ignoreInconsistentSolutions, entities.toArray());
     }
 
     public DefaultShadowVariableSession<Solution_> forEntities(ConsistencyTracker<Solution_> consistencyTracker,
+            boolean ignoreInconsistentSolutions,
             Object... entities) {
         var graph = buildGraph(
                 new GraphDescriptor<>(solutionDescriptor, ChangedVariableNotifier.of(scoreDirector), entities)
                         .withConsistencyTracker(consistencyTracker)
-                        .withGraphCreator(graphCreator));
+                        .withGraphCreator(graphCreator)
+                        .withIgnoreInconsistentSolutions(ignoreInconsistentSolutions));
         return new DefaultShadowVariableSession<>(graph);
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -2,11 +2,13 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.function.IntFunction;
+
+import ai.timefold.solver.core.api.score.analysis.EntityVariablePair;
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 
 import org.jspecify.annotations.NonNull;
 
@@ -75,17 +77,21 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
     }
 
     @Override
-    public Collection<Object> getInconsistentEntities() {
-        var out = new LinkedHashSet<>();
+    public List<LoopedVariableInfo> getInconsistentGroups() {
+        var out = new ArrayList<LoopedVariableInfo>();
         var graphTrackingInconsistentEntities = new DefaultTopologicalOrderGraph(this.nodeTopologicalOrders.length);
         graph.forEachEdge(graphTrackingInconsistentEntities::addEdge);
         graphTrackingInconsistentEntities.commitChanges(new BitSet());
         var loopedComponentList = graphTrackingInconsistentEntities.getLoopedComponentList();
         for (var loopedComponent : loopedComponentList) {
+            var entityVariablePairs = new LinkedHashSet<EntityVariablePair>(loopedComponent.size());
             for (var nodeId : loopedComponent) {
                 var node = this.nodeList.get(nodeId);
-                out.add(node.entity());
+                for (var variable : node.variableReferences()) {
+                    entityVariablePairs.add(new EntityVariablePair(node.entity(), variable.id().name()));
+                }
             }
+            out.add(new LoopedVariableInfo(entityVariablePairs));
         }
         return out;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/DefaultVariableReferenceGraph.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.function.IntFunction;
 
 import ai.timefold.solver.core.api.score.analysis.EntityVariablePair;
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 
 import org.jspecify.annotations.NonNull;
 
@@ -77,8 +77,8 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
     }
 
     @Override
-    public List<LoopedVariableInfo> getInconsistentGroups() {
-        var out = new ArrayList<LoopedVariableInfo>();
+    public List<VariableLoop> getVariableLoops() {
+        var out = new ArrayList<VariableLoop>();
         var graphTrackingInconsistentEntities = new DefaultTopologicalOrderGraph(this.nodeTopologicalOrders.length);
         graph.forEachEdge(graphTrackingInconsistentEntities::addEdge);
         graphTrackingInconsistentEntities.commitChanges(new BitSet());
@@ -91,7 +91,7 @@ final class DefaultVariableReferenceGraph<Solution_> extends AbstractVariableRef
                     entityVariablePairs.add(new EntityVariablePair(node.entity(), variable.id().name()));
                 }
             }
-            out.add(new LoopedVariableInfo(entityVariablePairs));
+            out.add(new VariableLoop(entityVariablePairs));
         }
         return out;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
@@ -3,7 +3,7 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 import java.util.Collections;
 import java.util.List;
 
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 final class EmptyVariableReferenceGraph implements VariableReferenceGraph {
@@ -27,7 +27,7 @@ final class EmptyVariableReferenceGraph implements VariableReferenceGraph {
     }
 
     @Override
-    public List<LoopedVariableInfo> getInconsistentGroups() {
+    public List<VariableLoop> getVariableLoops() {
         return Collections.emptyList();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/EmptyVariableReferenceGraph.java
@@ -1,8 +1,9 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 final class EmptyVariableReferenceGraph implements VariableReferenceGraph {
@@ -26,7 +27,7 @@ final class EmptyVariableReferenceGraph implements VariableReferenceGraph {
     }
 
     @Override
-    public Collection<Object> getInconsistentEntities() {
+    public List<LoopedVariableInfo> getInconsistentGroups() {
         return Collections.emptyList();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -1,12 +1,14 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.BitSet;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Spliterators;
 import java.util.function.IntFunction;
 import java.util.stream.StreamSupport;
+
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 
 import org.jspecify.annotations.NonNull;
 
@@ -110,7 +112,7 @@ public final class FixedVariableReferenceGraph<Solution_>
     }
 
     @Override
-    public Collection<Object> getInconsistentEntities() {
+    public List<LoopedVariableInfo> getInconsistentGroups() {
         return Collections.emptyList();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/FixedVariableReferenceGraph.java
@@ -8,7 +8,7 @@ import java.util.Spliterators;
 import java.util.function.IntFunction;
 import java.util.stream.StreamSupport;
 
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 
 import org.jspecify.annotations.NonNull;
 
@@ -112,7 +112,7 @@ public final class FixedVariableReferenceGraph<Solution_>
     }
 
     @Override
-    public List<LoopedVariableInfo> getInconsistentGroups() {
+    public List<VariableLoop> getVariableLoops() {
         return Collections.emptyList();
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 public final class SingleDirectionalParentVariableReferenceGraph<Solution_> implements VariableReferenceGraph {
@@ -139,7 +139,7 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
     }
 
     @Override
-    public List<LoopedVariableInfo> getInconsistentGroups() {
+    public List<VariableLoop> getVariableLoops() {
         return Collections.emptyList();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/SingleDirectionalParentVariableReferenceGraph.java
@@ -2,7 +2,6 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -12,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 public final class SingleDirectionalParentVariableReferenceGraph<Solution_> implements VariableReferenceGraph {
@@ -139,7 +139,7 @@ public final class SingleDirectionalParentVariableReferenceGraph<Solution_> impl
     }
 
     @Override
-    public Collection<Object> getInconsistentEntities() {
+    public List<LoopedVariableInfo> getInconsistentGroups() {
         return Collections.emptyList();
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -1,8 +1,8 @@
 package ai.timefold.solver.core.impl.domain.variable.declarative;
 
-import java.util.Collection;
 import java.util.List;
 
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 public sealed interface VariableReferenceGraph
@@ -71,5 +71,5 @@ public sealed interface VariableReferenceGraph
         // Most graphs do not have edges that depend on a list variable's contents.
     }
 
-    Collection<Object> getInconsistentEntities();
+    List<LoopedVariableInfo> getInconsistentGroups();
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/VariableReferenceGraph.java
@@ -2,7 +2,7 @@ package ai.timefold.solver.core.impl.domain.variable.declarative;
 
 import java.util.List;
 
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 
 public sealed interface VariableReferenceGraph
@@ -71,5 +71,5 @@ public sealed interface VariableReferenceGraph
         // Most graphs do not have edges that depend on a list variable's contents.
     }
 
-    List<LoopedVariableInfo> getInconsistentGroups();
+    List<VariableLoop> getVariableLoops();
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AbstractAcceptor.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/localsearch/decider/acceptor/AbstractAcceptor.java
@@ -21,7 +21,7 @@ public abstract class AbstractAcceptor<Solution_> extends LocalSearchPhaseLifecy
     // ************************************************************************
     @Override
     public final boolean isAccepted(LocalSearchMoveScope<Solution_> moveScope) {
-        if (moveScope.getScore().isInvalid()) {
+        if (moveScope.getScore().isStructurallyFlawed()) {
             return false;
         }
         return isStructurallyValidSolutionAccepted(moveScope);

--- a/core/src/main/java/ai/timefold/solver/core/impl/move/MoveDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/move/MoveDirector.java
@@ -410,16 +410,24 @@ public sealed class MoveDirector<Solution_, Score_ extends Score<Score_>>
      *        to ensure the score is up to date.
      */
     public final void execute(Move<Solution_> move, boolean guaranteeFreshScore) {
-        move.execute(this);
-        externalScoreDirector.updateShadowVariables();
+        executeAllowingStructurallyFlawedSolutions(move);
+        if (!backingScoreDirector.isLastVariableUpdateSuccessful()) {
+            throw new IllegalArgumentException("The move (%s) caused the solution to become structurally flawed."
+                    .formatted(move));
+        }
         if (guaranteeFreshScore) {
             backingScoreDirector.calculateScore();
         }
     }
 
+    void executeAllowingStructurallyFlawedSolutions(Move<Solution_> move) {
+        move.execute(this);
+        externalScoreDirector.updateShadowVariables();
+    }
+
     public final InnerScore<Score_> executeTemporary(Move<Solution_> move) {
         var ephemeralMoveDirector = ephemeral();
-        ephemeralMoveDirector.execute(move);
+        ephemeralMoveDirector.executeAllowingStructurallyFlawedSolutions(move);
         var score = backingScoreDirector.calculateScore();
         ephemeralMoveDirector.close(); // This undoes the move.
         return score;
@@ -428,7 +436,7 @@ public sealed class MoveDirector<Solution_, Score_ extends Score<Score_>>
     public @Nullable <Result_> Result_ executeTemporary(Move<Solution_> move,
             TemporaryMovePostprocessor<Solution_, Score_, @Nullable Result_> postprocessor) {
         try (var ephemeralMoveDirector = ephemeral()) {
-            ephemeralMoveDirector.execute(move);
+            ephemeralMoveDirector.executeAllowingStructurallyFlawedSolutions(move);
             var score = backingScoreDirector.calculateScore();
             return postprocessor.apply(score, ephemeralMoveDirector.createUndoMove());
         }
@@ -440,6 +448,26 @@ public sealed class MoveDirector<Solution_, Score_ extends Score<Score_>>
         var ephemeralMoveDirector = ephemeral();
         ephemeralMoveDirector.execute(move, true);
         var result = postprocessor.apply(backingScoreDirector.getWorkingSolution());
+        ephemeralMoveDirector.close(); // This undoes the move.
+        if (guaranteeFreshScore) {
+            backingScoreDirector.calculateScore();
+        }
+        return result;
+    }
+
+    public @Nullable <Result_> Result_ executeTemporaryHandlingStructurallyFlawedSolutions(Move<Solution_> move,
+            Function<Solution_, @Nullable Result_> postprocessor,
+            Function<Solution_, @Nullable Result_> flawedSolutionProcessor,
+            boolean guaranteeFreshScore) {
+        var ephemeralMoveDirector = ephemeral();
+        ephemeralMoveDirector.executeAllowingStructurallyFlawedSolutions(move);
+        var score = backingScoreDirector.calculateScore();
+        Result_ result;
+        if (score.isStructurallyFlawed()) {
+            result = flawedSolutionProcessor.apply(backingScoreDirector.getWorkingSolution());
+        } else {
+            result = postprocessor.apply(backingScoreDirector.getWorkingSolution());
+        }
         ephemeralMoveDirector.close(); // This undoes the move.
         if (guaranteeFreshScore) {
             backingScoreDirector.calculateScore();

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultCustomPhase.java
@@ -88,7 +88,7 @@ public final class DefaultCustomPhase<Solution_>
                 () -> phaseTermination.isPhaseTerminated(stepScope.getPhaseScope()));
         customPhaseCommand.changeWorkingSolution(commandContext);
         calculateWorkingStepScore(stepScope, customPhaseCommand);
-        if (stepScope.getScore().isInvalid()) {
+        if (stepScope.getScore().isStructurallyFlawed()) {
             throw new IllegalStateException("The custom phase command (%s) resulted in an inconsistent solution."
                     .formatted(customPhaseCommand));
         }

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultPhaseCommandContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultPhaseCommandContext.java
@@ -62,7 +62,7 @@ final class DefaultPhaseCommandContext<Solution_> implements PhaseCommandContext
     }
 
     @Override
-    public @Nullable <Result_> Result_ executeTemporarilyHandlingStructurallyFlawedSolutions(Move<Solution_> move,
+    public @Nullable <Result_> Result_ executeTemporarily(Move<Solution_> move,
             Function<Solution_, @Nullable Result_> temporarySolutionConsumer,
             Function<Solution_, @Nullable Result_> structurallyFlawedSolutionConsumer) {
         return moveDirector.executeTemporaryHandlingStructurallyFlawedSolutions(move,
@@ -85,7 +85,7 @@ final class DefaultPhaseCommandContext<Solution_> implements PhaseCommandContext
     }
 
     @Override
-    public @Nullable <Result_> Result_ executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions(
+    public @Nullable <Result_> Result_ executeTemporarilyAndCalculateScore(
             Move<Solution_> move, Function<Solution_, @Nullable Result_> temporarySolutionConsumer,
             Function<Solution_, @Nullable Result_> structurallyFlawedSolutionConsumer) {
         return moveDirector.executeTemporaryHandlingStructurallyFlawedSolutions(move,

--- a/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultPhaseCommandContext.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/phase/custom/DefaultPhaseCommandContext.java
@@ -62,6 +62,15 @@ final class DefaultPhaseCommandContext<Solution_> implements PhaseCommandContext
     }
 
     @Override
+    public @Nullable <Result_> Result_ executeTemporarilyHandlingStructurallyFlawedSolutions(Move<Solution_> move,
+            Function<Solution_, @Nullable Result_> temporarySolutionConsumer,
+            Function<Solution_, @Nullable Result_> structurallyFlawedSolutionConsumer) {
+        return moveDirector.executeTemporaryHandlingStructurallyFlawedSolutions(move,
+                temporarySolutionConsumer, structurallyFlawedSolutionConsumer,
+                false);
+    }
+
+    @Override
     public <Score_ extends Score<Score_>> Score_ executeTemporarily(Move<Solution_> move) {
         Score_ score = executeTemporarily(move, solution -> moveDirector.getScoreDirector()
                 .getSolutionDescriptor()
@@ -73,6 +82,15 @@ final class DefaultPhaseCommandContext<Solution_> implements PhaseCommandContext
     public @Nullable <Result_> Result_ executeTemporarilyAndCalculateScore(Move<Solution_> move,
             Function<Solution_, @Nullable Result_> temporarySolutionConsumer) {
         return moveDirector.executeTemporary(move, temporarySolutionConsumer, true);
+    }
+
+    @Override
+    public @Nullable <Result_> Result_ executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions(
+            Move<Solution_> move, Function<Solution_, @Nullable Result_> temporarySolutionConsumer,
+            Function<Solution_, @Nullable Result_> structurallyFlawedSolutionConsumer) {
+        return moveDirector.executeTemporaryHandlingStructurallyFlawedSolutions(move,
+                temporarySolutionConsumer, structurallyFlawedSolutionConsumer,
+                true);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/BendableBigDecimalScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/BendableBigDecimalScoreDefinition.java
@@ -29,6 +29,11 @@ public class BendableBigDecimalScoreDefinition extends AbstractBendableScoreDefi
     }
 
     @Override
+    public BendableBigDecimalScore getStructurallyFlawedScore(BendableBigDecimalScore score) {
+        return new BendableBigDecimalScore(-1L, score.hardScores(), score.softScores());
+    }
+
+    @Override
     public BendableBigDecimalScore getZeroScore() {
         return BendableBigDecimalScore.zero(hardLevelsSize, softLevelsSize);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/BendableScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/BendableScoreDefinition.java
@@ -29,6 +29,11 @@ public class BendableScoreDefinition extends AbstractBendableScoreDefinition<Ben
     }
 
     @Override
+    public BendableScore getStructurallyFlawedScore(BendableScore score) {
+        return new BendableScore(-1L, score.hardScores(), score.softScores());
+    }
+
+    @Override
     public BendableScore getZeroScore() {
         return BendableScore.zero(hardLevelsSize, softLevelsSize);
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/HardMediumSoftBigDecimalScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/HardMediumSoftBigDecimalScoreDefinition.java
@@ -40,6 +40,11 @@ public class HardMediumSoftBigDecimalScoreDefinition extends AbstractScoreDefini
     }
 
     @Override
+    public HardMediumSoftBigDecimalScore getStructurallyFlawedScore(HardMediumSoftBigDecimalScore score) {
+        return new HardMediumSoftBigDecimalScore(-1L, score.hardScore(), score.mediumScore(), score.softScore());
+    }
+
+    @Override
     public HardMediumSoftBigDecimalScore getZeroScore() {
         return HardMediumSoftBigDecimalScore.ZERO;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/HardMediumSoftScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/HardMediumSoftScoreDefinition.java
@@ -39,6 +39,11 @@ public class HardMediumSoftScoreDefinition extends AbstractScoreDefinition<HardM
     }
 
     @Override
+    public HardMediumSoftScore getStructurallyFlawedScore(HardMediumSoftScore score) {
+        return new HardMediumSoftScore(-1L, score.hardScore(), score.mediumScore(), score.softScore());
+    }
+
+    @Override
     public HardMediumSoftScore getZeroScore() {
         return HardMediumSoftScore.ZERO;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/HardSoftBigDecimalScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/HardSoftBigDecimalScoreDefinition.java
@@ -40,6 +40,11 @@ public class HardSoftBigDecimalScoreDefinition extends AbstractScoreDefinition<H
     }
 
     @Override
+    public HardSoftBigDecimalScore getStructurallyFlawedScore(HardSoftBigDecimalScore score) {
+        return new HardSoftBigDecimalScore(-1L, score.hardScore(), score.softScore());
+    }
+
+    @Override
     public HardSoftBigDecimalScore getZeroScore() {
         return HardSoftBigDecimalScore.ZERO;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/HardSoftScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/HardSoftScoreDefinition.java
@@ -39,6 +39,11 @@ public class HardSoftScoreDefinition extends AbstractScoreDefinition<HardSoftSco
     }
 
     @Override
+    public HardSoftScore getStructurallyFlawedScore(HardSoftScore score) {
+        return new HardSoftScore(-1L, score.hardScore(), score.softScore());
+    }
+
+    @Override
     public HardSoftScore getZeroScore() {
         return HardSoftScore.ZERO;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/ScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/ScoreDefinition.java
@@ -58,6 +58,13 @@ public interface ScoreDefinition<Score_ extends Score<Score_>> {
     Score_ getStructurallyFlawedScore();
 
     /**
+     * The same score as the argument, except with a negative structural score
+     *
+     * @return never null
+     */
+    Score_ getStructurallyFlawedScore(Score_ score);
+
+    /**
      * The score that represents zero.
      *
      * @return never null

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/SimpleBigDecimalScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/SimpleBigDecimalScoreDefinition.java
@@ -39,6 +39,11 @@ public class SimpleBigDecimalScoreDefinition extends AbstractScoreDefinition<Sim
     }
 
     @Override
+    public SimpleBigDecimalScore getStructurallyFlawedScore(SimpleBigDecimalScore score) {
+        return new SimpleBigDecimalScore(-1L, score.score());
+    }
+
+    @Override
     public SimpleBigDecimalScore getZeroScore() {
         return SimpleBigDecimalScore.ZERO;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/SimpleScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/SimpleScoreDefinition.java
@@ -34,6 +34,11 @@ public class SimpleScoreDefinition extends AbstractScoreDefinition<SimpleScore> 
     }
 
     @Override
+    public SimpleScore getStructurallyFlawedScore(SimpleScore score) {
+        return new SimpleScore(-1L, score.score());
+    }
+
+    @Override
     public SimpleScore getZeroScore() {
         return SimpleScore.ZERO;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -111,7 +111,8 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         this.lookUpManager = lookUpEnabled ? new LookupManager(solutionDescriptor.getLookUpStrategyResolver()) : null;
         this.constraintMatchPolicy = builder.constraintMatchPolicy;
         this.expectShadowVariablesInCorrectState = builder.expectShadowVariablesInCorrectState;
-        this.ignoreInconsistentSolutions = !solutionDescriptor.hasAnyShadowVariablesInconsistentMember();
+        this.ignoreInconsistentSolutions = !solutionDescriptor.hasAnyShadowVariablesInconsistentMember()
+                && !builder.forceAllowInconsistentSolutions;
         this.variableDescriptorCache = new VariableDescriptorCache<>(solutionDescriptor);
         this.shadowVariableSupport = ShadowVariableSupport.create(this);
         this.shadowVariableSupport.linkShadowVariables();
@@ -527,6 +528,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             var childThreadScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
                     .withLookUpEnabled(lookUpEnabled)
                     .withConstraintMatchPolicy(constraintMatchPolicy)
+                    .withForceAllowInconsistentSolutions(!ignoreInconsistentSolutions)
                     .buildDerived();
             // ScoreCalculationCountTermination takes into account previous phases
             // but the calculationCount of partitions is maxed, not summed.
@@ -536,6 +538,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             var childThreadScoreDirector = scoreDirectorFactory.createScoreDirectorBuilder()
                     .withLookUpEnabled(true)
                     .withConstraintMatchPolicy(constraintMatchPolicy)
+                    .withForceAllowInconsistentSolutions(!ignoreInconsistentSolutions)
                     .buildDerived();
             childThreadScoreDirector.setWorkingSolution(cloneWorkingSolution());
             return childThreadScoreDirector;
@@ -808,6 +811,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         // Most score directors don't need derived status; CS will override this.
         try (var uncorruptedScoreDirector = assertionScoreDirectorFactory.createScoreDirectorBuilder()
                 .withConstraintMatchPolicy(ConstraintMatchPolicy.ENABLED)
+                .withForceAllowInconsistentSolutions(!ignoreInconsistentSolutions)
                 .buildDerived()) {
             uncorruptedScoreDirector.setWorkingSolution(workingSolution);
             var uncorruptedInnerScore = uncorruptedScoreDirector.calculateScore();
@@ -1006,6 +1010,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         protected ConstraintMatchPolicy constraintMatchPolicy = ConstraintMatchPolicy.DISABLED;
         protected boolean lookUpEnabled = false;
         protected boolean expectShadowVariablesInCorrectState = true;
+        protected boolean forceAllowInconsistentSolutions = false;
 
         protected AbstractScoreDirectorBuilder(Factory_ scoreDirectorFactory) {
             this.scoreDirectorFactory = Objects.requireNonNull(scoreDirectorFactory);
@@ -1026,6 +1031,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         @SuppressWarnings("unchecked")
         public Builder_ withExpectShadowVariablesInCorrectState(boolean expectShadowVariablesInCorrectState) {
             this.expectShadowVariablesInCorrectState = expectShadowVariablesInCorrectState;
+            return (Builder_) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Builder_ withForceAllowInconsistentSolutions(boolean forceAllowInconsistentSolutions) {
+            this.forceAllowInconsistentSolutions = forceAllowInconsistentSolutions;
             return (Builder_) this;
         }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -2,10 +2,10 @@ package ai.timefold.solver.core.impl.score.director;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -15,6 +15,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.solution.cloner.SolutionCloner;
 import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.api.solver.change.ProblemChange;
 import ai.timefold.solver.core.api.solver.change.ProblemChangeDirector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -346,12 +347,16 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         // Do nothing
     }
 
-    public Collection<Object> computeInconsistentEntities() {
-        return shadowVariableSupport.getInconsistentEntities();
+    public List<LoopedVariableInfo> computeInconsistentGroups() {
+        return shadowVariableSupport.getInconsistentGroups();
     }
 
     public void unassignInconsistentEntities() {
-        var inconsistentEntities = computeInconsistentEntities();
+        var inconsistentCycles = computeInconsistentGroups();
+        var inconsistentEntities = new LinkedHashSet<>();
+        for (var inconsistentCycle : inconsistentCycles) {
+            inconsistentEntities.addAll(inconsistentCycle.getEntitySet());
+        }
         if (listVariableStateSupply != null) {
             var listVariableDescriptor = listVariableStateSupply.getSourceVariableDescriptor();
             var listElementClass = listVariableStateSupply.getSourceVariableDescriptor().getElementType();

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -495,6 +495,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         lastVariableUpdateSuccessful = shadowVariableSupport.updateShadowVariables();
     }
 
+    @Override
     public boolean isLastVariableUpdateSuccessful() {
         return lastVariableUpdateSuccessful;
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -15,7 +15,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.solution.cloner.SolutionCloner;
 import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
 import ai.timefold.solver.core.api.score.Score;
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 import ai.timefold.solver.core.api.solver.change.ProblemChange;
 import ai.timefold.solver.core.api.solver.change.ProblemChangeDirector;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
@@ -347,12 +347,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         // Do nothing
     }
 
-    public List<LoopedVariableInfo> computeInconsistentGroups() {
-        return shadowVariableSupport.getInconsistentGroups();
+    public List<VariableLoop> computeVariableLoops() {
+        return shadowVariableSupport.getVariableLoops();
     }
 
     public void unassignInconsistentEntities() {
-        var inconsistentCycles = computeInconsistentGroups();
+        var inconsistentCycles = computeVariableLoops();
         var inconsistentEntities = new LinkedHashSet<>();
         for (var inconsistentCycle : inconsistentCycles) {
             inconsistentEntities.addAll(inconsistentCycle.getEntitySet());

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScore.java
@@ -40,13 +40,17 @@ public record InnerScore<Score_ extends Score<Score_>>(Score_ raw, int unassigne
             throw new IllegalArgumentException("The unassignedCount (%d) must be >= 0."
                     .formatted(unassignedCount));
         }
+        if (raw.structuralScore() > 0) {
+            throw new IllegalArgumentException("The structuralScore (%d) must be <= 0."
+                    .formatted(raw.structuralScore()));
+        }
     }
 
     public boolean isFullyAssigned() {
         return unassignedCount == 0;
     }
 
-    public boolean isInvalid() {
+    public boolean isStructurallyFlawed() {
         return raw.structuralScore() < 0;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -332,6 +332,11 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
     }
 
     /**
+     * @return true if the last {@link #updateShadowVariables()} was successful, false otherwise.
+     */
+    boolean isLastVariableUpdateSuccessful();
+
+    /**
      * A derived score director is created from a root score director.
      * The derived score director can be used to create separate* instances for use cases like multithreaded solving.
      */

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariablesInconsistent;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.api.score.stream.ConstraintRef;
@@ -332,7 +333,10 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
     }
 
     /**
-     * @return true if the last {@link #updateShadowVariables()} was successful, false otherwise.
+     * @return true if the last {@link #updateShadowVariables()} did not result in a structurally flawed solutions,
+     *         false otherwise.
+     *         <p>
+     *         Note: Planning models with {@link ShadowVariablesInconsistent} will always result in successful updates.
      */
     boolean isLastVariableUpdateSuccessful();
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/test/AbstractConstraintAssertion.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/test/AbstractConstraintAssertion.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score.stream.test;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -85,7 +86,9 @@ public abstract class AbstractConstraintAssertion<Solution_, Score_ extends Scor
                         var constraintRef = constraintMatchTotal.getConstraintRef();
                         constraintAnalyses.put(constraintRef, constraintMatchTotal);
                     }
-                    return s.analyze(workingScore, constraintAnalyses, ScoreAnalysisFetchPolicy.FETCH_ALL)
+                    return s.analyze(workingScore, constraintAnalyses, Collections.emptyList(),
+                            null,
+                            ScoreAnalysisFetchPolicy.FETCH_ALL)
                             .summarize();
                 },
                 () -> "Score analysis is only available in Timefold Solver Enterprise Edition.");

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -9,8 +9,8 @@ import java.util.function.Function;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.variable.InconsistentSolutionException;
 import ai.timefold.solver.core.api.score.Score;
-import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.api.score.analysis.ScoreAnalysis;
+import ai.timefold.solver.core.api.score.analysis.VariableLoop;
 import ai.timefold.solver.core.api.solver.RecommendedAssignment;
 import ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy;
 import ai.timefold.solver.core.api.solver.SolutionManager;
@@ -65,7 +65,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
     }
 
     private <Result_> Result_ callScoreDirector(String feature, Solution_ solution, SolutionUpdatePolicy solutionUpdatePolicy,
-            BiFunction<InnerScoreDirector<Solution_, Score_>, List<LoopedVariableInfo>, Result_> function,
+            BiFunction<InnerScoreDirector<Solution_, Score_>, List<VariableLoop>, Result_> function,
             ConstraintMatchPolicy constraintMatchPolicy,
             boolean cloneSolution, boolean handlesStructurallyFlawedSolutions) {
         var isShadowVariableUpdateEnabled = solutionUpdatePolicy.isShadowVariableUpdateEnabled();
@@ -93,15 +93,15 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
 
             // if handlesStructurallyFlawedSolutions is true, then the score can never be structurally flawed
             // and all variable updates will be successful
-            List<LoopedVariableInfo> inconsistentEntities = null;
+            List<VariableLoop> inconsistentEntities = null;
             if (solutionUpdatePolicy.isScoreUpdateEnabled()) {
                 var score = scoreDirector.calculateScore();
                 if (score.isStructurallyFlawed()) {
-                    inconsistentEntities = scoreDirector.computeInconsistentGroups();
+                    inconsistentEntities = scoreDirector.computeVariableLoops();
                     throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
                 }
                 if (handlesStructurallyFlawedSolutions) {
-                    inconsistentEntities = scoreDirector.computeInconsistentGroups();
+                    inconsistentEntities = scoreDirector.computeVariableLoops();
                     if (!inconsistentEntities.isEmpty()) {
                         scoreDirector.getSolutionDescriptor().setScore(
                                 scoreDirector.getWorkingSolution(),
@@ -110,12 +110,12 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
                     }
                 }
             } else if (!scoreDirector.isLastVariableUpdateSuccessful()) {
-                inconsistentEntities = scoreDirector.computeInconsistentGroups();
+                inconsistentEntities = scoreDirector.computeVariableLoops();
                 throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
             }
 
             if (inconsistentEntities == null) {
-                inconsistentEntities = (handlesStructurallyFlawedSolutions) ? scoreDirector.computeInconsistentGroups()
+                inconsistentEntities = (handlesStructurallyFlawedSolutions) ? scoreDirector.computeVariableLoops()
                         : Collections.emptyList();
             }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -85,7 +85,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
             }
             if (solutionUpdatePolicy.isScoreUpdateEnabled()) {
                 var score = scoreDirector.calculateScore();
-                if (score.isInvalid()) {
+                if (score.isStructurallyFlawed()) {
                     var inconsistentEntities = scoreDirector.computeInconsistentEntities();
                     throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
                 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -1,6 +1,5 @@
 package ai.timefold.solver.core.impl.solver;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -10,6 +9,7 @@ import java.util.function.Function;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.variable.InconsistentSolutionException;
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.api.score.analysis.LoopedVariableInfo;
 import ai.timefold.solver.core.api.score.analysis.ScoreAnalysis;
 import ai.timefold.solver.core.api.solver.RecommendedAssignment;
 import ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy;
@@ -65,7 +65,7 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
     }
 
     private <Result_> Result_ callScoreDirector(String feature, Solution_ solution, SolutionUpdatePolicy solutionUpdatePolicy,
-            BiFunction<InnerScoreDirector<Solution_, Score_>, Collection<Object>, Result_> function,
+            BiFunction<InnerScoreDirector<Solution_, Score_>, List<LoopedVariableInfo>, Result_> function,
             ConstraintMatchPolicy constraintMatchPolicy,
             boolean cloneSolution, boolean handlesStructurallyFlawedSolutions) {
         var isShadowVariableUpdateEnabled = solutionUpdatePolicy.isShadowVariableUpdateEnabled();
@@ -93,15 +93,15 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
 
             // if handlesStructurallyFlawedSolutions is true, then the score can never be structurally flawed
             // and all variable updates will be successful
-            Collection<Object> inconsistentEntities = null;
+            List<LoopedVariableInfo> inconsistentEntities = null;
             if (solutionUpdatePolicy.isScoreUpdateEnabled()) {
                 var score = scoreDirector.calculateScore();
                 if (score.isStructurallyFlawed()) {
-                    inconsistentEntities = scoreDirector.computeInconsistentEntities();
+                    inconsistentEntities = scoreDirector.computeInconsistentGroups();
                     throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
                 }
                 if (handlesStructurallyFlawedSolutions) {
-                    inconsistentEntities = scoreDirector.computeInconsistentEntities();
+                    inconsistentEntities = scoreDirector.computeInconsistentGroups();
                     if (!inconsistentEntities.isEmpty()) {
                         scoreDirector.getSolutionDescriptor().setScore(
                                 scoreDirector.getWorkingSolution(),
@@ -110,12 +110,12 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
                     }
                 }
             } else if (!scoreDirector.isLastVariableUpdateSuccessful()) {
-                inconsistentEntities = scoreDirector.computeInconsistentEntities();
+                inconsistentEntities = scoreDirector.computeInconsistentGroups();
                 throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
             }
 
             if (inconsistentEntities == null) {
-                inconsistentEntities = (handlesStructurallyFlawedSolutions) ? scoreDirector.computeInconsistentEntities()
+                inconsistentEntities = (handlesStructurallyFlawedSolutions) ? scoreDirector.computeInconsistentGroups()
                         : Collections.emptyList();
             }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolutionManager.java
@@ -1,7 +1,10 @@
 package ai.timefold.solver.core.impl.solver;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
@@ -57,17 +60,21 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
                             .formatted(this.getClass().getSimpleName(), solutionUpdatePolicy));
         }
         return callScoreDirector("Solution update", solution, solutionUpdatePolicy,
-                s -> s.getSolutionDescriptor().getScore(s.getWorkingSolution()), ConstraintMatchPolicy.DISABLED, false);
+                (s, inconsistentEntities) -> s.getSolutionDescriptor().getScore(s.getWorkingSolution()),
+                ConstraintMatchPolicy.DISABLED, false, false);
     }
 
     private <Result_> Result_ callScoreDirector(String feature, Solution_ solution, SolutionUpdatePolicy solutionUpdatePolicy,
-            Function<InnerScoreDirector<Solution_, Score_>, Result_> function, ConstraintMatchPolicy constraintMatchPolicy,
-            boolean cloneSolution) {
+            BiFunction<InnerScoreDirector<Solution_, Score_>, Collection<Object>, Result_> function,
+            ConstraintMatchPolicy constraintMatchPolicy,
+            boolean cloneSolution, boolean handlesStructurallyFlawedSolutions) {
         var isShadowVariableUpdateEnabled = solutionUpdatePolicy.isShadowVariableUpdateEnabled();
         var nonNullSolution = Objects.requireNonNull(solution);
         try (var scoreDirector = getScoreDirectorFactory().createScoreDirectorBuilder().withLookUpEnabled(cloneSolution)
                 .withConstraintMatchPolicy(constraintMatchPolicy)
-                .withExpectShadowVariablesInCorrectState(!isShadowVariableUpdateEnabled).build()) {
+                .withExpectShadowVariablesInCorrectState(!isShadowVariableUpdateEnabled)
+                .withForceAllowInconsistentSolutions(handlesStructurallyFlawedSolutions)
+                .build()) {
             nonNullSolution = cloneSolution ? scoreDirector.cloneSolution(nonNullSolution) : nonNullSolution;
             if (isShadowVariableUpdateEnabled) {
                 scoreDirector.setWorkingSolution(nonNullSolution);
@@ -83,17 +90,36 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
                         Requested constraint matching but score director doesn't support it.
                         Maybe use Constraint Streams instead of Easy or Incremental score calculator?""");
             }
+
+            // if handlesStructurallyFlawedSolutions is true, then the score can never be structurally flawed
+            // and all variable updates will be successful
+            Collection<Object> inconsistentEntities = null;
             if (solutionUpdatePolicy.isScoreUpdateEnabled()) {
                 var score = scoreDirector.calculateScore();
                 if (score.isStructurallyFlawed()) {
-                    var inconsistentEntities = scoreDirector.computeInconsistentEntities();
+                    inconsistentEntities = scoreDirector.computeInconsistentEntities();
                     throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
                 }
+                if (handlesStructurallyFlawedSolutions) {
+                    inconsistentEntities = scoreDirector.computeInconsistentEntities();
+                    if (!inconsistentEntities.isEmpty()) {
+                        scoreDirector.getSolutionDescriptor().setScore(
+                                scoreDirector.getWorkingSolution(),
+                                scoreDirector.getScoreDefinition().getStructurallyFlawedScore()
+                                        .add(score.raw()));
+                    }
+                }
             } else if (!scoreDirector.isLastVariableUpdateSuccessful()) {
-                var inconsistentEntities = scoreDirector.computeInconsistentEntities();
+                inconsistentEntities = scoreDirector.computeInconsistentEntities();
                 throw new InconsistentSolutionException(feature, nonNullSolution, inconsistentEntities);
             }
-            return function.apply(scoreDirector);
+
+            if (inconsistentEntities == null) {
+                inconsistentEntities = (handlesStructurallyFlawedSolutions) ? scoreDirector.computeInconsistentEntities()
+                        : Collections.emptyList();
+            }
+
+            return function.apply(scoreDirector, inconsistentEntities);
         }
     }
 
@@ -122,9 +148,10 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
                 TimefoldSolverEnterpriseService.loadOrFail(TimefoldSolverEnterpriseService.Feature.SCORE_ANALYSIS);
         var currentScore = (Score_) scoreDirectorFactory.getSolutionDescriptor().getScore(solution);
         var analysis = callScoreDirector("Score analysis", solution, solutionUpdatePolicy,
-                scoreDirector -> enterpriseService.analyze(scoreDirector.calculateScore(),
-                        scoreDirector.getConstraintMatchTotalMap(), fetchPolicy),
-                ConstraintMatchPolicy.match(fetchPolicy), false);
+                (scoreDirector, inconsistentEntities) -> enterpriseService.analyze(scoreDirector.calculateScore(),
+                        scoreDirector.getConstraintMatchTotalMap(), inconsistentEntities,
+                        scoreDirector.getScoreDefinition(), fetchPolicy),
+                ConstraintMatchPolicy.match(fetchPolicy), false, true);
         assertFreshScore(solution, currentScore, analysis.score(), solutionUpdatePolicy);
         return analysis;
     }
@@ -144,9 +171,10 @@ public final class DefaultSolutionManager<Solution_, Score_ extends Score<Score_
         var enterpriseService =
                 TimefoldSolverEnterpriseService.loadOrFail(TimefoldSolverEnterpriseService.Feature.RECOMMENDATIONS);
         return callScoreDirector("Recommended assignment",
-                solution, SolutionUpdatePolicy.UPDATE_ALL, enterpriseService.buildRecommender(solverFactory, solution,
-                        evaluatedEntityOrElement, propositionFunction, fetchPolicy),
-                ConstraintMatchPolicy.match(fetchPolicy), true);
+                solution, SolutionUpdatePolicy.UPDATE_ALL,
+                (scoreDirector, inconsistentEntities) -> enterpriseService.buildRecommender(solverFactory, solution,
+                        evaluatedEntityOrElement, propositionFunction, fetchPolicy).apply((InnerScoreDirector) scoreDirector),
+                ConstraintMatchPolicy.match(fetchPolicy), true, false);
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -55,11 +55,11 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
         var scoreDirector = solverScope.getScoreDirector();
         @SuppressWarnings("rawtypes")
         InnerScore innerScore = scoreDirector.calculateScore();
-        if (innerScore.isInvalid()) {
+        if (innerScore.isStructurallyFlawed()) {
             LOGGER.warn("The initial solution passed to the solver is inconsistent. Unassigning involved entities.");
             scoreDirector.unassignInconsistentEntities();
             innerScore = scoreDirector.calculateScore();
-            if (innerScore.isInvalid()) {
+            if (innerScore.isStructurallyFlawed()) {
                 // If there were a fixed dependency loop, the shadow variable session would fail fast before here
                 throw new IllegalStateException(
                         "Impossible state: The initial solution passed to the solver is inconsistent even after unassigning involved entities.");

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
@@ -145,7 +145,7 @@ public class SolutionManagerTest {
                         "is inconsistent", "Solution update", "requires a consistent solution")
                 .hasFieldOrPropertyWithValue("solution", inconsistentSolution)
                 .matches(exception -> {
-                    var inconsistentGroups = ((InconsistentSolutionException) exception).getInconsistentGroups();
+                    var inconsistentGroups = ((InconsistentSolutionException) exception).getVariableLoops();
                     if (inconsistentGroups.size() != 1) {
                         return false;
                     }
@@ -218,7 +218,7 @@ public class SolutionManagerTest {
                         "is inconsistent", "Solution update", "requires a consistent solution")
                 .hasFieldOrPropertyWithValue("solution", inconsistentSolution)
                 .matches(exception -> {
-                    var inconsistentGroups = ((InconsistentSolutionException) exception).getInconsistentGroups();
+                    var inconsistentGroups = ((InconsistentSolutionException) exception).getVariableLoops();
                     if (inconsistentGroups.size() != 1) {
                         return false;
                     }

--- a/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/solver/SolutionManagerTest.java
@@ -13,6 +13,7 @@ import java.util.function.Function;
 import ai.timefold.solver.core.api.domain.variable.InconsistentSolutionException;
 import ai.timefold.solver.core.api.score.HardSoftScore;
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.api.score.analysis.EntityVariablePair;
 import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
 import ai.timefold.solver.core.config.solver.SolverConfig;
 import ai.timefold.solver.core.testdomain.list.shadowhistory.TestdataListEntityWithShadowHistory;
@@ -143,7 +144,18 @@ public class SolutionManagerTest {
                 .hasMessageContainingAll("The solution (",
                         "is inconsistent", "Solution update", "requires a consistent solution")
                 .hasFieldOrPropertyWithValue("solution", inconsistentSolution)
-                .hasFieldOrPropertyWithValue("involvedEntityCollection", Set.of(valueA1, valueA2));
+                .matches(exception -> {
+                    var inconsistentGroups = ((InconsistentSolutionException) exception).getInconsistentGroups();
+                    if (inconsistentGroups.size() != 1) {
+                        return false;
+                    }
+                    return inconsistentGroups.getFirst().involvedVariableSet()
+                            .equals(Set.of(
+                                    new EntityVariablePair(valueA1, "startTime"),
+                                    new EntityVariablePair(valueA1, "endTime"),
+                                    new EntityVariablePair(valueA2, "startTime"),
+                                    new EntityVariablePair(valueA2, "endTime")));
+                });
     }
 
     private void assertShadowedListValueAllNull(SoftAssertions softly, TestdataListValueWithShadowHistory current) {
@@ -205,7 +217,18 @@ public class SolutionManagerTest {
                 .hasMessageContainingAll("The solution (",
                         "is inconsistent", "Solution update", "requires a consistent solution")
                 .hasFieldOrPropertyWithValue("solution", inconsistentSolution)
-                .hasFieldOrPropertyWithValue("involvedEntityCollection", Set.of(valueA1, valueA2));
+                .matches(exception -> {
+                    var inconsistentGroups = ((InconsistentSolutionException) exception).getInconsistentGroups();
+                    if (inconsistentGroups.size() != 1) {
+                        return false;
+                    }
+                    return inconsistentGroups.getFirst().involvedVariableSet()
+                            .equals(Set.of(
+                                    new EntityVariablePair(valueA1, "startTime"),
+                                    new EntityVariablePair(valueA1, "endTime"),
+                                    new EntityVariablePair(valueA2, "startTime"),
+                                    new EntityVariablePair(valueA2, "endTime")));
+                });
     }
 
     @ParameterizedTest

--- a/core/src/test/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
@@ -60,6 +60,7 @@ class DefaultExhaustiveSearchPhaseTest {
         var workingSolution = new TestdataSolution();
         when(phaseScope.getWorkingSolution()).thenReturn(workingSolution);
         InnerScoreDirector<TestdataSolution, SimpleScore> scoreDirector = mock(InnerScoreDirector.class);
+        when(scoreDirector.isLastVariableUpdateSuccessful()).thenReturn(true);
         var moveDirector = new MoveDirector<>(scoreDirector);
         doAnswer(invocation -> {
             var move = (Move<TestdataSolution>) invocation.getArgument(0);
@@ -120,6 +121,7 @@ class DefaultExhaustiveSearchPhaseTest {
         var workingSolution = new TestdataSolution();
         when(phaseScope.getWorkingSolution()).thenReturn(workingSolution);
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector = mock(InnerScoreDirector.class);
+        when(scoreDirector.isLastVariableUpdateSuccessful()).thenReturn(true);
         var moveDirector = new MoveDirector<>(scoreDirector);
         doAnswer(invocation -> {
             var move = (Move<TestdataListSolution>) invocation.getArgument(0);

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SelectorBasedListAssignMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SelectorBasedListAssignMoveTest.java
@@ -40,6 +40,7 @@ class SelectorBasedListAssignMoveTest {
     void setUp() {
         when(innerScoreDirector.getSolutionDescriptor())
                 .thenReturn(variableDescriptor.getEntityDescriptor().getSolutionDescriptor());
+        when(innerScoreDirector.isLastVariableUpdateSuccessful()).thenReturn(true);
         when(otherInnerScoreDirector.getValueRangeManager()).thenReturn(valueRangeManager);
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SelectorBasedListSwapMoveTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/SelectorBasedListSwapMoveTest.java
@@ -42,6 +42,7 @@ class SelectorBasedListSwapMoveTest {
 
     @BeforeEach
     void setUp() {
+        when(innerScoreDirector.isLastVariableUpdateSuccessful()).thenReturn(true);
         when(otherInnerScoreDirector.getValueRangeManager()).thenReturn(valueRangeManager);
     }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/phase/custom/DefaultPhaseCommandContextTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/phase/custom/DefaultPhaseCommandContextTest.java
@@ -53,7 +53,7 @@ class DefaultPhaseCommandContextTest {
         when(scoreDirector.calculateScore()).thenReturn(InnerScore.fullyAssigned(SimpleScore.of(0)));
 
         var result = commandContext
-                .executeTemporarilyHandlingStructurallyFlawedSolutions(move,
+                .executeTemporarily(move,
                         solutionConsumer,
                         flawedSolutionConsumer);
 
@@ -69,7 +69,7 @@ class DefaultPhaseCommandContextTest {
         when(scoreDirector.calculateScore()).thenReturn(InnerScore.fullyAssigned(new SimpleScore(-1, 0)));
 
         var result = commandContext
-                .executeTemporarilyHandlingStructurallyFlawedSolutions(move,
+                .executeTemporarily(move,
                         solutionConsumer,
                         flawedSolutionConsumer);
 
@@ -85,7 +85,7 @@ class DefaultPhaseCommandContextTest {
         when(scoreDirector.calculateScore()).thenReturn(InnerScore.fullyAssigned(SimpleScore.of(0)));
 
         var result = commandContext
-                .executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions(move,
+                .executeTemporarilyAndCalculateScore(move,
                         solutionConsumer,
                         flawedSolutionConsumer);
 
@@ -101,7 +101,7 @@ class DefaultPhaseCommandContextTest {
         when(scoreDirector.calculateScore()).thenReturn(InnerScore.fullyAssigned(new SimpleScore(-1, 0)));
 
         var result = commandContext
-                .executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions(move,
+                .executeTemporarilyAndCalculateScore(move,
                         solutionConsumer,
                         flawedSolutionConsumer);
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/phase/custom/DefaultPhaseCommandContextTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/phase/custom/DefaultPhaseCommandContextTest.java
@@ -1,0 +1,115 @@
+package ai.timefold.solver.core.impl.phase.custom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+
+import ai.timefold.solver.core.api.score.SimpleScore;
+import ai.timefold.solver.core.impl.move.MoveDirector;
+import ai.timefold.solver.core.impl.score.director.InnerScore;
+import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.preview.api.move.Move;
+import ai.timefold.solver.core.testdomain.TestdataSolution;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DefaultPhaseCommandContextTest {
+
+    Move<TestdataSolution> move;
+    DefaultPhaseCommandContext<TestdataSolution> commandContext;
+    InnerScoreDirector<TestdataSolution, SimpleScore> scoreDirector;
+    Function<TestdataSolution, String> solutionConsumer;
+    Function<TestdataSolution, String> flawedSolutionConsumer;
+
+    private static final String SUCCESS = "success";
+    private static final String ERROR = "error";
+
+    @BeforeEach
+    void setUp() {
+        var solution = TestdataSolution.generateSolution(3, 2);
+        move = mock(Move.class);
+        scoreDirector = mock(InnerScoreDirector.class);
+        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
+
+        commandContext = new DefaultPhaseCommandContext<>(new MoveDirector<>(scoreDirector), () -> false);
+
+        solutionConsumer = Mockito.mock(Function.class);
+        when(solutionConsumer.apply(any())).thenReturn(SUCCESS);
+
+        flawedSolutionConsumer = Mockito.mock(Function.class);
+        when(flawedSolutionConsumer.apply(any())).thenReturn(ERROR);
+    }
+
+    @Test
+    void executeTemporarilyHandlingStructurallyFlawedSolutions_moveDoesNotFlawSolution() {
+        when(scoreDirector.calculateScore()).thenReturn(InnerScore.fullyAssigned(SimpleScore.of(0)));
+
+        var result = commandContext
+                .executeTemporarilyHandlingStructurallyFlawedSolutions(move,
+                        solutionConsumer,
+                        flawedSolutionConsumer);
+
+        assertThat(result).isEqualTo(SUCCESS);
+        verify(solutionConsumer, times(1)).apply(any());
+        verify(flawedSolutionConsumer, never()).apply(any());
+        verify(move, times(1)).execute(any(MoveDirector.class));
+        verify(scoreDirector, times(1)).calculateScore();
+    }
+
+    @Test
+    void executeTemporarilyHandlingStructurallyFlawedSolutions_moveFlawsSolution() {
+        when(scoreDirector.calculateScore()).thenReturn(InnerScore.fullyAssigned(new SimpleScore(-1, 0)));
+
+        var result = commandContext
+                .executeTemporarilyHandlingStructurallyFlawedSolutions(move,
+                        solutionConsumer,
+                        flawedSolutionConsumer);
+
+        assertThat(result).isEqualTo(ERROR);
+        verify(solutionConsumer, never()).apply(any());
+        verify(flawedSolutionConsumer, times(1)).apply(any());
+        verify(move, times(1)).execute(any(MoveDirector.class));
+        verify(scoreDirector, times(1)).calculateScore();
+    }
+
+    @Test
+    void executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions_moveDoesNotFlawSolution() {
+        when(scoreDirector.calculateScore()).thenReturn(InnerScore.fullyAssigned(SimpleScore.of(0)));
+
+        var result = commandContext
+                .executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions(move,
+                        solutionConsumer,
+                        flawedSolutionConsumer);
+
+        assertThat(result).isEqualTo(SUCCESS);
+        verify(solutionConsumer, times(1)).apply(any());
+        verify(flawedSolutionConsumer, never()).apply(any());
+        verify(move, times(1)).execute(any(MoveDirector.class));
+        verify(scoreDirector, times(2)).calculateScore();
+    }
+
+    @Test
+    void executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions_moveFlawsSolution() {
+        when(scoreDirector.calculateScore()).thenReturn(InnerScore.fullyAssigned(new SimpleScore(-1, 0)));
+
+        var result = commandContext
+                .executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions(move,
+                        solutionConsumer,
+                        flawedSolutionConsumer);
+
+        assertThat(result).isEqualTo(ERROR);
+        verify(solutionConsumer, never()).apply(any());
+        verify(flawedSolutionConsumer, times(1)).apply(any());
+        verify(move, times(1)).execute(any(MoveDirector.class));
+        verify(scoreDirector, times(2)).calculateScore();
+    }
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/DefaultSolverTest.java
@@ -1556,7 +1556,7 @@ class DefaultSolverTest {
     }
 
     @Test
-    void solveCustomPhaseReturnsInconsistent() {
+    void solveCustomPhaseReturnsStructurallyFlawed() {
         // Solver config
         var solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataDependencyNoInconsistentFieldSolution.class, TestdataDependencyNoInconsistentFieldEntity.class,
@@ -1600,8 +1600,8 @@ class DefaultSolverTest {
         problem.setValues(values);
 
         assertThatCode(() -> PlannerTestUtils.solve(solverConfig, problem, false))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContainingAll("The custom phase command", "resulted in an inconsistent solution.");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContainingAll("The move ", "caused the solution to become structurally flawed.");
     }
 
     @Test

--- a/docs/src/modules/ROOT/pages/constraints-and-score/overview.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/overview.adoc
@@ -165,6 +165,32 @@ such as xref:constraints-and-score/overview.adoc#hardSoftScore[HardSoftScore]
 and xref:constraints-and-score/overview.adoc#hardMediumSoftScore[HardMediumSoftScore].
 
 
+[#structuralScore]
+=== Structural score
+
+All `Score` implementations have an implicit xref:constraints-and-score/overview.adoc#structuralScore[structural] component that outranks every score level.
+It is `0` if the solution is structurally sound and negative if the solution is structurally flawed.
+A solution is structurally flawed when some of its xref:domain-modeling/modeling-planning-problems.adoc#shadowVariable[shadow variables] form a dependency loop and cannot be calculated
+(see xref:domain-modeling/modeling-planning-problems.adoc#detectingInconsistencies[Detecting Inconsistencies in Shadow Variables]).
+
+Because the structural component is compared before every other level,
+a score with a negative structural component is worse than any score with a `0` structural component,
+no matter how many score constraints are broken.
+It therefore behaves like a super hard score level,
+and a score with a negative structural component is not xref:#scoreLevel[feasible].
+
+During solving, the structural component is always `0`,
+because Timefold Solver never accepts a structurally flawed solution.
+A negative structural component only appears on solutions that were modified outside of a solver step,
+such as a solution modified by a xref:optimization-algorithms/overview.adoc#customSolverPhase[custom phase]
+or a solution passed to `Solver.solve(...)`.
+
+When it is not `0`, the structural component is printed as the leading `structural` level of the score string,
+for example ``-1structural/0hard/-5soft``.
+When it is `0`, it is omitted,
+so a structurally sound score is printed as usual, for example ``0hard/-5soft``.
+
+
 [#paretoScoring]
 === Pareto scoring (AKA multi-objective optimization scoring)
 

--- a/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
@@ -93,10 +93,9 @@ In that case, use `ScoreAnalysisFetchPolicy.FETCH_MATCH_COUNT` instead of the de
 
 [NOTE]
 ====
-`SolutionManager.analyze(...)` requires a structurally sound solution.
-If the solution has a negative xref:constraints-and-score/overview.adoc#structuralScore[structural score],
-the method fails fast and throws an `InconsistentSolutionException`
-instead of returning a `ScoreAnalysis`.
+The score analysis of structurally flawed solutions has a structural flaw analysis,
+which can be used to get inconsistent entities.
+Constraint analyses are still available for structurally flawed solutions, but will exclude any matches sourced from an inconsistent entity.
 ====
 
 It is also possible to print the score summary:

--- a/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
@@ -91,6 +91,14 @@ For performance reasons and especially with large datasets that you'll later nee
 In that case, use `ScoreAnalysisFetchPolicy.FETCH_MATCH_COUNT` instead of the default `ScoreAnalysisFetchPolicy.FETCH_ALL` when calling `SolutionManager.analyze(...)`.
 ====
 
+[NOTE]
+====
+`SolutionManager.analyze(...)` requires a structurally sound solution.
+If the solution has a negative xref:constraints-and-score/overview.adoc#structuralScore[structural score],
+the method fails fast and throws an `InconsistentSolutionException`
+instead of returning a `ScoreAnalysis`.
+====
+
 It is also possible to print the score summary:
 
 [tabs]

--- a/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
+++ b/docs/src/modules/ROOT/pages/constraints-and-score/understanding-the-score.adoc
@@ -91,12 +91,9 @@ For performance reasons and especially with large datasets that you'll later nee
 In that case, use `ScoreAnalysisFetchPolicy.FETCH_MATCH_COUNT` instead of the default `ScoreAnalysisFetchPolicy.FETCH_ALL` when calling `SolutionManager.analyze(...)`.
 ====
 
-[NOTE]
-====
-The score analysis of structurally flawed solutions has a structural flaw analysis,
+NOTE: The score analysis of structurally flawed solutions has a structural flaw analysis,
 which can be used to get inconsistent entities.
 Constraint analyses are still available for structurally flawed solutions, but will exclude any matches sourced from an inconsistent entity.
-====
 
 It is also possible to print the score summary:
 

--- a/docs/src/modules/ROOT/pages/domain-modeling/modeling-planning-problems.adoc
+++ b/docs/src/modules/ROOT/pages/domain-modeling/modeling-planning-problems.adoc
@@ -2051,9 +2051,12 @@ that is `0` for structurally sound solutions and negative for structurally flawe
 A structurally flawed score is worse than any structurally sound score,
 so a structurally flawed solution is never accepted during solving.
 
-When a structurally flawed solution is passed to `SolutionManager.update(...)` or `SolutionManager.analyze(...)`,
-these methods fail fast and throw an `InconsistentSolutionException`,
+When a structurally flawed solution is passed to `SolutionManager.update(...)`,
+the method fails fast and throws an `InconsistentSolutionException`,
 which exposes the solution and the entities involved in the inconsistency.
+When passed to `SolutionManager.analyze(...)`,
+the returned xref:constraints-and-score/understanding-the-score.adoc[Score analysis]
+has a structural flaw analysis that can be used to get the inconsistent entities.
 
 When a structurally flawed solution is passed to `Solver.solve`,
 the `Solver` logs a warning and unassigns the involved planning entities before solving.

--- a/docs/src/modules/ROOT/pages/domain-modeling/modeling-planning-problems.adoc
+++ b/docs/src/modules/ROOT/pages/domain-modeling/modeling-planning-problems.adoc
@@ -2065,8 +2065,15 @@ for example because an involved entity is xref:domain-modeling/modeling-planning
 the `Solver` throws an `Exception`.
 ====
 
+If no entity have a `@ShadowVariablesInconsistent` property, you do not need to handle inconsistencies in any constraints, since the Solver will not calculate the score for any structurally flawed solutions.
+
+
+==== Deprecated: Per entity inconsistency tracking
+
 To detect whether an entity has inconsistent shadow variables, annotate a boolean field with `@ShadowVariablesInconsistent`.
 The solver will set this field to true if the entity has any inconsistent shadow variables.
+
+IMPORTANT: If you use `@ShadowVariablesInconsistent`, you would need to handle inconsistent entities in your constraints, and have a slower solve speed. It is recommended to avoid that annotation, and to remove it if you currently have it.
 
 [tabs]
 ====

--- a/docs/src/modules/ROOT/pages/domain-modeling/modeling-planning-problems.adoc
+++ b/docs/src/modules/ROOT/pages/domain-modeling/modeling-planning-problems.adoc
@@ -2035,7 +2035,32 @@ For example, if variable `a` depends on `b` and `b` depends on `a`, both are in 
 - It depends on another variable that is inconsistent.
 For example, if `c` depends on `a`, and `a` is in a loop with `b`, then `c` is also considered part of the loop.
 
-When a declarative shadow variable is inconsistent, it will be set to `null`.
+When a declarative shadow variable is inconsistent, the solver's reaction depends on whether any entity in the model declares a `@ShadowVariablesInconsistent` field.
+If at least one entity declares such a field, the inconsistent shadow variables are set to `null`
+and the `@ShadowVariablesInconsistent` field of every involved entity is set to `true`.
+If no entity declares such a field, the shadow variable update fails instead
+and the solution's score receives a negative xref:constraints-and-score/overview.adoc#structuralScore[structural score],
+which marks the solution as structurally flawed.
+Models that relied on inconsistent shadow variables being silently set to `null`
+must therefore declare a `@ShadowVariablesInconsistent` field to keep that behavior.
+
+[NOTE]
+====
+The xref:constraints-and-score/overview.adoc#structuralScore[structural score] is a component of every `Score`
+that is `0` for structurally sound solutions and negative for structurally flawed ones.
+A structurally flawed score is worse than any structurally sound score,
+so a structurally flawed solution is never accepted during solving.
+
+When a structurally flawed solution is passed to `SolutionManager.update(...)` or `SolutionManager.analyze(...)`,
+these methods fail fast and throw an `InconsistentSolutionException`,
+which exposes the solution and the entities involved in the inconsistency.
+
+When a structurally flawed solution is passed to `Solver.solve`,
+the `Solver` logs a warning and unassigns the involved planning entities before solving.
+If the inconsistency cannot be resolved this way,
+for example because an involved entity is xref:domain-modeling/modeling-planning-problems.adoc#pinnedPlanningEntities[pinned],
+the `Solver` throws an `Exception`.
+====
 
 To detect whether an entity has inconsistent shadow variables, annotate a boolean field with `@ShadowVariablesInconsistent`.
 The solver will set this field to true if the entity has any inconsistent shadow variables.

--- a/docs/src/modules/ROOT/pages/optimization-algorithms/overview.adoc
+++ b/docs/src/modules/ROOT/pages/optimization-algorithms/overview.adoc
@@ -879,6 +879,13 @@ As defined above, but the executed move is immediately undone.
 The provided `Function` is executed while the move is still applied,
 so that the user can perform arbitrary calculations on the working solution with the move applied.
 The return value of the provided `Function` is returned by this method.
+`Object executeTemporarilyHandlingStructurallyFlawedSolutions(Move, Function, Function)`::
+As `executeTemporarily(Move, Function)`, but the executed move is allowed to result in a
+xref:constraints-and-score/overview.adoc#structuralScore[structurally flawed] solution.
+If the temporarily modified solution is structurally flawed,
+the second provided `Function` is executed with it instead of the first one.
+`executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions(Move, Function, Function)`
+is the counterpart that guarantees a fresh score at the end of the method's invocation.
 `boolean isPhaseTerminated()`::
 Returns `true` if the `PhaseCommand` should terminate.
 `Object lookUpWorkingObject(Object externalObject)`::
@@ -891,6 +898,16 @@ Any change on the planning entities in a `PhaseCommand` must be done through the
 to avoid corrupting the `Solver`.
 For performance reasons, these methods will not compute a fresh score before it finishes.
 If you want a fresh score computed, these methods have counterparts, `executeAndCalculateScore` and `executeTemporarilyAndCalculateScore`.
+
+If a `Move` causes the working solution to become
+xref:constraints-and-score/overview.adoc#structuralScore[structurally flawed],
+the `execute`, `executeAndCalculateScore`, `executeTemporarily` and `executeTemporarilyAndCalculateScore` methods
+fail fast and throw an `IllegalArgumentException`.
+If a `PhaseCommand` leaves the working solution structurally flawed when it returns,
+the `Solver` throws an `IllegalStateException`.
+To inspect a structurally flawed solution instead of failing fast,
+use the `executeTemporarilyHandlingStructurallyFlawedSolutions` or
+`executeTemporarilyAndCalculateScoreHandlingStructurallyFlawedSolutions` methods described above.
 
 Long-running commands may want to periodically check `isPhaseTerminated` and when it returns `true`,
 terminate the command by returning.


### PR DESCRIPTION
For the record, I strongly dislike this change to `ScoreAnalysis` (returning with structural flaws instead of throwing an exception), and it will force the old implementation of the graph to live forever in some ways.