### PR TITLE
fix: false positive warnings for new properties

### DIFF
--- a/service/quarkus/runtime/src/main/java/ai/timefold/solver/service/quarkus/deployment/config/TimefoldRenamedPropertiesFallbackInterceptor.java
+++ b/service/quarkus/runtime/src/main/java/ai/timefold/solver/service/quarkus/deployment/config/TimefoldRenamedPropertiesFallbackInterceptor.java
@@ -60,14 +60,11 @@ public class TimefoldRenamedPropertiesFallbackInterceptor extends FallbackConfig
     private static String toLegacyName(String name) {
         var exactLegacyName = RENAMED_EXACT_PROPERTIES.get(name);
         if (exactLegacyName != null) {
-            logWarningForResolvedKey(name, exactLegacyName);
             return exactLegacyName;
         }
         for (Map.Entry<String, String> prefix : RENAMED_PROPERTY_PREFIXES.entrySet()) {
             if (name.startsWith(prefix.getKey())) {
-                var legacyName = prefix.getValue() + name.substring(prefix.getKey().length());
-                logWarningForResolvedKey(name, legacyName);
-                return legacyName;
+                return prefix.getValue() + name.substring(prefix.getKey().length());
             }
         }
         return name;
@@ -76,10 +73,19 @@ public class TimefoldRenamedPropertiesFallbackInterceptor extends FallbackConfig
     @Override
     public ConfigValue getValue(final ConfigSourceInterceptorContext context, final String name) {
         List<String> legacyNames = RENAMED_PROPERTIES_WITH_MULTIPLE_LEGACY_NAMES.get(name);
-        if (legacyNames == null) {
-            return super.getValue(context, name);
+        if (legacyNames != null) {
+            return resolveWithLegacyNames(context, name, legacyNames);
         }
 
+        var legacyName = toLegacyName(name);
+        if (legacyName.equals(name)) {
+            return context.proceed(name);
+        }
+        return resolveWithLegacyNames(context, name, List.of(legacyName));
+    }
+
+    private static ConfigValue resolveWithLegacyNames(ConfigSourceInterceptorContext context, String name,
+            List<String> legacyNames) {
         ConfigValue value = context.proceed(name);
         for (String legacyName : legacyNames) {
             ConfigValue legacyValue = context.proceed(legacyName);

--- a/service/quarkus/runtime/src/test/java/ai/timefold/solver/service/quarkus/deployment/config/TimefoldRenamedPropertiesFallbackInterceptorTest.java
+++ b/service/quarkus/runtime/src/test/java/ai/timefold/solver/service/quarkus/deployment/config/TimefoldRenamedPropertiesFallbackInterceptorTest.java
@@ -9,8 +9,12 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
@@ -27,19 +31,21 @@ class TimefoldRenamedPropertiesFallbackInterceptorTest {
 
     private static List<LogRecord> captureLogs(Runnable action) {
         Logger julLogger = Logger.getLogger(TimefoldRenamedPropertiesFallbackInterceptor.class.getName());
-        List<LogRecord> records = new ArrayList<>();
+        List<LogRecord> logRecords = new ArrayList<>();
         Handler handler = new Handler() {
             @Override
-            public void publish(LogRecord record) {
-                records.add(record);
+            public void publish(LogRecord logRecord) {
+                logRecords.add(logRecord);
             }
 
             @Override
             public void flush() {
+                // nothing to flush
             }
 
             @Override
             public void close() {
+                // nothing to close
             }
         };
         Level originalLevel = julLogger.getLevel();
@@ -51,7 +57,23 @@ class TimefoldRenamedPropertiesFallbackInterceptorTest {
             julLogger.removeHandler(handler);
             julLogger.setLevel(originalLevel);
         }
-        return records;
+        return logRecords;
+    }
+
+    /**
+     * Returns a single pair of new-property-name, deprecated-property-name for every mapping type defined
+     * in {@link TimefoldRenamedPropertiesFallbackInterceptor}.
+     *
+     * @return a stream of arguments for parameterized tests representing each property mapping type
+     */
+    private static Stream<Arguments> renamedProperties() {
+        return Stream.of(
+                // RENAMED_EXACT_PROPERTIES
+                Arguments.of("timefold.model.name", "timefold.application.name"),
+                // RENAMED_PROPERTY_PREFIXES
+                Arguments.of("timefold.model.default-config.something", "ai.timefold.model.default-config.something"),
+                // RENAMED_PROPERTIES_WITH_MULTIPLE_LEGACY_NAMES
+                Arguments.of("timefold.model.id", "timefold.application.id"));
     }
 
     @Test
@@ -155,22 +177,22 @@ class TimefoldRenamedPropertiesFallbackInterceptorTest {
         assertThat(config.getRawValue("timefold.model.name")).isNull();
     }
 
-    @Test
-    void logsWarningWhenLegacyPropertyIsDefined() {
-        SmallRyeConfig config = buildConfig(Map.of("timefold.application.name", "my-app"));
+    @ParameterizedTest
+    @MethodSource("renamedProperties")
+    void logsWarningWhenLegacyPropertyIsDefined(String newName, String legacyName) {
+        SmallRyeConfig config = buildConfig(Map.of(legacyName, "my-value"));
+        List<LogRecord> logRecords = captureLogs(() -> config.getRawValue(newName));
 
-        List<LogRecord> records = captureLogs(() -> config.getRawValue("timefold.model.name"));
-
-        assertThat(records)
-                .anySatisfy(record -> assertThat(record.getMessage()).contains("Deprecated configuration key"));
+        assertThat(logRecords)
+                .anySatisfy(logRecord -> assertThat(logRecord.getMessage()).contains("Deprecated configuration key"));
     }
 
-    @Test
-    void doesNotLogWarningWhenOnlyNewPropertyIsDefined() {
-        SmallRyeConfig config = buildConfig(Map.of("timefold.model.name", "my-app"));
+    @ParameterizedTest
+    @MethodSource("renamedProperties")
+    void doesNotLogWarningWhenOnlyNewPropertyIsDefined(String newName, String legacyName) {
+        SmallRyeConfig config = buildConfig(Map.of(newName, "my-value"));
+        List<LogRecord> logRecords = captureLogs(() -> config.getRawValue(newName));
 
-        List<LogRecord> records = captureLogs(() -> config.getRawValue("timefold.model.name"));
-
-        assertThat(records).isEmpty();
+        assertThat(logRecords).isEmpty();
     }
 }

--- a/service/quarkus/runtime/src/test/java/ai/timefold/solver/service/quarkus/deployment/config/TimefoldRenamedPropertiesFallbackInterceptorTest.java
+++ b/service/quarkus/runtime/src/test/java/ai/timefold/solver/service/quarkus/deployment/config/TimefoldRenamedPropertiesFallbackInterceptorTest.java
@@ -2,7 +2,13 @@ package ai.timefold.solver.service.quarkus.deployment.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +23,35 @@ class TimefoldRenamedPropertiesFallbackInterceptorTest {
                 .withInterceptors(new TimefoldRenamedPropertiesFallbackInterceptor())
                 .withSources(new PropertiesConfigSource(properties, "test", 100))
                 .build();
+    }
+
+    private static List<LogRecord> captureLogs(Runnable action) {
+        Logger julLogger = Logger.getLogger(TimefoldRenamedPropertiesFallbackInterceptor.class.getName());
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        Level originalLevel = julLogger.getLevel();
+        julLogger.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+        try {
+            action.run();
+        } finally {
+            julLogger.removeHandler(handler);
+            julLogger.setLevel(originalLevel);
+        }
+        return records;
     }
 
     @Test
@@ -118,5 +153,24 @@ class TimefoldRenamedPropertiesFallbackInterceptorTest {
     void unknownPropertyReturnsNull() {
         SmallRyeConfig config = buildConfig(Map.of());
         assertThat(config.getRawValue("timefold.model.name")).isNull();
+    }
+
+    @Test
+    void logsWarningWhenLegacyPropertyIsDefined() {
+        SmallRyeConfig config = buildConfig(Map.of("timefold.application.name", "my-app"));
+
+        List<LogRecord> records = captureLogs(() -> config.getRawValue("timefold.model.name"));
+
+        assertThat(records)
+                .anySatisfy(record -> assertThat(record.getMessage()).contains("Deprecated configuration key"));
+    }
+
+    @Test
+    void doesNotLogWarningWhenOnlyNewPropertyIsDefined() {
+        SmallRyeConfig config = buildConfig(Map.of("timefold.model.name", "my-app"));
+
+        List<LogRecord> records = captureLogs(() -> config.getRawValue("timefold.model.name"));
+
+        assertThat(records).isEmpty();
     }
 }


### PR DESCRIPTION
The warning must only be logged when a legacy value is actually chosen over the new one, not merely because the requested name happens to have a known legacy counterpart (which may itself be unset).

Closes https://github.com/TimefoldAI/timefold-solver/issues/2616.