### PR TITLE
refactor: standardize handling of BigDecimal in scores

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/api/score/BendableBigDecimalScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/BendableBigDecimalScore.java
@@ -151,7 +151,7 @@ public record BendableBigDecimalScore(long structuralScore, BigDecimal[] hardSco
             return false;
         }
         for (var hardScore : hardScores) {
-            if (hardScore.compareTo(BigDecimal.ZERO) < 0) {
+            if (ScoreUtil.isNegative(hardScore)) {
                 return false;
             }
         }
@@ -294,12 +294,12 @@ public record BendableBigDecimalScore(long structuralScore, BigDecimal[] hardSco
                 return false;
             }
             for (var i = 0; i < hardScores.length; i++) {
-                if (!hardScores[i].stripTrailingZeros().equals(other.hardScore(i).stripTrailingZeros())) {
+                if (!ScoreUtil.equalsIgnoringScale(hardScores[i], other.hardScore(i))) {
                     return false;
                 }
             }
             for (var i = 0; i < softScores.length; i++) {
-                if (!softScores[i].stripTrailingZeros().equals(other.softScore(i).stripTrailingZeros())) {
+                if (!ScoreUtil.equalsIgnoringScale(softScores[i], other.softScore(i))) {
                     return false;
                 }
             }
@@ -312,10 +312,10 @@ public record BendableBigDecimalScore(long structuralScore, BigDecimal[] hardSco
     public int hashCode() {
         var hash = Long.hashCode(structuralScore);
         for (var hardScore : hardScores) {
-            hash = 31 * hash + hardScore.stripTrailingZeros().hashCode();
+            hash = 31 * hash + ScoreUtil.hashCodeIgnoringScale(hardScore);
         }
         for (var softScore : softScores) {
-            hash = 31 * hash + softScore.stripTrailingZeros().hashCode();
+            hash = 31 * hash + ScoreUtil.hashCodeIgnoringScale(softScore);
         }
         return hash;
     }
@@ -343,7 +343,7 @@ public record BendableBigDecimalScore(long structuralScore, BigDecimal[] hardSco
 
     @Override
     public String toShortString() {
-        return ScoreUtil.buildBendableShortString(this, n -> ((BigDecimal) n).compareTo(BigDecimal.ZERO) != 0);
+        return ScoreUtil.buildBendableShortString(this, ScoreUtil.BIG_DECIMAL_NOT_ZERO);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/api/score/BendableBigDecimalScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/BendableBigDecimalScore.java
@@ -3,7 +3,6 @@ package ai.timefold.solver.core.api.score;
 import static ai.timefold.solver.core.impl.score.ScoreUtil.STRUCTURAL_LABEL;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Arrays;
 
 import ai.timefold.solver.core.impl.score.ScoreUtil;
@@ -192,16 +191,11 @@ public record BendableBigDecimalScore(long structuralScore, BigDecimal[] hardSco
     public BendableBigDecimalScore multiply(double multiplicand) {
         var newHardScores = new BigDecimal[hardScores.length];
         var newSoftScores = new BigDecimal[softScores.length];
-        var bigDecimalMultiplicand = BigDecimal.valueOf(multiplicand);
         for (var i = 0; i < newHardScores.length; i++) {
-            // The (unspecified) scale/precision of the multiplicand should have no impact on the returned scale/precision
-            newHardScores[i] = hardScores[i].multiply(bigDecimalMultiplicand).setScale(hardScores[i].scale(),
-                    RoundingMode.FLOOR);
+            newHardScores[i] = ScoreUtil.multiply(hardScores[i], multiplicand);
         }
         for (var i = 0; i < newSoftScores.length; i++) {
-            // The (unspecified) scale/precision of the multiplicand should have no impact on the returned scale/precision
-            newSoftScores[i] = softScores[i].multiply(bigDecimalMultiplicand).setScale(softScores[i].scale(),
-                    RoundingMode.FLOOR);
+            newSoftScores[i] = ScoreUtil.multiply(softScores[i], multiplicand);
         }
         return new BendableBigDecimalScore(
                 newHardScores, newSoftScores);
@@ -211,14 +205,11 @@ public record BendableBigDecimalScore(long structuralScore, BigDecimal[] hardSco
     public BendableBigDecimalScore divide(double divisor) {
         var newHardScores = new BigDecimal[hardScores.length];
         var newSoftScores = new BigDecimal[softScores.length];
-        var bigDecimalDivisor = BigDecimal.valueOf(divisor);
         for (var i = 0; i < newHardScores.length; i++) {
-            var hardScore = hardScores[i];
-            newHardScores[i] = hardScore.divide(bigDecimalDivisor, hardScore.scale(), RoundingMode.FLOOR);
+            newHardScores[i] = ScoreUtil.divide(hardScores[i], divisor);
         }
         for (var i = 0; i < newSoftScores.length; i++) {
-            var softScore = softScores[i];
-            newSoftScores[i] = softScore.divide(bigDecimalDivisor, softScore.scale(), RoundingMode.FLOOR);
+            newSoftScores[i] = ScoreUtil.divide(softScores[i], divisor);
         }
         return new BendableBigDecimalScore(
                 newHardScores, newSoftScores);
@@ -228,17 +219,11 @@ public record BendableBigDecimalScore(long structuralScore, BigDecimal[] hardSco
     public BendableBigDecimalScore power(double exponent) {
         var newHardScores = new BigDecimal[hardScores.length];
         var newSoftScores = new BigDecimal[softScores.length];
-        var actualExponent = BigDecimal.valueOf(exponent);
-        // The (unspecified) scale/precision of the exponent should have no impact on the returned scale/precision
-        // TODO FIXME remove .intValue() so non-integer exponents produce correct results
-        // None of the normal Java libraries support BigDecimal.pow(BigDecimal)
         for (var i = 0; i < newHardScores.length; i++) {
-            var hardScore = hardScores[i];
-            newHardScores[i] = hardScore.pow(actualExponent.intValue()).setScale(hardScore.scale(), RoundingMode.FLOOR);
+            newHardScores[i] = ScoreUtil.power(hardScores[i], exponent);
         }
         for (var i = 0; i < newSoftScores.length; i++) {
-            var softScore = softScores[i];
-            newSoftScores[i] = softScore.pow(actualExponent.intValue()).setScale(softScore.scale(), RoundingMode.FLOOR);
+            newSoftScores[i] = ScoreUtil.power(softScores[i], exponent);
         }
         return new BendableBigDecimalScore(
                 newHardScores, newSoftScores);

--- a/core/src/main/java/ai/timefold/solver/core/api/score/HardMediumSoftBigDecimalScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/HardMediumSoftBigDecimalScore.java
@@ -32,19 +32,11 @@ public record HardMediumSoftBigDecimalScore(long structuralScore, BigDecimal har
             BigDecimal.ZERO, BigDecimal.ZERO);
     public static final HardMediumSoftBigDecimalScore ONE_HARD = new HardMediumSoftBigDecimalScore(BigDecimal.ONE,
             BigDecimal.ZERO, BigDecimal.ZERO);
-    private static final HardMediumSoftBigDecimalScore MINUS_ONE_HARD =
-            new HardMediumSoftBigDecimalScore(BigDecimal.ONE.negate(),
-                    BigDecimal.ZERO, BigDecimal.ZERO);
     public static final HardMediumSoftBigDecimalScore ONE_MEDIUM =
             new HardMediumSoftBigDecimalScore(BigDecimal.ZERO,
                     BigDecimal.ONE, BigDecimal.ZERO);
-    private static final HardMediumSoftBigDecimalScore MINUS_ONE_MEDIUM =
-            new HardMediumSoftBigDecimalScore(BigDecimal.ZERO,
-                    BigDecimal.ONE.negate(), BigDecimal.ZERO);
     public static final HardMediumSoftBigDecimalScore ONE_SOFT = new HardMediumSoftBigDecimalScore(BigDecimal.ZERO,
             BigDecimal.ZERO, BigDecimal.ONE);
-    private static final HardMediumSoftBigDecimalScore MINUS_ONE_SOFT =
-            new HardMediumSoftBigDecimalScore(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ONE.negate());
 
     public HardMediumSoftBigDecimalScore(BigDecimal hardScore, BigDecimal mediumScore,
             BigDecimal softScore) {
@@ -72,57 +64,29 @@ public record HardMediumSoftBigDecimalScore(long structuralScore, BigDecimal har
 
     public static HardMediumSoftBigDecimalScore of(BigDecimal hardScore, BigDecimal mediumScore,
             BigDecimal softScore) {
-        if (Objects.equals(hardScore, BigDecimal.ONE.negate()) && mediumScore.signum() == 0 && softScore.signum() == 0) {
-            return MINUS_ONE_HARD;
-        } else if (hardScore.signum() == 0) {
-            if (Objects.equals(mediumScore, BigDecimal.ONE.negate()) && softScore.signum() == 0) {
-                return MINUS_ONE_MEDIUM;
-            } else if (mediumScore.signum() == 0) {
-                if (Objects.equals(softScore, BigDecimal.ONE.negate())) {
-                    return MINUS_ONE_SOFT;
-                } else if (softScore.signum() == 0) {
-                    return ZERO;
-                } else if (Objects.equals(softScore, BigDecimal.ONE)) {
-                    return ONE_SOFT;
-                }
-            } else if (Objects.equals(mediumScore, BigDecimal.ONE) && softScore.signum() == 0) {
-                return ONE_MEDIUM;
-            }
-        } else if (Objects.equals(hardScore, BigDecimal.ONE) && mediumScore.signum() == 0 && softScore.signum() == 0) {
-            return ONE_HARD;
+        if (ScoreUtil.isZero(hardScore) && ScoreUtil.isZero(mediumScore) && ScoreUtil.isZero(softScore)) {
+            return ZERO;
         }
         return new HardMediumSoftBigDecimalScore(hardScore, mediumScore, softScore);
     }
 
     public static HardMediumSoftBigDecimalScore ofHard(BigDecimal hardScore) {
-        if (Objects.equals(hardScore, BigDecimal.ONE.negate())) {
-            return MINUS_ONE_HARD;
-        } else if (hardScore.signum() == 0) {
+        if (ScoreUtil.isZero(hardScore)) {
             return ZERO;
-        } else if (Objects.equals(hardScore, BigDecimal.ONE)) {
-            return ONE_HARD;
         }
         return new HardMediumSoftBigDecimalScore(hardScore, BigDecimal.ZERO, BigDecimal.ZERO);
     }
 
     public static HardMediumSoftBigDecimalScore ofMedium(BigDecimal mediumScore) {
-        if (Objects.equals(mediumScore, BigDecimal.ONE.negate())) {
-            return MINUS_ONE_MEDIUM;
-        } else if (mediumScore.signum() == 0) {
+        if (ScoreUtil.isZero(mediumScore)) {
             return ZERO;
-        } else if (Objects.equals(mediumScore, BigDecimal.ONE)) {
-            return ONE_MEDIUM;
         }
         return new HardMediumSoftBigDecimalScore(BigDecimal.ZERO, mediumScore, BigDecimal.ZERO);
     }
 
     public static HardMediumSoftBigDecimalScore ofSoft(BigDecimal softScore) {
-        if (Objects.equals(softScore, BigDecimal.ONE.negate())) {
-            return MINUS_ONE_SOFT;
-        } else if (softScore.signum() == 0) {
+        if (ScoreUtil.isZero(softScore)) {
             return ZERO;
-        } else if (Objects.equals(softScore, BigDecimal.ONE)) {
-            return ONE_SOFT;
         }
         return new HardMediumSoftBigDecimalScore(BigDecimal.ZERO, BigDecimal.ZERO, softScore);
     }
@@ -134,7 +98,7 @@ public record HardMediumSoftBigDecimalScore(long structuralScore, BigDecimal har
      */
     @Override
     public boolean isFeasible() {
-        return structuralScore >= 0 && hardScore.compareTo(BigDecimal.ZERO) >= 0;
+        return structuralScore >= 0 && !ScoreUtil.isNegative(hardScore);
     }
 
     @Override
@@ -176,7 +140,7 @@ public record HardMediumSoftBigDecimalScore(long structuralScore, BigDecimal har
         var exponentBigDecimal = BigDecimal.valueOf(exponent);
         // The (unspecified) scale/precision of the exponent should have no impact on the returned scale/precision
         // TODO FIXME remove .intValue() so non-integer exponents produce correct results
-        // None of the normal Java libraries support BigDecimal.pow(BigDecimal)
+        //  None of the normal Java libraries support BigDecimal.pow(BigDecimal)
         return of(hardScore.pow(exponentBigDecimal.intValue()).setScale(hardScore.scale(), RoundingMode.FLOOR),
                 mediumScore.pow(exponentBigDecimal.intValue()).setScale(mediumScore.scale(), RoundingMode.FLOOR),
                 softScore.pow(exponentBigDecimal.intValue()).setScale(softScore.scale(), RoundingMode.FLOOR));
@@ -201,17 +165,17 @@ public record HardMediumSoftBigDecimalScore(long structuralScore, BigDecimal har
     public boolean equals(Object o) {
         if (o instanceof HardMediumSoftBigDecimalScore(var otherStructuralScore, var otherHardScore, var otherMediumScore, var otherSoftScore)) {
             return structuralScore == otherStructuralScore
-                    && hardScore.stripTrailingZeros().equals(otherHardScore.stripTrailingZeros())
-                    && mediumScore.stripTrailingZeros().equals(otherMediumScore.stripTrailingZeros())
-                    && softScore.stripTrailingZeros().equals(otherSoftScore.stripTrailingZeros());
+                    && ScoreUtil.equalsIgnoringScale(hardScore, otherHardScore)
+                    && ScoreUtil.equalsIgnoringScale(mediumScore, otherMediumScore)
+                    && ScoreUtil.equalsIgnoringScale(softScore, otherSoftScore);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(structuralScore, hardScore.stripTrailingZeros(), mediumScore.stripTrailingZeros(),
-                softScore.stripTrailingZeros());
+        return Objects.hash(structuralScore, ScoreUtil.hashCodeIgnoringScale(hardScore),
+                ScoreUtil.hashCodeIgnoringScale(mediumScore), ScoreUtil.hashCodeIgnoringScale(softScore));
     }
 
     @Override
@@ -233,7 +197,7 @@ public record HardMediumSoftBigDecimalScore(long structuralScore, BigDecimal har
 
     @Override
     public String toShortString() {
-        return ScoreUtil.buildShortString(this, n -> ((BigDecimal) n).compareTo(BigDecimal.ZERO) != 0,
+        return ScoreUtil.buildShortString(this, ScoreUtil.BIG_DECIMAL_NOT_ZERO,
                 HARD_LABEL, MEDIUM_LABEL, SOFT_LABEL);
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/api/score/HardMediumSoftBigDecimalScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/HardMediumSoftBigDecimalScore.java
@@ -6,7 +6,6 @@ import static ai.timefold.solver.core.impl.score.ScoreUtil.SOFT_LABEL;
 import static ai.timefold.solver.core.impl.score.ScoreUtil.STRUCTURAL_LABEL;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Objects;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
@@ -117,33 +116,20 @@ public record HardMediumSoftBigDecimalScore(long structuralScore, BigDecimal har
 
     @Override
     public HardMediumSoftBigDecimalScore multiply(double multiplicand) {
-        // Intentionally not taken "new BigDecimal(multiplicand, MathContext.UNLIMITED)"
-        // because together with the floor rounding it gives unwanted behaviour
-        var multiplicandBigDecimal = BigDecimal.valueOf(multiplicand);
-        // The (unspecified) scale/precision of the multiplicand should have no impact on the returned scale/precision
-        return of(hardScore.multiply(multiplicandBigDecimal).setScale(hardScore.scale(), RoundingMode.FLOOR),
-                mediumScore.multiply(multiplicandBigDecimal).setScale(mediumScore.scale(), RoundingMode.FLOOR),
-                softScore.multiply(multiplicandBigDecimal).setScale(softScore.scale(), RoundingMode.FLOOR));
+        return of(ScoreUtil.multiply(hardScore, multiplicand), ScoreUtil.multiply(mediumScore, multiplicand),
+                ScoreUtil.multiply(softScore, multiplicand));
     }
 
     @Override
     public HardMediumSoftBigDecimalScore divide(double divisor) {
-        var divisorBigDecimal = BigDecimal.valueOf(divisor);
-        // The (unspecified) scale/precision of the divisor should have no impact on the returned scale/precision
-        return of(hardScore.divide(divisorBigDecimal, hardScore.scale(), RoundingMode.FLOOR),
-                mediumScore.divide(divisorBigDecimal, mediumScore.scale(), RoundingMode.FLOOR),
-                softScore.divide(divisorBigDecimal, softScore.scale(), RoundingMode.FLOOR));
+        return of(ScoreUtil.divide(hardScore, divisor), ScoreUtil.divide(mediumScore, divisor),
+                ScoreUtil.divide(softScore, divisor));
     }
 
     @Override
     public HardMediumSoftBigDecimalScore power(double exponent) {
-        var exponentBigDecimal = BigDecimal.valueOf(exponent);
-        // The (unspecified) scale/precision of the exponent should have no impact on the returned scale/precision
-        // TODO FIXME remove .intValue() so non-integer exponents produce correct results
-        //  None of the normal Java libraries support BigDecimal.pow(BigDecimal)
-        return of(hardScore.pow(exponentBigDecimal.intValue()).setScale(hardScore.scale(), RoundingMode.FLOOR),
-                mediumScore.pow(exponentBigDecimal.intValue()).setScale(mediumScore.scale(), RoundingMode.FLOOR),
-                softScore.pow(exponentBigDecimal.intValue()).setScale(softScore.scale(), RoundingMode.FLOOR));
+        return of(ScoreUtil.power(hardScore, exponent), ScoreUtil.power(mediumScore, exponent),
+                ScoreUtil.power(softScore, exponent));
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/api/score/HardSoftBigDecimalScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/HardSoftBigDecimalScore.java
@@ -52,14 +52,8 @@ public record HardSoftBigDecimalScore(long structuralScore, BigDecimal hardScore
 
     public static HardSoftBigDecimalScore of(BigDecimal hardScore, BigDecimal softScore) {
         // Optimization for frequently seen values.
-        if (hardScore.signum() == 0) {
-            if (softScore.signum() == 0) {
-                return ZERO;
-            } else if (Objects.equals(softScore, BigDecimal.ONE)) {
-                return ONE_SOFT;
-            }
-        } else if (Objects.equals(hardScore, BigDecimal.ONE) && softScore.signum() == 0) {
-            return ONE_HARD;
+        if (ScoreUtil.isZero(hardScore) && ScoreUtil.isZero(softScore)) {
+            return ZERO;
         }
         // Every other case is constructed.
         return new HardSoftBigDecimalScore(hardScore, softScore);
@@ -67,10 +61,8 @@ public record HardSoftBigDecimalScore(long structuralScore, BigDecimal hardScore
 
     public static HardSoftBigDecimalScore ofHard(BigDecimal hardScore) {
         // Optimization for frequently seen values.
-        if (hardScore.signum() == 0) {
+        if (ScoreUtil.isZero(hardScore)) {
             return ZERO;
-        } else if (Objects.equals(hardScore, BigDecimal.ONE)) {
-            return ONE_HARD;
         }
         // Every other case is constructed.
         return new HardSoftBigDecimalScore(hardScore, BigDecimal.ZERO);
@@ -78,10 +70,8 @@ public record HardSoftBigDecimalScore(long structuralScore, BigDecimal hardScore
 
     public static HardSoftBigDecimalScore ofSoft(BigDecimal softScore) {
         // Optimization for frequently seen values.
-        if (softScore.signum() == 0) {
+        if (ScoreUtil.isZero(softScore)) {
             return ZERO;
-        } else if (Objects.equals(softScore, BigDecimal.ONE)) {
-            return ONE_SOFT;
         }
         // Every other case is constructed.
         return new HardSoftBigDecimalScore(BigDecimal.ZERO, softScore);
@@ -89,7 +79,7 @@ public record HardSoftBigDecimalScore(long structuralScore, BigDecimal hardScore
 
     @Override
     public boolean isFeasible() {
-        return structuralScore >= 0 && hardScore.signum() >= 0;
+        return structuralScore >= 0 && !ScoreUtil.isNegative(hardScore);
     }
 
     @Override
@@ -131,7 +121,7 @@ public record HardSoftBigDecimalScore(long structuralScore, BigDecimal hardScore
         var exponentBigDecimal = BigDecimal.valueOf(exponent);
         // The (unspecified) scale/precision of the exponent should have no impact on the returned scale/precision
         // TODO FIXME remove .intValue() so non-integer exponents produce correct results
-        // None of the normal Java libraries support BigDecimal.pow(BigDecimal)
+        //  None of the normal Java libraries support BigDecimal.pow(BigDecimal)
         return of(hardScore.pow(exponentBigDecimal.intValue()).setScale(hardScore.scale(), RoundingMode.FLOOR),
                 softScore.pow(exponentBigDecimal.intValue()).setScale(softScore.scale(), RoundingMode.FLOOR));
     }
@@ -155,15 +145,16 @@ public record HardSoftBigDecimalScore(long structuralScore, BigDecimal hardScore
     public boolean equals(Object o) {
         if (o instanceof HardSoftBigDecimalScore(var otherStructuralScore, var otherHardScore, var otherSoftScore)) {
             return structuralScore == otherStructuralScore
-                    && hardScore.stripTrailingZeros().equals(otherHardScore.stripTrailingZeros())
-                    && softScore.stripTrailingZeros().equals(otherSoftScore.stripTrailingZeros());
+                    && ScoreUtil.equalsIgnoringScale(hardScore, otherHardScore)
+                    && ScoreUtil.equalsIgnoringScale(softScore, otherSoftScore);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(structuralScore, hardScore.stripTrailingZeros(), softScore.stripTrailingZeros());
+        return Objects.hash(structuralScore, ScoreUtil.hashCodeIgnoringScale(hardScore),
+                ScoreUtil.hashCodeIgnoringScale(softScore));
     }
 
     @Override
@@ -181,7 +172,7 @@ public record HardSoftBigDecimalScore(long structuralScore, BigDecimal hardScore
 
     @Override
     public String toShortString() {
-        return ScoreUtil.buildShortString(this, n -> ((BigDecimal) n).compareTo(BigDecimal.ZERO) != 0, HARD_LABEL, SOFT_LABEL);
+        return ScoreUtil.buildShortString(this, ScoreUtil.BIG_DECIMAL_NOT_ZERO, HARD_LABEL, SOFT_LABEL);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/api/score/HardSoftBigDecimalScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/HardSoftBigDecimalScore.java
@@ -5,7 +5,6 @@ import static ai.timefold.solver.core.impl.score.ScoreUtil.SOFT_LABEL;
 import static ai.timefold.solver.core.impl.score.ScoreUtil.STRUCTURAL_LABEL;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Objects;
 
 import ai.timefold.solver.core.impl.score.ScoreUtil;
@@ -96,34 +95,17 @@ public record HardSoftBigDecimalScore(long structuralScore, BigDecimal hardScore
 
     @Override
     public HardSoftBigDecimalScore multiply(double multiplicand) {
-        // Intentionally not taken "new BigDecimal(multiplicand, MathContext.UNLIMITED)"
-        // because together with the floor rounding it gives unwanted behaviour
-        var multiplicandBigDecimal = BigDecimal.valueOf(multiplicand);
-        // The (unspecified) scale/precision of the multiplicand should have no impact on the returned scale/precision
-        return of(hardScore.multiply(multiplicandBigDecimal).setScale(hardScore.scale(), RoundingMode.FLOOR),
-                softScore.multiply(multiplicandBigDecimal).setScale(softScore.scale(), RoundingMode.FLOOR));
+        return of(ScoreUtil.multiply(hardScore, multiplicand), ScoreUtil.multiply(softScore, multiplicand));
     }
 
     @Override
     public HardSoftBigDecimalScore divide(double divisor) {
-        // Intentionally not taken "new BigDecimal(multiplicand, MathContext.UNLIMITED)"
-        // because together with the floor rounding it gives unwanted behaviour
-        var divisorBigDecimal = BigDecimal.valueOf(divisor);
-        // The (unspecified) scale/precision of the divisor should have no impact on the returned scale/precision
-        return of(hardScore.divide(divisorBigDecimal, hardScore.scale(), RoundingMode.FLOOR),
-                softScore.divide(divisorBigDecimal, softScore.scale(), RoundingMode.FLOOR));
+        return of(ScoreUtil.divide(hardScore, divisor), ScoreUtil.divide(softScore, divisor));
     }
 
     @Override
     public HardSoftBigDecimalScore power(double exponent) {
-        // Intentionally not taken "new BigDecimal(multiplicand, MathContext.UNLIMITED)"
-        // because together with the floor rounding it gives unwanted behaviour
-        var exponentBigDecimal = BigDecimal.valueOf(exponent);
-        // The (unspecified) scale/precision of the exponent should have no impact on the returned scale/precision
-        // TODO FIXME remove .intValue() so non-integer exponents produce correct results
-        //  None of the normal Java libraries support BigDecimal.pow(BigDecimal)
-        return of(hardScore.pow(exponentBigDecimal.intValue()).setScale(hardScore.scale(), RoundingMode.FLOOR),
-                softScore.pow(exponentBigDecimal.intValue()).setScale(softScore.scale(), RoundingMode.FLOOR));
+        return of(ScoreUtil.power(hardScore, exponent), ScoreUtil.power(softScore, exponent));
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/api/score/Score.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/Score.java
@@ -50,7 +50,9 @@ public sealed interface Score<Score_ extends Score<Score_>>
      * When rounding is needed, it should be floored (as defined by {@link Math#floor(double)}).
      * <p>
      * If the implementation has a scale/precision, then the unspecified scale/precision of the double multiplicand
-     * should have no impact on the returned scale/precision.
+     * should have no impact on the returned scale/precision,
+     * and the returned scale/precision is never coarser than 0 (whole units),
+     * even if this Score's own scale/precision is coarser than that.
      *
      * @param multiplicand value to be multiplied by this Score.
      * @return this * multiplicand
@@ -62,7 +64,9 @@ public sealed interface Score<Score_ extends Score<Score_>>
      * When rounding is needed, it should be floored (as defined by {@link Math#floor(double)}).
      * <p>
      * If the implementation has a scale/precision, then the unspecified scale/precision of the double divisor
-     * should have no impact on the returned scale/precision.
+     * should have no impact on the returned scale/precision,
+     * and the returned scale/precision is never coarser than 0 (whole units),
+     * even if this Score's own scale/precision is coarser than that.
      *
      * @param divisor value by which this Score is to be divided
      * @return this / divisor
@@ -74,7 +78,9 @@ public sealed interface Score<Score_ extends Score<Score_>>
      * When rounding is needed, it should be floored (as defined by {@link Math#floor(double)}).
      * <p>
      * If the implementation has a scale/precision, then the unspecified scale/precision of the double exponent
-     * should have no impact on the returned scale/precision.
+     * should have no impact on the returned scale/precision,
+     * and the returned scale/precision is never coarser than 0 (whole units),
+     * even if this Score's own scale/precision is coarser than that.
      *
      * @param exponent value by which this Score is to be powered
      * @return this ^ exponent

--- a/core/src/main/java/ai/timefold/solver/core/api/score/SimpleBigDecimalScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/SimpleBigDecimalScore.java
@@ -3,7 +3,6 @@ package ai.timefold.solver.core.api.score;
 import static ai.timefold.solver.core.impl.score.ScoreUtil.STRUCTURAL_LABEL;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 import ai.timefold.solver.core.impl.score.ScoreUtil;
 
@@ -57,31 +56,17 @@ public record SimpleBigDecimalScore(long structuralScore, BigDecimal score) impl
 
     @Override
     public SimpleBigDecimalScore multiply(double multiplicand) {
-        // Intentionally not taken "new BigDecimal(multiplicand, MathContext.UNLIMITED)"
-        // because together with the floor rounding it gives unwanted behaviour
-        var multiplicandBigDecimal = BigDecimal.valueOf(multiplicand);
-        // The (unspecified) scale/precision of the multiplicand should have no impact on the returned scale/precision
-        return of(score.multiply(multiplicandBigDecimal).setScale(score.scale(), RoundingMode.FLOOR));
+        return of(ScoreUtil.multiply(score, multiplicand));
     }
 
     @Override
     public SimpleBigDecimalScore divide(double divisor) {
-        // Intentionally not taken "new BigDecimal(multiplicand, MathContext.UNLIMITED)"
-        // because together with the floor rounding it gives unwanted behaviour
-        var divisorBigDecimal = BigDecimal.valueOf(divisor);
-        // The (unspecified) scale/precision of the divisor should have no impact on the returned scale/precision
-        return of(score.divide(divisorBigDecimal, score.scale(), RoundingMode.FLOOR));
+        return of(ScoreUtil.divide(score, divisor));
     }
 
     @Override
     public SimpleBigDecimalScore power(double exponent) {
-        // Intentionally not taken "new BigDecimal(multiplicand, MathContext.UNLIMITED)"
-        // because together with the floor rounding it gives unwanted behaviour
-        var exponentBigDecimal = BigDecimal.valueOf(exponent);
-        // The (unspecified) scale/precision of the exponent should have no impact on the returned scale/precision
-        // TODO FIXME remove .intValue() so non-integer exponents produce correct results
-        // None of the normal Java libraries support BigDecimal.pow(BigDecimal)
-        return of(score.pow(exponentBigDecimal.intValue()).setScale(score.scale(), RoundingMode.FLOOR));
+        return of(ScoreUtil.power(score, exponent));
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/api/score/SimpleBigDecimalScore.java
+++ b/core/src/main/java/ai/timefold/solver/core/api/score/SimpleBigDecimalScore.java
@@ -39,13 +39,10 @@ public record SimpleBigDecimalScore(long structuralScore, BigDecimal score) impl
     }
 
     public static SimpleBigDecimalScore of(BigDecimal score) {
-        if (score.signum() == 0) {
+        if (ScoreUtil.isZero(score)) {
             return ZERO;
-        } else if (score.equals(BigDecimal.ONE)) {
-            return ONE;
-        } else {
-            return new SimpleBigDecimalScore(score);
         }
+        return new SimpleBigDecimalScore(score);
     }
 
     @Override
@@ -111,14 +108,14 @@ public record SimpleBigDecimalScore(long structuralScore, BigDecimal score) impl
     public boolean equals(Object o) {
         if (o instanceof SimpleBigDecimalScore(var otherStructuralScore, var otherScore)) {
             return structuralScore == otherStructuralScore
-                    && score.stripTrailingZeros().equals(otherScore.stripTrailingZeros());
+                    && ScoreUtil.equalsIgnoringScale(score, otherScore);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(structuralScore) ^ score.stripTrailingZeros().hashCode();
+        return Long.hashCode(structuralScore) ^ ScoreUtil.hashCodeIgnoringScale(score);
     }
 
     @Override
@@ -131,7 +128,7 @@ public record SimpleBigDecimalScore(long structuralScore, BigDecimal score) impl
 
     @Override
     public String toShortString() {
-        return ScoreUtil.buildShortString(this, n -> ((BigDecimal) n).compareTo(BigDecimal.ZERO) != 0, "");
+        return ScoreUtil.buildShortString(this, ScoreUtil.BIG_DECIMAL_NOT_ZERO, "");
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/BaseTopologicalOrderGraph.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/declarative/BaseTopologicalOrderGraph.java
@@ -70,7 +70,7 @@ public interface BaseTopologicalOrderGraph {
          */
         @Override
         public int compareTo(NodeTopologicalOrder other) {
-            return graph.getTopologicalOrder(nodeId) - graph.getTopologicalOrder(other.nodeId);
+            return Integer.compare(graph.getTopologicalOrder(nodeId), graph.getTopologicalOrder(other.nodeId));
         }
 
         @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/RuinedPosition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/heuristic/selector/move/generic/list/ruin/RuinedPosition.java
@@ -4,6 +4,6 @@ record RuinedPosition(Object ruinedValue, int index) implements Comparable<Ruine
 
     @Override
     public int compareTo(RuinedPosition other) {
-        return index - other.index;
+        return Integer.compare(index, other.index);
     }
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/ScoreUtil.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/ScoreUtil.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.score;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
@@ -228,7 +229,8 @@ public final class ScoreUtil {
      * A shared constant has scale 0, and zero keeps its meaning at every scale,
      * because zero multiplied or divided stays zero.
      * Every other value must keep the scale that the caller supplied, because {@code multiply()},
-     * {@code divide()} and {@code power()} take the scale of their result from the scale of the input.
+     * {@code divide()} and {@code power()} take the scale of their result from the scale of the input,
+     * clamped to never go below 0 (see {@link #nonNegativeScale}).
      * If {@code SimpleBigDecimalScore.of(new BigDecimal("1.0"))} returned the shared {@code ONE}, which has scale 0,
      * then {@code multiply(1.2)} would give 1 instead of 1.2.
      *
@@ -284,6 +286,61 @@ public final class ScoreUtil {
      */
     public static int hashCodeIgnoringScale(BigDecimal value) {
         return value.stripTrailingZeros().hashCode();
+    }
+
+    /**
+     * Clamps a FLOOR-rounding target scale so it is never coarser than whole units (never below 0),
+     * whatever BigDecimal scale arithmetic derived it from —
+     * a single operand's own scale, or a difference between two operands' scales.
+     * <p>
+     * A negative target scale means "round to the nearest ten, hundred, ..."
+     * Combined with FLOOR rounding, that can erase most or all of an otherwise exact computation:
+     * 150 floored to the nearest hundred is 100,
+     * and a derived divide-scale of -3 turns an exact quotient of 5 into 0.
+     * Clamping at 0 removes that failure mode without changing anything for the common case,
+     * where the derived scale is already 0 or higher.
+     *
+     * @return {@code scale}, or 0 if {@code scale} is negative
+     */
+    public static int nonNegativeScale(int scale) {
+        return Math.max(scale, 0);
+    }
+
+    /**
+     * Multiplies a {@link BigDecimal} score level by a double multiplicand,
+     * per the {@link Score#multiply(double)} contract:
+     * the multiplicand's own (unspecified) scale must not affect the result,
+     * and rounding, when needed, is {@link RoundingMode#FLOOR}.
+     * <p>
+     * The target scale is {@link #nonNegativeScale}, not {@code base.scale()} directly —
+     * see there for why.
+     * If {@code base} is 100 with scale -2
+     * (a value expressed coarser than whole units, e.g. {@code new BigDecimal("1E+2")}),
+     * this gives 150 for a multiplicand of 1.5;
+     * flooring onto {@code base}'s own scale would have given 100 instead.
+     */
+    public static BigDecimal multiply(BigDecimal base, double multiplicand) {
+        var raw = base.multiply(BigDecimal.valueOf(multiplicand));
+        return raw.setScale(nonNegativeScale(base.scale()), RoundingMode.FLOOR);
+    }
+
+    /**
+     * Divides a {@link BigDecimal} score level by a double divisor.
+     * See {@link #multiply(BigDecimal, double)} for the scale-flooring rationale.
+     */
+    public static BigDecimal divide(BigDecimal base, double divisor) {
+        return base.divide(BigDecimal.valueOf(divisor), nonNegativeScale(base.scale()), RoundingMode.FLOOR);
+    }
+
+    /**
+     * Raises a {@link BigDecimal} score level to a double exponent.
+     * See {@link #multiply(BigDecimal, double)} for the scale-flooring rationale.
+     */
+    public static BigDecimal power(BigDecimal base, double exponent) {
+        // TODO FIXME remove .intValue() so non-integer exponents produce correct results
+        //      None of the normal Java libraries support BigDecimal.pow(BigDecimal)
+        var raw = base.pow(BigDecimal.valueOf(exponent).intValue());
+        return raw.setScale(nonNegativeScale(base.scale()), RoundingMode.FLOOR);
     }
 
     private ScoreUtil() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/ScoreUtil.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/ScoreUtil.java
@@ -14,6 +14,13 @@ public final class ScoreUtil {
     public static final String MEDIUM_LABEL = "medium";
     public static final String SOFT_LABEL = "soft";
     public static final String[] LEVEL_SUFFIXES = new String[] { HARD_LABEL, SOFT_LABEL };
+    /**
+     * For {@link #buildShortString} and {@link #buildBendableShortString}
+     * of a BigDecimal-based score.
+     *
+     * @see #isZero(BigDecimal)
+     */
+    public static final Predicate<Number> BIG_DECIMAL_NOT_ZERO = n -> !isZero((BigDecimal) n);
 
     public static String[] parseScoreTokens(Class<? extends Score<?>> scoreClass, String scoreString, String... levelSuffixes) {
         var scoreTokens = new String[levelSuffixes.length];
@@ -207,6 +214,76 @@ public final class ScoreUtil {
             return "0";
         }
         return shortString.toString();
+    }
+
+    /**
+     * Tests if a {@link BigDecimal} score level is numerically zero, at any scale.
+     * <p>
+     * Never use {@link BigDecimal#equals(Object)} for this test.
+     * {@code equals()} also compares the scale,
+     * so {@code new BigDecimal("0.00")} is not equal to {@link BigDecimal#ZERO},
+     * although both are zero.
+     * <p>
+     * Zero is the only value that a score factory is permitted to replace with a shared constant.
+     * A shared constant has scale 0, and zero keeps its meaning at every scale,
+     * because zero multiplied or divided stays zero.
+     * Every other value must keep the scale that the caller supplied, because {@code multiply()},
+     * {@code divide()} and {@code power()} take the scale of their result from the scale of the input.
+     * If {@code SimpleBigDecimalScore.of(new BigDecimal("1.0"))} returned the shared {@code ONE}, which has scale 0,
+     * then {@code multiply(1.2)} would give 1 instead of 1.2.
+     *
+     * @return true if the value is zero at any scale
+     */
+    public static boolean isZero(BigDecimal value) {
+        return value.signum() == 0;
+    }
+
+    /**
+     * Tests if a {@link BigDecimal} score level is negative, at any scale, for an {@code isFeasible()} check.
+     * <p>
+     * {@link BigDecimal#signum()} already handles scale and negative-zero forms correctly,
+     * so unlike {@link #isZero} this only gives the sign test one spelling.
+     * Writing it with {@code compareTo()} would not be a bug.
+     *
+     * @return true if the value is less than zero
+     */
+    public static boolean isNegative(BigDecimal value) {
+        return value.signum() < 0;
+    }
+
+    /**
+     * Tests two {@link BigDecimal} score levels for numerical equality,
+     * ignoring the scale, so that 1.0 and 1.00 are equal.
+     * <p>
+     * This is what stops the scale from causing a false score corruption.
+     * A score that a solver built one move at a time can carry a higher scale
+     * than the same score calculated from scratch,
+     * because {@link BigDecimal#add(BigDecimal)} keeps the larger scale of its two operands.
+     * Both must still be equal, and {@code AbstractScoreDirector} compares them with {@code equals()}.
+     * <p>
+     * {@code toString()} keeps the scale, although this ignores it.
+     * That difference is deliberate,
+     * because {@code toString()} is also the persistence format that {@code parseScore()} reads back.
+     * A score of 10.00 that printed as 10 would parse back at scale 0,
+     * and {@code multiply(0.5)} would then give 5 instead of 5.00,
+     * with nothing to report the loss.
+     * <p>
+     * Pair every use with {@link #hashCodeIgnoringScale}.
+     *
+     * @return true if both values are the same number, whatever their scale
+     */
+    public static boolean equalsIgnoringScale(BigDecimal a, BigDecimal b) {
+        return a.compareTo(b) == 0;
+    }
+
+    /**
+     * The hash of a {@link BigDecimal} score level that ignores the scale,
+     * so that 1.0 and 1.00 hash alike.
+     *
+     * @see #equalsIgnoringScale which this must agree with
+     */
+    public static int hashCodeIgnoringScale(BigDecimal value) {
+        return value.stripTrailingZeros().hashCode();
     }
 
     private ScoreUtil() {

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/definition/AbstractScoreDefinition.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/definition/AbstractScoreDefinition.java
@@ -5,6 +5,7 @@ import java.math.RoundingMode;
 import java.util.Objects;
 
 import ai.timefold.solver.core.api.score.Score;
+import ai.timefold.solver.core.impl.score.ScoreUtil;
 
 /**
  * Abstract superclass for {@link ScoreDefinition}.
@@ -42,7 +43,7 @@ public abstract class AbstractScoreDefinition<Score_ extends Score<Score_>>
     }
 
     protected static BigDecimal divide(BigDecimal dividend, BigDecimal divisor) {
-        return dividend.divide(divisor, dividend.scale() - divisor.scale(), RoundingMode.FLOOR);
+        return dividend.divide(divisor, ScoreUtil.nonNegativeScale(dividend.scale() - divisor.scale()), RoundingMode.FLOOR);
     }
 
     /**

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/BendableBigDecimalScoreInliner.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.BendableBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.ScoreUtil;
 import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
@@ -32,7 +33,7 @@ final class BendableBigDecimalScoreInliner extends AbstractScoreInliner<Bendable
         Integer singleLevel = null;
         var constraintWeight = constraintWeightMap.get(constraint);
         for (var i = 0; i < constraintWeight.levelsSize(); i++) {
-            if (!constraintWeight.hardOrSoftScore(i).equals(BigDecimal.ZERO)) {
+            if (!ScoreUtil.isZero(constraintWeight.hardOrSoftScore(i))) {
                 if (singleLevel != null) {
                     singleLevel = null;
                     break;

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftBigDecimalScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardMediumSoftBigDecimalScoreInliner.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.HardMediumSoftBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.ScoreUtil;
 import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
@@ -31,11 +32,11 @@ final class HardMediumSoftBigDecimalScoreInliner extends AbstractScoreInliner<Ha
         var softConstraintWeight = constraintWeight.softScore();
         var context =
                 new HardMediumSoftBigDecimalScoreContext(this, constraint, constraintWeight);
-        if (mediumConstraintWeight.equals(BigDecimal.ZERO) && softConstraintWeight.equals(BigDecimal.ZERO)) {
+        if (ScoreUtil.isZero(mediumConstraintWeight) && ScoreUtil.isZero(softConstraintWeight)) {
             return WeightedScoreImpacter.of(context, HardMediumSoftBigDecimalScoreContext::changeHardScoreBy);
-        } else if (hardConstraintWeight.equals(BigDecimal.ZERO) && softConstraintWeight.equals(BigDecimal.ZERO)) {
+        } else if (ScoreUtil.isZero(hardConstraintWeight) && ScoreUtil.isZero(softConstraintWeight)) {
             return WeightedScoreImpacter.of(context, HardMediumSoftBigDecimalScoreContext::changeMediumScoreBy);
-        } else if (hardConstraintWeight.equals(BigDecimal.ZERO) && mediumConstraintWeight.equals(BigDecimal.ZERO)) {
+        } else if (ScoreUtil.isZero(hardConstraintWeight) && ScoreUtil.isZero(mediumConstraintWeight)) {
             return WeightedScoreImpacter.of(context, HardMediumSoftBigDecimalScoreContext::changeSoftScoreBy);
         } else {
             return WeightedScoreImpacter.of(context, HardMediumSoftBigDecimalScoreContext::changeScoreBy);

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreInliner.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/stream/common/inliner/HardSoftBigDecimalScoreInliner.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import ai.timefold.solver.core.api.score.HardSoftBigDecimalScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.impl.score.ScoreUtil;
 import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.stream.common.AbstractConstraint;
 
@@ -26,9 +27,9 @@ final class HardSoftBigDecimalScoreInliner extends AbstractScoreInliner<HardSoft
             buildWeightedScoreImpacter(AbstractConstraint<?, ?, ?> constraint) {
         var constraintWeight = constraintWeightMap.get(constraint);
         var context = new HardSoftBigDecimalScoreContext(this, constraint, constraintWeight);
-        if (constraintWeight.softScore().equals(BigDecimal.ZERO)) {
+        if (ScoreUtil.isZero(constraintWeight.softScore())) {
             return WeightedScoreImpacter.of(context, HardSoftBigDecimalScoreContext::changeHardScoreBy);
-        } else if (constraintWeight.hardScore().equals(BigDecimal.ZERO)) {
+        } else if (ScoreUtil.isZero(constraintWeight.hardScore())) {
             return WeightedScoreImpacter.of(context, HardSoftBigDecimalScoreContext::changeSoftScoreBy);
         } else {
             return WeightedScoreImpacter.of(context, HardSoftBigDecimalScoreContext::changeScoreBy);

--- a/core/src/test/java/ai/timefold/solver/core/api/score/BendableBigDecimalScoreTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/BendableBigDecimalScoreTest.java
@@ -43,6 +43,8 @@ class BendableBigDecimalScoreTest extends AbstractScoreTest {
     private static final BigDecimal MINUS_5000 = BigDecimal.valueOf(-5000);
     private static final BigDecimal MINUS_8000 = BigDecimal.valueOf(-8000);
     private static final BigDecimal MIN_INTEGER = BigDecimal.valueOf(Integer.MIN_VALUE);
+    private static final BigDecimal COARSE_HUNDRED = new BigDecimal("1E+2");
+    private static final BigDecimal FIVE_POINT_ZERO = new BigDecimal("5.0");
 
     private final BendableBigDecimalScoreDefinition scoreDefinitionHSS = new BendableBigDecimalScoreDefinition(1, 2);
     private final BendableBigDecimalScoreDefinition scoreDefinitionHHSSS = new BendableBigDecimalScoreDefinition(2, 3);
@@ -114,7 +116,7 @@ class BendableBigDecimalScoreTest extends AbstractScoreTest {
 
     @Test
     void getHardOrSoftScore() {
-        BendableBigDecimalScore initializedScore = scoreDefinitionHSS.createScore(BigDecimal.valueOf(-5),
+        var initializedScore = scoreDefinitionHSS.createScore(BigDecimal.valueOf(-5),
                 BigDecimal.valueOf(-10), BigDecimal.valueOf(-200));
         assertThat(initializedScore.hardOrSoftScore(0)).isEqualTo(BigDecimal.valueOf(-5));
         assertThat(initializedScore.hardOrSoftScore(1)).isEqualTo(BigDecimal.valueOf(-10));
@@ -175,11 +177,11 @@ class BendableBigDecimalScoreTest extends AbstractScoreTest {
 
     @Test
     void zero() {
-        BendableBigDecimalScore manualZero = BendableBigDecimalScore.zero(0, 1);
+        var manualZero = BendableBigDecimalScore.zero(0, 1);
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(manualZero.zero()).isEqualTo(manualZero);
             softly.assertThat(manualZero.isZero()).isTrue();
-            BendableBigDecimalScore manualOne = BendableBigDecimalScore.ofSoft(0, 1, 0, BigDecimal.ONE);
+            var manualOne = BendableBigDecimalScore.ofSoft(0, 1, 0, BigDecimal.ONE);
             softly.assertThat(manualOne.isZero()).isFalse();
         });
     }
@@ -261,6 +263,24 @@ class BendableBigDecimalScoreTest extends AbstractScoreTest {
                 .isEqualTo(scoreDefinitionHHSSS.createScore(FOUR, MINUS_FIVE, FOUR, ZERO, ZERO));
         assertThat(scoreDefinitionHHSSS.createScore(PLUS_24, MINUS_24, PLUS_24, ZERO, ZERO).divide(5.0))
                 .isEqualTo(scoreDefinitionHHSSS.createScore(FOUR, MINUS_FIVE, FOUR, ZERO, ZERO));
+    }
+
+    @Test
+    void multiplyClampsNegativeScale() {
+        assertThat(scoreDefinitionHHSSS.createScore(COARSE_HUNDRED, FIVE_POINT_ZERO, ZERO, ZERO, ZERO).multiply(1.5))
+                .isEqualTo(scoreDefinitionHHSSS.createScore(new BigDecimal("150"), new BigDecimal("7.5"), ZERO, ZERO, ZERO));
+    }
+
+    @Test
+    void divideClampsNegativeScale() {
+        assertThat(scoreDefinitionHHSSS.createScore(COARSE_HUNDRED, FIVE_POINT_ZERO, ZERO, ZERO, ZERO).divide(2.0))
+                .isEqualTo(scoreDefinitionHHSSS.createScore(new BigDecimal("50"), new BigDecimal("2.5"), ZERO, ZERO, ZERO));
+    }
+
+    @Test
+    void powerClampsNegativeScale() {
+        assertThat(scoreDefinitionHHSSS.createScore(COARSE_HUNDRED, FIVE_POINT_ZERO, ZERO, ZERO, ZERO).power(0.0))
+                .isEqualTo(scoreDefinitionHHSSS.createScore(ONE, new BigDecimal("1.0"), ONE, ONE, ONE));
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/api/score/HardMediumSoftBigDecimalScoreTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/HardMediumSoftBigDecimalScoreTest.java
@@ -151,6 +151,27 @@ class HardMediumSoftBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void multiplyClampsNegativeScale() {
+        assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("1E+2"), BigDecimal.ZERO, new BigDecimal("5.0"))
+                .multiply(1.5))
+                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("150"), BigDecimal.ZERO, new BigDecimal("7.5")));
+    }
+
+    @Test
+    void divideClampsNegativeScale() {
+        assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("1E+2"), BigDecimal.ZERO, new BigDecimal("5.0"))
+                .divide(2.0))
+                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("50"), BigDecimal.ZERO, new BigDecimal("2.5")));
+    }
+
+    @Test
+    void powerClampsNegativeScale() {
+        assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("1E+2"), BigDecimal.ZERO, new BigDecimal("5.0"))
+                .power(0.0))
+                .isEqualTo(HardMediumSoftBigDecimalScore.of(BigDecimal.ONE, BigDecimal.ONE, new BigDecimal("1.0")));
+    }
+
+    @Test
     void negate() {
         assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"), new BigDecimal("-5.0"))
                 .negate())
@@ -184,12 +205,12 @@ class HardMediumSoftBigDecimalScoreTest extends AbstractScoreTest {
 
     @Test
     void zero() {
-        HardMediumSoftBigDecimalScore manualZero =
+        var manualZero =
                 HardMediumSoftBigDecimalScore.of(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(manualZero.zero()).isEqualTo(manualZero);
             softly.assertThat(manualZero.isZero()).isTrue();
-            HardMediumSoftBigDecimalScore manualOne =
+            var manualOne =
                     HardMediumSoftBigDecimalScore.of(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ONE);
             softly.assertThat(manualOne.isZero()).isFalse();
         });

--- a/core/src/test/java/ai/timefold/solver/core/api/score/HardMediumSoftBigDecimalScoreTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/HardMediumSoftBigDecimalScoreTest.java
@@ -23,6 +23,18 @@ class HardMediumSoftBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void ofKeepsScaleOfNonZeroLevel() {
+        assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("1.0"), BigDecimal.ZERO, BigDecimal.ZERO)
+                .hardScore().scale()).isEqualTo(1);
+    }
+
+    @Test
+    void ofKeepsScaleOfNegativeLevel() {
+        assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("-1.0"), BigDecimal.ZERO, BigDecimal.ZERO)
+                .hardScore().scale()).isEqualTo(1);
+    }
+
+    @Test
     void parseScore() {
         assertThat(HardMediumSoftBigDecimalScore.parseScore("-147.2hard/-3.2medium/-258.3soft")).isEqualTo(
                 HardMediumSoftBigDecimalScore.of(new BigDecimal("-147.2"), new BigDecimal("-3.2"), new BigDecimal("-258.3")));

--- a/core/src/test/java/ai/timefold/solver/core/api/score/HardSoftBigDecimalScoreTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/HardSoftBigDecimalScoreTest.java
@@ -21,6 +21,12 @@ class HardSoftBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void ofKeepsScaleOfNonZeroLevel() {
+        assertThat(HardSoftBigDecimalScore.of(new BigDecimal("1.0"), BigDecimal.ZERO).hardScore().scale())
+                .isEqualTo(1);
+    }
+
+    @Test
     void parseScore() {
         assertThat(HardSoftBigDecimalScore.parseScore("-147.2hard/-258.3soft"))
                 .isEqualTo(HardSoftBigDecimalScore.of(new BigDecimal("-147.2"), new BigDecimal("-258.3")));

--- a/core/src/test/java/ai/timefold/solver/core/api/score/HardSoftBigDecimalScoreTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/HardSoftBigDecimalScoreTest.java
@@ -115,6 +115,24 @@ class HardSoftBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void multiplyClampsNegativeScale() {
+        assertThat(HardSoftBigDecimalScore.of(new BigDecimal("1E+2"), new BigDecimal("5.0")).multiply(1.5))
+                .isEqualTo(HardSoftBigDecimalScore.of(new BigDecimal("150"), new BigDecimal("7.5")));
+    }
+
+    @Test
+    void divideClampsNegativeScale() {
+        assertThat(HardSoftBigDecimalScore.of(new BigDecimal("1E+2"), new BigDecimal("5.0")).divide(2.0))
+                .isEqualTo(HardSoftBigDecimalScore.of(new BigDecimal("50"), new BigDecimal("2.5")));
+    }
+
+    @Test
+    void powerClampsNegativeScale() {
+        assertThat(HardSoftBigDecimalScore.of(new BigDecimal("1E+2"), new BigDecimal("5.0")).power(0.0))
+                .isEqualTo(HardSoftBigDecimalScore.of(BigDecimal.ONE, new BigDecimal("1.0")));
+    }
+
+    @Test
     void negate() {
         assertThat(HardSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("-5.0")).negate())
                 .isEqualTo(HardSoftBigDecimalScore.of(new BigDecimal("-4.0"), new BigDecimal("5.0")));
@@ -136,11 +154,11 @@ class HardSoftBigDecimalScoreTest extends AbstractScoreTest {
 
     @Test
     void zero() {
-        HardSoftBigDecimalScore manualZero = HardSoftBigDecimalScore.of(BigDecimal.ZERO, BigDecimal.ZERO);
+        var manualZero = HardSoftBigDecimalScore.of(BigDecimal.ZERO, BigDecimal.ZERO);
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(manualZero.zero()).isEqualTo(manualZero);
             softly.assertThat(manualZero.isZero()).isTrue();
-            HardSoftBigDecimalScore manualOne = HardSoftBigDecimalScore.of(BigDecimal.ZERO, BigDecimal.ONE);
+            var manualOne = HardSoftBigDecimalScore.of(BigDecimal.ZERO, BigDecimal.ONE);
             softly.assertThat(manualOne.isZero()).isFalse();
         });
     }

--- a/core/src/test/java/ai/timefold/solver/core/api/score/SimpleBigDecimalScoreTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/SimpleBigDecimalScoreTest.java
@@ -20,6 +20,11 @@ class SimpleBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void ofKeepsScaleOfNonZeroLevel() {
+        assertThat(SimpleBigDecimalScore.of(new BigDecimal("1.0")).score().scale()).isEqualTo(1);
+    }
+
+    @Test
     void toShortString() {
         assertThat(SimpleBigDecimalScore.of(new BigDecimal("0.0")).toShortString()).isEqualTo("0");
         assertThat(SimpleBigDecimalScore.of(new BigDecimal("-147.2")).toShortString()).isEqualTo("-147.2");

--- a/core/src/test/java/ai/timefold/solver/core/api/score/SimpleBigDecimalScoreTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/api/score/SimpleBigDecimalScoreTest.java
@@ -94,6 +94,24 @@ class SimpleBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void multiplyClampsNegativeScale() {
+        assertThat(SimpleBigDecimalScore.of(new BigDecimal("1E+2")).multiply(1.5))
+                .isEqualTo(SimpleBigDecimalScore.of(new BigDecimal("150")));
+    }
+
+    @Test
+    void divideClampsNegativeScale() {
+        assertThat(SimpleBigDecimalScore.of(new BigDecimal("1E+2")).divide(2.0))
+                .isEqualTo(SimpleBigDecimalScore.of(new BigDecimal("50")));
+    }
+
+    @Test
+    void powerClampsNegativeScale() {
+        assertThat(SimpleBigDecimalScore.of(new BigDecimal("1E+2")).power(0.0))
+                .isEqualTo(SimpleBigDecimalScore.of(BigDecimal.ONE));
+    }
+
+    @Test
     void negate() {
         assertThat(SimpleBigDecimalScore.of(new BigDecimal("5.0")).negate())
                 .isEqualTo(SimpleBigDecimalScore.of(new BigDecimal("-5.0")));

--- a/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/bavet/common/index/ScalingNavigableMapTest.java
@@ -149,7 +149,7 @@ class ScalingNavigableMapTest {
         assertThat(map.isArrayBased()).isFalse();
         assertThat(map.size()).isEqualTo(keyCount);
         assertThat(ascendingKeys(map)).isSorted();
-        assertThat(descendingKeys(map)).isSortedAccordingTo((a, b) -> b - a);
+        assertThat(descendingKeys(map)).isSortedAccordingTo((a, b) -> Integer.compare(b, a));
     }
 
     @Test

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/ScoreUtilTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/ScoreUtilTest.java
@@ -1,0 +1,82 @@
+package ai.timefold.solver.core.impl.score;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+class ScoreUtilTest {
+
+    @Test
+    void isZero() {
+        assertThat(ScoreUtil.isZero(BigDecimal.ZERO)).isTrue();
+        assertThat(ScoreUtil.isZero(new BigDecimal("0.00"))).isTrue();
+        assertThat(ScoreUtil.isZero(new BigDecimal("-0.0"))).isTrue();
+        assertThat(ScoreUtil.isZero(BigDecimal.ONE)).isFalse();
+        assertThat(ScoreUtil.isZero(BigDecimal.ONE.negate())).isFalse();
+    }
+
+    @Test
+    void isNegative() {
+        assertThat(ScoreUtil.isNegative(BigDecimal.ONE.negate())).isTrue();
+        assertThat(ScoreUtil.isNegative(BigDecimal.ZERO)).isFalse();
+        assertThat(ScoreUtil.isNegative(new BigDecimal("-0.0"))).isFalse();
+        assertThat(ScoreUtil.isNegative(BigDecimal.ONE)).isFalse();
+    }
+
+    @Test
+    void equalsIgnoringScale() {
+        assertThat(ScoreUtil.equalsIgnoringScale(new BigDecimal("1.0"), new BigDecimal("1.00"))).isTrue();
+        assertThat(ScoreUtil.equalsIgnoringScale(new BigDecimal("1.0"), new BigDecimal("1.1"))).isFalse();
+    }
+
+    @Test
+    void hashCodeIgnoringScale() {
+        assertThat(ScoreUtil.hashCodeIgnoringScale(new BigDecimal("1.0")))
+                .isEqualTo(ScoreUtil.hashCodeIgnoringScale(new BigDecimal("1.00")));
+    }
+
+    @Test
+    void nonNegativeScale() {
+        assertThat(ScoreUtil.nonNegativeScale(2)).isEqualTo(2);
+        assertThat(ScoreUtil.nonNegativeScale(0)).isEqualTo(0);
+        assertThat(ScoreUtil.nonNegativeScale(-2)).isEqualTo(0);
+    }
+
+    @Test
+    void multiplyNormalScale() {
+        assertThat(ScoreUtil.multiply(new BigDecimal("5.0"), 1.5)).isEqualTo(new BigDecimal("7.5"));
+    }
+
+    @Test
+    void multiplyClampsNegativeScale() {
+        // Flooring onto the receiver's own scale (-2, nearest hundred) would wrongly give 100.
+        assertThat(ScoreUtil.multiply(new BigDecimal("1E+2"), 1.5)).isEqualTo(new BigDecimal("150"));
+    }
+
+    @Test
+    void divideNormalScale() {
+        assertThat(ScoreUtil.divide(new BigDecimal("5.0"), 2.0)).isEqualTo(new BigDecimal("2.5"));
+    }
+
+    @Test
+    void divideClampsNegativeScale() {
+        // Flooring onto the receiver's own scale (-2, nearest hundred) would wrongly give 0.
+        assertThat(ScoreUtil.divide(new BigDecimal("1E+2"), 2.0)).isEqualTo(new BigDecimal("50"));
+    }
+
+    @Test
+    void powerNormalScale() {
+        assertThat(ScoreUtil.power(new BigDecimal("5.0"), 2.0)).isEqualTo(new BigDecimal("25.0"));
+    }
+
+    @Test
+    void powerClampsNegativeScale() {
+        // Any exponent other than 0 stays an exact multiple of the receiver's own coarse scale,
+        // so exponent 0 is the only one that actually reproduces the bug: 100^0 = 1, and flooring
+        // 1 onto scale -2 (nearest hundred) would wrongly give 0.
+        assertThat(ScoreUtil.power(new BigDecimal("1E+2"), 0.0)).isEqualTo(BigDecimal.ONE);
+    }
+
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/definition/BendableBigDecimalScoreDefinitionTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/definition/BendableBigDecimalScoreDefinitionTest.java
@@ -108,4 +108,13 @@ class BendableBigDecimalScoreDefinitionTest {
                 .isEqualTo(scoreDefinition.createScore(BigDecimal.ZERO, BigDecimal.ONE));
     }
 
+    @Test
+    void divideBySanitizedDivisorClampsNegativeScale() {
+        var scoreDefinition = new BendableBigDecimalScoreDefinition(1, 1);
+        var dividend = scoreDefinition.createScore(new BigDecimal("1E+1"), BigDecimal.TEN);
+        var divisor = scoreDefinition.createScore(new BigDecimal("2.00"), BigDecimal.valueOf(2));
+        assertThat(scoreDefinition.divideBySanitizedDivisor(dividend, divisor))
+                .isEqualTo(scoreDefinition.createScore(BigDecimal.valueOf(5), BigDecimal.valueOf(5)));
+    }
+
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/definition/HardMediumSoftBigDecimalScoreDefinitionTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/definition/HardMediumSoftBigDecimalScoreDefinitionTest.java
@@ -58,4 +58,16 @@ class HardMediumSoftBigDecimalScoreDefinitionTest {
                         new Number[] { BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ONE }));
     }
 
+    @Test
+    void divideBySanitizedDivisorClampsNegativeScale() {
+        var scoreDefinition = new HardMediumSoftBigDecimalScoreDefinition();
+        var dividend = scoreDefinition.fromLevelNumbers(
+                new Number[] { new BigDecimal("1E+1"), BigDecimal.TEN, BigDecimal.TEN });
+        var divisor = scoreDefinition.fromLevelNumbers(
+                new Number[] { new BigDecimal("2.00"), BigDecimal.valueOf(2), BigDecimal.valueOf(2) });
+        assertThat(scoreDefinition.divideBySanitizedDivisor(dividend, divisor))
+                .isEqualTo(scoreDefinition.fromLevelNumbers(
+                        new Number[] { BigDecimal.valueOf(5), BigDecimal.valueOf(5), BigDecimal.valueOf(5) }));
+    }
+
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/definition/HardSoftBigDecimalScoreDefinitionTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/definition/HardSoftBigDecimalScoreDefinitionTest.java
@@ -57,4 +57,13 @@ class HardSoftBigDecimalScoreDefinitionTest {
                         new Number[] { BigDecimal.ZERO, BigDecimal.ONE }));
     }
 
+    @Test
+    void divideBySanitizedDivisorClampsNegativeScale() {
+        var scoreDefinition = new HardSoftBigDecimalScoreDefinition();
+        var dividend = scoreDefinition.fromLevelNumbers(new Number[] { new BigDecimal("1E+1"), BigDecimal.TEN });
+        var divisor = scoreDefinition.fromLevelNumbers(new Number[] { new BigDecimal("2.00"), BigDecimal.valueOf(2) });
+        assertThat(scoreDefinition.divideBySanitizedDivisor(dividend, divisor))
+                .isEqualTo(scoreDefinition.fromLevelNumbers(new Number[] { BigDecimal.valueOf(5), BigDecimal.valueOf(5) }));
+    }
+
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/score/definition/SimpleBigDecimalScoreDefinitionTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/score/definition/SimpleBigDecimalScoreDefinitionTest.java
@@ -49,4 +49,13 @@ class SimpleBigDecimalScoreDefinitionTest {
                 .isEqualTo(scoreDefinition.fromLevelNumbers(new Number[] { BigDecimal.ONE }));
     }
 
+    @Test
+    void divideBySanitizedDivisorClampsNegativeScale() {
+        var scoreDefinition = new SimpleBigDecimalScoreDefinition();
+        var dividend = scoreDefinition.fromLevelNumbers(new Number[] { new BigDecimal("1E+1") });
+        var divisor = scoreDefinition.fromLevelNumbers(new Number[] { new BigDecimal("2.00") });
+        assertThat(scoreDefinition.divideBySanitizedDivisor(dividend, divisor))
+                .isEqualTo(scoreDefinition.fromLevelNumbers(new Number[] { BigDecimal.valueOf(5) }));
+    }
+
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/common/TestSortableObject.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/common/TestSortableObject.java
@@ -6,6 +6,6 @@ public interface TestSortableObject extends Comparable<TestSortableObject> {
 
     @Override
     default int compareTo(TestSortableObject o) {
-        return getComparatorValue() - o.getComparatorValue();
+        return Integer.compare(getComparatorValue(), o.getComparatorValue());
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/common/TestSortableObjectComparator.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/common/TestSortableObjectComparator.java
@@ -9,6 +9,6 @@ public class TestSortableObjectComparator implements Comparator<TestSortableObje
 
     @Override
     public int compare(TestSortableObject v1, TestSortableObject v2) {
-        return v1.getComparatorValue() - v2.getComparatorValue();
+        return Integer.compare(v1.getComparatorValue(), v2.getComparatorValue());
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/common/TestdataObjectSortableDescendingComparator.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/common/TestdataObjectSortableDescendingComparator.java
@@ -12,7 +12,7 @@ public class TestdataObjectSortableDescendingComparator implements Comparator<Te
     @Override
     public int compare(TestdataObject o1, TestdataObject o2) {
         // Descending order
-        return extractCode(o2.getCode()) - extractCode(o1.getCode());
+        return Integer.compare(extractCode(o2.getCode()), extractCode(o1.getCode()));
     }
 
     public static int extractCode(String code) {

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/multientity/TestdataMixedMultiEntityFirstEntityComparator.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/multientity/TestdataMixedMultiEntityFirstEntityComparator.java
@@ -6,6 +6,6 @@ public class TestdataMixedMultiEntityFirstEntityComparator implements Comparator
     @Override
     public int compare(TestdataMixedMultiEntityFirstEntity v1, TestdataMixedMultiEntityFirstEntity v2) {
         // ASC sort
-        return v1.getDifficulty() - v2.getDifficulty();
+        return Integer.compare(v1.getDifficulty(), v2.getDifficulty());
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/multientity/TestdataMixedMultiEntitySecondValueComparator.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/multientity/TestdataMixedMultiEntitySecondValueComparator.java
@@ -6,6 +6,6 @@ public class TestdataMixedMultiEntitySecondValueComparator implements Comparator
     @Override
     public int compare(TestdataMixedMultiEntitySecondValue v1, TestdataMixedMultiEntitySecondValue v2) {
         // ASC sort
-        return v1.getStrength() - v2.getStrength();
+        return Integer.compare(v1.getStrength(), v2.getStrength());
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/singleentity/TestdataMixedEntityComparator.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/singleentity/TestdataMixedEntityComparator.java
@@ -5,6 +5,6 @@ import java.util.Comparator;
 public class TestdataMixedEntityComparator implements Comparator<TestdataMixedEntity> {
     @Override
     public int compare(TestdataMixedEntity v1, TestdataMixedEntity v2) {
-        return v1.getDifficulty() - v2.getDifficulty();
+        return Integer.compare(v1.getDifficulty(), v2.getDifficulty());
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/singleentity/TestdataMixedOtherValueComparator.java
+++ b/core/src/test/java/ai/timefold/solver/core/testdomain/mixed/singleentity/TestdataMixedOtherValueComparator.java
@@ -5,6 +5,6 @@ import java.util.Comparator;
 public class TestdataMixedOtherValueComparator implements Comparator<TestdataMixedOtherValue> {
     @Override
     public int compare(TestdataMixedOtherValue o1, TestdataMixedOtherValue o2) {
-        return o1.getStrength() - o2.getStrength();
+        return Integer.compare(o1.getStrength(), o2.getStrength());
     }
 }


### PR DESCRIPTION
Fully backwards compatible, in some cases even marginally improving performance.

Includes an unrelated change to integer comparisons, which are now safer and together bring Sonar rating back to A.