### PR TITLE
fix: use the same tag keyset everywhere

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolver.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolver.java
@@ -2,7 +2,6 @@ package ai.timefold.solver.core.impl.solver;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -18,6 +17,7 @@ import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescr
 import ai.timefold.solver.core.impl.phase.Phase;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverTags;
 import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.recaller.BestSolutionRecaller;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
@@ -27,7 +27,6 @@ import ai.timefold.solver.core.impl.solver.termination.UniversalTermination;
 import org.jspecify.annotations.NullMarked;
 
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Tags;
 
 /**
  * Default implementation for {@link Solver}.
@@ -130,11 +129,8 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
         return basicPlumbingTermination.isEveryProblemChangeProcessed();
     }
 
-    public void setMonitorTagMap(Map<String, String> monitorTagMap) {
-        var monitoringTags = Objects.requireNonNullElse(monitorTagMap, Collections.<String, String> emptyMap())
-                .entrySet().stream().map(entry -> Tags.of(entry.getKey(), entry.getValue()))
-                .reduce(Tags.empty(), Tags::and);
-        solverScope.setMonitoringTags(monitoringTags);
+    public void setMonitorTags(SolverTags solverTags) {
+        solverScope.setMonitoringTags(solverTags.asTags());
     }
 
     // ************************************************************************

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -38,6 +38,7 @@ import ai.timefold.solver.core.impl.phase.PhaseFactory;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactory;
 import ai.timefold.solver.core.impl.score.director.ScoreDirectorFactoryFactory;
 import ai.timefold.solver.core.impl.solver.change.DefaultProblemChangeDirector;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverTags;
 import ai.timefold.solver.core.impl.solver.random.DefaultRandomSource;
 import ai.timefold.solver.core.impl.solver.random.RandomSource;
 import ai.timefold.solver.core.impl.solver.recaller.BestSolutionRecaller;
@@ -52,8 +53,6 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.micrometer.core.instrument.Tags;
 
 /**
  * Builds {@link DefaultSolver} instances out of a {@link SolverConfig},
@@ -134,7 +133,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
 
         var solverScope = new SolverScope<Solution_>(clock);
         var monitoringConfig = solverConfig.determineMetricConfig();
-        solverScope.setMonitoringTags(Tags.empty());
+        solverScope.setMonitoringTags(SolverTags.withoutProblemId().asTags());
         var solverMetricList = Objects.requireNonNull(monitoringConfig.getSolverMetricList());
         if (!solverMetricList.isEmpty()) {
             solverScope.setSolverMetricSet(EnumSet.copyOf(solverMetricList));

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverFactory.java
@@ -133,7 +133,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
 
         var solverScope = new SolverScope<Solution_>(clock);
         var monitoringConfig = solverConfig.determineMetricConfig();
-        solverScope.setMonitoringTags(SolverTags.withoutProblemId().asTags());
+        solverScope.setMonitoringTags(SolverTags.withoutProblemId(clock).asTags());
         var solverMetricList = Objects.requireNonNull(monitoringConfig.getSolverMetricList());
         if (!solverMetricList.isEmpty()) {
             solverScope.setSolverMetricSet(EnumSet.copyOf(solverMetricList));

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/DefaultSolverManager.java
@@ -1,7 +1,6 @@
 package ai.timefold.solver.core.impl.solver;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,6 +25,7 @@ import ai.timefold.solver.core.api.solver.event.NewBestSolutionEvent;
 import ai.timefold.solver.core.api.solver.event.SolverJobStartedEvent;
 import ai.timefold.solver.core.config.solver.SolverManagerConfig;
 import ai.timefold.solver.core.config.util.ConfigUtils;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverTags;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -98,7 +98,7 @@ public final class DefaultSolverManager<Solution_> implements SolverManager<Solu
             @Nullable BiConsumer<? super Object, ? super Throwable> exceptionHandler,
             SolverConfigOverride configOverride) {
         var solver = solverFactory.buildSolver(configOverride);
-        ((DefaultSolver<Solution_>) solver).setMonitorTagMap(Map.of("problem.id", problemId.toString()));
+        ((DefaultSolver<Solution_>) solver).setMonitorTags(SolverTags.withProblemId(problemId));
         BiConsumer<? super Object, ? super Throwable> finalExceptionHandler =
                 (exceptionHandler != null) ? exceptionHandler : defaultExceptionHandler;
         var solverJob = problemIdToSolverJobMap.compute(problemId, (key, oldSolverJob) -> {

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/SolverTags.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/SolverTags.java
@@ -1,0 +1,37 @@
+package ai.timefold.solver.core.impl.solver.monitoring;
+
+import java.util.Objects;
+
+import ai.timefold.solver.core.api.solver.SolverManager;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import io.micrometer.core.instrument.Tags;
+
+/**
+ * Some Micrometer registries like Prometheus require each meter
+ * to be registered with the same tag key set. In order to enforce
+ * each {@link Tags} instance having the same keys, this class is
+ * to be used instead of creating the {@link Tags} manually.
+ * <p>
+ * Each field is nullable; when null, the value of the tag will be "null".
+ *
+ * @param problemId The problem id passed to {@link SolverManager}, or a benchmark id
+ */
+@NullMarked
+public record SolverTags(@Nullable Object problemId) {
+    public Tags asTags() {
+        return Tags.of(
+                "problem.id", Objects.requireNonNullElse(
+                        problemId, "null").toString());
+    }
+
+    public static SolverTags withProblemId(Object problemId) {
+        return new SolverTags(problemId);
+    }
+
+    public static SolverTags withoutProblemId() {
+        return new SolverTags(null);
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/SolverTags.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/solver/monitoring/SolverTags.java
@@ -1,11 +1,11 @@
 package ai.timefold.solver.core.impl.solver.monitoring;
 
-import java.util.Objects;
+import java.time.Clock;
+import java.time.ZoneOffset;
 
 import ai.timefold.solver.core.api.solver.SolverManager;
 
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 import io.micrometer.core.instrument.Tags;
 
@@ -14,24 +14,20 @@ import io.micrometer.core.instrument.Tags;
  * to be registered with the same tag key set. In order to enforce
  * each {@link Tags} instance having the same keys, this class is
  * to be used instead of creating the {@link Tags} manually.
- * <p>
- * Each field is nullable; when null, the value of the tag will be "null".
  *
  * @param problemId The problem id passed to {@link SolverManager}, or a benchmark id
  */
 @NullMarked
-public record SolverTags(@Nullable Object problemId) {
+public record SolverTags(Object problemId) {
     public Tags asTags() {
-        return Tags.of(
-                "problem.id", Objects.requireNonNullElse(
-                        problemId, "null").toString());
+        return Tags.of("problem.id", problemId.toString());
     }
 
     public static SolverTags withProblemId(Object problemId) {
         return new SolverTags(problemId);
     }
 
-    public static SolverTags withoutProblemId() {
-        return new SolverTags(null);
+    public static SolverTags withoutProblemId(Clock clock) {
+        return new SolverTags(clock.instant().atOffset(ZoneOffset.UTC));
     }
 }

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/SolverMetricsIT.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/SolverMetricsIT.java
@@ -3,7 +3,11 @@ package ai.timefold.solver.core.impl.solver;
 import static ai.timefold.solver.core.testutil.PlannerAssert.assertCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.when;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,8 +60,10 @@ import ai.timefold.solver.core.testutil.PlannerTestUtils;
 
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
@@ -65,6 +71,15 @@ import io.micrometer.core.instrument.Tags;
 
 @ExtendWith(SoftAssertionsExtension.class)
 class SolverMetricsIT extends AbstractMeterTest {
+    private static final Instant SOLVE_START_TIME = Instant.EPOCH;
+    private static final String PROBLEM_ID = SOLVE_START_TIME.atOffset(ZoneOffset.UTC).toString();
+    private Clock mockClock;
+
+    @BeforeEach
+    void setUp() {
+        mockClock = Mockito.mock(Clock.class);
+        when(mockClock.instant()).thenReturn(SOLVE_START_TIME);
+    }
 
     @Test
     void checkDefaultMeters() {
@@ -73,6 +88,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataSolution.class, TestdataEntity.class);
+        solverConfig.setClock(mockClock);
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
 
         var solver = (DefaultSolver<TestdataSolution>) solverFactory.buildSolver();
@@ -100,32 +116,32 @@ class SolverMetricsIT extends AbstractMeterTest {
                                         null,
                                         Meter.Type.COUNTER),
                                 new Meter.Id(SolverMetric.SCORE_CALCULATION_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.MOVE_EVALUATION_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_ENTITY_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_VARIABLE_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_VALUE_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_SIZE_LOG.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE));
@@ -162,6 +178,7 @@ class SolverMetricsIT extends AbstractMeterTest {
         Metrics.addRegistry(meterRegistry);
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
+        solverConfig.setClock(mockClock);
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
 
         var solver = (DefaultSolver<TestdataSolution>) solverFactory.buildSolver();
@@ -190,32 +207,32 @@ class SolverMetricsIT extends AbstractMeterTest {
                                         null,
                                         Meter.Type.COUNTER),
                                 new Meter.Id(SolverMetric.SCORE_CALCULATION_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.MOVE_EVALUATION_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_ENTITY_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_VARIABLE_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_VALUE_COUNT.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_SIZE_LOG.getMeterId(),
-                                        Tags.of("problem.id", "null"),
+                                        Tags.of("problem.id", PROBLEM_ID),
                                         null,
                                         null,
                                         Meter.Type.GAUGE));
@@ -253,6 +270,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataSolution.class, TestdataEntity.class);
+        solverConfig.setClock(mockClock);
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
 
         var solver = solverFactory.buildSolver();
@@ -308,6 +326,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataSolution.class, TestdataEntity.class);
+        solverConfig.setClock(mockClock);
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
 
         var solver = solverFactory.buildSolver();
@@ -381,6 +400,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataHardSoftScoreSolution.class, TestdataEntity.class);
+        solverConfig.setClock(mockClock);
         solverConfig.setScoreDirectorFactoryConfig(
                 new ScoreDirectorFactoryConfig().withEasyScoreCalculatorClass(BestScoreMetricEasyScoreCalculator.class));
         solverConfig.setTerminationConfig(new TerminationConfig().withBestScoreLimit("0hard/2soft"));
@@ -470,6 +490,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataHardSoftScoreSolution.class, TestdataEntity.class);
+        solverConfig.setClock(mockClock);
         solverConfig.setScoreDirectorFactoryConfig(
                 new ScoreDirectorFactoryConfig().withEasyScoreCalculatorClass(BestScoreMetricEasyScoreCalculator.class));
         solverConfig.setTerminationConfig(new TerminationConfig().withBestScoreLimit("0hard/3soft"));
@@ -581,6 +602,7 @@ class SolverMetricsIT extends AbstractMeterTest {
         var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
                 .withScoreDirectorFactory(
                         new ScoreDirectorFactoryConfig().withEasyScoreCalculatorClass(ErrorThrowingEasyScoreCalculator.class));
+        solverConfig.setClock(mockClock);
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
 
         var solver = solverFactory.buildSolver();
@@ -611,6 +633,7 @@ class SolverMetricsIT extends AbstractMeterTest {
         var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
                 .withPhases(new ConstructionHeuristicPhaseConfig())
                 .withMonitoringConfig(new MonitoringConfig().withSolverMetricList(List.of(SolverMetric.MOVE_COUNT_PER_TYPE)));
+        solverConfig.setClock(mockClock);
 
         var problem = new TestdataSolution("s1");
         var v1 = new TestdataValue("v1");
@@ -650,6 +673,7 @@ class SolverMetricsIT extends AbstractMeterTest {
                 .buildSolverConfig(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class)
                 .withPhases(new ConstructionHeuristicPhaseConfig())
                 .withMonitoringConfig(new MonitoringConfig().withSolverMetricList(List.of(SolverMetric.MOVE_COUNT_PER_TYPE)));
+        solverConfig.setClock(mockClock);
 
         var problem = new TestdataListSolution();
         var v1 = new TestdataListValue("v1");
@@ -684,6 +708,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class,
                 TestdataEntity.class);
+        solverConfig.setClock(mockClock);
         solverConfig.setPhaseConfigList(Collections.singletonList(new ExhaustiveSearchPhaseConfig()));
 
         var problem = new TestdataSolution("s1");
@@ -730,6 +755,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class,
                 TestdataEntity.class);
+        solverConfig.setClock(mockClock);
         solverConfig.withPhases(new ExhaustiveSearchPhaseConfig())
                 .withMonitoringConfig(new MonitoringConfig().withSolverMetricList(List.of(SolverMetric.MOVE_COUNT_PER_TYPE)));
 
@@ -768,6 +794,7 @@ class SolverMetricsIT extends AbstractMeterTest {
         Metrics.addRegistry(meterRegistry);
 
         var solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
+        solverConfig.setClock(mockClock);
         var phaseConfig = new LocalSearchPhaseConfig();
         phaseConfig.setTerminationConfig(new TerminationConfig().withStepCountLimit(20));
         solverConfig.withPhases(phaseConfig)
@@ -817,6 +844,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solverConfig = PlannerTestUtils
                 .buildSolverConfig(TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class);
+        solverConfig.setClock(mockClock);
         var phaseConfig = new LocalSearchPhaseConfig();
         phaseConfig.setTerminationConfig(new TerminationConfig().withScoreCalculationCountLimit(20L));
         solverConfig.withPhases(phaseConfig)

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/SolverMetricsIT.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/SolverMetricsIT.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -42,6 +41,7 @@ import ai.timefold.solver.core.impl.heuristic.selector.move.generic.SelectorBase
 import ai.timefold.solver.core.impl.phase.event.PhaseLifecycleListenerAdapter;
 import ai.timefold.solver.core.impl.phase.scope.AbstractStepScope;
 import ai.timefold.solver.core.impl.score.director.ScoreDirector;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverTags;
 import ai.timefold.solver.core.impl.solver.scope.SolverScope;
 import ai.timefold.solver.core.preview.api.move.builtin.Moves;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
@@ -100,32 +100,32 @@ class SolverMetricsIT extends AbstractMeterTest {
                                         null,
                                         Meter.Type.COUNTER),
                                 new Meter.Id(SolverMetric.SCORE_CALCULATION_COUNT.getMeterId(),
-                                        Tags.empty(),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.MOVE_EVALUATION_COUNT.getMeterId(),
-                                        Tags.empty(),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_ENTITY_COUNT.getMeterId(),
-                                        Tags.empty(),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_VARIABLE_COUNT.getMeterId(),
-                                        Tags.empty(),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_VALUE_COUNT.getMeterId(),
-                                        Tags.empty(),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_SIZE_LOG.getMeterId(),
-                                        Tags.empty(),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE));
@@ -141,6 +141,7 @@ class SolverMetricsIT extends AbstractMeterTest {
         // make it return the average, and the solver holds
         // onto the solver scope, meaning it won't automatically
         // be deregistered.
+        // Prometheus requires the tag set to be constant, so everything except global meters gets a problem id
         assertThat(meterRegistry.getMeters().stream().map(Meter::getId))
                 .containsExactlyInAnyOrder(
                         new Meter.Id(SolverMetric.SOLVE_DURATION.getMeterId(),
@@ -164,7 +165,6 @@ class SolverMetricsIT extends AbstractMeterTest {
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
 
         var solver = (DefaultSolver<TestdataSolution>) solverFactory.buildSolver();
-        solver.setMonitorTagMap(Map.of("tag.key", "tag.value"));
         meterRegistry.publish();
         assertThat(meterRegistry.getMeters().stream().map(Meter::getId)).isEmpty();
 
@@ -176,6 +176,7 @@ class SolverMetricsIT extends AbstractMeterTest {
         var latch = new CountDownLatch(1);
         solver.addEventListener(event -> {
             if (!updatedTime.get()) {
+                // Prometheus requires the tag set to be constant, so everything except global meters gets a problem id
                 assertThat(meterRegistry.getMeters().stream().map(Meter::getId))
                         .containsExactlyInAnyOrder(
                                 new Meter.Id(SolverMetric.SOLVE_DURATION.getMeterId(),
@@ -189,32 +190,32 @@ class SolverMetricsIT extends AbstractMeterTest {
                                         null,
                                         Meter.Type.COUNTER),
                                 new Meter.Id(SolverMetric.SCORE_CALCULATION_COUNT.getMeterId(),
-                                        Tags.of("tag.key", "tag.value"),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.MOVE_EVALUATION_COUNT.getMeterId(),
-                                        Tags.of("tag.key", "tag.value"),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_ENTITY_COUNT.getMeterId(),
-                                        Tags.of("tag.key", "tag.value"),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_VARIABLE_COUNT.getMeterId(),
-                                        Tags.of("tag.key", "tag.value"),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_VALUE_COUNT.getMeterId(),
-                                        Tags.of("tag.key", "tag.value"),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE),
                                 new Meter.Id(SolverMetric.PROBLEM_SIZE_LOG.getMeterId(),
-                                        Tags.of("tag.key", "tag.value"),
+                                        Tags.of("problem.id", "null"),
                                         null,
                                         null,
                                         Meter.Type.GAUGE));
@@ -255,7 +256,7 @@ class SolverMetricsIT extends AbstractMeterTest {
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
 
         var solver = solverFactory.buildSolver();
-        ((DefaultSolver<TestdataSolution>) solver).setMonitorTagMap(Map.of("solver.id", UUID.randomUUID().toString()));
+        ((DefaultSolver<TestdataSolution>) solver).setMonitorTags(SolverTags.withProblemId(UUID.randomUUID().toString()));
         meterRegistry.publish();
 
         var solution = new TestdataSolution("s1");
@@ -400,7 +401,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solver = solverFactory.buildSolver();
         ((DefaultSolver<TestdataHardSoftScoreSolution>) solver)
-                .setMonitorTagMap(Map.of("solver.id", UUID.randomUUID().toString()));
+                .setMonitorTags(SolverTags.withProblemId(UUID.randomUUID().toString()));
         meterRegistry.publish();
         var solution = new TestdataHardSoftScoreSolution("s1");
         solution.setValueList(Arrays.asList(new TestdataValue("none"), new TestdataValue("reward")));
@@ -503,7 +504,7 @@ class SolverMetricsIT extends AbstractMeterTest {
 
         var solver = solverFactory.buildSolver();
         ((DefaultSolver<TestdataHardSoftScoreSolution>) solver)
-                .setMonitorTagMap(Map.of("solver.id", UUID.randomUUID().toString()));
+                .setMonitorTags(SolverTags.withProblemId(UUID.randomUUID().toString()));
         var step = new AtomicInteger(-1);
 
         ((DefaultSolver<TestdataHardSoftScoreSolution>) solver)
@@ -583,7 +584,7 @@ class SolverMetricsIT extends AbstractMeterTest {
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
 
         var solver = solverFactory.buildSolver();
-        ((DefaultSolver<TestdataSolution>) solver).setMonitorTagMap(Map.of("solver.id", UUID.randomUUID().toString()));
+        ((DefaultSolver<TestdataSolution>) solver).setMonitorTags(SolverTags.withProblemId(UUID.randomUUID().toString()));
         meterRegistry.publish();
 
         var solution = new TestdataSolution("s1");

--- a/tools/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/SubSingleBenchmarkRunner.java
+++ b/tools/benchmark/src/main/java/ai/timefold/solver/benchmark/impl/SubSingleBenchmarkRunner.java
@@ -1,6 +1,5 @@
 package ai.timefold.solver.benchmark.impl;
 
-import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
@@ -13,13 +12,13 @@ import ai.timefold.solver.core.config.solver.SolverConfig;
 import ai.timefold.solver.core.enterprise.TimefoldSolverEnterpriseService;
 import ai.timefold.solver.core.impl.solver.DefaultSolver;
 import ai.timefold.solver.core.impl.solver.DefaultSolverFactory;
+import ai.timefold.solver.core.impl.solver.monitoring.SolverTags;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Tags;
 
 public class SubSingleBenchmarkRunner<Solution_> implements Callable<SubSingleBenchmarkRunner<Solution_>> {
 
@@ -81,9 +80,8 @@ public class SubSingleBenchmarkRunner<Solution_> implements Callable<SubSingleBe
             solverConfig = new SolverConfig(solverConfig);
             solverConfig.offerRandomSeedFromSubSingleIndex(subSingleBenchmarkResult.getSubSingleBenchmarkIndex());
         }
-        var subSingleBenchmarkTagMap = new HashMap<String, String>();
         var runId = UUID.randomUUID().toString();
-        subSingleBenchmarkTagMap.put("timefold.benchmark.run", runId);
+        var subSingleBenchmarkSolverTags = SolverTags.withProblemId(runId);
         solverConfig = new SolverConfig(solverConfig);
         randomSeed = solverConfig.getRandomSeed();
 
@@ -93,14 +91,14 @@ public class SubSingleBenchmarkRunner<Solution_> implements Callable<SubSingleBe
         // Register metrics
         var statisticRegistry = new StatisticRegistry<Solution_>(solverFactory.getSolutionDescriptor().getScoreDefinition());
         Metrics.addRegistry(statisticRegistry);
-        var runTag = Tags.of("timefold.benchmark.run", runId);
+        var runTag = subSingleBenchmarkSolverTags.asTags();
         subSingleBenchmarkResult.getEffectiveSubSingleStatisticMap().forEach((statisticType, subSingleStatistic) -> {
             subSingleStatistic.open(statisticRegistry, runTag);
             subSingleStatistic.initPointList();
         });
 
         var solver = (DefaultSolver<Solution_>) solverFactory.buildSolver();
-        solver.setMonitorTagMap(subSingleBenchmarkTagMap);
+        solver.setMonitorTags(subSingleBenchmarkSolverTags);
         solver.addPhaseLifecycleListener(statisticRegistry);
         var solution = solver.solve(problem);
 


### PR DESCRIPTION
Some meter registries require the same keyset to be used for meters with the same name.